### PR TITLE
feat(make): add GNU Make 4.3 xpkg (musl-static, XLINGS_RES mirror)

### DIFF
--- a/pkgs/m/make.lua
+++ b/pkgs/m/make.lua
@@ -1,0 +1,58 @@
+package = {
+    spec = "1",
+    homepage = "https://www.gnu.org/software/make",
+    -- base info
+    name = "make",
+    description = "GNU Make — tool which controls the generation of executables from source files",
+
+    authors = {"GNU"},
+    licenses = {"GPL-3.0+"},
+    repo = "https://git.savannah.gnu.org/cgit/make.git",
+    docs = "https://www.gnu.org/software/make/manual",
+
+    -- xim pkg info
+    type = "package",
+    archs = {"x86_64"},
+    status = "stable", -- dev, stable, deprecated
+    categories = {"make", "gnu", "build-system"},
+    keywords = {"make", "gnu", "makefile", "build-system"},
+
+    -- xvm: xlings version management
+    xvm_enable = true,
+
+    programs = { "make", "gmake" },
+
+    xpm = {
+        linux = {
+            ["latest"] = { ref = "4.3" },
+            ["4.3"] = "XLINGS_RES",
+        },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+
+function install()
+    -- XLINGS_RES ships a musl-static tarball (no glibc dependency, so no
+    -- elfpatch step is needed). It extracts to `make-<ver>-linux-x86_64/`.
+    local srcdir = pkginfo.install_file():replace(".tar.gz", "")
+    os.tryrm(pkginfo.install_dir())
+    os.mv(srcdir, pkginfo.install_dir())
+    return true
+end
+
+function config()
+    local bindir = path.join(pkginfo.install_dir(), "bin")
+    local root = "make@" .. pkginfo.version()
+    xvm.add("make", { bindir = bindir })
+    -- gmake is a symlink to `make` in the same bindir; tie its lifecycle to make@<ver>.
+    xvm.add("gmake", { bindir = bindir, binding = root })
+    return true
+end
+
+function uninstall()
+    xvm.remove("make")
+    xvm.remove("gmake")
+    return true
+end


### PR DESCRIPTION
## Summary
Adds `pkgs/m/make.lua` so users can `xlings install make` and get GNU Make 4.3.

## Key shape
- Backed by `xlings-res/make` mirror, **referenced as the `XLINGS_RES` magic string** (no per-version URL needed — xpkg picks GitHub or gitcode based on the user's `mirror` config; same pattern as `binutils`, `gcc`, `linux-headers`, `glibc`)
- Binary is **musl-static** (built with `musl-gcc -static`), so:
  - **zero glibc dependency** (verified: `strings | grep GLIBC_` is empty)
  - **no elfpatch step needed** in `install()` (no dynamic interpreter to rewrite)
  - 276 KB stripped binary, 318 KB tarball

## Mirror status (already done before this PR)
| | URL |
|---|---|
| GLOBAL | https://github.com/xlings-res/make/releases/tag/4.3 |
| CN | https://gitcode.com/xlings-res/make/releases/tag/4.3 |
| asset | `make-4.3-linux-x86_64.tar.gz` |
| sha256 | `2c7aa65d8369a39b5ecc55d4521a4d8065532f270535fffb6f504272fac6d5f0` (identical on both mirrors) |

## Local sandbox verification (Linux)
- `xlings config --add-xpkg pkgs/m/make.lua` ✓
- `xlings install local:make@4.3` → resolved XLINGS_RES, downloaded tarball, extracted to `data/xpkgs/<ns>-x-make/4.3/`
- `bin/make --version` → `GNU Make 4.3`  ✓
- `bin/gmake --version` → same (symlink to `make`) ✓
- `file bin/make` → `ELF ... statically linked, stripped` ✓
- xvm metadata: both `make` and `gmake` registered with bindings to `make@4.3` ✓
- `xlings remove local:make` → install dir cleanly removed ✓

(Note: real shim creation in `subos/default/bin/` requires the full xvm bootstrap which an isolated `XLINGS_HOME` lacks — the install/remove path is exercised by CI's `linux-install-test`, which uses a properly-bootstrapped xlings.)

## Why this is the first dedicated `make` xpkg in the index
Originally `make` only existed in `xim-pkgindex-fromsource` (built-from-source). `fromsource:make` had a self-cyclic dep (`make@4.3` listed itself) which blocked any install — and even after fixing the cycle, users without `make` on host couldn't bootstrap. Publishing a prebuilt `xim:make` solves both:
- Users get a one-line install
- All `fromsource` packages that need `make` for their build can now declare `xim:make@4.3` as a clean cross-namespace dep (follow-up PRs)

## Test plan
- [ ] `linux-install-test` passes (downloads via XLINGS_RES, registers shims, removes cleanly)
- [ ] `linux-test` package-file lint stays green
- [ ] `index-registration` and `static-and-isolation` stay green