### PR TITLE
fix(shortcut-tool): resolve Desktop via %USERPROFILE% on Windows

### DIFF
--- a/pkgs/s/shortcut-tool.lua
+++ b/pkgs/s/shortcut-tool.lua
@@ -87,7 +87,10 @@ function create_windows_shortcut(name, target, icon, args)
     os.tryrm(vbs_path)
 
     -- copy to desktop and move to start menu
-    os.cp(name .. ".lnk", path.join("C:/Users", os.getenv("USERNAME"), "Desktop"))
+    -- Use %USERPROFILE% so the Desktop resolves correctly on systems
+    -- where the user profile is not under C:\Users\<name>\ (different
+    -- drive letter, non-default profile path, non-ASCII user name).
+    os.cp(name .. ".lnk", path.join(tostring(os.getenv("USERPROFILE")), "Desktop"))
     os.mv(name .. ".lnk", shortcut_dir[os.host()])
 
     log.info("Shortcut created: " .. name .. ".lnk")
@@ -96,7 +99,7 @@ end
 function shortcut_remove(name)
     local filepath = nil
     if os.host() == "windows" then
-        os.tryrm(path.join("C:/Users", os.getenv("USERNAME"), "Desktop", name .. ".lnk"))
+        os.tryrm(path.join(tostring(os.getenv("USERPROFILE")), "Desktop", name .. ".lnk"))
         filepath = path.join(shortcut_dir[os.host()], name .. ".lnk")
     elseif os.host() == "linux" then
         local filename = name:replace(" ", "-") .. ".xvm.desktop"


### PR DESCRIPTION
## Summary

`create_windows_shortcut` and `shortcut_remove` both hardcoded `C:/Users/<USERNAME>/Desktop`, which fails when:

- Windows is installed on a drive other than `C:` (common on CN machines)
- The user profile path does not follow the default `C:\Users\<name>` convention (domain-joined workstations with redirected homes)
- `$USERNAME` is empty or contains characters unsafe to concatenate (some CI / service accounts)

Switched both call sites to `%USERPROFILE%\Desktop`, which is what the Windows Shell itself uses when resolving the Desktop folder.

Not a complete Desktop resolution fix — OneDrive-redirected desktops still need a registry lookup at `HKCU\…\Shell Folders\Desktop` — but it addresses the common drive-letter and profile-path cases.

## Also

This is the first `pkgs/**/*.lua` change landing after the `windows-test` CI job was merged (#62), so it doubles as the first real exercise of that job: parser + install + artifact checks + uninstall + cleanup against a `type=script` package.

## Test plan

- [x] Diff reviewed — only two `path.join("C:/Users", USERNAME, "Desktop"[, …])` → `path.join(tostring(os.getenv("USERPROFILE")), "Desktop"[, …])` edits
- [ ] `windows-test` CI: installs `xlings`, parses meta (name=shortcut-tool, type=script, has_windows=true), registers + installs + uninstalls on a real `windows-latest` runner. No strict shim/install-dir assertions for `type=script`, so the job should pass cleanly.
- [ ] `linux-test` CI: add-xpkg registration should succeed.