### PR TITLE
feat(busybox): add 1.35.0 (upstream static-musl prebuilt, x86_64)

### DIFF
--- a/pkgs/b/busybox.lua
+++ b/pkgs/b/busybox.lua
@@ -1,0 +1,83 @@
+function __busybox_url(version)
+    return format("https://busybox.net/downloads/binaries/%s-x86_64-linux-musl/busybox", version)
+end
+
+package = {
+    spec = "1",
+
+    name = "busybox",
+    description = "The Swiss Army Knife of Embedded Linux — single static binary providing 400+ POSIX utilities",
+    homepage = "https://busybox.net",
+    authors = {"Erik Andersen", "Rob Landley", "Denys Vlasenko"},
+    licenses = {"GPL-2.0-only"},
+    repo = "https://git.busybox.net/busybox",
+    docs = "https://busybox.net/about.html",
+
+    -- xim pkg info
+    type = "package",
+    archs = {"x86_64"},
+    status = "stable",
+    categories = {"system", "shell", "cli", "utilities"},
+    keywords = {"busybox", "shell", "ash", "coreutils", "embedded", "static"},
+
+    -- Upstream ships a single static-musl binary that bundles 400+ applets
+    -- (sh, ls, cat, awk, grep, …). Each applet is invoked by argv[0]
+    -- dispatch — `busybox ls /tmp` works, and so does a `ls` symlink that
+    -- points at busybox. We declare only `busybox`; users who want
+    -- individual applet shims can run `busybox --install -s <dir>` on the
+    -- installed binary to populate them.
+    programs = {"busybox"},
+    xvm_enable = true,
+
+    -- The /downloads/binaries/<ver>-x86_64-linux-musl/busybox URL is a
+    -- bare ELF — statically linked against musl, stripped, no glibc/musl
+    -- runtime needed at the user side. xlings's is_archive_ predicate
+    -- (filename suffix check) will treat it as a non-archive payload, so
+    -- it lands as-is in the runtime download dir; install() moves it.
+    --
+    -- 1.35.0 is the most recent x86_64 prebuilt published upstream
+    -- (Jan 2022). Newer point releases (1.36, 1.37) are source-only on
+    -- busybox.net — no static prebuilt directory yet — so we stay on
+    -- 1.35.0 until upstream publishes 1.36+ binaries.
+    xpm = {
+        linux = {
+            ["latest"] = { ref = "1.35.0" },
+            ["1.35.0"] = {
+                url = __busybox_url("1.35.0"),
+                sha256 = "6e123e7f3202a8c1e9b1f94d8941580a25135382b99e8d3e34fb858bba311348",
+            },
+        },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+import("xim.libxpkg.log")
+
+function install()
+    -- The download is a bare ELF (no archive). xlings parks it at
+    -- pkginfo.install_file() inside the runtime download dir; we move
+    -- it under install_dir/bin/busybox and chmod +x. (xlings does set
+    -- 0644 on plain downloads; the binary needs to be executable.)
+    os.tryrm(pkginfo.install_dir())
+    local bindir = path.join(pkginfo.install_dir(), "bin")
+    os.mkdir(bindir)
+    local target = path.join(bindir, "busybox")
+    os.mv(pkginfo.install_file(), target)
+    os.execute('chmod +x "' .. target .. '"')
+    return true
+end
+
+function config()
+    xvm.add("busybox", {
+        bindir = path.join(pkginfo.install_dir(), "bin"),
+    })
+    log.info("busybox installed. Use `busybox <applet>` (e.g. `busybox ls -la`)")
+    log.info("or `busybox --install -s <dir>` to populate per-applet symlinks.")
+    return true
+end
+
+function uninstall()
+    xvm.remove("busybox")
+    return true
+end


### PR DESCRIPTION
## Summary
Add `xim:busybox@1.35.0` — single 1.1 MB statically-linked binary bundling 402 POSIX-flavored applets (sh, ash, ls, cat, awk, grep, sed, tar, gzip, find, xargs, …).

## Why upstream URL (no `XLINGS_RES` needed)
busybox.net publishes an [official prebuilt index](https://busybox.net/downloads/binaries/) and ships a stable static-musl x86_64 binary at `1.35.0-x86_64-linux-musl/busybox`. Confirmed:
- `1131168` bytes
- `ELF 64-bit LSB executable, statically linked, stripped`
- sha256 `6e123e7f3202a8c1e9b1f94d8941580a25135382b99e8d3e34fb858bba311348`

The user asked to prefer static prebuilt over rebuilding when one exists; this is the textbook case.

## Why 1.35.0 instead of 1.36 / 1.37
1.35.0 is the most recent x86_64 prebuilt published upstream (Jan 2022). 1.36 and 1.37 are source-only on the prebuilt index — no static binary directory yet. We can bump when upstream publishes 1.36+ prebuilts; this PR ships what's actually available.

## Layout / declared programs
Only `busybox` is declared. The 402 applets are reached via argv[0] dispatch (`busybox ls`, or symlinks named `ls` pointing at busybox). Users who want individual applet shims can run `busybox --install -s <dir>` themselves — we don't auto-create them since that would clash with system commands once `subos/default/bin` is on PATH.

## URL / download semantics
URL ends in `/busybox` (no extension). xlings's `is_archive_` predicate (suffix-based) treats this as a non-archive, so install() mv's the bare ELF directly into `install_dir/bin/busybox` and `chmod +x`.

## Verification (local isolated xlings 0.4.9)
- ✅ install completes; install_dir/bin/busybox is the 1.1 MB static ELF; sha256 matches
- ✅ `busybox echo hello` → ok
- ✅ `busybox awk 'BEGIN { print 6*7 }'` → 42
- ✅ `busybox sh -c '...'` (ash) → ok
- ✅ `busybox --list | wc -l` → 402
- ✅ via xvm shim after `xlings use busybox 1.35.0`: all above commands work through `subos/default/bin/busybox`

## Test plan
- [x] Local iso e2e
- [ ] CI (linux-test, static-and-isolation, index-registration, install-tests, windows-test)