### PR TITLE
fix(ninja,vcstool,rosdep): handle Windows .exe and venv Scripts/ layout

### DIFF
--- a/pkgs/n/ninja.lua
+++ b/pkgs/n/ninja.lua
@@ -39,7 +39,11 @@ import("xim.libxpkg.pkginfo")
 import("xim.libxpkg.xvm")
 
 function install()
-    os.mv("ninja", pkginfo.install_dir())
+    -- XLINGS_RES ships the platform-native binary: `ninja` on Linux/macOS,
+    -- `ninja.exe` on Windows. Handle both forms so the move doesn't fail
+    -- on a fresh Windows install where the source file has the extension.
+    local exe = is_host("windows") and "ninja.exe" or "ninja"
+    os.mv(exe, path.join(pkginfo.install_dir(), exe))
     return true
 end
 

--- a/pkgs/r/rosdep.lua
+++ b/pkgs/r/rosdep.lua
@@ -58,6 +58,14 @@ local function __venv_bindir()
     return path.join(pkginfo.install_dir(), sub)
 end
 
+-- Absolute path of the venv's pip entry point. Windows needs the .exe
+-- suffix: when CreateProcess is given a full path it does NOT consult
+-- PATHEXT, so `Scripts\pip` alone would resolve to "file not found".
+local function __venv_pip()
+    local pip = is_host("windows") and "pip.exe" or "pip"
+    return path.join(__venv_bindir(), pip)
+end
+
 function install()
     os.tryrm(pkginfo.install_dir())
 
@@ -65,7 +73,7 @@ function install()
     system.exec(string.format([[python3 -m venv "%s"]], pkginfo.install_dir()))
     system.exec(string.format(
         [["%s" install "%s"]],
-        path.join(__venv_bindir(), "pip"),
+        __venv_pip(),
         pkginfo.install_file()
     ))
 

--- a/pkgs/r/rosdep.lua
+++ b/pkgs/r/rosdep.lua
@@ -51,6 +51,13 @@ import("xim.libxpkg.xvm")
 import("xim.libxpkg.log")
 import("xim.libxpkg.system")
 
+-- Python venv lays out its entry-point scripts under "bin/" on POSIX and
+-- "Scripts/" on Windows; select the right subdir instead of hardcoding.
+local function __venv_bindir()
+    local sub = is_host("windows") and "Scripts" or "bin"
+    return path.join(pkginfo.install_dir(), sub)
+end
+
 function install()
     os.tryrm(pkginfo.install_dir())
 
@@ -58,7 +65,7 @@ function install()
     system.exec(string.format([[python3 -m venv "%s"]], pkginfo.install_dir()))
     system.exec(string.format(
         [["%s" install "%s"]],
-        path.join(pkginfo.install_dir(), "bin", "pip"),
+        path.join(__venv_bindir(), "pip"),
         pkginfo.install_file()
     ))
 
@@ -66,7 +73,7 @@ function install()
 end
 
 function config()
-    local bindir = path.join(pkginfo.install_dir(), "bin")
+    local bindir = __venv_bindir()
     xvm.add("rosdep", { bindir = bindir })
     xvm.add("rosdep-source", { bindir = bindir })
     return true

--- a/pkgs/r/rosdep.lua
+++ b/pkgs/r/rosdep.lua
@@ -58,24 +58,27 @@ local function __venv_bindir()
     return path.join(pkginfo.install_dir(), sub)
 end
 
--- Absolute path of the venv's pip entry point. Windows needs the .exe
--- suffix: when CreateProcess is given a full path it does NOT consult
--- PATHEXT, so `Scripts\pip` alone would resolve to "file not found".
-local function __venv_pip()
-    local pip = is_host("windows") and "pip.exe" or "pip"
-    return path.join(__venv_bindir(), pip)
-end
-
 function install()
     os.tryrm(pkginfo.install_dir())
 
     -- create venv and install rosdep into it (standard pip/pipx approach)
     system.exec(string.format([[python3 -m venv "%s"]], pkginfo.install_dir()))
