### PR TITLE
feat(dash): add dash 0.5.13.3 (musl-static, XLINGS_RES mirror)

### DIFF
--- a/pkgs/d/dash.lua
+++ b/pkgs/d/dash.lua
@@ -1,0 +1,58 @@
+package = {
+    spec = "1",
+    homepage = "http://gondor.apana.org.au/~herbert/dash/",
+    -- base info
+    name = "dash",
+    description = "Debian Almquist Shell — small POSIX-compliant shell",
+
+    authors = {"Herbert Xu", "Debian"},
+    licenses = {"BSD-3-Clause", "GPL-2.0+"},
+    repo = "https://git.kernel.org/pub/scm/utils/dash/dash.git",
+
+    -- xim pkg info
+    type = "package",
+    archs = {"x86_64"},
+    status = "stable",
+    categories = {"shell", "cli", "posix"},
+    keywords = {"dash", "shell", "posix", "ash", "debian"},
+
+    -- xvm: xlings version management
+    xvm_enable = true,
+
+    programs = { "dash" },
+
+    -- Upstream is source-only on git.kernel.org. The XLINGS_RES tarball is
+    -- a fully-static musl-libc build (no glibc runtime dependency), so the
+    -- binary is portable across Linux distributions.
+    --   Source:  https://git.kernel.org/.../dash.git/snapshot/dash-<ver>.tar.gz
+    --   Mirror:  github.com/xlings-res/dash, gitcode.com/xlings-res/dash
+    xpm = {
+        linux = {
+            ["latest"] = { ref = "0.5.13.3" },
+            ["0.5.13.3"] = "XLINGS_RES",
+        },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+
+function install()
+    -- XLINGS_RES tarball expands to `dash-<ver>-linux-x86_64/` — same
+    -- layout as the make xpkg, so reuse the same staging idiom.
+    local srcdir = pkginfo.install_file():replace(".tar.gz", "")
+    os.tryrm(pkginfo.install_dir())
+    os.mv(srcdir, pkginfo.install_dir())
+    return true
+end
+
+function config()
+    local bindir = path.join(pkginfo.install_dir(), "bin")
+    xvm.add("dash", { bindir = bindir })
+    return true
+end
+
+function uninstall()
+    xvm.remove("dash")
+    return true
+end


### PR DESCRIPTION
## Summary

dash upstream is source-only on git.kernel.org, so this xpkg pulls a fully-static musl-libc binary built specifically for xlings and mirrored on \`github.com/xlings-res/dash\` and \`gitcode.com/xlings-res/dash\`.

### Build provenance

| | |
|---|---|
| Source | https://git.kernel.org/pub/scm/utils/dash/dash.git/snapshot/dash-0.5.13.3.tar.gz |
| Compiler | xim:musl-gcc@15.1.0 (full \`-static\` link) |
| Tarball | \`dash-0.5.13.3-linux-x86_64.tar.gz\` (130 KB) — \`bin/dash\` 182 KB stripped |
| SHA256 | \`67b2bb7e149a3d6a54e4984c193d2dc865eba8b23ca5852af96a25cf3fcc0c8d\` |

The package follows the \`make.lua\` XLINGS_RES template — install just \`mv\`'s the staged tarball directory into install_dir, config registers \`dash\` under xvm. No glibc dependency, portable across linux distros on x86_64.

### Mirror status

- **github.com/xlings-res/dash @ 0.5.13.3**: tarball uploaded, download URL live (HTTP 200, sha matches)
- **gitcode.com/xlings-res/dash @ 0.5.13.3**: release metadata + asset entry registered, but the upstream OBS callback service was transiently failing during this PR's window (\`Fail to read response body … obs_callback … err:EOF\`); the physical file currently 404s. XLINGS_RES has GitHub→GitCode fallback baked in (\`build_xlings_res_fallback_urls_\` in xlings/installer.cppm), so this doesn't block users — and a follow-up will retry the gitcode upload once the OBS callback service is healthy.

### Verified end-to-end in an isolated XLINGS_HOME

- [x] \`xlings install xim:dash\` resolves XLINGS_RES → fetches from xlings-res/dash GitHub release
- [x] install_dir layout: \`bin/dash\` + \`share/man/man1/dash.1\` + \`COPYING\` + \`ChangeLog\`
- [x] \`file(1)\` confirms statically linked, ELF 64-bit, stripped
- [x] xvm shim created as symlink to xlings binary
- [x] \`dash -c 'echo' / 'for ; do … done' / '\$((6 * 7))' / '\$@'\` all behave per POSIX
- [x] \`xlings info dash\` reports installed=yes, active=0.5.13.3
- [x] \`xlings remove\` cleans shim + install_dir
- [x] Reinstall is idempotent