### PR TITLE
feat(updater): implement Phase 2 auto-bump + add zoxide

### DIFF
--- a/.github/scripts/version-check.py
+++ b/.github/scripts/version-check.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Dry-run upstream version checker for xim-pkgindex.
+"""Upstream version checker (and optional bumper) for xim-pkgindex.
 
 Scans every `pkgs/**/*.lua` for an opt-in `url_template` field on any
 platform inside the `xpm` table. For each opted-in package, queries the
@@ -7,24 +7,35 @@ GitHub Releases API for the latest tag, compares against the version
 recorded in `xpm.<plat>.["latest"].ref`, and prints a JSON report of
 every package whose upstream has moved ahead.
 
-This script does **not** modify any package description and does **not**
-open any pull request. Phase 2 will add those steps once Phase 1 has
-proved its output shape and stability.
+In `--apply` mode the script additionally downloads each new artifact,
+computes its sha256, and rewrites the lua file in-place: a new
+`["<upstream>"] = { url = ..., sha256 = ... }` block is **appended**
+right after `["latest"]` on every opted-in platform, and `["latest"].ref`
+is bumped to point at it. Existing version blocks are left intact (so
+pinned consumers keep working). The companion workflow
+`version-bump.yml` then commits each modified file to its own branch
+and opens a PR.
 
 See docs/spec/url-template.md for the contract this script consumes.
 
 Usage
 -----
 
+    # Phase 1: dry-run (default) — JSON report on stdout, no file changes
     python3 .github/scripts/version-check.py [--workspace <path>]
-                                              [--token <github-token>]
 
-Output is JSON on stdout. Exit code is 0 on a clean run regardless of
-whether updates were found; non-zero only on operational errors (e.g.
-a malformed lua, a 5xx from GitHub).
+    # Phase 2: apply — modify lua files in place
+    python3 .github/scripts/version-check.py --apply [--only <pkg>]
+
+`--only <pkg>` restricts both the scan and the bump to a single package
+identified by its lua file basename (e.g. `zoxide`).
+
+Exit code is 0 on a clean run regardless of whether updates were found;
+non-zero only on operational errors.
 """
 
 import argparse
+import hashlib
 import json
 import os
 import re
@@ -243,6 +254,132 @@ def check_package(lua_path: Path, token: str | None) -> dict[str, Any] | None:
     return record
 
 