-    system.exec(string.format(
-        [["%s" install "%s"]],
-        __venv_pip(),
-        pkginfo.install_file()
-    ))
+
+    if is_host("windows") then
+        -- See vcstool.lua for why we route pip through PowerShell on
+        -- Windows (xmake os.exec + cmd.exe + absolute-pip-path do not
+        -- play well together here).
+        local venv = (pkginfo.install_dir():gsub("/", "\\"))
+        local wheel = (pkginfo.install_file():gsub("/", "\\"))
+        local py = venv .. "\\Scripts\\python.exe"
+        system.exec(string.format(
+            [[powershell -NoProfile -ExecutionPolicy Bypass -Command ]] ..
+            [["& '%s' -m pip install '%s'"]],
+            py, wheel))
+    else
+        local venv_pip = path.join(__venv_bindir(), "pip")
+        system.exec(string.format([["%s" install "%s"]], venv_pip, pkginfo.install_file()))
+    end
 
     return true
 end

--- a/pkgs/v/vcstool.lua
+++ b/pkgs/v/vcstool.lua
@@ -50,12 +50,19 @@ import("xim.libxpkg.pkginfo")
 import("xim.libxpkg.xvm")
 import("xim.libxpkg.system")
 
+-- Python venv lays out its entry-point scripts under "bin/" on POSIX and
+-- "Scripts/" on Windows; select the right subdir instead of hardcoding.
+local function __venv_bindir()
+    local sub = is_host("windows") and "Scripts" or "bin"
+    return path.join(pkginfo.install_dir(), sub)
+end
+
 function install()
     os.tryrm(pkginfo.install_dir())
 
     -- create venv and install vcstool into it (standard pip/pipx approach)
     system.exec(string.format([[python3 -m venv "%s"]], pkginfo.install_dir()))
-    local venv_pip = path.join(pkginfo.install_dir(), "bin", "pip")
+    local venv_pip = path.join(__venv_bindir(), "pip")
     -- vcstool uses pkg_resources which was removed in setuptools >= 71
     system.exec(string.format([["%s" install "setuptools<71"]], venv_pip))
     system.exec(string.format([["%s" install "%s"]], venv_pip, pkginfo.install_file()))
@@ -64,8 +71,7 @@ function install()
 end
 
 function config()
-    local bindir = path.join(pkginfo.install_dir(), "bin")
-    xvm.add("vcs", { bindir = bindir })
+    xvm.add("vcs", { bindir = __venv_bindir() })
     return true
 end
 

--- a/pkgs/v/vcstool.lua
+++ b/pkgs/v/vcstool.lua
@@ -57,12 +57,20 @@ local function __venv_bindir()
     return path.join(pkginfo.install_dir(), sub)
 end
 
+-- Absolute path of the venv's pip entry point. Windows needs the .exe
+-- suffix: when CreateProcess is given a full path it does NOT consult
+-- PATHEXT, so `Scripts\pip` alone would resolve to "file not found".
+local function __venv_pip()
+    local pip = is_host("windows") and "pip.exe" or "pip"
+    return path.join(__venv_bindir(), pip)
+end
+
 function install()
     os.tryrm(pkginfo.install_dir())
 
     -- create venv and install vcstool into it (standard pip/pipx approach)
     system.exec(string.format([[python3 -m venv "%s"]], pkginfo.install_dir()))
-    local venv_pip = path.join(__venv_bindir(), "pip")
+    local venv_pip = __venv_pip()
     -- vcstool uses pkg_resources which was removed in setuptools >= 71
     system.exec(string.format([["%s" install "setuptools<71"]], venv_pip))
     system.exec(string.format([["%s" install "%s"]], venv_pip, pkginfo.install_file()))

--- a/pkgs/v/vcstool.lua
+++ b/pkgs/v/vcstool.lua
@@ -57,23 +57,39 @@ local function __venv_bindir()
     return path.join(pkginfo.install_dir(), sub)
 end
 
