### PR TITLE
ci(deploy): pass build-time + commit metadata to xpkgindex

### DIFF
--- a/.github/workflows/pkgindex-deloy.yml
+++ b/.github/workflows/pkgindex-deloy.yml
@@ -36,7 +36,21 @@ jobs:
         run: pip install git+https://github.com/d2learn/xpkgindex.git
 
       - name: Generate static site
-        run: xpkgindex generate . --output site
+        # Hand build provenance to xpkgindex via the env-var contract added
+        # in d2learn/xpkgindex (Apr 2026). When at least one is set the
+        # generator emits a "Build Info" section on the About page.
+        env:
+          XPKGINDEX_BUILD_TIME:       ${{ github.event.head_commit.timestamp }}
+          XPKGINDEX_BUILD_COMMIT:     ${{ github.sha }}
+          XPKGINDEX_BUILD_COMMIT_URL: ${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}
+        run: |
+          # workflow_dispatch leaves head_commit.timestamp empty; fall back
+          # to "now" so the About page always shows a meaningful build time.
+          if [ -z "$XPKGINDEX_BUILD_TIME" ]; then
+            XPKGINDEX_BUILD_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+            export XPKGINDEX_BUILD_TIME
+          fi
+          xpkgindex generate . --output site
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
## Summary

xpkgindex (d2learn/xpkgindex@4092199, Apr 2026) now optionally renders a "Build Info" section on the generated About page when the `XPKGINDEX_BUILD_*` environment variables are set. This PR wires the deploy workflow to fill those vars so the live site shows when it was built and which commit it was built from.

| variable | source |
| --- | --- |
| `XPKGINDEX_BUILD_TIME` | `github.event.head_commit.timestamp`, with a `date -u` fallback for `workflow_dispatch` runs |
| `XPKGINDEX_BUILD_COMMIT` | `github.sha` |
| `XPKGINDEX_BUILD_COMMIT_URL` | `${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}` so the short hash on the About page is clickable |

If a future deploy ever pins to a pre-build-info xpkgindex revision, the env vars are simply ignored and the page renders as before — pure additive change.

## Test plan

- [x] Local: ran `python3 -m xpkgindex generate . --output site` against this repo with the env vars set; `site/about.html` contains a `<section class="about-build-info">` block with timestamp + linked short commit, just above the existing footer.
- [x] Local: ran the same command without env vars; about.html has no Build Info section.
- [ ] CI: existing `linux-test` / `index-registration` / `static-and-isolation` / install-test matrix should be unaffected (only deploy workflow touched).
- [ ] Live site: after merge, dispatch the deploy workflow and confirm `/about.html` shows the Build Info section.