+def find_block_range(text: str, key: str, search_from: int = 0) -> tuple[int, int] | None:
+    """Return the (body_start, body_end) offset range of `<key> = { ... }`.
+
+    body_start is just past the opening `{`; body_end is the index of the
+    matching closing `}` (exclusive of it). Returns None if not found or
+    if braces are unbalanced.
+    """
+    m = re.search(rf"\b{re.escape(key)}\s*=\s*\{{", text[search_from:])
+    if not m:
+        return None
+    body_start = search_from + m.end()
+    depth = 1
+    i = body_start
+    while i < len(text) and depth > 0:
+        c = text[i]
+        if c == "{":
+            depth += 1
+        elif c == "}":
+            depth -= 1
+        i += 1
+    if depth != 0:
+        return None
+    return (body_start, i - 1)
+
+
+def compute_sha256(url: str, token: str | None) -> str:
+    """Stream the URL and return its sha256 hex digest."""
+    h = hashlib.sha256()
+    req = urllib.request.Request(
+        url, headers={"User-Agent": "xim-pkgindex-version-bump"}
+    )
+    # Auth header is harmless for public release artifacts but lifts rate
+    # limits when GitHub returns a redirect through api.github.com.
+    if token and "github.com" in url:
+        req.add_header("Authorization", f"Bearer {token}")
+    with urllib.request.urlopen(req, timeout=180) as resp:
+        while True:
+            chunk = resp.read(64 * 1024)
+            if not chunk:
+                break
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def apply_bump(
+    lua_path: Path,
+    current: str,
+    upstream: str,
+    proposed_urls: dict[str, str],
+    token: str | None,
+) -> dict[str, Any]:
+    """Edit lua_path in place: append `["<upstream>"] = {...}` per platform
+    and bump `["latest"].ref` from <current> to <upstream>. Existing
+    version entries are untouched.
+
+    Returns a record describing what happened (status + per-platform).
+    """
+    text = lua_path.read_text(encoding="utf-8")
+
+    # Locate xpm block once so per-platform searches stay scoped to it.
+    xpm = find_block_range(text, "xpm")
+    if not xpm:
+        return {"status": "error", "reason": "xpm block not found"}
+
+    edits: list[tuple[int, int, str]] = []
+    per_platform: dict[str, str] = {}
+    for plat, new_url in proposed_urls.items():
+        plat_range = find_block_range(text, plat, xpm[0])
+        if not plat_range or plat_range[1] > xpm[1]:
+            continue
+        plat_body = text[plat_range[0] : plat_range[1]]
+
+        # Capture the leading whitespace of the `["latest"]` line so the
+        # new version block we append matches the existing indentation.
+        latest_pat = re.compile(
+            r'(?m)^(?P<indent>[ \t]*)\["latest"\]\s*=\s*\{\s*ref\s*=\s*"'
+            + re.escape(current)
+            + r'"\s*\}\s*,?[ \t]*\n'
+        )
+        m = latest_pat.search(plat_body)
+        if not m:
+            # Either ref doesn't match expected current (already bumped?)
+            # or the block is shaped differently. Skip this platform.
+            continue
+        indent = m.group("indent")
+
+        try:
+            sha = compute_sha256(new_url, token)
+        except (urllib.error.URLError, TimeoutError) as e:
+            return {
+                "status": "error",
+                "reason": f"failed to download {new_url}: {e}",
+            }
+
+        # Build the replacement: keep the latest line (with bumped ref)
+        # and immediately follow it with the new version block.
+        replacement = (
+            f'{indent}["latest"] = {{ ref = "{upstream}" }},\n'
+            f'{indent}["{upstream}"] = {{\n'
+            f'{indent}    url = "{new_url}",\n'
+            f'{indent}    sha256 = "{sha}",\n'
+            f'{indent}}},\n'
+        )
+
+        edits.append(
+            (
+                plat_range[0] + m.start(),
+                plat_range[0] + m.end(),
+                replacement,
+            )
+        )
+        per_platform[plat] = sha
+
+    if not edits:
+        return {"status": "no-edit", "reason": "no matching latest line on any platform"}
+
+    # Apply edits from the end of the file backward so earlier offsets
+    # stay valid.
+    new_text = text
+    for start, end, repl in sorted(edits, key=lambda e: -e[0]):
+        new_text = new_text[:start] + repl + new_text[end:]
+
+    lua_path.write_text(new_text, encoding="utf-8")
+    return {"status": "applied", "platforms": per_platform}
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument(
@@ -256,6 +393,19 @@ def main() -> int:
         help="GitHub API token (for rate-limit headroom). "
         "Falls back to $GITHUB_TOKEN.",
     )
+    ap.add_argument(
+        "--apply",
+        action="store_true",
+        help="Modify lua files in place: append a new version block and "
+        "bump ['latest'].ref for every package whose upstream is ahead. "
+        "Without this flag the script is dry-run only.",
+    )
+    ap.add_argument(
+        "--only",
+        default=None,
+        help="Restrict scanning (and bumping) to a single package by lua "
+        "basename (e.g. 'zoxide' for pkgs/z/zoxide.lua).",
+    )
     args = ap.parse_args()
 
     pkg_dir = Path(args.workspace) / "pkgs"
@@ -266,11 +416,26 @@ def main() -> int:
     records: list[dict[str, Any]] = []
     skipped = 0
     for lua in sorted(pkg_dir.glob("*/*.lua")):
+        if args.only and lua.stem != args.only:
+            continue
         rec = check_package(lua, args.token)
         if rec is None:
             skipped += 1
             continue
         records.append(rec)
