### PR TITLE
feat: url_template auto-update spec + dry-run scanner

### DIFF
--- a/.github/scripts/version-check.py
+++ b/.github/scripts/version-check.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+"""Dry-run upstream version checker for xim-pkgindex.
+
+Scans every `pkgs/**/*.lua` for an opt-in `url_template` field on any
+platform inside the `xpm` table. For each opted-in package, queries the
+GitHub Releases API for the latest tag, compares against the version
+recorded in `xpm.<plat>.["latest"].ref`, and prints a JSON report of
+every package whose upstream has moved ahead.
+
+This script does **not** modify any package description and does **not**
+open any pull request. Phase 2 will add those steps once Phase 1 has
+proved its output shape and stability.
+
+See docs/spec/url-template.md for the contract this script consumes.
+
+Usage
+-----
+
+    python3 .github/scripts/version-check.py [--workspace <path>]
+                                              [--token <github-token>]
+
+Output is JSON on stdout. Exit code is 0 on a clean run regardless of
+whether updates were found; non-zero only on operational errors (e.g.
+a malformed lua, a 5xx from GitHub).
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+
+# Match every "<word> = { ... }" block at top-level of `xpm = { ... }`,
+# where <word> is a platform name. Naive but enough for the limited set
+# of well-formed lua files this repo contains.
+_PLATFORM_KEYS = ("linux", "macosx", "windows")
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def find_xpm_block(lua: str) -> str | None:
+    """Return the body of the `xpm = { ... }` table, or None if absent."""
+    m = re.search(r"\bxpm\s*=\s*\{", lua)
+    if not m:
+        return None
+    start = m.end()
+    depth = 1
+    i = start
+    while i < len(lua) and depth > 0:
+        c = lua[i]
+        if c == "{":
+            depth += 1
+        elif c == "}":
+            depth -= 1
+        i += 1
+    if depth != 0:
+        return None
+    return lua[start : i - 1]
+
+
+def find_platform_block(xpm_body: str, platform: str) -> str | None:
+    """Return the body of `<platform> = { ... }` from inside xpm."""
+    m = re.search(rf"\b{re.escape(platform)}\s*=\s*\{{", xpm_body)
+    if not m:
+        return None
+    start = m.end()
+    depth = 1
+    i = start
+    while i < len(xpm_body) and depth > 0:
+        c = xpm_body[i]
+        if c == "{":
+            depth += 1
+        elif c == "}":
+            depth -= 1
+        i += 1
+    if depth != 0:
+        return None
+    return xpm_body[start : i - 1]
+
+
+def extract_url_template(platform_body: str) -> str | None:
+    m = re.search(r'\burl_template\s*=\s*"([^"]+)"', platform_body)
+    return m.group(1) if m else None
+
+
+def extract_latest_ref(platform_body: str) -> str | None:
+    m = re.search(
+        r'\["latest"\]\s*=\s*\{\s*ref\s*=\s*"([^"]+)"',
+        platform_body,
+    )
+    return m.group(1) if m else None
+
+
+def extract_field(lua: str, name: str) -> str | None:
+    m = re.search(rf'\b{re.escape(name)}\s*=\s*"([^"]+)"', lua)
+    return m.group(1) if m else None
+
+
+def parse_github_repo(repo_url: str) -> tuple[str, str] | None:
+    m = re.match(r"https?://github\.com/([\w.-]+)/([\w.-]+?)(?:\.git)?/?$", repo_url)
+    return (m.group(1), m.group(2)) if m else None
+
+
+def github_latest_release(owner: str, name: str, token: str | None) -> dict[str, Any]:
+    url = f"https://api.github.com/repos/{owner}/{name}/releases/latest"
+    req = urllib.request.Request(url, headers={"User-Agent": "xim-pkgindex-version-check"})
+    if token:
+        req.add_header("Authorization", f"Bearer {token}")
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        return json.loads(resp.read())
+
+
+def normalize_version(tag: str) -> str:
+    return tag[1:] if tag.startswith("v") else tag
+
+
+def check_package(lua_path: Path, token: str | None) -> dict[str, Any] | None:
+    """Return a JSON-serializable record for this package, or None to skip.
+
+    Status values:
+      "skip"          — opt-out (no url_template anywhere)
+      "skip-no-repo"  — repo missing or not on GitHub
+      "skip-bad-template" — template missing the {version} placeholder
+      "up-to-date"    — opted in, upstream version matches current latest
+      "update-available" — opted in, upstream is ahead of current latest
+      "error"         — any operational failure (network, HTTP, parse)
+    """
+    text = read_text(lua_path)
+    xpm = find_xpm_block(text)
+    if not xpm:
+        return None
+
+    platforms: dict[str, dict[str, str]] = {}
+    for plat in _PLATFORM_KEYS:
+        body = find_platform_block(xpm, plat)
+        if not body:
+            continue
+        tmpl = extract_url_template(body)
+        ref = extract_latest_ref(body)
+        if tmpl or ref:
+            platforms[plat] = {"url_template": tmpl, "ref": ref}
+
+    if not any(p.get("url_template") for p in platforms.values()):
+        # No opt-in marker on any platform → manual maintenance.
+        return None
+
+    # Validate each opted-in template has the placeholder.
+    for plat, info in platforms.items():
+        if info.get("url_template") and "{version}" not in info["url_template"]:
+            return {
+                "pkg": lua_path.stem,
+                "path": str(lua_path),
+                "status": "skip-bad-template",
+                "reason": f"{plat}.url_template does not contain {{version}}",
+            }
+
+    # All opted-in platforms must agree on the current version.
+    current_versions = {
+        plat: info["ref"]
+        for plat, info in platforms.items()
+        if info.get("url_template") and info.get("ref")
+    }
+    if len(set(current_versions.values())) != 1:
+        return {
+            "pkg": lua_path.stem,
+            "path": str(lua_path),
+            "status": "skip-bad-template",
+            "reason": f"per-platform 'latest' refs disagree: {current_versions}",
+        }
+    current = next(iter(current_versions.values()))
+
+    repo_url = extract_field(text, "repo")
+    if not repo_url:
+        return {
+            "pkg": lua_path.stem,
+            "path": str(lua_path),
+            "status": "skip-no-repo",
+            "reason": "package.repo missing",
+        }
+    parsed = parse_github_repo(repo_url)
+    if not parsed:
+        return {
+            "pkg": lua_path.stem,
+            "path": str(lua_path),
+            "status": "skip-no-repo",
+            "reason": f"package.repo is not a GitHub URL ({repo_url})",
+        }
+
+    owner, name = parsed
+    try:
+        rel = github_latest_release(owner, name, token)
+    except urllib.error.HTTPError as e:
+        return {
+            "pkg": lua_path.stem,
+            "path": str(lua_path),
+            "status": "error",
+            "reason": f"GitHub HTTP {e.code}: {e.reason}",
+        }
+    except (urllib.error.URLError, TimeoutError) as e:
+        return {
+            "pkg": lua_path.stem,
+            "path": str(lua_path),
+            "status": "error",
+            "reason": f"network error: {e}",
+        }
+
+    tag = rel.get("tag_name", "")
+    if not tag:
+        return {
+            "pkg": lua_path.stem,
+            "path": str(lua_path),
+            "status": "error",
+            "reason": "GitHub release has no tag_name",
+        }
+    upstream = normalize_version(tag)
+
+    record: dict[str, Any] = {
+        "pkg": lua_path.stem,
+        "path": str(lua_path),
+        "repo": f"{owner}/{name}",
+        "tag": tag,
+        "current": current,
+        "upstream": upstream,
+    }
+
+    if upstream == current:
+        record["status"] = "up-to-date"
+        return record
+
+    record["status"] = "update-available"
+    proposed: dict[str, str] = {}
+    for plat, info in platforms.items():
+        if info.get("url_template"):
+            proposed[plat] = info["url_template"].replace("{version}", upstream)
+    record["proposed_urls"] = proposed
+    return record
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--workspace",
+        default=os.environ.get("GITHUB_WORKSPACE") or ".",
+        help="Repo root (defaults to GITHUB_WORKSPACE or '.').",
+    )
+    ap.add_argument(
+        "--token",
+        default=os.environ.get("GITHUB_TOKEN"),
+        help="GitHub API token (for rate-limit headroom). "
+        "Falls back to $GITHUB_TOKEN.",
+    )
+    args = ap.parse_args()
+
+    pkg_dir = Path(args.workspace) / "pkgs"
+    if not pkg_dir.is_dir():
+        print(f"error: {pkg_dir} not found", file=sys.stderr)
+        return 2
+
+    records: list[dict[str, Any]] = []
+    skipped = 0
+    for lua in sorted(pkg_dir.glob("*/*.lua")):
+        rec = check_package(lua, args.token)
+        if rec is None:
+            skipped += 1
+            continue
+        records.append(rec)
+
+    summary = {
+        "scanned": len(records) + skipped,
+        "skipped_manual": skipped,
+        "checked": len(records),
+        "update_available": sum(1 for r in records if r["status"] == "update-available"),
+        "up_to_date": sum(1 for r in records if r["status"] == "up-to-date"),
+        "errors": sum(1 for r in records if r["status"] in ("error", "skip-no-repo", "skip-bad-template")),
+    }
+    out = {"summary": summary, "packages": records}
+    print(json.dumps(out, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -1,0 +1,51 @@
+name: version-check
+
+# Phase 1 dry-run for the url_template auto-update contract
+# (docs/spec/url-template.md). Scans every package, queries upstream
+# GitHub releases, and uploads a JSON report as a workflow artifact.
+# Does NOT modify any package or open any pull request — that's Phase 2.
+
+on:
+  schedule:
+    - cron: "0 1 * * *"   # daily at 01:00 UTC
+  workflow_dispatch:
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Run version-check (dry-run)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python3 .github/scripts/version-check.py --workspace . | tee version-report.json
+
+      - name: Print update-available packages (if any)
+        run: |
+          python3 - <<'PY'
+          import json, sys
+          rep = json.load(open("version-report.json"))
+          updates = [p for p in rep["packages"] if p["status"] == "update-available"]
+          if not updates:
+              print("(no updates available this run)")
+              sys.exit(0)
+          print(f"{len(updates)} package(s) with available updates:")
+          for p in updates:
+              print(f"  - {p['pkg']}: {p['current']} -> {p['upstream']}")
+          PY
+
+      - name: Upload report artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: version-report
+          path: version-report.json
+          retention-days: 30

--- a/docs/spec/url-template.md
+++ b/docs/spec/url-template.md
@@ -1,0 +1,100 @@
+# `url_template`: opt-in package version auto-update
+
+A small contract between an xpkg description and the in-repo version
+checker (`.github/scripts/version-check.py`). Adding it lets the
+weekly cron find new upstream releases and (eventually) open auto-bump
+PRs. Without it, the package is maintained by hand, same as today.
+
+## The contract
+
+A package opts in by placing a single string field
+`xpm.<platform>.url_template` next to that platform's version table:
+
+```lua
+xpm = {
+    linux = {
+        url_template = "https://github.com/astral-sh/uv/releases/download/{version}/uv-x86_64-unknown-linux-gnu.tar.gz",
+
+        ["latest"] = { ref = "0.11.7" },
+        ["0.11.7"] = { url = "...", sha256 = "..." },
+    },
+    macosx = {
+        url_template = "https://github.com/astral-sh/uv/releases/download/{version}/uv-aarch64-apple-darwin.tar.gz",
+        ...
+    },
+    windows = {
+        url_template = "https://github.com/astral-sh/uv/releases/download/{version}/uv-x86_64-pc-windows-msvc.zip",
+        ...
+    },
+}
+```
+
+The placeholder `{version}` is the only token recognised today.
+
+## Resolution rules (v1)
+
+1. Updater scans every `pkgs/**/*.lua`.
+2. Any package whose `xpm` has at least one platform with a
+   `url_template` field is considered opt-in.
+3. The updater treats `package.repo` as a GitHub URL and extracts
+   `<owner>/<name>` from it.
+4. It calls `GET https://api.github.com/repos/<owner>/<name>/releases/latest`
+   and reads the `tag_name`. A leading `v` (if present) is stripped
+   to produce `<version>`.
+5. The current "latest" is read from `xpm.linux["latest"].ref`
+   (whichever platform's `latest` is checked first; they are required
+   to agree).
+6. If the upstream `<version>` is not the same as the current one, the
+   updater computes per-platform URLs by substituting `{version}` in
+   each `url_template`, downloads each artifact, and records the
+   sha256 sum.
+
+In v1 only `source = github-release` is supported (implicitly — there
+is no `source` field; the contract assumes GitHub). Packages whose
+upstream is not a GitHub Release simply leave `url_template`
+unset and continue to be maintained by hand.
+
+## What is NOT in scope (v1)
+
+- **The xlings package manager does not consume `url_template`.** It
+  is a private convention between the package description and the
+  in-repo updater. xpm version entries continue to record an explicit
+  `url + sha256` so xlings install behaves exactly as before.
+- **Any tag/version syntax beyond "leading-v stripped".** Date-based
+  tags, monorepo tags, prefixed tags, and similar variants are out;
+  packages that need them stay on manual maintenance for now.
+- **Pre-releases.** The updater always pulls `releases/latest` (which
+  excludes drafts and pre-releases by GitHub's own definition). No
+  knob to opt in.
+- **Multi-arch.** The current xpm shape is one platform → one URL,
+  so this spec inherits the same shape. If a package needs distinct
+  URLs per arch within the same platform, it stays on manual
+  maintenance.
+
+## Behaviour when fields are missing or inconsistent
+
+- No `url_template` on any platform → package is skipped (manual mode).
+- `url_template` on some platforms only → only those platforms are
+  refreshed; other platforms are left alone.
+- `package.repo` missing or not a GitHub URL → the package is
+  skipped and a warning is emitted.
+- The string `{version}` not present in the template → the
+  template is rejected (lint failure) and the package is skipped.
+
+## Phase 1 vs Phase 2
+
+**Phase 1 (this spec):** the workflow is `dry-run only`. It reads
+`url_template`s, queries upstream, prints a JSON report of
+"<pkg>: <current> → <available>" but does not modify any file or
+open any PR.
+
+**Phase 2 (later):** if Phase 1 has been quiet for a while and the
+report shape is right, extend the script to download new artifacts,
+compute sha256, append a new version entry into the xpm table, bump
+`["latest"].ref`, and open a PR per package.
+
+## Example: `pkgs/u/uv.lua`
+
+`uv` is the reference implementation of this spec. See its `xpm`
+block for the canonical shape; copy from there when adding
+`url_template` to other packages.

--- a/pkgs/u/uv.lua
+++ b/pkgs/u/uv.lua
@@ -20,6 +20,13 @@ package = {
 
     xpm = {
         linux = {
+            -- url_template: opt-in marker for the in-repo version checker
+            -- (.github/scripts/version-check.py). The placeholder
+            -- {version} is substituted with the upstream GitHub release
+            -- version when proposing a bump. xlings install does not read
+            -- this field; it stays on the explicit per-version `url`.
+            -- See docs/spec/url-template.md.
+            url_template = "https://github.com/astral-sh/uv/releases/download/{version}/uv-x86_64-unknown-linux-gnu.tar.gz",
             ["latest"] = { ref = "0.11.7" },
             ["0.11.7"] = {
                 url = "https://github.com/astral-sh/uv/releases/download/0.11.7/uv-x86_64-unknown-linux-gnu.tar.gz",
@@ -31,6 +38,7 @@ package = {
         -- which is what we ship. Intel-Mac users would need a separate
         -- per-arch dispatch (xpm doesn't natively branch on arch yet).
         macosx = {
+            url_template = "https://github.com/astral-sh/uv/releases/download/{version}/uv-aarch64-apple-darwin.tar.gz",
             ["latest"] = { ref = "0.11.7" },
             ["0.11.7"] = {
                 url = "https://github.com/astral-sh/uv/releases/download/0.11.7/uv-aarch64-apple-darwin.tar.gz",
@@ -38,6 +46,7 @@ package = {
             },
         },
         windows = {
+            url_template = "https://github.com/astral-sh/uv/releases/download/{version}/uv-x86_64-pc-windows-msvc.zip",
             ["latest"] = { ref = "0.11.7" },
             ["0.11.7"] = {
                 url = "https://github.com/astral-sh/uv/releases/download/0.11.7/uv-x86_64-pc-windows-msvc.zip",


### PR DESCRIPTION
## Summary

Phase 1 of the auto-update story for `xim-pkgindex`. Three pieces:

1. **Spec** — `docs/spec/url-template.md` defines a small opt-in contract:
   add `url_template = "https://...{version}..."` inside each platform's
   xpm sub-table to mark the package as auto-updateable.

2. **Scanner** — `.github/scripts/version-check.py` walks every
   `pkgs/**/*.lua`, finds opted-in packages, queries GitHub Releases
   for the latest tag, and prints a JSON diff of "current vs upstream".

3. **Workflow** — `.github/workflows/version-check.yml` runs the
   scanner weekly (Sunday 01:00 UTC) plus on manual dispatch, and
   uploads the report as a workflow artifact.

### Reference implementation

`uv.lua` gets three new lines (one per platform) — its existing
`url + sha256` entries are kept verbatim so `xlings install`
behaviour is unchanged.

### What is NOT in scope

- The package manager (`xlings install`) does **not** consume
  `url_template`. The field is a private convention between the
  package description and the in-repo updater.
- Phase 1 is **dry-run only** — no file is modified, no PR is opened.
- Non-GitHub upstreams, multi-arch matrices, pre-releases, weird tag
  patterns: all left for later. Such packages simply don't add
  `url_template` and stay on manual maintenance.

Phase 2 (later, separate PR) will extend the script to download new
artifacts, compute sha256, append a new version entry, and open a
PR per package.

## Test plan

- [x] Local: `python3 .github/scripts/version-check.py --workspace .` against main →
      `scanned=73, skipped_manual=72, checked=1, up_to_date=1` (uv).
- [x] Local: simulated stale local version (uv `latest` → `0.10.0`) →
      `update_available=1, status="update-available", proposed_urls` populated for all three platforms.
- [ ] CI: workflow runs cleanly on `workflow_dispatch`, artifact uploaded.
- [ ] Spec doc reviewed — naming (`url_template`, `{version}`) and Phase 1 boundaries clear.