### PR TITLE
trendradar: add 6.6.1 package

### DIFF
--- a/pkgs/t/trendradar.lua
+++ b/pkgs/t/trendradar.lua
@@ -28,7 +28,6 @@ package = {
             },
         },
         macosx = {
-            deps = {"python"},
             ["latest"] = { ref = "6.6.1" },
             ["6.6.1"] = {
                 url = "https://github.com/sansan0/TrendRadar/archive/refs/tags/v6.6.1.tar.gz",

--- a/pkgs/t/trendradar.lua
+++ b/pkgs/t/trendradar.lua
@@ -1,0 +1,138 @@
+package = {
+    spec = "1",
+
+    name = "trendradar",
+    description = "AI-driven public opinion and trend monitor with multi-platform aggregation, RSS, and smart alerts",
+    homepage = "https://sansan0.github.io/TrendRadar/",
+    maintainers = {"sansan0"},
+    licenses = {"GPL-3.0"},
+    repo = "https://github.com/sansan0/TrendRadar",
+    docs = "https://github.com/sansan0/TrendRadar#readme",
+
+    type = "package",
+    archs = {"x86_64", "aarch64"},
+    status = "stable",
+    categories = {"ai", "rss", "news", "monitoring"},
+    keywords = {"trendradar", "trend", "hot-news", "rss", "mcp", "ai", "alerts"},
+
+    programs = {"trendradar", "trendradar-mcp"},
+    xvm_enable = true,
+
+    xpm = {
+        linux = {
+            deps = {"python"},
+            ["latest"] = { ref = "6.6.1" },
+            ["6.6.1"] = {
+                url = "https://github.com/sansan0/TrendRadar/archive/refs/tags/v6.6.1.tar.gz",
+                sha256 = "1e7ffcfdb6fca901a0de61fb20e2d27375cb00511ffb5cb88a07206a9141b8f5",
+            },
+        },
+        macosx = {
+            deps = {"python"},
+            ["latest"] = { ref = "6.6.1" },
+            ["6.6.1"] = {
+                url = "https://github.com/sansan0/TrendRadar/archive/refs/tags/v6.6.1.tar.gz",
+                sha256 = "1e7ffcfdb6fca901a0de61fb20e2d27375cb00511ffb5cb88a07206a9141b8f5",
+            },
+        },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.system")
+import("xim.libxpkg.xvm")
+
+function __source_dir()
+    return path.join(pkginfo.install_dir(), "source")
+end
+
+function __venv_dir()
+    return path.join(pkginfo.install_dir(), "venv")
+end
+
+function __venv_bindir()
+    return path.join(__venv_dir(), "bin")
+end
+
+function __archive_source_dir()
+    local archive = pkginfo.install_file()
+    return path.join(path.directory(archive), "TrendRadar-" .. pkginfo.version())
+end
+
+function __subos_bindir()
+    local xlings_home = os.getenv("XLINGS_HOME") or path.join(os.getenv("HOME"), ".xlings")
+    return path.join(xlings_home, "subos", "default", "bin")
+end
+
+function __write_wrapper(name)
+    local wrapper = path.join(pkginfo.install_dir(), "bin", name)
+    local target = path.join(__venv_bindir(), name)
+    local script = string.format([[#!/usr/bin/env bash
+cd "%s" || exit $?
+exec "%s" "$@"
+]], __source_dir(), target)
+    io.writefile(wrapper, script)
+    system.exec(string.format([[chmod +x "%s"]], wrapper))
+end
+
+function __write_subos_shim(name)
+    local shim = path.join(__subos_bindir(), name)
+    local target = path.join(pkginfo.install_dir(), "bin", name)
+    os.mkdir(__subos_bindir())
+    os.tryrm(shim)
+    system.exec(string.format([[ln -s "%s" "%s"]], target, shim))
+end
+
+function __remove_subos_shim(name)
+    os.tryrm(path.join(__subos_bindir(), name))
+end
+
+function __xvm_add()
+    local bindir = path.join(pkginfo.install_dir(), "bin")
+    xvm.add("trendradar", {
+        bindir = bindir,
+        alias = "trendradar",
+    })
+    xvm.add("trendradar-mcp", {
+        bindir = bindir,
+        alias = "trendradar-mcp",
+        binding = "trendradar@" .. pkginfo.version(),
+    })
+end
+
+function install()
+    os.tryrm(pkginfo.install_dir())
+    os.mkdir(pkginfo.install_dir())
+
+    os.cp(__archive_source_dir(), __source_dir(), {
+        symlink = true,
+        verbose = true,
+    })
+
+    system.exec(string.format([[python3 -m venv "%s"]], __venv_dir()))
+    local venv_pip = path.join(__venv_bindir(), "pip")
+    system.exec(string.format([["%s" install --upgrade pip]], venv_pip))
+    system.exec(string.format([["%s" install "%s"]], venv_pip, __source_dir()))
+
+    os.mkdir(path.join(pkginfo.install_dir(), "bin"))
+    __write_wrapper("trendradar")
+    __write_wrapper("trendradar-mcp")
+
+    __xvm_add()
+    __write_subos_shim("trendradar")
+    __write_subos_shim("trendradar-mcp")
+    return true
+end
+
+function config()
+    __xvm_add()
+    return true
+end
+
+function uninstall()
+    xvm.remove("trendradar")
+    xvm.remove("trendradar-mcp")
+    __remove_subos_shim("trendradar")
+    __remove_subos_shim("trendradar-mcp")
+    return true
+end

--- a/tests/t/test_trendradar.py
+++ b/tests/t/test_trendradar.py
@@ -1,0 +1,80 @@
+"""测试 trendradar 包"""
+import pytest
+from tests.lib.xpkg_parser import parse_xpkg
+from tests.lib.assertions import (
+    assert_required_fields, assert_valid_spec, assert_valid_type,
+    assert_no_typos, assert_no_exec_xvm, assert_no_bashrc_modification,
+    assert_no_direct_path_modification, assert_uses_new_api,
+    assert_xim_add_succeeds, assert_install_succeeds,
+    assert_command_output, assert_xvm_registered,
+)
+from tests.lib.platform_utils import skip_if_not
+
+PKG = "trendradar"
+PKG_FILE = "pkgs/t/trendradar.lua"
+
+
+@pytest.fixture(scope='module')
+def meta():
+    return parse_xpkg(PKG_FILE)
+
+
+class TestStatic:
+    @pytest.mark.static
+    def test_required_fields(self, meta):
+        assert_required_fields(meta)
+
+    @pytest.mark.static
+    def test_valid_spec(self, meta):
+        assert_valid_spec(meta)
+
+    @pytest.mark.static
+    def test_valid_type(self, meta):
+        assert_valid_type(meta)
+
+    @pytest.mark.static
+    def test_no_typos(self):
+        assert_no_typos(PKG_FILE)
+
+
+class TestIndex:
+    @pytest.mark.index
+    def test_xim_add(self):
+        assert_xim_add_succeeds(PKG_FILE)
+
+
+class TestIsolation:
+    @pytest.mark.isolation
+    def test_no_exec_xvm(self):
+        assert_no_exec_xvm(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_no_bashrc(self):
+        assert_no_bashrc_modification(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_no_path_modification(self):
+        assert_no_direct_path_modification(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_new_api(self):
+        assert_uses_new_api(PKG_FILE)
+
+
+class TestLifecycle:
+    @pytest.mark.lifecycle
+    @skip_if_not('linux')
+    def test_install(self):
+        assert_install_succeeds(PKG, timeout=600)
+
+
+class TestVerify:
+    @pytest.mark.verify
+    @skip_if_not('linux')
+    def test_trendradar_help(self):
+        assert_command_output("trendradar --help", contains="TrendRadar")
+
+    @pytest.mark.verify
+    @skip_if_not('linux')
+    def test_xvm_trendradar(self):
+        assert_xvm_registered("trendradar")


### PR DESCRIPTION
## Summary
- add TrendRadar 6.6.1 package for Linux/macOS from sansan0/TrendRadar
- install from the v6.6.1 source archive into an isolated Python venv
- expose trendradar and trendradar-mcp wrappers and clean shims on removal
- add static/index/isolation/lifecycle tests

## Local validation
- pytest tests/t/test_trendradar.py -m "static or isolation" -q
- pytest tests/t/test_trendradar.py -m index -q
- .github/scripts/posix-test.sh "pkgs/t/trendradar.lua" ... linux in isolated XLINGS_HOME
- isolated manual install/help/remove: trendradar --help and shim cleanup