+
+    if args.apply:
+        for rec in records:
+            if rec["status"] != "update-available":
+                continue
+            applied = apply_bump(
+                Path(rec["path"]),
+                rec["current"],
+                rec["upstream"],
+                rec["proposed_urls"],
+                args.token,
+            )
+            rec["apply"] = applied
 
     summary = {
         "scanned": len(records) + skipped,
@@ -279,6 +444,11 @@ def main() -> int:
         "update_available": sum(1 for r in records if r["status"] == "update-available"),
         "up_to_date": sum(1 for r in records if r["status"] == "up-to-date"),
         "errors": sum(1 for r in records if r["status"] in ("error", "skip-no-repo", "skip-bad-template")),
+        "applied": sum(
+            1
+            for r in records
+            if r.get("apply", {}).get("status") == "applied"
+        ),
     }
     out = {"summary": summary, "packages": records}
     print(json.dumps(out, indent=2))

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,0 +1,113 @@
+name: version-bump
+
+# Phase 2 of the url_template auto-update contract
+# (docs/spec/url-template.md). Runs the dry-run scanner; for every
+# package whose upstream is ahead, applies the bump in-place on a
+# dedicated `auto/bump-<pkg>-<upstream>` branch and opens a PR.
+# Idempotent: if the branch already exists on origin, that package is
+# skipped so an open PR is not clobbered.
+
+on:
+  schedule:
+    - cron: "0 2 * * 1"   # Mondays 02:00 UTC (one cycle behind the daily scan)
+  workflow_dispatch:
+    inputs:
+      only:
+        description: "Restrict to a single package by lua basename (optional)"
+        required: false
+        default: ""
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Configure git identity
+        run: |
+          git config user.name  "xim-pkgindex-bot[bot]"
+          git config user.email "xim-pkgindex-bot@users.noreply.github.com"
+
+      - name: Scan for available updates
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ONLY_ARG=""
+          if [ -n "${{ inputs.only }}" ]; then
+            ONLY_ARG="--only ${{ inputs.only }}"
+          fi
+          python3 .github/scripts/version-check.py --workspace . $ONLY_ARG > scan.json
+          python3 -c "
+          import json
+          d = json.load(open('scan.json'))
+          for p in d['packages']:
+              if p['status'] == 'update-available':
+                  print(f\"{p['pkg']}\t{p['current']}\t{p['upstream']}\")
+          " > to-bump.tsv
+          echo "Packages to bump:"
+          cat to-bump.tsv || true
+
+      - name: Bump each package on its own branch and open PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ ! -s to-bump.tsv ]; then
+            echo "No updates available — nothing to do."
+            exit 0
+          fi
+
+          while IFS=$'\t' read -r pkg current upstream; do
+            branch="auto/bump-${pkg}-${upstream}"
+            echo "::group::${pkg}: ${current} -> ${upstream}"
+
+            if git ls-remote --exit-code --heads origin "${branch}" >/dev/null 2>&1; then
+              echo "Branch ${branch} already exists on origin — skipping (open PR assumed)."
+              echo "::endgroup::"
+              continue
+            fi
+
+            # Start from a clean main checkout for each package so a
+            # failure on one doesn't leak into the next.
+            git checkout -B "${branch}" origin/main
+
+            python3 .github/scripts/version-check.py --workspace . --apply --only "${pkg}" > /dev/null
+
+            if git diff --quiet; then
+              echo "No file change after --apply (already at ${upstream}?) — skipping."
+              echo "::endgroup::"
+              continue
+            fi
+
+            git add -A
+            git commit -m "auto: bump ${pkg} ${current} -> ${upstream}"
+            git push origin "${branch}"
+
+            printf '%s\n' \
+              "Automated version bump from the \`url_template\` auto-update contract (see [docs/spec/url-template.md](../blob/main/docs/spec/url-template.md)). Produced by \`.github/workflows/version-bump.yml\`." \
+              "" \
+              "- **Package:** \`${pkg}\`" \
+              "- **Current:** \`${current}\` → **Upstream:** \`${upstream}\`" \
+              "" \
+              "Existing version blocks are preserved untouched; only \`['latest'].ref\` is bumped and a new \`['${upstream}']\` block is appended on every opted-in platform. \`sha256\` values were computed from the freshly-downloaded artifacts." \
+              > /tmp/pr-body.md
+
+            gh pr create \
+              --base main \
+              --head "${branch}" \
+              --title "auto: bump ${pkg} ${current} -> ${upstream}" \
+              --body-file /tmp/pr-body.md
+            echo "::endgroup::"
+          done < to-bump.tsv

