### PR TITLE
fix(version-bump): keep CI artifacts out of the auto-bump commit

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -42,21 +42,23 @@ jobs:
       - name: Scan for available updates
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # Write transient outputs under $RUNNER_TEMP so a later
+        # `git add -A` inside the workspace can't accidentally commit them.
         run: |
           ONLY_ARG=""
           if [ -n "${{ inputs.only }}" ]; then
             ONLY_ARG="--only ${{ inputs.only }}"
           fi
-          python3 .github/scripts/version-check.py --workspace . $ONLY_ARG > scan.json
+          python3 .github/scripts/version-check.py --workspace . $ONLY_ARG > "$RUNNER_TEMP/scan.json"
           python3 -c "
-          import json
-          d = json.load(open('scan.json'))
+          import json, os
+          d = json.load(open(os.environ['RUNNER_TEMP'] + '/scan.json'))
           for p in d['packages']:
               if p['status'] == 'update-available':
                   print(f\"{p['pkg']}\t{p['current']}\t{p['upstream']}\")
-          " > to-bump.tsv
+          " > "$RUNNER_TEMP/to-bump.tsv"
           echo "Packages to bump:"
-          cat to-bump.tsv || true
+          cat "$RUNNER_TEMP/to-bump.tsv" || true
 
       - name: Bump each package on its own branch and open PR
         env:
@@ -64,7 +66,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          if [ ! -s to-bump.tsv ]; then
+          if [ ! -s "$RUNNER_TEMP/to-bump.tsv" ]; then
             echo "No updates available — nothing to do."
             exit 0
           fi
@@ -91,7 +93,11 @@ jobs:
               continue
             fi
 
-            git add -A
+            # Stage only the package file we just bumped — any other
+            # workspace artifact (e.g. CI byproducts) stays out of the
+            # commit on principle.
+            pkg_file="pkgs/${pkg:0:1}/${pkg}.lua"
+            git add "$pkg_file"
             git commit -m "auto: bump ${pkg} ${current} -> ${upstream}"
             git push origin "${branch}"
 


### PR DESCRIPTION
## Summary
The first run of `version-bump.yml` after #70 merged accidentally committed `scan.json` and `to-bump.tsv` into the bump branch (the workflow wrote them to the workspace root and `git add -A` swept them in).

Two safety belts:
1. Write transient outputs under `\$RUNNER_TEMP` so they live on the runner's scratch filesystem, not inside the checkout.
2. Stage only the package file (`pkgs/<l>/<pkg>.lua`) for the auto-bump commit, instead of `git add -A`. Anything else the workflow happens to drop in the workspace is now ignored on principle.

## Test plan
- [ ] CI green on this PR (workflow YAML changes only)
- [ ] After merge: re-run `version-bump` via `workflow_dispatch` (`only=zoxide`) and confirm the resulting PR contains exactly **one** file change (`pkgs/z/zoxide.lua`)