### PR TITLE
feat(gcc): add 16.1.0 prebuilt (XLINGS_RES) and bump latest

### DIFF
--- a/pkgs/g/gcc.lua
+++ b/pkgs/g/gcc.lua
@@ -17,12 +17,14 @@ package = {
     categories = { "compiler", "gnu", "language" },
     keywords = { "compiler", "gnu", "gcc", "language", "c", "c++" },
 
-    programs = {
-        "gcc", "g++", "c++", "cpp",
-        "gcc-ar", "gcc-nm", "gcc-ranlib",
-        "gcov", "gcov-dump", "gcov-tool",
-        "x86_64-linux-gnu-gcc", "x86_64-linux-gnu-g++", "x86_64-linux-gnu-c++",
-    },
+    -- Cross-platform common-denominator only.
+    -- Linux installs additionally register cpp / gcc-ar / gcc-nm / gcc-ranlib /
+    -- gcov{,-dump,-tool} / x86_64-linux-gnu-{gcc,g++,c++} via xvm.add inside
+    -- the for-loop in __config_linux (see linux_programs below). They are
+    -- intentionally NOT in the top-level `programs` so that the windows
+    -- declared-program audit (which has no per-platform programs mechanism
+    -- yet) doesn't demand mingw-w64 to provide them.
+    programs = { "gcc", "g++", "c++" },
 
     -- xvm: xlings version management
     xvm_enable = true,
@@ -55,6 +57,17 @@ import("xim.libxpkg.system")
 import("xim.libxpkg.xvm")
 import("xim.libxpkg.pkgmanager")
 import("xim.libxpkg.elfpatch")
+
+-- Linux-only program list (registered as xvm shims by __config_linux).
+-- Kept separate from package.programs so that the cross-platform declared-
+-- program audit (which runs on windows where mingw-w64 only ships gcc/g++/c++)
+-- doesn't demand shims that only exist on linux.
+local linux_programs = {
+    "gcc", "g++", "c++", "cpp",
+    "gcc-ar", "gcc-nm", "gcc-ranlib",
+    "gcov", "gcov-dump", "gcov-tool",
+    "x86_64-linux-gnu-gcc", "x86_64-linux-gnu-g++", "x86_64-linux-gnu-c++",
+}
 
 local gcc_tool = {
     ["gcc-ar"] = true, ["gcc-nm"] = true, ["gcc-ranlib"] = true,
@@ -124,7 +137,7 @@ function uninstall()
     end
 
     local gcc_version = "gcc-" .. pkginfo.version()
-    for _, prog in ipairs(package.programs) do
+    for _, prog in ipairs(linux_programs) do
         if gcc_tool[prog] then
             xvm.remove(prog, gcc_version)
         else
@@ -172,10 +185,10 @@ function __config_linux()
         }
     }
 
-    for _, prog in ipairs(package.programs) do
+    for _, prog in ipairs(linux_programs) do
 
         config.alias = prog
-    
+
         if compiler_entry[prog] then config.alias = prog .. alias_args end
 
         if gcc_tool[prog] then

--- a/pkgs/g/gcc.lua
+++ b/pkgs/g/gcc.lua
@@ -35,7 +35,8 @@ package = {
                 -- home/xlings/.xlings_data/subos/linux/usr/include/bits/errno.h:26:11: fatal error: linux/errno.h: No such file or directory
                 "linux-headers@5.11.1",
             },
-            ["latest"] = { ref = "15.1.0" },
+            ["latest"] = { ref = "16.1.0" },
+            ["16.1.0"] = "XLINGS_RES",
             ["15.1.0"] = "XLINGS_RES",
             ["13.3.0"] = "XLINGS_RES",
             ["11.5.0"] = "XLINGS_RES",


### PR DESCRIPTION
## Summary
- Add \`gcc@16.1.0\` to \`xim:gcc\` linux entries via \`XLINGS_RES\` (resolves to GLOBAL=github.com/xlings-res/gcc, CN=gitcode.com/xlings-res/gcc)
- Bump linux \`latest\` ref: \`15.1.0\` → \`16.1.0\`
- Windows entry untouched (still 15.1.0; 16 mingw64 mapping is a separate task)

## Tarball
- Name: \`gcc-16.1.0-linux-x86_64.tar.gz\`
- Size: ~491 MB
- sha256: \`6eb2876de32703f5d2894c27450a2b0cf82b998e074dbe18c646f0c631138fb5\`
- github mirror: https://github.com/xlings-res/gcc/releases/tag/16.1.0 ✅ uploaded
- gitcode mirror: pending manual upload (no automation token in env yet)

Built from upstream \`gcc-16.1.0.tar.xz\` via the d2learn fromsource pipeline (\`fromsource:gcc@16.1.0\` shipped in xim-pkgindex-fromsource#61). Specs file rewritten to canonical \`/home/xlings/.xlings_data/subos/linux/...\` to match the existing 15.1.0/13.3.0/11.5.0/9.4.0 prebuilt convention.

## Verification (local isolated xlings 0.4.9)

\`xlings install xim:gcc@16.1.0\` clean-install in a fresh iso environment:
- ✅ tarball pulled, extracted, copied to install dir, ELF interpreter rewritten via \`elfpatch.auto\` to point at xim:glibc@2.39 dynamic linker
- ✅ \`xlings use gcc 16.1.0\` switches xvm shim
- ✅ \`gcc --version\` → \`gcc (xlings-fromsource) 16.1.0\`
- ✅ compile + run hello.c via xvm shim:
  ```
  $ gcc -O2 -o hello hello.c
  $ ./hello
  xvm-shim says GCC 16.1.0
  exit 0
  ```
- ✅ \`__GNUC__ / __GNUC_MINOR__ / __GNUC_PATCHLEVEL__\` correctly expand to 16/1/0

## Test plan
- [x] Tarball uploaded to github xlings-res/gcc 16.1.0
- [x] Local iso clean-install + functional test
- [ ] CI (linux-test, static-and-isolation, index-registration, install-tests)
- [ ] gitcode mirror upload (manual)