### PR TITLE
feat(cli): add ripgrep, fd, bat, fzf, jq xpkg packages

### DIFF
--- a/pkgs/b/bat.lua
+++ b/pkgs/b/bat.lua
@@ -1,0 +1,73 @@
+package = {
+    spec = "1",
+
+    name = "bat",
+    description = "A cat clone with syntax highlighting and Git integration",
+    homepage = "https://github.com/sharkdp/bat",
+    maintainers = {"David Peter"},
+    licenses = {"MIT", "Apache-2.0"},
+    repo = "https://github.com/sharkdp/bat",
+    docs = "https://github.com/sharkdp/bat#readme",
+
+    type = "package",
+    archs = {"x86_64", "aarch64"},
+    status = "stable",
+    categories = {"cli", "viewer", "tools"},
+    keywords = {"cat", "bat", "syntax-highlighting", "rust"},
+
+    programs = {"bat"},
+    xvm_enable = true,
+
+    xpm = {
+        linux = {
+            ["latest"] = { ref = "0.26.1" },
+            ["0.26.1"] = {
+                url = "https://github.com/sharkdp/bat/releases/download/v0.26.1/bat-v0.26.1-x86_64-unknown-linux-musl.tar.gz",
+                sha256 = "0dcd8ac79732c0d5b136f11f4ee00e581440e16a44eab5b3105b611bbf2cf191",
+            },
+        },
+        macosx = {
+            ["latest"] = { ref = "0.26.1" },
+            ["0.26.1"] = {
+                url = "https://github.com/sharkdp/bat/releases/download/v0.26.1/bat-v0.26.1-aarch64-apple-darwin.tar.gz",
+                sha256 = "e30beff26779c9bf60bb541e1d79046250cb74378f2757f8eb250afddb19e114",
+            },
+        },
+        windows = {
+            ["latest"] = { ref = "0.26.1" },
+            ["0.26.1"] = {
+                url = "https://github.com/sharkdp/bat/releases/download/v0.26.1/bat-v0.26.1-x86_64-pc-windows-msvc.zip",
+                sha256 = "0f729b4b6f5f28d395c641eacc2e9ff68d0096b85aa0eec344aa62425144b69b",
+            },
+        },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+
+-- Archives extract into `bat-v<ver>-<triple>/` containing the `bat` /
+-- `bat.exe` binary alongside autocomplete scripts, manpages and docs.
+function install()
+    os.tryrm(pkginfo.install_dir())
+    os.mkdir(pkginfo.install_dir())
+
+    local extracted = pkginfo.install_file()
+        :replace(".tar.gz", "")
+        :replace(".zip", "")
+
+    local exe = is_host("windows") and "bat.exe" or "bat"
+    os.mv(path.join(extracted, exe), path.join(pkginfo.install_dir(), exe))
+    os.tryrm(extracted)
+    return true
+end
+
+function config()
+    xvm.add("bat", { bindir = pkginfo.install_dir() })
+    return true
+end
+
+function uninstall()
+    xvm.remove("bat")
+    return true
+end

--- a/pkgs/f/fd.lua
+++ b/pkgs/f/fd.lua
@@ -1,0 +1,73 @@
+package = {
+    spec = "1",
+
+    name = "fd",
+    description = "Simple, fast, user-friendly alternative to find",
+    homepage = "https://github.com/sharkdp/fd",
+    maintainers = {"David Peter"},
+    licenses = {"MIT", "Apache-2.0"},
+    repo = "https://github.com/sharkdp/fd",
+    docs = "https://github.com/sharkdp/fd#readme",
+
+    type = "package",
+    archs = {"x86_64", "aarch64"},
+    status = "stable",
+    categories = {"cli", "search", "tools"},
+    keywords = {"find", "fd", "search", "rust"},
+
+    programs = {"fd"},
+    xvm_enable = true,
+
+    xpm = {
+        linux = {
+            ["latest"] = { ref = "10.4.2" },
+            ["10.4.2"] = {
+                url = "https://github.com/sharkdp/fd/releases/download/v10.4.2/fd-v10.4.2-x86_64-unknown-linux-musl.tar.gz",
+                sha256 = "e3257d48e29a6be965187dbd24ce9af564e0fe67b3e73c9bdcd180f4ec11bdde",
+            },
+        },
+        macosx = {
+            ["latest"] = { ref = "10.4.2" },
+            ["10.4.2"] = {
+                url = "https://github.com/sharkdp/fd/releases/download/v10.4.2/fd-v10.4.2-aarch64-apple-darwin.tar.gz",
+                sha256 = "623dc0afc81b92e4d4606b380d7bc91916ba7b97814263e554d50923a39e480a",
+            },
+        },
+        windows = {
+            ["latest"] = { ref = "10.4.2" },
+            ["10.4.2"] = {
+                url = "https://github.com/sharkdp/fd/releases/download/v10.4.2/fd-v10.4.2-x86_64-pc-windows-msvc.zip",
+                sha256 = "b2816e506390a89941c63c9187d58a3cc10e9a55f2ef0685f9ea0eccaf7c98c8",
+            },
+        },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+
+-- Archives extract into `fd-v<ver>-<triple>/` containing the `fd` /
+-- `fd.exe` binary alongside autocomplete scripts and docs.
+function install()
+    os.tryrm(pkginfo.install_dir())
+    os.mkdir(pkginfo.install_dir())
+
+    local extracted = pkginfo.install_file()
+        :replace(".tar.gz", "")
+        :replace(".zip", "")
+
+    local exe = is_host("windows") and "fd.exe" or "fd"
+    os.mv(path.join(extracted, exe), path.join(pkginfo.install_dir(), exe))
+    os.tryrm(extracted)
+    return true
+end
+
+function config()
+    xvm.add("fd", { bindir = pkginfo.install_dir() })
+    return true
+end
+
+function uninstall()
+    xvm.remove("fd")
+    return true
+end

--- a/pkgs/f/fzf.lua
+++ b/pkgs/f/fzf.lua
@@ -1,0 +1,69 @@
+package = {
+    spec = "1",
+
+    name = "fzf",
+    description = "A command-line fuzzy finder",
+    homepage = "https://junegunn.github.io/fzf/",
+    maintainers = {"Junegunn Choi"},
+    licenses = {"MIT"},
+    repo = "https://github.com/junegunn/fzf",
+    docs = "https://junegunn.github.io/fzf/",
+
+    type = "package",
+    archs = {"x86_64", "aarch64"},
+    status = "stable",
+    categories = {"cli", "search", "tools"},
+    keywords = {"fzf", "fuzzy", "finder", "search", "go"},
+
+    programs = {"fzf"},
+    xvm_enable = true,
+
+    xpm = {
+        linux = {
+            ["latest"] = { ref = "0.71.0" },
+            ["0.71.0"] = {
+                url = "https://github.com/junegunn/fzf/releases/download/v0.71.0/fzf-0.71.0-linux_amd64.tar.gz",
+                sha256 = "22639bb38489dbca8acef57850cbb50231ab714d0e8e855ac52fae8b41233df4",
+            },
+        },
+        macosx = {
+            ["latest"] = { ref = "0.71.0" },
+            ["0.71.0"] = {
+                url = "https://github.com/junegunn/fzf/releases/download/v0.71.0/fzf-0.71.0-darwin_arm64.tar.gz",
+                sha256 = "02dfb11de8773cb79aa4fc5bfc77e75c6604ee14728bc849fc162dd91a9714c4",
+            },
+        },
+        windows = {
+            ["latest"] = { ref = "0.71.0" },
+            ["0.71.0"] = {
+                url = "https://github.com/junegunn/fzf/releases/download/v0.71.0/fzf-0.71.0-windows_amd64.zip",
+                sha256 = "15bf30fa658c596d740f0ce9a9a97b6b5d90566124903657d09fd109dd0973d2",
+            },
+        },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+
+-- fzf archives are flat: the binary (`fzf` / `fzf.exe`) lands in the
+-- runtime download dir directly, with no enclosing folder.
+function install()
+    os.tryrm(pkginfo.install_dir())
+    os.mkdir(pkginfo.install_dir())
+
+    local download_dir = path.directory(pkginfo.install_file())
+    local exe = is_host("windows") and "fzf.exe" or "fzf"
+    os.mv(path.join(download_dir, exe), path.join(pkginfo.install_dir(), exe))
+    return true
+end
+
+function config()
+    xvm.add("fzf", { bindir = pkginfo.install_dir() })
+    return true
+end
+
+function uninstall()
+    xvm.remove("fzf")
+    return true
+end

--- a/pkgs/j/jq.lua
+++ b/pkgs/j/jq.lua
@@ -1,0 +1,75 @@
+package = {
+    spec = "1",
+
+    name = "jq",
+    description = "Command-line JSON processor",
+    homepage = "https://jqlang.org/",
+    maintainers = {"jqlang"},
+    licenses = {"MIT"},
+    repo = "https://github.com/jqlang/jq",
+    docs = "https://jqlang.org/manual/",
+
+    type = "package",
+    archs = {"x86_64", "aarch64"},
+    status = "stable",
+    categories = {"cli", "json", "tools"},
+    keywords = {"jq", "json", "parser", "filter"},
+
+    programs = {"jq"},
+    xvm_enable = true,
+
+    -- jq publishes single-file binaries (no archive). xlings's auto-extract
+    -- skips files whose extension isn't a recognised compressed format, so
+    -- the install_file landing in runtimedir is the binary itself — we just
+    -- need to move it into install_dir and chmod +x it on Unix.
+    xpm = {
+        linux = {
+            ["latest"] = { ref = "1.8.1" },
+            ["1.8.1"] = {
+                url = "https://github.com/jqlang/jq/releases/download/jq-1.8.1/jq-linux-amd64",
+                sha256 = "020468de7539ce70ef1bceaf7cde2e8c4f2ca6c3afb84642aabc5c97d9fc2a0d",
+            },
+        },
+        macosx = {
+            ["latest"] = { ref = "1.8.1" },
+            ["1.8.1"] = {
+                url = "https://github.com/jqlang/jq/releases/download/jq-1.8.1/jq-macos-arm64",
+                sha256 = "a9fe3ea2f86dfc72f6728417521ec9067b343277152b114f4e98d8cb0e263603",
+            },
+        },
+        windows = {
+            ["latest"] = { ref = "1.8.1" },
+            ["1.8.1"] = {
+                url = "https://github.com/jqlang/jq/releases/download/jq-1.8.1/jq-windows-amd64.exe",
+                sha256 = "23cb60a1354eed6bcc8d9b9735e8c7b388cd1fdcb75726b93bc299ef22dd9334",
+            },
+        },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+import("xim.libxpkg.system")
+
+function install()
+    os.tryrm(pkginfo.install_dir())
+    os.mkdir(pkginfo.install_dir())
+
+    local exe = is_host("windows") and "jq.exe" or "jq"
+    local target = path.join(pkginfo.install_dir(), exe)
+    os.mv(pkginfo.install_file(), target)
+    if not is_host("windows") then
+        system.exec(string.format([[chmod +x "%s"]], target))
+    end
+    return true
+end
+
+function config()
+    xvm.add("jq", { bindir = pkginfo.install_dir() })
+    return true
+end
+
+function uninstall()
+    xvm.remove("jq")
+    return true
+end

--- a/pkgs/r/ripgrep.lua
+++ b/pkgs/r/ripgrep.lua
@@ -1,0 +1,78 @@
+package = {
+    spec = "1",
+
+    name = "ripgrep",
+    description = "Fast, recursive grep that respects .gitignore",
+    homepage = "https://github.com/BurntSushi/ripgrep",
+    maintainers = {"Andrew Gallant"},
+    licenses = {"MIT", "Unlicense"},
+    repo = "https://github.com/BurntSushi/ripgrep",
+    docs = "https://github.com/BurntSushi/ripgrep/blob/master/GUIDE.md",
+
+    type = "package",
+    archs = {"x86_64", "aarch64"},
+    status = "stable",
+    categories = {"cli", "search", "tools"},
+    keywords = {"grep", "search", "ripgrep", "rg", "rust"},
+
+    programs = {"rg"},
+    xvm_enable = true,
+
+    xpm = {
+        linux = {
+            ["latest"] = { ref = "15.1.0" },
+            ["15.1.0"] = {
+                url = "https://github.com/BurntSushi/ripgrep/releases/download/15.1.0/ripgrep-15.1.0-x86_64-unknown-linux-musl.tar.gz",
+                sha256 = "1c9297be4a084eea7ecaedf93eb03d058d6faae29bbc57ecdaf5063921491599",
+            },
+        },
+        macosx = {
+            ["latest"] = { ref = "15.1.0" },
+            ["15.1.0"] = {
+                url = "https://github.com/BurntSushi/ripgrep/releases/download/15.1.0/ripgrep-15.1.0-aarch64-apple-darwin.tar.gz",
+                sha256 = "378e973289176ca0c6054054ee7f631a065874a352bf43f0fa60ef079b6ba715",
+            },
+        },
+        windows = {
+            ["latest"] = { ref = "15.1.0" },
+            ["15.1.0"] = {
+                url = "https://github.com/BurntSushi/ripgrep/releases/download/15.1.0/ripgrep-15.1.0-x86_64-pc-windows-msvc.zip",
+                sha256 = "124510b94b6baa3380d051fdf4650eaa80a302c876d611e9dba0b2e18d87493a",
+            },
+        },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+
+-- Archive layouts:
+--   linux/macOS .tar.gz → enclosing dir `ripgrep-<ver>-<triple>/` with `rg`
+--   windows .zip        → enclosing dir `ripgrep-<ver>-<triple>/` with `rg.exe`
+--
+-- xlings auto-extracts the archive into the runtime download dir, so the
+-- extracted folder lives next to install_file with the same name minus the
+-- archive suffix.
+function install()
+    os.tryrm(pkginfo.install_dir())
+    os.mkdir(pkginfo.install_dir())
+
+    local extracted = pkginfo.install_file()
+        :replace(".tar.gz", "")
+        :replace(".zip", "")
+
+    local exe = is_host("windows") and "rg.exe" or "rg"
+    os.mv(path.join(extracted, exe), path.join(pkginfo.install_dir(), exe))
+    os.tryrm(extracted)
+    return true
+end
+
+function config()
+    xvm.add("rg", { bindir = pkginfo.install_dir() })
+    return true
+end
+
+function uninstall()
+    xvm.remove("rg")
+    return true
+end


### PR DESCRIPTION
## Summary

First wave of "essential daily-driver" CLI tools. All five are single-binary static distributions on three platforms (linux x86_64 / macOS aarch64 / windows x86_64), no runtime deps.

| pkg | ver | what |
| --- | --- | --- |
| ripgrep | 15.1.0 | fast recursive grep that respects .gitignore |
| fd      | 10.4.2 | friendly `find` replacement |
| bat     | 0.26.1 | `cat` with syntax highlighting + Git integration |
| fzf     | 0.71.0 | command-line fuzzy finder |
| jq      | 1.8.1  | JSON processor |

### Archive layouts

The lua files document this; in short:

- `ripgrep`, `fd`, `bat`: ship inside an enclosing dir `<name>-<ver>-<triple>/` (binary lives at the top of that dir).
- `fzf`: flat tarball — binary at the top of the extraction dir.
- `jq`: a single bare binary with **no** archive — install hook just `os.mv`s it into `install_dir` and `chmod +x` on POSIX.

All five end up with a single `xvm.add` shim (`rg`, `fd`, `bat`, `fzf`, `jq`).

## Test plan

- [x] Local sandbox (Linux): install + `--version` works for ripgrep (15.1.0), fd (10.4.2), bat (0.26.1), fzf (0.71.0).
- [ ] Local sandbox: jq install hung at the same after-download / before-install-hook stall we've seen with the ollama tarball — looks like the same xlings-side issue, unrelated to the package description. CI on a fresh runner is expected to install cleanly.
- [ ] CI: `linux-install-test` / `macos-install-test` / `windows-test` will exercise install + uninstall + shim cleanup for all 5 on real runners per platform.

## Why these five first

They're the "I install these on every new machine" set — extremely common in shell setups, single binary, zero deps, 1-3 MB each. Future waves planned: starship / zoxide / lazygit / just (effort tools), then typst / deno / mise (2026 hot ones).