--- a/docs/spec/url-template.md
+++ b/docs/spec/url-template.md
@@ -83,15 +83,42 @@ unset and continue to be maintained by hand.
 
 ## Phase 1 vs Phase 2
 
-**Phase 1 (this spec):** the workflow is `dry-run only`. It reads
-`url_template`s, queries upstream, prints a JSON report of
-"<pkg>: <current> → <available>" but does not modify any file or
-open any PR.
+Both phases now ship in the same script (`.github/scripts/version-check.py`)
+behind the `--apply` flag and as separate scheduled workflows.
 
-**Phase 2 (later):** if Phase 1 has been quiet for a while and the
-report shape is right, extend the script to download new artifacts,
-compute sha256, append a new version entry into the xpm table, bump
-`["latest"].ref`, and open a PR per package.
+**Phase 1 — `version-check.yml` (default, dry-run):** runs daily at
+01:00 UTC. Reads `url_template`s, queries upstream, prints a JSON
+report of "<pkg>: <current> → <available>", uploads it as a workflow
+artifact, and does not modify any file or open any PR.
+
+**Phase 2 — `version-bump.yml` (`--apply`):** runs weekly (Mondays
+02:00 UTC) or on manual dispatch. For every package the dry-run flags
+as `update-available`, the script:
+
+1. Downloads the new artifact for each opted-in platform and computes
+   its sha256.
+2. Bumps `["latest"].ref` to the upstream version on every opted-in
+   platform.
+3. **Appends** a new `["<upstream>"] = { url, sha256 }` block right
+   after `["latest"]` on the same platform. Existing version blocks
+   are left untouched, so consumers pinned to an older version keep
+   working unchanged.
+
+The workflow then commits the modified lua to a per-package branch
+named `auto/bump-<pkg>-<upstream>` and opens a PR via `gh`. If that
+branch already exists on origin (i.e. an open PR is already pending
+for the same target version) the package is skipped — the run is
+idempotent.
+
+Manual one-shot:
+
+```bash
+# preview only — no file changes
+python3 .github/scripts/version-check.py --workspace .
+
+# apply (modifies pkgs/**/*.lua in place)
+python3 .github/scripts/version-check.py --workspace . --apply [--only <pkg>]
+```
 
 ## Example: `pkgs/u/uv.lua`
 

