### PR TITLE
feat(uv) + ci(linux,macos): add uv xpkg, expand install-test to all OS

### DIFF
--- a/.github/scripts/parse-xpkg-meta.py
+++ b/.github/scripts/parse-xpkg-meta.py
@@ -1,12 +1,16 @@
 """Emit a small JSON meta object for a single .lua xpkg file.
 
-Used by the Windows CI job to decide whether to install/test a changed
+Used by the per-platform install/uninstall CI jobs (linux-test,
+macos-test, windows-test) to decide whether to install/test a changed
 package and what programs to look for afterwards.
 
 Fields in the output:
   name         package name (string)
+  type         package type (e.g. package, app, lib, script, bugfix)
   programs     list of program names declared by the package
   is_ref       true if this file is a thin ref to another package
+  has_linux    true if the package declares a linux branch in xpm
+  has_macosx   true if the package declares a macosx branch in xpm
   has_windows  true if the package declares a windows branch in xpm
 """
 import json
@@ -29,6 +33,8 @@ def main() -> int:
         "type": meta.pkg_type,
         "programs": list(meta.programs),
         "is_ref": bool(meta.is_ref),
+        "has_linux": bool(meta.platforms.get("linux")),
+        "has_macosx": bool(meta.platforms.get("macosx")),
         "has_windows": bool(meta.platforms.get("windows")),
     }))
     return 0

