### PR TITLE
feat(pkg): migrate openssl/gcc/d2x to declarative elfpatch

### DIFF
--- a/pkgs/d/d2x.lua
+++ b/pkgs/d/d2x.lua
@@ -49,7 +49,9 @@ package = {
 
 import("xim.libxpkg.pkginfo")
 import("xim.libxpkg.xvm")
-import("xim.libxpkg.elfpatch")
+-- elfpatch import removed: predicate-driven auto-patch (post 2026-05-02
+-- design) reads glibc.lua's exports.runtime.loader and rewrites our
+-- INTERP / RPATH automatically. No install-hook elfpatch call needed.
 
 function install()
     local d2xdir = pkginfo.install_file()
@@ -58,15 +60,6 @@ function install()
     os.tryrm(pkginfo.install_dir())
     os.mv(d2xdir, pkginfo.install_dir())
 
-    if os.host() ~= "windows" then
-        local glibc_dir = pkginfo.dep_install_dir("glibc", "2.39")
-        local loader = glibc_dir and path.join(glibc_dir, "lib64", "ld-linux-x86-64.so.2") or nil
-        elfpatch.auto({
-            enable = true,
-            shrink = true,
-            interpreter = loader,
-        })
-    end
     return true
 end
 

--- a/pkgs/g/gcc.lua
+++ b/pkgs/g/gcc.lua
@@ -56,7 +56,11 @@ import("xim.libxpkg.log")
 import("xim.libxpkg.system")
 import("xim.libxpkg.xvm")
 import("xim.libxpkg.pkgmanager")
-import("xim.libxpkg.elfpatch")
+-- elfpatch import removed: predicate-driven auto-patch (post 2026-05-02
+-- design) reads glibc.lua's exports.runtime.loader and rewrites our
+-- INTERP / RPATH automatically. Default scan = "convention" already
+-- covers libexec/ (where cc1 / cc1plus / collect2 live), so the gcc-
+-- specific bins = { "bin", "libexec" } is no longer needed.
 
 -- Linux-only program list (registered as xvm shims by __config_linux).
 -- Kept separate from package.programs so that the cross-platform declared-
@@ -105,17 +109,6 @@ function install()
         os.cp(srcdir, pkginfo.install_dir(), {
             symlink = true,
             verbose = true,
-        })
-
-        -- Point interpreter directly to glibc xpkgs (not subos symlink)
-        local glibc_dir = pkginfo.dep_install_dir("glibc", "2.39")
-        local loader = glibc_dir and path.join(glibc_dir, "lib64", "ld-linux-x86-64.so.2") or nil
-        elfpatch.auto({
-            enable = true,
-            shrink = true,
-            bins = { "bin", "libexec" },
-            libs = { "lib64" },
-            interpreter = loader,
         })
     end
     return true

--- a/pkgs/o/openssl.lua
+++ b/pkgs/o/openssl.lua
@@ -32,7 +32,9 @@ import("xim.libxpkg.pkginfo")
 import("xim.libxpkg.system")
 import("xim.libxpkg.xvm")
 import("xim.libxpkg.log")
-import("xim.libxpkg.elfpatch")
+-- elfpatch import removed: predicate-driven auto-patch (post 2026-05-02
+-- design) reads glibc.lua's exports.runtime.loader and rewrites our
+-- INTERP / RPATH automatically. No install-hook elfpatch call needed.
 
 local libs = {
     "libcrypto.so", "libcrypto.so.3", "libcrypto.a",
@@ -68,16 +70,6 @@ function install()
     os.tryrm(pkginfo.install_dir())
     os.mv(openssl_dir, pkginfo.install_dir())
 
-    -- Point interpreter directly to glibc xpkgs
-    local glibc_dir = pkginfo.dep_install_dir("glibc", "2.39")
-    local loader = glibc_dir and path.join(glibc_dir, "lib64", "ld-linux-x86-64.so.2") or nil
-    elfpatch.auto({
-        enable = true,
-        shrink = true,
-        bins = { "bin" },
-        libs = { "lib64" },
-        interpreter = loader,
-    })
     return true
 end
 


### PR DESCRIPTION
## Summary

Follow-up to **#104 (binutils pilot)**. Three remaining consumers drop the install-hook `elfpatch.auto({...})` call and hardcoded glibc loader resolution. xlings 0.4.11+ predicate-driven auto-patch reads glibc.lua's `xpm.linux.exports.runtime.loader` and rewrites consumer INTERP / RPATH automatically.

Net effect: **+11 / -33 lines** across 3 files; no consumer in `pkgs/` imports the deprecated alias after this PR.

## Diff shape (each file mirrors #104 binutils diff)

| file | -lines | +lines | notes |
|---|---|---|---|
| `pkgs/o/openssl.lua` | 11 | 3 | template-identical to #104 |
| `pkgs/g/gcc.lua` | 11 | 4 | dropped `bins = { "bin", "libexec" }` — convention-scan default already covers `libexec/` (cc1/cc1plus/collect2) |
| `pkgs/d/d2x.lua` | 11 | 4 | template-identical to #104; existing `if os.host() ~= "windows"` guard removed since the elfpatch block is gone |

## Verification path

Per the migration doc (`docs/migrations/2026-05-02-elfpatch-declarative-consumer-migration.md` merged in #105):

* **`xpkg test`** — lua syntax + index registration
* **`pkgindex test`** (the critical one) — installs each changed package on linux/macos/windows runners and exercises the produced binaries. End-to-end success implies the auto-patch rewrote INTERP to the installed glibc xpkg's `lib64/ld-linux-x86-64.so.2` and added the right RPATH entries.

If `linux-install-test` shows `command not found` / `binary not executable`, suspect the runner is on xlings < 0.4.11 (the deprecation alias should still let install succeed though).

## Schedule alignment

* Requires **xlings 0.4.11+** (predicate-driven trigger)
* Requires **libxpkg 0.0.33+** (exports schema parser)
* On older xlings the legacy elfpatch.auto deprecation alias still works at install time, but these three packages no longer call into it. INTERP/RPATH patching now flows through deps_exports lookup post-hook (the new path).

## Test plan

- [x] Pilot reference: #104 binutils diff + #105 migration doc
- [ ] `xpkg test`: lua syntax + index registration
- [ ] `pkgindex test`: 3-platform install / smoke run