### PR TITLE
fix(script-shim): create CLI shim explicitly for type=script packages

### DIFF
--- a/pkgs/c/configure-project-installer.lua
+++ b/pkgs/c/configure-project-installer.lua
@@ -16,7 +16,11 @@ package = {
 
     xpm = {
         linux = {
-            deps = { "make", "gcc", "xpkg-helper" },
+            deps = {
+                "xim:make@4.3",
+                "xim:gcc@15.1.0",
+                "xim:xpkg-helper@0.0.1",
+            },
             ["latest"] = { ref = "0.0.1" },
             ["0.0.1"] = {}
         },
@@ -27,6 +31,7 @@ package = {
 import("xim.libxpkg.log")
 import("xim.libxpkg.utils")
 import("xim.libxpkg.system")
+import("xim.libxpkg.pkginfo")
 import("xim.libxpkg.pkgmanager")
 
 local __xscript_input = {
@@ -130,4 +135,43 @@ function xpkg_main(installdir, ...)
     end
 
     log.info("✅ installed to: ${green}%s", installdir)
+end
+
+-- ─────────────────────────────────────────────────────────────────────
+-- xpkg lifecycle: create a CLI shim that runs xpkg_main via `xlings script`
+--
+-- xlings's auto-shim for type="script" packages currently registers an xvm
+-- alias pointing to the xpkgs copy of this lua, but `xlings script` only
+-- resolves scripts via the xim-pkgindex tree. So the auto-registered path
+-- is non-functional. Write the shim ourselves with the index-relative path
+-- so `system.exec("configure-project-installer ...")` works after install.
+-- ─────────────────────────────────────────────────────────────────────
+
+local function __script_path()
+    -- pkginfo.install_dir() = <data>/xpkgs/xim-x-configure-project-installer/<ver>/
+    -- walk up three levels to <data>/, then xim-pkgindex/pkgs/c/.
+    return path.join(pkginfo.install_dir(), "..", "..", "..",
+        "xim-pkgindex", "pkgs", "c", "configure-project-installer.lua")
+end
+
+local function __shim_path()
+    return path.join(system.bindir(), "configure-project-installer")
+end
+
+function install()
+    return true
+end
+
+function config()
+    local shim = __shim_path()
+    io.writefile(shim, string.format(
+        "#!/bin/sh\nexec xlings script %s \"$@\"\n", __script_path()
+    ))
+    os.exec(string.format("chmod +x %q", shim))
+    return true
+end
+
+function uninstall()
+    os.tryrm(__shim_path())
+    return true
 end

--- a/pkgs/x/xpkg-helper.lua
+++ b/pkgs/x/xpkg-helper.lua
@@ -15,6 +15,8 @@ package = {
     categories = {"tools", "xpkg", "helper" },
     keywords = {"xpackage", "helper", "xscript"},
 
+    programs = { "xpkg-helper" },
+
     xpm = {
         windows = { ["0.0.1"] = { } },
         linux = { ["0.0.1"] = { } },
@@ -26,6 +28,7 @@ import("xim.libxpkg.log")
 import("xim.libxpkg.xvm")
 import("xim.libxpkg.system")
 import("xim.libxpkg.utils")
+import("xim.libxpkg.pkginfo")
 
 local __xscript_input = {
     ["--export-path"] = false,
@@ -118,4 +121,36 @@ function xpkg_main(xpkgname, ...)
         "${bright}%s${clear} | ${yellow}%s${clear} - ${green}ok",
         pkgname, cmds["--export-path"]
     )
+end
+
+-- ─────────────────────────────────────────────────────────────────────
+-- xpkg lifecycle: create a CLI shim that runs xpkg_main via `xlings script`
+-- (same workaround as configure-project-installer.lua — see comment there)
+-- ─────────────────────────────────────────────────────────────────────
+
+local function __script_path()
+    return path.join(pkginfo.install_dir(), "..", "..", "..",
+        "xim-pkgindex", "pkgs", "x", "xpkg-helper.lua")
+end
+
+local function __shim_path()
+    return path.join(system.bindir(), "xpkg-helper")
+end
+
+function install()
+    return true
+end
+
+function config()
+    local shim = __shim_path()
+    io.writefile(shim, string.format(
+        "#!/bin/sh\nexec xlings script %s \"$@\"\n", __script_path()
+    ))
+    os.exec(string.format("chmod +x %q", shim))
+    return true
+end
+
+function uninstall()
+    os.tryrm(__shim_path())
+    return true
 end


### PR DESCRIPTION
## Problem

When you `xlings install xim:configure-project-installer@0.0.1` (or `xim:xpkg-helper@0.0.1`) with the current xlings 0.4.x, the install **silently fails to write a CLI shim** to `subos/default/bin/`. The xvm metadata gets an alias entry, but no executable file appears on PATH — so any consumer that does `system.exec("configure-project-installer ...")` crashes with `command not found`.

This is what's been blocking the entire `xim-pkgindex-fromsource` build pipeline since the V1 spec migration: 9 fromsource packages (zlib, xz-utils, libffi, ncurses, util-linux, automake, openssl, python, readline) all rely on `configure-project-installer` being on PATH.

## Root cause

xlings's auto-shim handler for `type = "script"` registers an xvm alias of the form:
```
xlings script <xpkgs install-dir>/<name>.lua
```
But `xlings script` rejects that path — it only resolves scripts that live at `<xim-pkgindex>/pkgs/<dir>/<name>.lua`. So even when `system.exec` finds the shim (which it doesn't here, since no file is written), the shim's command would still fail with "package file not found".

## Fix (this PR)

Both `pkgs/c/configure-project-installer.lua` and `pkgs/x/xpkg-helper.lua` now define explicit `install()` / `config()` / `uninstall()` lifecycle hooks. `config()` writes a tiny `#!/bin/sh` shim to `system.bindir()` whose body is:
```
exec xlings script <pkginfo.install_dir>/../../../xim-pkgindex/pkgs/<dir>/<name>.lua "$@"
```
i.e. it walks up from the xpkgs install dir three levels (to `data/`), then back down into `xim-pkgindex/pkgs/<dir>/<name>.lua` — the path `xlings script` actually accepts.

Also tidies `pkgs/c/configure-project-installer.lua` deps: was `{ "make", "gcc", "xpkg-helper" }` unprefixed (would now be ambiguous now that fromsource and xim both have those names); namespaced to `xim:make@4.3`, `xim:gcc@15.1.0`, `xim:xpkg-helper@0.0.1`.

## Local verification

```
$ XLINGS_HOME=/tmp/xlings-iso-fs xlings install xim:configure-project-installer@0.0.1 -y
$ ls /tmp/xlings-iso-fs/subos/default/bin/configure-project-installer
-rwxrwxr-x ... configure-project-installer  ← exists now
$ /tmp/xlings-iso-fs/subos/default/bin/configure-project-installer
   Configure Project Installer - 0.0.1
   ...usage shown ...

$ XLINGS_HOME=/tmp/xlings-iso-fs xlings install xim:xpkg-helper@0.0.1 -y
$ /tmp/xlings-iso-fs/subos/default/bin/xpkg-helper
   XPackage Helper Tools - 0.0.1
   Usage: xpkg-helper [namespace:]<pkgname>[@version]
```

Both shims work; `system.exec("<name> ...")` from any downstream package now finds them on PATH.

## Test plan
- [ ] `linux-test` / `index-registration` / `static-and-isolation` pass
- [ ] No regression on `xim:configure-project-installer` / `xim:xpkg-helper` install (now installs *more* — also creates the shim — but doesn't change anything else)
- [ ] Once merged, fromsource installs that depend on configure-project-installer (zlib/xz-utils/...) start working in iso environments — separate fromsource sweep PR will follow.