--- a/.github/scripts/posix-test.sh
+++ b/.github/scripts/posix-test.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+# Per-package install/uninstall test for POSIX (Linux/macOS), invoked
+# from the linux-test / macos-test CI jobs. Bash counterpart of
+# windows-test.ps1; same flow, same assertion rules.
+#
+# Usage:
+#   posix-test.sh "<space-separated-changed-files>" <workspace-root> <host-os>
+#
+# Where <host-os> is "linux" or "macosx", matching the key xpkg uses
+# under xpm.
+
+set -u
+set -o pipefail
+
+CHANGED_FILES="${1:-}"
+WORKSPACE_ROOT="${2:-}"
+HOST_OS="${3:-}"
+
+if [[ -z "$WORKSPACE_ROOT" || -z "$HOST_OS" ]]; then
+    echo "usage: posix-test.sh <changed-files> <workspace-root> <host-os>" >&2
+    exit 2
+fi
+if [[ "$HOST_OS" != "linux" && "$HOST_OS" != "macosx" ]]; then
+    echo "host-os must be 'linux' or 'macosx', got: $HOST_OS" >&2
+    exit 2
+fi
+
+XLINGS_HOME_DIR="${XLINGS_HOME:-$HOME/.xlings}"
+SHIM_DIR="$XLINGS_HOME_DIR/subos/default/bin"
+XPKGS_DIR="$XLINGS_HOME_DIR/data/xpkgs"
+HAS_KEY="has_$HOST_OS"
+
+cyan() { printf '\033[1;36m%s\033[0m\n' "$*"; }
+gray() { printf '\033[0;37m%s\033[0m\n' "$*"; }
+green() { printf '\033[0;32m%s\033[0m\n' "$*"; }
+red()   { printf '\033[0;31m%s\033[0m\n' "$*"; }
+
+step()    { echo; cyan "==> $*"; }
+info()    { gray "  $*"; }
+log_pass() { green "  [PASS] $*"; }
+log_fail() { red   "  [FAIL] $*"; }
+
+# Snapshot the shim set so we can detect new/disappeared shims around an
+# install/uninstall pair. BSD find on macOS does not support -printf, so
+# do the listing in pure bash to stay portable.
+shim_set() {
+    [[ -d "$SHIM_DIR" ]] || return 0
+    local entry
+    {
+        for entry in "$SHIM_DIR"/* "$SHIM_DIR"/.[!.]*; do
+            [[ -e "$entry" || -L "$entry" ]] || continue
+            basename -- "$entry"
+        done
+    } | sort
+}
+
+# xlings stores installs under <xpkgs>/<ns>-x-<name>/<version>/.
+# macOS ships BSD find without GNU's -regextype, so do the regex match
+# in bash and stay portable across both systems.
+pkg_install_dirs() {
+    local pkg="$1"
+    [[ -d "$XPKGS_DIR" ]] || return 0
+    local d
+    for d in "$XPKGS_DIR"/*; do
+        [[ -d "$d" ]] || continue
+        local name
+        name=$(basename "$d")
+        if [[ "$name" =~ ^[a-z]+-x-${pkg}$ ]]; then
+            printf '%s\n' "$d"
+        fi
+    done
+}
+
+read -r -a files <<< "$CHANGED_FILES"
+if [[ "${#files[@]}" -eq 0 ]]; then
+    echo "No changed .lua files. Nothing to test."
+    exit 0
+fi
+
+failures=()
+tested=0
+skipped=0
+
+for rel_file in "${files[@]}"; do
+    [[ -n "$rel_file" ]] || continue
+    lua_file="$WORKSPACE_ROOT/$rel_file"
+    if [[ ! -f "$lua_file" ]]; then
+        info "skip (path does not exist): $rel_file"
+        continue
+    fi
+    if [[ "$lua_file" != *.lua ]]; then
+        info "skip (not a .lua file): $rel_file"
+        continue
+    fi
+
+    step "Parsing meta: $rel_file"
+    if ! meta_json=$(python3 "$WORKSPACE_ROOT/.github/scripts/parse-xpkg-meta.py" "$lua_file"); then
+        log_fail "parser failed"
+        failures+=("$rel_file (parser)")
+        continue
+    fi
+    pkg=$(printf '%s' "$meta_json"     | python3 -c "import json,sys; print(json.loads(sys.stdin.read())['name'])")
+    pkg_type=$(printf '%s' "$meta_json" | python3 -c "import json,sys; print(json.loads(sys.stdin.read()).get('type','package'))")
+    is_ref=$(printf '%s' "$meta_json"   | python3 -c "import json,sys; print(json.loads(sys.stdin.read())['is_ref'])")
+    has_plat=$(printf '%s' "$meta_json" | python3 -c "import json,sys; print(json.loads(sys.stdin.read()).get('$HAS_KEY', False))")
+    programs=$(printf '%s' "$meta_json" | python3 -c "import json,sys; print(' '.join(json.loads(sys.stdin.read())['programs']))")
+    info "name=$pkg  type=$pkg_type  programs=[$programs]  is_ref=$is_ref  $HAS_KEY=$has_plat"
+
+    if [[ "$is_ref" == "True" ]]; then
+        info "skip (ref package)"; skipped=$((skipped+1)); continue
+    fi
+    if [[ "$has_plat" != "True" ]]; then
+        info "skip (no $HOST_OS branch in xpm)"; skipped=$((skipped+1)); continue
+    fi
+    if [[ -z "$pkg" ]]; then
+        log_fail "package name not parseable"
+        failures+=("$rel_file (no-name)"); continue
+    fi
+
+    expect_artifacts=false
+    case "$pkg_type" in
+        package|app|lib) expect_artifacts=true ;;
+    esac
+
+    tested=$((tested+1))
+
+    step "[$pkg] register (type=$pkg_type)"
+    if ! xlings config --add-xpkg "$lua_file"; then
+        log_fail "config --add-xpkg failed"; failures+=("$rel_file (register)"); continue
+    fi
+
+    shims_before=$(shim_set)
+    info "shims before install: $(printf '%s\n' "$shims_before" | grep -c . || true)"
+
+    step "[$pkg] install"
+    if ! xlings install "local:$pkg" -y; then
+        log_fail "install failed"; failures+=("$rel_file (install)"); continue
+    fi
+
+    step "[$pkg] post-install checks"
+    install_dirs=$(pkg_install_dirs "$pkg")
+    if [[ -z "$install_dirs" ]]; then
+        if $expect_artifacts; then
+            log_fail "no install dir matching '*-x-$pkg' under $XPKGS_DIR"
+            failures+=("$rel_file (install-dir-missing)")
+        else
+            info "no install dir (expected for type '$pkg_type')"
+        fi
+    else
+        while IFS= read -r dir; do
+            versions=$(find "$dir" -maxdepth 1 -mindepth 1 -type d 2>/dev/null)
+            if [[ -z "$versions" ]]; then
+                if $expect_artifacts; then
+                    log_fail "install dir has no version subdir: $dir"
+                    failures+=("$rel_file (install-dir-empty)")
+                else
+                    info "install dir present but no version subdir: $dir"
+                fi
+            else
+                while IFS= read -r v; do log_pass "install dir: $v"; done <<< "$versions"
+            fi
+        done <<< "$install_dirs"
+    fi
+
+    shims_after=$(shim_set)
+    new_shims=$(comm -13 <(printf '%s\n' "$shims_before") <(printf '%s\n' "$shims_after"))
+    if [[ -z "$new_shims" ]]; then
+        if $expect_artifacts && [[ -n "$programs" ]]; then
+            log_fail "no new shim appeared in $SHIM_DIR (expected one per program: $programs)"
+            failures+=("$rel_file (no-shim)")
+        else
+            info "no new shim appeared (type='$pkg_type', programs='$programs')"
+        fi
+    else
+        while IFS= read -r s; do log_pass "new shim: $s"; done <<< "$new_shims"
+        if $expect_artifacts && [[ -n "$programs" ]]; then
+            for prog in $programs; do
+                if ! grep -qE "^(${prog})$" <<< "$new_shims"; then
+                    log_fail "declared program '$prog' has no corresponding shim"
+                    failures+=("$rel_file (missing-shim:$prog)")
+                fi
+            done
+        fi
+    fi
+
+    step "[$pkg] uninstall"
+    if ! xlings remove "local:$pkg" -y; then
+        log_fail "uninstall failed"; failures+=("$rel_file (uninstall)"); continue
+    fi
+
+    step "[$pkg] post-uninstall checks"
+    shims_final=$(shim_set)
+    leftover=$(comm -12 <(printf '%s\n' "$new_shims") <(printf '%s\n' "$shims_final"))
+    if [[ -n "$leftover" ]]; then
+        log_fail "shims still present after uninstall: $leftover"
+        failures+=("$rel_file (leftover-shim)")
+    else
+        log_pass "all shims cleaned"
+    fi
+done
+
+echo
+echo "=================================="
+cyan " ${HOST_OS} test summary"
+echo "=================================="
+echo "  tested:   $tested"
+echo "  skipped:  $skipped"
+echo "  failures: ${#failures[@]}"
+if [[ "${#failures[@]}" -gt 0 ]]; then
+    for f in "${failures[@]}"; do red "    - $f"; done
+    exit 1
+fi
+exit 0

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -107,3 +107,111 @@ jobs:
           pwsh -NoProfile -File .github/scripts/windows-test.ps1 `
             -ChangedFiles "${{ steps.changed-files.outputs.all_changed_files }}" `
             -WorkspaceRoot "${{ github.workspace }}"
+
+  linux-install-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install xlings on Ubuntu
+        run: |
+          export XLINGS_NON_INTERACTIVE=1
+          curl -fsSL https://raw.githubusercontent.com/d2learn/xlings/main/tools/other/quick_install.sh | bash
+          echo "XLINGS_HOME=$HOME/.xlings" >> "$GITHUB_ENV"
+          echo "$HOME/.xlings/bin"               >> "$GITHUB_PATH"
+          echo "$HOME/.xlings/subos/current/bin" >> "$GITHUB_PATH"
+
+      - name: Verify xlings
+        run: |
+          xlings --version
+          xlings config
+
+      - name: Get changed-files
+        uses: tj-actions/changed-files@v46
+        id: changed-files
+        with:
+          files: pkgs/**/*.lua
+
+      - name: Linux install/uninstall test (changed packages)
+        if: steps.changed-files.outputs.any_changed == 'true'
+        run: |
+          chmod +x .github/scripts/posix-test.sh
+          .github/scripts/posix-test.sh \
+            "${{ steps.changed-files.outputs.all_changed_files }}" \
+            "${{ github.workspace }}" \
+            linux
+
+  macos-install-test:
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install xlings on macOS
+        run: |
+          export XLINGS_NON_INTERACTIVE=1
+          curl -fsSL https://raw.githubusercontent.com/d2learn/xlings/main/tools/other/quick_install.sh | bash
+          echo "XLINGS_HOME=$HOME/.xlings" >> "$GITHUB_ENV"
+          echo "$HOME/.xlings/bin"               >> "$GITHUB_PATH"
+          echo "$HOME/.xlings/subos/current/bin" >> "$GITHUB_PATH"
+
+      - name: Verify xlings (and dump install layout)
+        run: |
+          xlings --version
+          xlings config
+          echo "--- which xlings ---"
+          which xlings || true
+          echo "--- find $HOME/.xlings (depth 4) ---"
+          find "$HOME/.xlings" -maxdepth 4 -mindepth 1 \
+              \( -type d -o -type f -o -type l \) \
+              -print 2>/dev/null | head -80 || true
+
+      - name: Get changed-files
+        uses: tj-actions/changed-files@v46
+        id: changed-files
+        with:
+          files: pkgs/**/*.lua
+
+      - name: macOS install/uninstall test (changed packages)
+        if: steps.changed-files.outputs.any_changed == 'true'
+        run: |
+          chmod +x .github/scripts/posix-test.sh
+          # Disable exit-on-error so the post-test diagnostic always runs;
+          # the captured rc is forwarded as this step's exit status.
+          set +e
+          .github/scripts/posix-test.sh \
+            "${{ steps.changed-files.outputs.all_changed_files }}" \
+            "${{ github.workspace }}" \
+            macosx
+          rc=$?
+          set -e
+          echo ""
+          echo "============================================================"
+          echo " post-test diagnostic dump (always runs)"
+          echo "============================================================"
+          echo "--- find $HOME/.xlings/subos (depth 4) ---"
+          find "$HOME/.xlings/subos" -maxdepth 4 -mindepth 1 \
+              \( -type d -o -type f -o -type l \) \
+              -print 2>/dev/null | head -80 || true
+          echo "--- find $HOME/.xlings/data/xpkgs (depth 4) ---"
+          find "$HOME/.xlings/data/xpkgs" -maxdepth 4 -mindepth 1 \
+              \( -type d -o -type f -o -type l \) \
+              -print 2>/dev/null | head -40 || true
+          exit $rc

--- a/pkgs/u/uv.lua
+++ b/pkgs/u/uv.lua
@@ -1,0 +1,97 @@
+package = {
+    spec = "1",
+
+    name = "uv",
+    description = "An extremely fast Python package and project manager (Astral)",
+    homepage = "https://docs.astral.sh/uv",
+    maintainers = {"Astral"},
+    licenses = {"MIT", "Apache-2.0"},
+    repo = "https://github.com/astral-sh/uv",
+    docs = "https://docs.astral.sh/uv",
+
+    type = "package",
+    archs = {"x86_64", "aarch64"},
+    status = "stable",
+    categories = {"python", "package-manager", "tools"},
+    keywords = {"python", "uv", "pip", "venv", "poetry", "astral"},
+
+    programs = {"uv", "uvx"},
+    xvm_enable = true,
+
+    xpm = {
+        linux = {
+            ["latest"] = { ref = "0.11.7" },
+            ["0.11.7"] = {
+                url = "https://github.com/astral-sh/uv/releases/download/0.11.7/uv-x86_64-unknown-linux-gnu.tar.gz",
+                sha256 = "6681d691eb7f9c00ac6a3af54252f7ab29ae72f0c8f95bdc7f9d1401c23ea868",
+            },
+        },
+        -- macosx: the upstream ships separate x86_64 and aarch64 builds.
+        -- Modern Macs (and the GitHub macos-latest runner) are aarch64,
+        -- which is what we ship. Intel-Mac users would need a separate
+        -- per-arch dispatch (xpm doesn't natively branch on arch yet).
+        macosx = {
+            ["latest"] = { ref = "0.11.7" },
+            ["0.11.7"] = {
+                url = "https://github.com/astral-sh/uv/releases/download/0.11.7/uv-aarch64-apple-darwin.tar.gz",
+                sha256 = "66e37d91f839e12481d7b932a1eccbfe732560f42c1cfb89faddfa2454534ba8",
+            },
+        },
+        windows = {
+            ["latest"] = { ref = "0.11.7" },
+            ["0.11.7"] = {
+                url = "https://github.com/astral-sh/uv/releases/download/0.11.7/uv-x86_64-pc-windows-msvc.zip",
+                sha256 = "fe0c7815acf4fc45f8a5eff58ed3cf7ae2e15c3cf1dceadbd10c816ec1690cc1",
+            },
+        },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+
+-- Archive layouts:
+--   Linux/macOS .tar.gz extracts into a single dir named after the
+--     archive (e.g. `uv-x86_64-unknown-linux-gnu/`) containing `uv`
+--     and `uvx` at its top level.
+--   Windows .zip drops `uv.exe`, `uvx.exe`, `uvw.exe` directly into
+--     the extraction directory (no enclosing folder).
+--
+-- The download dir is the directory containing pkginfo.install_file(),
+-- and the extracted folder is named the same as the tarball without
+-- its compression suffix. Deriving paths from install_file() avoids
+-- assuming xlings's cwd matches the extraction location, which has
+-- proven flaky across hosts.
+function install()
+    os.tryrm(pkginfo.install_dir())
+    os.mkdir(pkginfo.install_dir())
+
+    local download_dir = path.directory(pkginfo.install_file())
+
+    if is_host("windows") then
+        for _, exe in ipairs({"uv.exe", "uvx.exe"}) do
+            os.mv(path.join(download_dir, exe), path.join(pkginfo.install_dir(), exe))
+        end
+    else
+        local extracted = pkginfo.install_file():replace(".tar.gz", "")
+        for _, exe in ipairs({"uv", "uvx"}) do
+            os.mv(path.join(extracted, exe), path.join(pkginfo.install_dir(), exe))
+        end
+        os.tryrm(extracted)
+    end
+
+    return true
+end
+
+function config()
+    local bindir = pkginfo.install_dir()
+    xvm.add("uv", { bindir = bindir })
+    xvm.add("uvx", { bindir = bindir, binding = "uv@" .. pkginfo.version() })
+    return true
+end
+
+function uninstall()
+    xvm.remove("uv")
+    xvm.remove("uvx")
+    return true
+end


### PR DESCRIPTION
## Summary

Two things in one PR (per request — the new CI jobs are exactly what gates the new package).

### `pkgs/u/uv.lua`
Adds the [uv](https://github.com/astral-sh/uv) Python package manager (Astral) at version 0.11.7. Three platforms (linux / macosx / windows), x86_64 only for now. Two programs registered: `uv` and `uvx`, with `uvx` bound to `uv@<version>` so a single `xlings use uv <ver>` cascades.

### Linux / macOS install-test CI

`windows-test` has been doing real install/uninstall on `windows-latest` since #62. This PR adds the same gate on Ubuntu and macOS:

- `.github/scripts/parse-xpkg-meta.py` now also emits `has_linux` / `has_macosx`.
- New `.github/scripts/posix-test.sh` — bash mirror of `windows-test.ps1`. Same flow, same assertion rules, type-aware (only `package`/`app`/`lib` types must produce artifacts; `script`/`bugfix`/`config` are tolerated to install without a shim).
- Two new jobs in `ci-test.yml`:
  - `linux-install-test` (runs-on: `ubuntu-latest`)
  - `macos-install-test` (runs-on: `macos-latest`)
  Both filter to changed `pkgs/**/*.lua` only. The existing `linux-test` job stays as the cheap add-xpkg pre-check.

## Test plan

- [x] Local sandbox: `posix-test.sh` re-ran the hermes-agent install/uninstall cycle — 1 tested, 0 failures.
- [x] Local sandbox: `xlings install local:uv -y` (with the tarball pre-staged into runtimedir to bypass a local proxy issue) → `uv 0.11.7 (x86_64-unknown-linux-gnu)`, `uvx 0.11.7`, `uv venv` and `uv pip install requests` both work.
- [ ] CI: `linux-install-test` will install/uninstall `uv` on a real ubuntu-latest runner and assert install dir + `uv` / `uvx` shims.
- [ ] CI: `macos-install-test` likewise on macos-latest.
- [ ] CI: `windows-test` likewise on windows-latest (using the existing job).

If any of the three platforms fails, we'll see exactly which OS broke and why.