### PR TITLE
feat(pkg): glibc declares exports + binutils drops install-hook elfpatch

### DIFF
--- a/pkgs/b/binutils.lua
+++ b/pkgs/b/binutils.lua
@@ -41,7 +41,9 @@ import("xim.libxpkg.log")
 import("xim.libxpkg.pkginfo")
 import("xim.libxpkg.system")
 import("xim.libxpkg.xvm")
-import("xim.libxpkg.elfpatch")
+-- elfpatch import removed: predicate-driven auto-patch (post 2026-05-02
+-- design) reads glibc.lua's exports.runtime.loader and rewrites our
+-- INTERP / RPATH automatically. No install-hook elfpatch call needed.
 
 function install()
 
@@ -50,16 +52,6 @@ function install()
     os.tryrm(pkginfo.install_dir())
     os.cp(glibcdir, pkginfo.install_dir(), {
         force = true, symlink = true
-    })
-
-    -- Point interpreter directly to glibc xpkgs
-    local glibc_dir = pkginfo.dep_install_dir("glibc", "2.39")
-    local loader = glibc_dir and path.join(glibc_dir, "lib64", "ld-linux-x86-64.so.2") or nil
-    elfpatch.auto({
-        enable = true,
-        shrink = true,
-        bins = { "bin" },
-        interpreter = loader,
     })
 
     return true

--- a/pkgs/g/glibc.lua
+++ b/pkgs/g/glibc.lua
@@ -31,6 +31,19 @@ package = {
 
     xpm = {
         linux = {
+            -- Declare the dynamic linker we ship so consumers don't have
+            -- to hardcode `path.join(glibc_dir, "lib64", "ld-linux-x86-64.so.2")`
+            -- in their own install hooks. xlings predicate-driven elfpatch
+            -- (regenerated post 2026-05-02 design) reads this and patches
+            -- consumer ELFs automatically. `abi` is the disambiguation tag
+            -- when a subos hosts both glibc and musl xpkgs.
+            exports = {
+                runtime = {
+                    loader = "lib64/ld-linux-x86-64.so.2",
+                    abi    = "linux-x86_64-glibc",
+                    -- libdirs not declared → falls back to {lib64, lib} convention
+                },
+            },
             ["latest"] = { ref = "2.39" },
             ["2.39"] = "XLINGS_RES",
         },


### PR DESCRIPTION
## Summary

Pilot migration for the declarative elfpatch design (libxpkg [openxlings/libxpkg#9](https://github.com/openxlings/libxpkg/pull/9), xlings TBD).

- `glibc.lua`: add `xpm.linux.exports.runtime.{loader, abi}`. xlings predicate-driven elfpatch reads this and patches consumer ELFs automatically.
- `binutils.lua`: drop install-hook `elfpatch.auto({enable, shrink, bins, interpreter})` call entirely; install hook is now just extract/copy work. Loader resolution + RPATH closure happen post-hook in xlings via `deps_exports` lookup.

## Why draft

Hard depends on:
1. `openxlings/libxpkg#9` merge + v0.0.33 tag
2. mcpplibs-index 0.0.33 entry
3. xlings add_requires bump → release of xlings 0.4.11+

After (3) merges, this can come out of draft. Until then, current users on xlings 0.4.10 wouldn't see any behavior change (the legacy `elfpatch.auto` deprecation alias is still in libxpkg's lua stdlib, but binutils.lua no longer calls it — meaning on 0.4.10 binutils would NOT be patched, i.e. it'd break).

So this PR must merge **after** xlings 0.4.11 releases with the predicate-driven auto-patch active.

## Diff

`binutils.lua`: -8 lines (loader resolution + elfpatch.auto block removed)
`glibc.lua`: +13 lines (exports block added)

After this lands, the same migration applies mechanically to `openssl.lua`, `gcc.lua`, `d2x.lua` — but those follow up.

## Test plan

- [ ] After full chain ships: install glibc + binutils in isolated XLINGS_HOME, `readelf -l <binutils-bin>` verifies INTERP points at glibc's xpkgs `lib64/ld-linux-x86-64.so.2`
- [ ] RPATH closure includes glibc's lib64 + binutils's own lib + subos sysroot