### PR TITLE
feat(claude-code): add cc-connect and cc-switch xpkgs

### DIFF
--- a/pkgs/c/cc-connect.lua
+++ b/pkgs/c/cc-connect.lua
@@ -1,0 +1,88 @@
+package = {
+    spec = "1",
+
+    name = "cc-connect",
+    description = "Bridge local AI coding agents (Claude Code, Codex, Cursor, Gemini CLI, etc.) to messaging platforms (Feishu, Slack, Telegram, Discord, ...)",
+    homepage = "https://github.com/chenhg5/cc-connect",
+    maintainers = {"chenhg5"},
+    licenses = {"MIT"},
+    repo = "https://github.com/chenhg5/cc-connect",
+    docs = "https://github.com/chenhg5/cc-connect#readme",
+
+    type = "package",
+    archs = {"x86_64", "aarch64"},
+    status = "stable",
+    categories = {"cli", "ai-agent", "tools"},
+    keywords = {"claude-code", "ai", "agent", "feishu", "lark", "slack", "messaging-bridge"},
+
+    programs = {"cc-connect"},
+    xvm_enable = true,
+
+    xpm = {
+        linux = {
+            url_template = "https://github.com/chenhg5/cc-connect/releases/download/v{version}/cc-connect-v{version}-linux-amd64.tar.gz",
+            ["latest"] = { ref = "1.3.2" },
+            ["1.3.2"] = {
+                url = "https://github.com/chenhg5/cc-connect/releases/download/v1.3.2/cc-connect-v1.3.2-linux-amd64.tar.gz",
+                sha256 = "4ed25a62166c1a3a7c41eb3320d9b90172c56749aec5b88d36380829e4c8a182",
+            },
+        },
+        macosx = {
+            url_template = "https://github.com/chenhg5/cc-connect/releases/download/v{version}/cc-connect-v{version}-darwin-arm64.tar.gz",
+            ["latest"] = { ref = "1.3.2" },
+            ["1.3.2"] = {
+                url = "https://github.com/chenhg5/cc-connect/releases/download/v1.3.2/cc-connect-v1.3.2-darwin-arm64.tar.gz",
+                sha256 = "f03153feef8e46c606d0097a491e92448289fe3b91b70cba0b05f8740dfafe95",
+            },
+        },
+        windows = {
+            url_template = "https://github.com/chenhg5/cc-connect/releases/download/v{version}/cc-connect-v{version}-windows-amd64.zip",
+            ["latest"] = { ref = "1.3.2" },
+            ["1.3.2"] = {
+                url = "https://github.com/chenhg5/cc-connect/releases/download/v1.3.2/cc-connect-v1.3.2-windows-amd64.zip",
+                sha256 = "88cbc4cbc3cfddb826e4b2030f4a34afd60b55dfc642d27ad2932d0b53cf5623",
+            },
+        },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+
+-- Archive layout: every platform's archive contains a single file at top
+-- level named `cc-connect-v<ver>-<os>-<arch>` (or `.exe` on Windows). We
+-- rename to a clean `cc-connect` / `cc-connect.exe` so callers don't have
+-- to know the build triple.
+function install()
+    os.tryrm(pkginfo.install_dir())
+    os.mkdir(pkginfo.install_dir())
+
+    local download_dir = path.directory(pkginfo.install_file())
+    local ver = pkginfo.version()
+    local src, dst
+    if is_host("windows") then
+        src = path.join(download_dir, "cc-connect-v" .. ver .. "-windows-amd64.exe")
+        dst = path.join(pkginfo.install_dir(), "cc-connect.exe")
+    elseif is_host("macosx") then
+        src = path.join(download_dir, "cc-connect-v" .. ver .. "-darwin-arm64")
+        dst = path.join(pkginfo.install_dir(), "cc-connect")
+    else
+        src = path.join(download_dir, "cc-connect-v" .. ver .. "-linux-amd64")
+        dst = path.join(pkginfo.install_dir(), "cc-connect")
+    end
+    os.mv(src, dst)
+    if not is_host("windows") then
+        os.exec("chmod +x " .. dst)
+    end
+    return true
+end
+
+function config()
+    xvm.add("cc-connect", { bindir = pkginfo.install_dir() })
+    return true
+end
+
+function uninstall()
+    xvm.remove("cc-connect")
+    return true
+end

--- a/pkgs/c/cc-switch.lua
+++ b/pkgs/c/cc-switch.lua
@@ -72,8 +72,11 @@ function install()
         local app_dst = path.join(pkginfo.install_dir(), "CC Switch.app")
         os.mv(app_src, app_dst)
         -- Symlink so xvm's bindir model keeps working with the bundle.
-        os.ln(path.join(app_dst, "Contents", "MacOS", "cc-switch"),
-              path.join(pkginfo.install_dir(), "cc-switch"))
+        -- xmake's sandbox exposes symlink creation through os.cp's
+        -- `symlink = true` flag, not via a separate os.ln.
+        os.cp(path.join(app_dst, "Contents", "MacOS", "cc-switch"),
+              path.join(pkginfo.install_dir(), "cc-switch"),
+              { force = true, symlink = true })
     else
         os.mv(pkginfo.install_file(),
               path.join(pkginfo.install_dir(), "cc-switch"))

--- a/pkgs/c/cc-switch.lua
+++ b/pkgs/c/cc-switch.lua
@@ -1,0 +1,94 @@
+package = {
+    spec = "1",
+
+    name = "cc-switch",
+    description = "Cross-platform desktop tool for switching providers across Claude Code / Codex / OpenCode / Gemini CLI / openclaw",
+    homepage = "https://github.com/farion1231/cc-switch",
+    maintainers = {"farion1231"},
+    licenses = {"MIT"},
+    repo = "https://github.com/farion1231/cc-switch",
+    docs = "https://github.com/farion1231/cc-switch#readme",
+
+    type = "app",
+    archs = {"x86_64", "aarch64"},
+    status = "stable",
+    categories = {"app", "ai-agent", "tools"},
+    keywords = {"claude-code", "codex", "gemini-cli", "tauri", "provider-switcher"},
+
+    programs = {"cc-switch"},
+    xvm_enable = true,
+
+    xpm = {
+        linux = {
+            url_template = "https://github.com/farion1231/cc-switch/releases/download/v{version}/CC-Switch-v{version}-Linux-x86_64.AppImage",
+            ["latest"] = { ref = "3.14.1" },
+            ["3.14.1"] = {
+                url = "https://github.com/farion1231/cc-switch/releases/download/v3.14.1/CC-Switch-v3.14.1-Linux-x86_64.AppImage",
+                sha256 = "a2e5c4183156437c96a1fe72df2a7b4b87ff6c857cdf0912e7057c34efcd5309",
+            },
+        },
+        macosx = {
+            url_template = "https://github.com/farion1231/cc-switch/releases/download/v{version}/CC-Switch-v{version}-macOS.zip",
+            ["latest"] = { ref = "3.14.1" },
+            ["3.14.1"] = {
+                url = "https://github.com/farion1231/cc-switch/releases/download/v3.14.1/CC-Switch-v3.14.1-macOS.zip",
+                sha256 = "595cdbb510405b12578ccc6250dd096cc8c85dc3def2af0e0ac8c5d3e28b3807",
+            },
+        },
+        windows = {
+            url_template = "https://github.com/farion1231/cc-switch/releases/download/v{version}/CC-Switch-v{version}-Windows-Portable.zip",
+            ["latest"] = { ref = "3.14.1" },
+            ["3.14.1"] = {
+                url = "https://github.com/farion1231/cc-switch/releases/download/v3.14.1/CC-Switch-v3.14.1-Windows-Portable.zip",
+                sha256 = "3747d1218e1fc7f3671b61d1ebf059f5a5aff556dd096b439484681b254eb866",
+            },
+        },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+
+-- Layout per platform:
+--   Linux: download is the AppImage itself (a single self-contained ELF).
+--          Rename to `cc-switch`, chmod +x, and that becomes the binary.
+--   macOS: zip extracts a `CC Switch.app/` bundle containing the real
+--          binary at `Contents/MacOS/cc-switch`. We move the whole .app
+--          into install_dir and expose the inner binary via a symlink so
+--          xvm's bindir model still works.
+--   Windows: zip drops `cc-switch.exe` + `portable.ini` at the top level
+--            of the extraction dir; we just lift `cc-switch.exe` out.
+function install()
+    os.tryrm(pkginfo.install_dir())
+    os.mkdir(pkginfo.install_dir())
+
+    local download_dir = path.directory(pkginfo.install_file())
+
+    if is_host("windows") then
+        os.mv(path.join(download_dir, "cc-switch.exe"),
+              path.join(pkginfo.install_dir(), "cc-switch.exe"))
+    elseif is_host("macosx") then
+        local app_src = path.join(download_dir, "CC Switch.app")
+        local app_dst = path.join(pkginfo.install_dir(), "CC Switch.app")
+        os.mv(app_src, app_dst)
+        -- Symlink so xvm's bindir model keeps working with the bundle.
+        os.ln(path.join(app_dst, "Contents", "MacOS", "cc-switch"),
+              path.join(pkginfo.install_dir(), "cc-switch"))
+    else
+        os.mv(pkginfo.install_file(),
+              path.join(pkginfo.install_dir(), "cc-switch"))
+        os.exec("chmod +x " .. path.join(pkginfo.install_dir(), "cc-switch"))
+    end
+
+    return true
+end
+
+function config()
+    xvm.add("cc-switch", { bindir = pkginfo.install_dir() })
+    return true
+end
+
+function uninstall()
+    xvm.remove("cc-switch")
+    return true
+end


### PR DESCRIPTION
## Summary
Two community tools in the Claude Code / AI-agent ecosystem.

### `pkgs/c/cc-connect.lua` — [chenhg5/cc-connect](https://github.com/chenhg5/cc-connect) (~6k ★, Go CLI)
Bridges local AI coding agents (Claude Code, Codex, Cursor, Gemini CLI, …) to messaging platforms (Feishu/Lark, Slack, Telegram, DingTalk, Discord, …). Useful companion to `claude-feishu` and similar agents.
- Single-binary release on all 3 platforms (`cc-connect-v<ver>-<os>-<arch>` at the archive top level).
- `install()` renames the build-triple-tagged file to a clean `cc-connect` (or `.exe`) so callers don't have to know the triple.
- Pinned at **v1.3.2**.
- Opted in to `url_template` auto-update on every platform.

### `pkgs/c/cc-switch.lua` — [farion1231/cc-switch](https://github.com/farion1231/cc-switch) (~51k ★, Tauri desktop)
Cross-platform GUI for switching providers across Claude Code / Codex / OpenCode / Gemini CLI / openclaw.
- Asymmetric packaging — each platform's release shape is different:
  - **Linux:** the AppImage *is* the single binary; we just rename and `chmod +x`.
  - **macOS:** zip contains a `CC Switch.app` bundle; we move the whole bundle into `install_dir` and symlink the inner `Contents/MacOS/cc-switch` so `xvm`'s bindir model still works.
  - **Windows:** Portable.zip drops `cc-switch.exe` + `portable.ini` at the top level — we lift just the `.exe`.
- Type `app` rather than `package` to flag the GUI nature (matches the `pkgs/c/code.lua` precedent).
- Pinned at **v3.14.1**.
- Opted in to `url_template` auto-update on every platform.

## Test plan
- [x] `pytest -m "static or isolation"` — passes locally
- [x] `xlings install cc-connect` → installs cleanly; `cc-connect --version` prints `cc-connect v1.3.2`; uninstall + reinstall idempotent
- [x] `xlings install cc-switch` → installs cleanly; the AppImage launches (DB migration logs print before the GUI fails on a headless box, confirming the binary is reached); uninstall + reinstall idempotent
- [ ] CI: `xpkg test` (static + isolation) green on this PR
- [ ] CI: `pkgindex test` (linux + windows install run) green on this PR