### PR TITLE
feat(updater): opt 8 GitHub-direct packages into url_template

### DIFF
--- a/pkgs/b/bat.lua
+++ b/pkgs/b/bat.lua
@@ -20,6 +20,7 @@ package = {
 
     xpm = {
         linux = {
+            url_template = "https://github.com/sharkdp/bat/releases/download/v{version}/bat-v{version}-x86_64-unknown-linux-musl.tar.gz",
             ["latest"] = { ref = "0.26.1" },
             ["0.26.1"] = {
                 url = "https://github.com/sharkdp/bat/releases/download/v0.26.1/bat-v0.26.1-x86_64-unknown-linux-musl.tar.gz",
@@ -27,6 +28,7 @@ package = {
             },
         },
         macosx = {
+            url_template = "https://github.com/sharkdp/bat/releases/download/v{version}/bat-v{version}-aarch64-apple-darwin.tar.gz",
             ["latest"] = { ref = "0.26.1" },
             ["0.26.1"] = {
                 url = "https://github.com/sharkdp/bat/releases/download/v0.26.1/bat-v0.26.1-aarch64-apple-darwin.tar.gz",
@@ -34,6 +36,7 @@ package = {
             },
         },
         windows = {
+            url_template = "https://github.com/sharkdp/bat/releases/download/v{version}/bat-v{version}-x86_64-pc-windows-msvc.zip",
             ["latest"] = { ref = "0.26.1" },
             ["0.26.1"] = {
                 url = "https://github.com/sharkdp/bat/releases/download/v0.26.1/bat-v0.26.1-x86_64-pc-windows-msvc.zip",

--- a/pkgs/f/fd.lua
+++ b/pkgs/f/fd.lua
@@ -20,6 +20,7 @@ package = {
 
     xpm = {
         linux = {
+            url_template = "https://github.com/sharkdp/fd/releases/download/v{version}/fd-v{version}-x86_64-unknown-linux-musl.tar.gz",
             ["latest"] = { ref = "10.4.2" },
             ["10.4.2"] = {
                 url = "https://github.com/sharkdp/fd/releases/download/v10.4.2/fd-v10.4.2-x86_64-unknown-linux-musl.tar.gz",
@@ -27,6 +28,7 @@ package = {
             },
         },
         macosx = {
+            url_template = "https://github.com/sharkdp/fd/releases/download/v{version}/fd-v{version}-aarch64-apple-darwin.tar.gz",
             ["latest"] = { ref = "10.4.2" },
             ["10.4.2"] = {
                 url = "https://github.com/sharkdp/fd/releases/download/v10.4.2/fd-v10.4.2-aarch64-apple-darwin.tar.gz",
@@ -34,6 +36,7 @@ package = {
             },
         },
         windows = {
+            url_template = "https://github.com/sharkdp/fd/releases/download/v{version}/fd-v{version}-x86_64-pc-windows-msvc.zip",
             ["latest"] = { ref = "10.4.2" },
             ["10.4.2"] = {
                 url = "https://github.com/sharkdp/fd/releases/download/v10.4.2/fd-v10.4.2-x86_64-pc-windows-msvc.zip",

--- a/pkgs/f/fzf.lua
+++ b/pkgs/f/fzf.lua
@@ -20,6 +20,7 @@ package = {
 
     xpm = {
         linux = {
+            url_template = "https://github.com/junegunn/fzf/releases/download/v{version}/fzf-{version}-linux_amd64.tar.gz",
             ["latest"] = { ref = "0.71.0" },
             ["0.71.0"] = {
                 url = "https://github.com/junegunn/fzf/releases/download/v0.71.0/fzf-0.71.0-linux_amd64.tar.gz",
@@ -27,6 +28,7 @@ package = {
             },
         },
         macosx = {
+            url_template = "https://github.com/junegunn/fzf/releases/download/v{version}/fzf-{version}-darwin_arm64.tar.gz",
             ["latest"] = { ref = "0.71.0" },
             ["0.71.0"] = {
                 url = "https://github.com/junegunn/fzf/releases/download/v0.71.0/fzf-0.71.0-darwin_arm64.tar.gz",
@@ -34,6 +36,7 @@ package = {
             },
         },
         windows = {
+            url_template = "https://github.com/junegunn/fzf/releases/download/v{version}/fzf-{version}-windows_amd64.zip",
             ["latest"] = { ref = "0.71.0" },
             ["0.71.0"] = {
                 url = "https://github.com/junegunn/fzf/releases/download/v0.71.0/fzf-0.71.0-windows_amd64.zip",

--- a/pkgs/g/github-gh.lua
+++ b/pkgs/g/github-gh.lua
@@ -22,6 +22,7 @@ package = {
 
     xpm = {
         linux = {
+            url_template = "https://github.com/cli/cli/releases/download/v{version}/gh_{version}_linux_amd64.tar.gz",
             ["latest"] = { ref = "2.86.0" },
             ["2.86.0"] = {
                 url = "https://github.com/cli/cli/releases/download/v2.86.0/gh_2.86.0_linux_amd64.tar.gz",
@@ -30,6 +31,7 @@ package = {
             -- ["2.86.0"] = "XLINGS_RES",
         },
         macosx = {
+            url_template = "https://github.com/cli/cli/releases/download/v{version}/gh_{version}_macOS_amd64.zip",
             ["latest"] = { ref = "2.86.0" },
             ["2.86.0"] = {
                 url = "https://github.com/cli/cli/releases/download/v2.86.0/gh_2.86.0_macOS_amd64.zip",
@@ -38,6 +40,7 @@ package = {
             -- ["2.86.0"] = "XLINGS_RES",
         },
         windows = {
+            url_template = "https://github.com/cli/cli/releases/download/v{version}/gh_{version}_windows_amd64.zip",
             ["latest"] = { ref = "2.86.0" },
             ["2.86.0"] = {
                 url = "https://github.com/cli/cli/releases/download/v2.86.0/gh_2.86.0_windows_amd64.zip",

--- a/pkgs/g/griddycode.lua
+++ b/pkgs/g/griddycode.lua
@@ -23,10 +23,12 @@ package = {
 
     xpm = {
         linux = {
+            url_template = "https://github.com/face-hh/griddycode/releases/download/v{version}/Linux.zip",
             ["latest"] = { ref = "1.2.2" },
             ["1.2.2"] = { url = "https://github.com/face-hh/griddycode/releases/download/v1.2.2/Linux.zip" },
         },
         windows = {
+            url_template = "https://github.com/face-hh/griddycode/releases/download/v{version}/Windows.zip",
             ["latest"] = { ref = "1.2.2" },
             ["1.2.2"] = { url = "https://github.com/face-hh/griddycode/releases/download/v1.2.2/Windows.zip" },
         },

--- a/pkgs/n/nvim.lua
+++ b/pkgs/n/nvim.lua
@@ -23,6 +23,7 @@ package = {
 
     xpm = {
         linux = {
+            url_template = "https://github.com/neovim/neovim/releases/download/v{version}/nvim-linux-x86_64.tar.gz",
             ["latest"] = { ref = "0.11.5" },
             ["0.11.5"] = {
                 url = "https://github.com/neovim/neovim/releases/download/v0.11.5/nvim-linux-x86_64.tar.gz",
@@ -30,6 +31,7 @@ package = {
             }
         },
         windows = {
+            url_template = "https://github.com/neovim/neovim/releases/download/v{version}/nvim-win64.zip",
             ["latest"] = { ref = "0.11.5" },
             ["0.11.5"] = {
                 url = "https://github.com/neovim/neovim/releases/download/v0.11.5/nvim-win64.zip",

--- a/pkgs/r/ripgrep.lua
+++ b/pkgs/r/ripgrep.lua
@@ -20,6 +20,7 @@ package = {
 
     xpm = {
         linux = {
+            url_template = "https://github.com/BurntSushi/ripgrep/releases/download/{version}/ripgrep-{version}-x86_64-unknown-linux-musl.tar.gz",
             ["latest"] = { ref = "15.1.0" },
             ["15.1.0"] = {
                 url = "https://github.com/BurntSushi/ripgrep/releases/download/15.1.0/ripgrep-15.1.0-x86_64-unknown-linux-musl.tar.gz",
@@ -27,6 +28,7 @@ package = {
             },
         },
         macosx = {
+            url_template = "https://github.com/BurntSushi/ripgrep/releases/download/{version}/ripgrep-{version}-aarch64-apple-darwin.tar.gz",
             ["latest"] = { ref = "15.1.0" },
             ["15.1.0"] = {
                 url = "https://github.com/BurntSushi/ripgrep/releases/download/15.1.0/ripgrep-15.1.0-aarch64-apple-darwin.tar.gz",
@@ -34,6 +36,7 @@ package = {
             },
         },
         windows = {
+            url_template = "https://github.com/BurntSushi/ripgrep/releases/download/{version}/ripgrep-{version}-x86_64-pc-windows-msvc.zip",
             ["latest"] = { ref = "15.1.0" },
             ["15.1.0"] = {
                 url = "https://github.com/BurntSushi/ripgrep/releases/download/15.1.0/ripgrep-15.1.0-x86_64-pc-windows-msvc.zip",

--- a/pkgs/x/xmake.lua
+++ b/pkgs/x/xmake.lua
@@ -22,6 +22,7 @@ package = {
 
     xpm = {
         linux = {
+            url_template = "https://github.com/xmake-io/xmake/releases/download/v{version}/xmake-bundle-v{version}.linux.x86_64",
             ["latest"] = { ref = "3.0.7" },
             ["3.0.7"] = {
                 url = "https://github.com/xmake-io/xmake/releases/download/v3.0.7/xmake-bundle-v3.0.7.linux.x86_64",
@@ -30,6 +31,7 @@ package = {
             -- ["3.0.7"] = "XLINGS_RES",
         },
         macosx = {
+            url_template = "https://github.com/xmake-io/xmake/releases/download/v{version}/xmake-bundle-v{version}.macos.arm64",
             ["latest"] = { ref = "3.0.7" },
             ["3.0.7"] = {
                 url = "https://github.com/xmake-io/xmake/releases/download/v3.0.7/xmake-bundle-v3.0.7.macos.arm64",
@@ -38,6 +40,7 @@ package = {
             -- ["3.0.7"] = "XLINGS_RES",
         },
         windows = {
+            url_template = "https://github.com/xmake-io/xmake/releases/download/v{version}/xmake-bundle-v{version}.win64.exe",
             ["latest"] = { ref = "3.0.7" },
             ["3.0.7"] = {
                 url = "https://github.com/xmake-io/xmake/releases/download/v3.0.7/xmake-bundle-v3.0.7.win64.exe",


### PR DESCRIPTION
## Summary
Adds the per-platform `url_template` opt-in marker to every package whose existing release URLs already point at GitHub Releases with a clean `{version}` substitution pattern. Each touched file gets one line per platform; nothing else changes.

After this lands, the `version-bump` workflow has **13 packages on its auto-bump radar** (was 5), and the next scheduled run will produce auto-PRs for whichever upstreams have moved ahead.

### Opted in (8 packages)

| Package | Repo | Platforms |
|---|---|---|
| `bat` | sharkdp/bat | linux + macosx + windows |
| `fd` | sharkdp/fd | linux + macosx + windows |
| `fzf` | junegunn/fzf | linux + macosx + windows |
| `github-gh` | cli/cli | linux + macosx + windows |
| `griddycode` | face-hh/griddycode | linux + windows |
| `nvim` | neovim/neovim | linux + windows |
| `ripgrep` | BurntSushi/ripgrep | linux + macosx + windows |
| `xmake` | xmake-io/xmake | linux + macosx + windows |

### Local dry-run (`.github/scripts/version-check.py`)

```
scanned: 76, opted-in: 13, up-to-date: 10, update-available: 3, errors: 0
```

`update-available` (these will get auto-bump PRs from version-bump on next run):
- `github-gh` 2.86.0 → 2.91.0
- `nvim` 0.11.5 → 0.12.2
- `xmake` 3.0.7 → 3.0.8

### Considered but skipped (intentional)

- **ollama** — pkg-internal TODO pins to v0.13.x because v0.14.0+ ships `.tar.zst`, which xlings's auto-extract doesn't yet handle. Auto-update would walk past the safe range.
- **jq** — upstream tag format is `jq-X.Y.Z`, not `vX.Y.Z`. The spec only strips a leading `v`.
- **khistory** — tag has a `pre-` prefix (`pre-v0.0.5`).
- **sourcetrail** — filename uses `2021_4_19` (underscores) but the version ref uses `2021.4.19` (dots); plain `{version}` substitution can't bridge that.
- **project-graph** — linux is on a 1.7.10 manual track, windows is at 1.2.7, and upstream is at 2.12.2 — a major-version cross that wants human review, not an auto-bump.
- **xlings** itself — xpm version blocks use the `"XLINGS_RES"` placeholder (xlings mirror), not direct GitHub URLs; opting in needs separate work to switch to GitHub-release URLs first.

## Test plan
- [x] `pytest -m "static or isolation"` — 491 passed
- [x] `version-check.py --workspace .` — 13 opted-in, 10 up-to-date, 3 update-available, 0 errors
- [ ] CI green on this PR