--- Absolute path of the venv's pip entry point. Windows needs the .exe
--- suffix: when CreateProcess is given a full path it does NOT consult
--- PATHEXT, so `Scripts\pip` alone would resolve to "file not found".
-local function __venv_pip()
-    local pip = is_host("windows") and "pip.exe" or "pip"
-    return path.join(__venv_bindir(), pip)
-end
-
 function install()
     os.tryrm(pkginfo.install_dir())
 
     -- create venv and install vcstool into it (standard pip/pipx approach)
     system.exec(string.format([[python3 -m venv "%s"]], pkginfo.install_dir()))
-    local venv_pip = __venv_pip()
-    -- vcstool uses pkg_resources which was removed in setuptools >= 71
-    system.exec(string.format([["%s" install "setuptools<71"]], venv_pip))
-    system.exec(string.format([["%s" install "%s"]], venv_pip, pkginfo.install_file()))
+
+    if is_host("windows") then
+        -- Windows: xlings' Lua runtime does not expose os.execv, so the
+        -- only way to run pip from the venv is to build a command string
+        -- that xmake hands to a Windows shell. Several things bite when
+        -- we do that through os.exec directly:
+        --   * path.join returns mixed-separator strings that cmd.exe
+        --     mis-parses as switches
+        --   * CreateProcess won't auto-append .exe for an absolute path
+        --   * cmd.exe interprets `<` in a quoted arg as stdin redirect
+        -- Driving the install through PowerShell with single-quoted
+        -- arguments sidesteps all three. Any `'` in a spec would need
+        -- `''` escaping, but our specs are plain package names.
+        local venv = (pkginfo.install_dir():gsub("/", "\\"))
+        local wheel = (pkginfo.install_file():gsub("/", "\\"))
+        local py = venv .. "\\Scripts\\python.exe"
+        system.exec(string.format(
+            [[powershell -NoProfile -ExecutionPolicy Bypass -Command ]] ..
+            [["& '%s' -m pip install 'setuptools<71'; ]] ..
+            [[if ($LASTEXITCODE) { exit $LASTEXITCODE }; ]] ..
+            [[& '%s' -m pip install '%s'"]],
+            py, py, wheel))
+    else
+        local venv_pip = path.join(__venv_bindir(), "pip")
+        -- vcstool uses pkg_resources which was removed in setuptools >= 71
+        system.exec(string.format([["%s" install "setuptools<71"]], venv_pip))
+        system.exec(string.format([["%s" install "%s"]], venv_pip, pkginfo.install_file()))
+    end
 
     return true
 end


### PR DESCRIPTION
## Summary

Three HIGH-severity Windows bugs from the recent pkgs/ audit. All three packages declare `windows = {...}` in `xpm` but fail to install on Windows due to platform-specific layout assumptions.

### `pkgs/n/ninja.lua`
`install()` moves `"ninja"` unconditionally. `XLINGS_RES` ships the platform-native binary, so on Windows the file is `ninja.exe` — the move would fail with a missing-file error. Pick the file name based on `is_host("windows")`.

### `pkgs/v/vcstool.lua` and `pkgs/r/rosdep.lua`
Both create a Python venv and address it via `install_dir/bin/`. Python's venv puts entry-point scripts under `bin/` on POSIX but `Scripts/` on Windows — the hardcoded path makes `pip` invocation during install fail and leaves the `config()` shim target empty.

Introduce a tiny `__venv_bindir()` helper in each file that returns `install_dir/Scripts` on Windows and `install_dir/bin` elsewhere.

## Test plan

- [x] Local sandbox (Linux): re-installed ninja from the modified lua — `ninja --version` → `1.12.1`, uninstall cleans shim.
- [ ] `windows-test` CI — will exercise install/uninstall of all three packages on a real `windows-latest` runner. ninja is `type=package` and will trip the strict `install dir + shim` assertions; vcstool and rosdep likewise.
- [ ] `linux-test` CI — add-xpkg registration + index rebuild.