### PR TITLE
fix(node): bind npm/npx to node version and fix os.host() precedence

### DIFF
--- a/pkgs/n/node.lua
+++ b/pkgs/n/node.lua
@@ -88,15 +88,16 @@ end
 function config()
     log.debug("Configuring Node.js ...")
     local bindir = pkginfo.install_dir()
-    if not os.host() == "windows" then
+    if os.host() ~= "windows" then
         bindir = path.join(pkginfo.install_dir(), "bin")
     end
 
-    xvm.add("node", { bindir = bindir })
-    xvm.add("node", { bindir = bindir, alias = "node" })
+    local node_binding = "node@" .. pkginfo.version()
 
-    local npm_cfg = { bindir = bindir, version = "node-" .. pkginfo.version() }
-    local npx_cfg = { bindir = bindir, version = "node-" .. pkginfo.version() }
+    xvm.add("node", { bindir = bindir })
+
+    local npm_cfg = { bindir = bindir, version = "node-" .. pkginfo.version(), binding = node_binding }
+    local npx_cfg = { bindir = bindir, version = "node-" .. pkginfo.version(), binding = node_binding }
     if os.host() == "windows" then
         npm_cfg.alias = "npm.cmd"
         npx_cfg.alias = "npx.cmd"


### PR DESCRIPTION
## Summary

Fixes two bugs in `pkgs/n/node.lua config()`:

1. **`if not os.host() == "windows"` is always false** — Lua operator precedence means `not os.host()` (non-nil string → false) is compared against `"windows"`, so the branch body never runs on any platform. `bindir` stays as `install_dir`, which is wrong on Linux/macOS (should be `install_dir/bin`). Replaced with `os.host() ~= "windows"`.

2. **npm/npx don't follow node on version switch** — they were registered without a `binding`, so `xlings use node <ver>` only moved node; npm/npx stayed on whatever version was installed last. Added `binding = "node@<ver>"` so switching node cascades to npm and npx via the xvm binding graph.

Also removed a redundant duplicate `xvm.add("node", ...)` whose vdata was immediately overwritten by the next add.

## Test plan

Verified in a sandboxed `XLINGS_HOME`:

- [x] `xlings install local:node@22.12.0` + `xlings install local:node@22.17.1` — both versions coexist
- [x] `xlings use node 22.17.1` → `node --version` = v22.17.1, `npm --version` = 10.9.2 (cascaded)
- [x] `xlings use node 22.12.0` → `node --version` = v22.12.0, `npm --version` = 10.9.0 (cascaded the other way)
- [x] Workspace map in `subos/default/.xlings.json` shows `node`, `npm`, `npx` all updated in lockstep on each switch