--- a/pkgs/z/zoxide.lua
+++ b/pkgs/z/zoxide.lua
@@ -1,0 +1,75 @@
+package = {
+    spec = "1",
+
+    name = "zoxide",
+    description = "A smarter cd command — jump to your most-used directories",
+    homepage = "https://github.com/ajeetdsouza/zoxide",
+    maintainers = {"ajeetdsouza"},
+    licenses = {"MIT"},
+    repo = "https://github.com/ajeetdsouza/zoxide",
+    docs = "https://github.com/ajeetdsouza/zoxide#readme",
+
+    type = "package",
+    archs = {"x86_64", "aarch64"},
+    status = "stable",
+    categories = {"cli", "navigation", "tools"},
+    keywords = {"cd", "navigation", "zoxide", "rust"},
+
+    programs = {"zoxide"},
+    xvm_enable = true,
+
+    xpm = {
+        linux = {
+            url_template = "https://github.com/ajeetdsouza/zoxide/releases/download/v{version}/zoxide-{version}-x86_64-unknown-linux-musl.tar.gz",
+            ["latest"] = { ref = "0.9.7" },
+            ["0.9.7"] = {
+                url = "https://github.com/ajeetdsouza/zoxide/releases/download/v0.9.7/zoxide-0.9.7-x86_64-unknown-linux-musl.tar.gz",
+                sha256 = "ee53a42c11fe8a175ef7b136bb91f588aef76e1ae7133e58a695b1199588ee7e",
+            },
+        },
+        macosx = {
+            url_template = "https://github.com/ajeetdsouza/zoxide/releases/download/v{version}/zoxide-{version}-aarch64-apple-darwin.tar.gz",
+            ["latest"] = { ref = "0.9.7" },
+            ["0.9.7"] = {
+                url = "https://github.com/ajeetdsouza/zoxide/releases/download/v0.9.7/zoxide-0.9.7-aarch64-apple-darwin.tar.gz",
+                sha256 = "4ce19ad9ea0fdf92265ef73b1cb38c605fbccfda815157c1e99c0af99115c4e4",
+            },
+        },
+        windows = {
+            url_template = "https://github.com/ajeetdsouza/zoxide/releases/download/v{version}/zoxide-{version}-x86_64-pc-windows-msvc.zip",
+            ["latest"] = { ref = "0.9.7" },
+            ["0.9.7"] = {
+                url = "https://github.com/ajeetdsouza/zoxide/releases/download/v0.9.7/zoxide-0.9.7-x86_64-pc-windows-msvc.zip",
+                sha256 = "d2f7640e977170d58c3f7057a9ecbfe6597de1a3dbbd992fb2fea1255e6098e4",
+            },
+        },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+
+-- Archive layout: every platform's archive (.tar.gz / .zip) drops files
+-- directly into the extraction dir with no enclosing folder — `zoxide`
+-- (or `zoxide.exe`) sits at the top alongside CHANGELOG / man / completions.
+-- So we always pull the binary out of `download_dir`, not a sub-extracted
+-- folder (unlike fd/bat which DO have an enclosing dir).
+function install()
+    os.tryrm(pkginfo.install_dir())
+    os.mkdir(pkginfo.install_dir())
+
+    local download_dir = path.directory(pkginfo.install_file())
+    local exe = is_host("windows") and "zoxide.exe" or "zoxide"
+    os.mv(path.join(download_dir, exe), path.join(pkginfo.install_dir(), exe))
+    return true
+end
+
+function config()
+    xvm.add("zoxide", { bindir = pkginfo.install_dir() })
+    return true
+end
+
+function uninstall()
+    xvm.remove("zoxide")
+    return true
+end


### PR DESCRIPTION
## Summary
- Extend the `url_template` auto-update flow with **Phase 2**: scan ➜ download ➜ append version block ➜ bump `['latest']` ➜ open PR.
- Adds `.github/workflows/version-bump.yml` (weekly + `workflow_dispatch`) that drives the new `--apply` mode of `version-check.py`. Each updated package lands on its own `auto/bump-<pkg>-<upstream>` branch and gets its own PR; existing branches are skipped so re-runs don't clobber open PRs.
- Existing version blocks are preserved untouched — only `['latest'].ref` is bumped and a new `["<upstream>"]` block is appended next to it. Pinned consumers stay on whatever they pinned.
- Spec doc (`docs/spec/url-template.md`) updated to move Phase 2 from "later" to current implementation.
- Adds `pkgs/z/zoxide.lua` with `url_template` opt-in, **deliberately pinned at 0.9.7** while upstream is 0.9.9 — this acts as the live exercise for the new workflow on its first run after merge.

## Test plan
- [x] `pytest -m "static or isolation"` — 491 passed locally
- [x] `version-check.py --workspace .` (dry-run) reports `zoxide: 0.9.7 → 0.9.9`
- [x] `version-check.py --apply --only zoxide` mutates `pkgs/z/zoxide.lua`: `latest=0.9.9`, new `["0.9.9"]` block appended, `["0.9.7"]` block preserved
- [x] Re-running `--apply` on the bumped file is a no-op (`status=up-to-date`)
- [x] `xlings install zoxide` against the bumped lua installs `zoxide 0.9.9` cleanly (sha256 verified end-to-end)
- [x] `xlings install zoxide` against the pinned lua installs `zoxide 0.9.7` cleanly
- [x] `xlings remove zoxide` cleans up
- [ ] CI: `xpkg test` (static + isolation) green on this PR
- [ ] CI: `pkgindex test` (linux + windows install run) green on this PR
- [ ] After merge: trigger `version-bump` via `workflow_dispatch` (`only=zoxide`) and confirm an `auto: bump zoxide 0.9.7 -> 0.9.9` PR appears

## Notes
- `version-check.yml` (Phase 1, daily dry-run) is unchanged; the two workflows are complementary.
- Phase 2 needs `contents: write` and `pull-requests: write` permissions — declared at the workflow level.