### PR TITLE
fix(musl-gcc): declare xim:patchelf dep so install-time relocation runs

### DIFF
--- a/pkgs/m/musl-gcc.lua
+++ b/pkgs/m/musl-gcc.lua
@@ -29,6 +29,19 @@ package = {
 
     xpm = {
         linux = {
+            -- patchelf is required by __patch_toolchain_dynamic_bins() in
+            -- install() — the prebuilt tarball ships every binutils binary
+            -- (~16 entries under bin/x86_64-linux-musl-* AND under
+            -- x86_64-linux-musl/bin/) with PT_INTERP hardcoded to the
+            -- canonical /home/xlings/.xlings_data/lib/ld-musl-x86_64.so.1
+            -- path. Without patchelf at install time the relocation step
+            -- silently no-ops (os.exec falls back), and the toolchain only
+            -- runs on machines where that exact canonical path resolves —
+            -- breaking any non-default XLINGS_HOME, container, fresh
+            -- machine, or "first ever musl-gcc install" scenario. Declaring
+            -- the dep guarantees patchelf is on the install-hook PATH.
+            deps = { "xim:patchelf@0.18.0" },
+
             -- toolchain build based on musl-gcc-static
             ["latest"] = { ref = "15.1.0" },
             ["15.1.0"] = "XLINGS_RES", -- deps musl-gcc


### PR DESCRIPTION
## Summary
Add `xim:patchelf@0.18.0` to `xim:musl-gcc.lua`'s `deps[]`. The install hook needs `patchelf` to relocate the prebuilt's hardcoded canonical PT_INTERP (`/home/xlings/.xlings_data/lib/ld-musl-x86_64.so.1`) to the actual install-time path. Without the dep, `__patch_toolchain_dynamic_bins()` silently no-ops and the toolchain only works on machines that already have the canonical path bridged.

## Symptom (without the fix)
On a fresh / non-default XLINGS_HOME / container install:
```
$ xlings install xim:musl-gcc@15.1.0
$ x86_64-linux-musl-gcc -static t.c
x86_64-linux-musl-gcc: fatal error: cannot execute '.../bin/x86_64-linux-musl-as':
  posix_spawn: No such file or directory
```

## Why the original maintainer didn't notice
On a long-running default-layout xlings install, `/home/xlings/.xlings_data/lib/ld-musl-x86_64.so.1` already exists (created by some past xpkg install bridging that canonical path → real install). Subsequent `xim:musl-gcc` installs *appear* to work even though `__patch_toolchain_dynamic_bins()` silently no-ops, because the bridging symlink covers it.

A fresh install lacks that bridge → the toolchain breaks.

## Verification (local isolated xlings 0.4.9)
- ✅ before fix: `as` PT_INTERP = `/home/xlings/.xlings_data/...` (unchanged), gcc -static fails
- ✅ after fix: `as` PT_INTERP rewritten to `<install_dir>/x86_64-linux-musl/lib/libc.so`, log shows `musl-gcc relocate: patched dynamic tools = 26`, gcc -static produces a working static ELF

## Test plan
- [x] Local iso e2e
- [ ] CI (linux-test, static-and-isolation, index-registration, install-tests, windows-test)