### PR TITLE
fix(version-bump): also redirect the to-bump.tsv read to RUNNER_TEMP

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -116,4 +116,4 @@ jobs:
               --title "auto: bump ${pkg} ${current} -> ${upstream}" \
               --body-file /tmp/pr-body.md
             echo "::endgroup::"
-          done < to-bump.tsv
+          done < "$RUNNER_TEMP/to-bump.tsv"


### PR DESCRIPTION
Follow-up to #71. The previous fix moved writes of `scan.json` and `to-bump.tsv` to `$RUNNER_TEMP` but missed the matching `done < to-bump.tsv` at the end of the loop, so the workflow exits with "No such file or directory" before doing anything (run 24938151753). One-line fix: point the read at the RUNNER_TEMP path.