### PR TITLE
feat(xlings): add 0.4.5 entry alongside 0.4.6

### DIFF
--- a/pkgs/x/xlings.lua
+++ b/pkgs/x/xlings.lua
@@ -34,6 +34,10 @@ package = {
                 url = "https://github.com/d2learn/xlings/releases/download/v0.4.6/xlings-0.4.6-linux-x86_64.tar.gz",
                 sha256 = "b7a61b944f784f0865b1874085f1840432b5a5b0f2b994983ab654ddabde5f9c",
             },
+            ["0.4.5"] = {
+                url = "https://github.com/d2learn/xlings/releases/download/v0.4.5/xlings-0.4.5-linux-x86_64.tar.gz",
+                sha256 = "2c1e1605376f0e427adbc0b070250af8843a000e1cb575be81265a7d742d75af",
+            },
             ["0.4.4"] = {
                 url = "https://github.com/d2learn/xlings/releases/download/v0.4.4/xlings-0.4.4-linux-x86_64.tar.gz",
                 sha256 = "bea197fe019dacc7062b54994aaa3d77ae92376eb60220d729d2f8e1de8361a6",
@@ -47,6 +51,10 @@ package = {
                 url = "https://github.com/d2learn/xlings/releases/download/v0.4.6/xlings-0.4.6-macosx-arm64.tar.gz",
                 sha256 = "c8e653da23a2c56f508b53c4c60066db5cc13b3e45a5897a17630e3d188f76e2",
             },
+            ["0.4.5"] = {
+                url = "https://github.com/d2learn/xlings/releases/download/v0.4.5/xlings-0.4.5-macosx-arm64.tar.gz",
+                sha256 = "dd4995cb951c1c45e145b05a57406676590948469a367fd15ce51f2ee7f5e574",
+            },
             ["0.4.4"] = {
                 url = "https://github.com/d2learn/xlings/releases/download/v0.4.4/xlings-0.4.4-macosx-arm64.tar.gz",
                 sha256 = "7051d331451e3f1ce9c9a8f35f4e4f14fd96b30912bcc944d46333ca9b6b0b7d",
@@ -59,6 +67,10 @@ package = {
             ["0.4.6"] = {
                 url = "https://github.com/d2learn/xlings/releases/download/v0.4.6/xlings-0.4.6-windows-x86_64.zip",
                 sha256 = "ed20e4bf2f0b6e4a3c981e87d1c65cec60483350b17e7c5c0f57f1e497aaa8f7",
+            },
+            ["0.4.5"] = {
+                url = "https://github.com/d2learn/xlings/releases/download/v0.4.5/xlings-0.4.5-windows-x86_64.zip",
+                sha256 = "46a62c229a6b729663e9068782f9ac9ea3b50ad193f8cdb159d90f1c43055d78",
             },
             ["0.4.4"] = {
                 url = "https://github.com/d2learn/xlings/releases/download/v0.4.4/xlings-0.4.4-windows-x86_64.zip",


### PR DESCRIPTION
## Summary
Backfill the `0.4.5` release that was skipped when #89 added `0.4.6`. After this PR, `xlings install xlings@0.4.5` resolves on all three platforms; `latest` stays on `0.4.6`.

| platform | url | sha256 |
| --- | --- | --- |
| linux x86_64    | `…/v0.4.5/xlings-0.4.5-linux-x86_64.tar.gz` | `2c1e1605376f0e427adbc0b070250af8843a000e1cb575be81265a7d742d75af` |
| macosx arm64    | `…/v0.4.5/xlings-0.4.5-macosx-arm64.tar.gz` | `dd4995cb951c1c45e145b05a57406676590948469a367fd15ce51f2ee7f5e574` |
| windows x86_64  | `…/v0.4.5/xlings-0.4.5-windows-x86_64.zip`  | `46a62c229a6b729663e9068782f9ac9ea3b50ad193f8cdb159d90f1c43055d78` |

sha256 values taken from GitHub's published release asset digests.

Same shape as the 0.4.6 entries already on main (#89): direct GitHub release URLs, no XLINGS_RES mirror dependency. No code changes — pure data add.

## Test plan
- [ ] CI `linux-test` / `linux-install-test` / `macos-install-test` / `windows-test` stay green
- [ ] `index-registration` / `static-and-isolation` stay green