### PR TITLE
feat(fish): add fish 4.6.0 (linux x86_64, official static-pie binary)

### DIFF
--- a/pkgs/f/fish.lua
+++ b/pkgs/f/fish.lua
@@ -1,0 +1,65 @@
+package = {
+    spec = "1",
+
+    name = "fish",
+    description = "Friendly interactive shell — smart, user-friendly, modern command-line",
+    homepage = "https://fishshell.com",
+    maintainers = {"fish-shell"},
+    licenses = {"GPL-2.0"},
+    repo = "https://github.com/fish-shell/fish-shell",
+    docs = "https://fishshell.com/docs/current/",
+
+    type = "package",
+    -- xpm only carries the x86_64 url; mark x86_64 to keep arch metadata
+    -- honest. aarch64 is published upstream too — add it here once
+    -- xpm gains a per-arch url shape.
+    archs = {"x86_64"},
+    status = "stable",
+    categories = {"shell", "cli"},
+    keywords = {"fish", "shell", "interactive", "rust"},
+
+    -- Upstream ships a single self-contained binary (static-pie linked,
+    -- no glibc/musl runtime dep), so the only declared program is `fish`.
+    programs = {"fish"},
+    xvm_enable = true,
+
+    -- 4.6.0 ships static-pie binaries on linux only; the macOS release
+    -- tarballs are .app bundles / .pkg installers (not flat CLI tarballs)
+    -- and Windows is upstream-unsupported, so this xpkg is linux-only.
+    xpm = {
+        linux = {
+            url_template = "https://github.com/fish-shell/fish-shell/releases/download/{version}/fish-{version}-linux-x86_64.tar.xz",
+            ["latest"] = { ref = "4.6.0" },
+            ["4.6.0"] = {
+                url = "https://github.com/fish-shell/fish-shell/releases/download/4.6.0/fish-4.6.0-linux-x86_64.tar.xz",
+                sha256 = "497c9c4e3fb3c006fe9d2c9a5a5447c1c90490b6b4ce6bfaf75e53b495c82f36",
+            },
+        },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+
+-- The fish-<ver>-linux-<arch>.tar.xz archives are flat: a single `fish`
+-- binary lands directly in the runtime download dir, with no enclosing
+-- folder. Mirror the fzf pattern: explicitly mv the bare binary into a
+-- fresh install_dir so xlings's auto-stage (which sees an empty install_dir
+-- otherwise) doesn't pull unrelated runtimedir entries in.
+function install()
+    os.tryrm(pkginfo.install_dir())
+    os.mkdir(pkginfo.install_dir())
+    local download_dir = path.directory(pkginfo.install_file())
+    os.mv(path.join(download_dir, "fish"), path.join(pkginfo.install_dir(), "fish"))
+    return true
+end
+
+function config()
+    xvm.add("fish", { bindir = pkginfo.install_dir() })
+    return true
+end
+
+function uninstall()
+    xvm.remove("fish")
+    return true
+end


### PR DESCRIPTION
## Summary

Adds `xim:fish@4.6.0` from the upstream linux-x86_64 release tarball (`fish-4.6.0-linux-x86_64.tar.xz`).

The archive is a single self-contained binary:
- `file` reports `static-pie linked`
- `strings` shows zero `GLIBC_*` symbol references
- The whole thing is one ~15 MB ELF, no sysroot / dynamic linker / shared lib integration needed

The xpkg follows the fzf flat-binary template: the tarball expands directly into `runtimedir/fish` (no enclosing dir), so the install hook explicitly moves the bare binary into a fresh install_dir to avoid xlings's auto-stage fallback (which would otherwise treat an empty install_dir as a signal to dump the entire runtimedir into it).

### Scope

Linux x86_64 only at 4.6.0 — upstream's 4.6.0 macOS release ships a `.app` bundle / `.pkg` installer (not a flat CLI tarball) and Windows is upstream-unsupported, so the xpm table omits both for now. aarch64 is also published upstream but only x86_64 is wired up since xpm currently carries one URL per platform.

### Verified end-to-end in an isolated XLINGS_HOME

- [x] `xlings install xim:fish@4.6.0` succeeds; install_dir contains the lone `fish` binary
- [x] subos shim created as symlink to the xlings binary
- [x] `fish --version` → `fish, version 4.6.0`
- [x] `fish -c 'echo hello-from-fish'` works; `fish -c 'math 21 x 2'` prints `42`
- [x] `xlings info fish` reports `installed=yes, active=4.6.0`
- [x] `xlings remove xim:fish@4.6.0` cleans shim + install_dir
- [x] Reinstall is idempotent