### PR TITLE
windows: update msvc/devcpp/rust/pmwrapper

### DIFF
--- a/pkgs/d/devcpp.lua
+++ b/pkgs/d/devcpp.lua
@@ -23,6 +23,7 @@ package = {
     },
 }
 
+import("common")
 import("xim.base.utils")
 import("xim.base.runtime")
 
@@ -39,15 +40,17 @@ function install()
     print("\t 1.先选English")
     print("\t 2.使用默认选项安装")
     print("\t 3.打开Dev-C++(这里可以重新选择IDE语言)")
-    os.exec(pkginfo.install_file)
+    common.xlings_exec(pkginfo.install_file)
+    utils.prompt("waiting install...", "")
     return true
 end
 
 function uninstall()
     local uninstall_exe = "C:\\Program Files (x86)\\Dev-Cpp\\uninstall.exe"
-    os.cd(path.directory(uninstall_exe))
     while os.isfile(uninstall_exe) do
-        os.exec("uninstall.exe")
+        --os.exec(uninstall_exe) -- failed for windows
+        print("\n\t**请查看系统提示/please check system notification**\n")
+        common.xlings_exec("\"" .. uninstall_exe .. "\"")
         utils.prompt("等待卸载/waiting uninstall...", "")
     end
     return true

--- a/pkgs/m/msvc.lua
+++ b/pkgs/m/msvc.lua
@@ -18,17 +18,19 @@ package = {
     }
 }
 
+import("common")
 import("core.tool.toolchain")
 
 -- https://learn.microsoft.com/en-us/visualstudio/install/workload-component-id-vs-build-tools?view=vs-2022
 local msvc_component = "Microsoft.VisualStudio.Component.VC.Tools.x86.x64"
 
 function installed()
-    return toolchain.load("msvc"):check() == "2022"
+    local msvc_path = [[C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC]]
+    return os.isdir(msvc_path) or toolchain.load("msvc"):check() == "2022"
 end
 
 function install()
-    os.exec(
+    common.xlings_exec(
         "vs_BuildTools.exe" ..
         -- " --installPath " .. vs_install_path ..
         " --add " .. msvc_component ..
@@ -42,7 +44,7 @@ function install()
 end
 
 function uninstall()
-    os.exec(
+    common.xlings_exec(
         "vs_BuildTools.exe" ..
         " --remove " .. msvc_component ..
         " --passive " ..

--- a/pkgs/r/rust.lua
+++ b/pkgs/r/rust.lua
@@ -39,6 +39,7 @@ import("xim.xinstall")
 function installed()
     os.exec("rustc --version")
     os.exec("cargo --version")
+    os.exec("rustup --version")
     return true
 end
 

--- a/pmwrapper.lua
+++ b/pmwrapper.lua
@@ -3,7 +3,7 @@
 
 pmwrapper = {
     ["dotnet-9"] = {
-        windows = {"winget", "microsoft.dotnet.sdk.9"},
+        windows = {"winget", "Microsoft.DotNet.SDK.9"},
     },
     ["gcc"] = {
         ubuntu = {"apt", "gcc"},
@@ -20,7 +20,7 @@ pmwrapper = {
         archlinux = {"pacman", "jdk8-openjdk"},
     },
     ["python"] = {
-        windows = {"winget", "python.python.3.9"},
+        windows = {"winget", "Python.Python.3.13"},
         ubuntu = {"apt", "python3"},
         archlinux = {"pacman", "python"},
     },


### PR DESCRIPTION
use common.xlings_exec to replace os.exec, avoid crash issue when run exe-file