### PR TITLE
fix(ci): only flag leftover shims that the package itself owns

### DIFF
--- a/.github/scripts/posix-test.sh
+++ b/.github/scripts/posix-test.sh
@@ -190,7 +190,25 @@ for rel_file in "${files[@]}"; do
 
     step "[$pkg] post-uninstall checks"
     shims_final=$(shim_set)
-    leftover=$(comm -12 <(printf '%s\n' "$new_shims") <(printf '%s\n' "$shims_final"))
+    survived=$(comm -12 <(printf '%s\n' "$new_shims") <(printf '%s\n' "$shims_final"))
+
+    # Only flag survivals that are owned by this package — i.e. shims
+    # whose name appears in the package's `programs` list. Shims that
+    # arrived as a side effect of installing the package's `deps` are
+    # the deps' own lifecycle (they remain installed even when this
+    # package goes away) and are not a leak.
+    leftover=""
+    if [[ -n "$survived" && -n "$programs" ]]; then
+        for shim in $survived; do
+            for prog in $programs; do
+                if [[ "$shim" == "$prog" ]]; then
+                    leftover="${leftover}${leftover:+ }${shim}"
+                    break
+                fi
+            done
+        done
+    fi
+
     if [[ -n "$leftover" ]]; then
         log_fail "shims still present after uninstall: $leftover"
         failures+=("$rel_file (leftover-shim)")

--- a/.github/scripts/windows-test.ps1
+++ b/.github/scripts/windows-test.ps1
@@ -185,7 +185,20 @@ foreach ($relFile in $files) {
     # --- post-uninstall checks ---
     Log-Step "[$pkg] post-uninstall checks"
     $shimsFinal = Get-ShimSet
-    $leftover = $newShims | Where-Object { $shimsFinal.ContainsKey($_) }
+    $survived = $newShims | Where-Object { $shimsFinal.ContainsKey($_) }
+
+    # Only flag survivals that are owned by this package — i.e. shims
+    # whose name appears in the package's `programs` list. Shims that
+    # arrived as a side effect of installing the package's `deps` are
+    # the deps' own lifecycle (they remain installed even when this
+    # package goes away) and are not a leak.
+    $leftover = @()
+    if ($survived -and $meta.programs -and $meta.programs.Count -gt 0) {
+        $progSet = @{}
+        foreach ($prog in $meta.programs) { $progSet[$prog] = $true }
+        $leftover = $survived | Where-Object { $progSet.ContainsKey($_) }
+    }
+
     if ($leftover -and $leftover.Count -gt 0) {
         Log-Fail "shims still present after uninstall: $($leftover -join ',')"
         $failures += "$relFile (leftover-shim)"

--- a/pkgs/s/sing-box-helper.lua
+++ b/pkgs/s/sing-box-helper.lua
@@ -15,16 +15,9 @@ package = {
     -- config-generation commands (server/client/import) work on any
     -- POSIX shell, but it isn't worth fanning out the platform table
     -- until someone asks for non-Linux deployment.
-    --
-    -- sing-box is a soft requirement (sing_box_bin() prints a friendly
-    -- error and aborts the command if it's missing), and intentionally
-    -- not declared as `deps = { "sing-box" }` here: declaring it would
-    -- make the CI install/uninstall harness flag the dep's shim as a
-    -- "leftover shim" after this package is uninstalled, which is a
-    -- limitation of the harness rather than a real leak. Until that's
-    -- fixed, install sing-box yourself first:  xlings install sing-box
     xpm = {
         linux = {
+            deps = {"sing-box"},
             ["1.0.0"] = {},
         },
     },
@@ -39,10 +32,10 @@ import("xim.libxpkg.json")
 local SYSTEMD_SERVICE = "sing-box.service"
 local SYSTEMD_UNIT_PATH = "/etc/systemd/system/" .. SYSTEMD_SERVICE
 
--- Resolve the installed sing-box binary at call time. The package no
--- longer declares sing-box as a hard dep (see the xpm comment for the
--- CI rationale), so callers MUST treat a nil return as "user hasn't
--- installed sing-box yet" and bail out with the printed hint.
+-- Resolve the installed sing-box binary at call time. The dependency
+-- declaration in `xpm.linux.deps` guarantees it is registered with xvm
+-- before any sing-box-helper command runs, but we still treat a nil
+-- info as "not yet wired up" and bail with a friendly hint.
 local function sing_box_bin()
     local info = xvm.info("sing-box")
     if not info or not info.SPath or info.SPath == "" then


### PR DESCRIPTION
## Why
Follow-up to #75. That PR shipped sing-box-helper with `deps = { "sing-box" }` removed because the install/uninstall test harness was misattributing the dep's shim as a "leftover shim" for the helper, failing the linux job. Dropping `deps` made CI green but turned `xlings install sing-box-helper` into a two-step process for users, which is a real UX regression — `deps` exists precisely so install is one command. This PR fixes the harness instead and restores the dep declaration.

## What
`posix-test.sh` and `windows-test.ps1` snapshot the shim set before install, again after install, and treat the difference as "shims this package created". After uninstall, any of those that survive are flagged as a `(leftover-shim)` failure.

That rule is too strict once a package declares `deps`. Installing the package legitimately auto-installs its deps, which create their own shims; those dep shims SHOULD survive when the dependent is uninstalled — they manage their own lifecycle.

The fix: filter the leftover check by the package's own `programs` list.

- A shim that survived uninstall **and** is named in this package's `programs` is a real leak — fail.
- A shim that survived but is **not** one of this package's `programs` came from a dep — leave it alone.

For type=script packages with `programs = []` (like sing-box-helper) the filter reduces to "never fail on leftovers", which is correct: script packages don't own any shim of their own.

Files touched:
- `.github/scripts/posix-test.sh` — bash filter via nested for loops.
- `.github/scripts/windows-test.ps1` — same shape using a hashset of programs.
- `pkgs/s/sing-box-helper.lua` — restored `deps = { "sing-box" }`; updated the `sing_box_bin()` comment to reflect the dep is back.

## Test plan
- [x] Reproduce the original failure: in a clean isolated `XLINGS_HOME`, run `posix-test.sh "pkgs/s/sing-box-helper.lua" $REPO linux` against the unfixed harness — fails on `(leftover-shim)` for `sing-box`.
- [x] With the patch + restored `deps`, the same run prints `[PASS] all shims cleaned` and exits 0.
- [x] `xlings install sing-box-helper` once again auto-pulls `sing-box` (`2 package(s) installed`).
- [ ] CI green on this PR (xpkg test + pkgindex test).