### PR TITLE
feat(xlings): add 0.4.12 + pin CI to v0.4.12

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -22,6 +22,7 @@ jobs:
       - name: Installation Xlings on Ubuntu
         run: |
           export XLINGS_NON_INTERACTIVE=1
+          export XLINGS_VERSION=v0.4.12
           curl -fsSL https://raw.githubusercontent.com/d2learn/xlings/main/tools/other/quick_install.sh | bash
           echo "XLINGS_HOME=$HOME/.xlings" >> "$GITHUB_ENV"
           echo "PATH=$HOME/.xlings/subos/current/bin:$HOME/.xlings/bin:$PATH" >> "$GITHUB_ENV"
@@ -75,6 +76,7 @@ jobs:
         shell: pwsh
         run: |
           $env:XLINGS_NON_INTERACTIVE = "1"
+          $env:XLINGS_VERSION = "v0.4.12"
           iex (Invoke-WebRequest `
             -Uri "https://raw.githubusercontent.com/d2learn/xlings/main/tools/other/quick_install.ps1" `
             -UseBasicParsing).Content
@@ -125,6 +127,7 @@ jobs:
       - name: Install xlings on Ubuntu
         run: |
           export XLINGS_NON_INTERACTIVE=1
+          export XLINGS_VERSION=v0.4.12
           curl -fsSL https://raw.githubusercontent.com/d2learn/xlings/main/tools/other/quick_install.sh | bash
           echo "XLINGS_HOME=$HOME/.xlings" >> "$GITHUB_ENV"
           echo "$HOME/.xlings/bin"               >> "$GITHUB_PATH"
@@ -167,6 +170,7 @@ jobs:
       - name: Install xlings on macOS
         run: |
           export XLINGS_NON_INTERACTIVE=1
+          export XLINGS_VERSION=v0.4.12
           curl -fsSL https://raw.githubusercontent.com/d2learn/xlings/main/tools/other/quick_install.sh | bash
           echo "XLINGS_HOME=$HOME/.xlings" >> "$GITHUB_ENV"
           echo "$HOME/.xlings/bin"               >> "$GITHUB_PATH"

--- a/.github/workflows/ci-xpkg-test.yml
+++ b/.github/workflows/ci-xpkg-test.yml
@@ -54,6 +54,7 @@ jobs:
       - name: Install xlings
         run: |
           export XLINGS_NON_INTERACTIVE=1
+          export XLINGS_VERSION=v0.4.12
           curl -fsSL https://raw.githubusercontent.com/d2learn/xlings/main/tools/other/quick_install.sh | bash
           echo "XLINGS_HOME=$HOME/.xlings" >> "$GITHUB_ENV"
           echo "PATH=$HOME/.xlings/subos/current/bin:$HOME/.xlings/bin:$PATH" >> "$GITHUB_ENV"

--- a/pkgs/x/xlings.lua
+++ b/pkgs/x/xlings.lua
@@ -36,7 +36,11 @@ package = {
     -- one version at a time.
     xpm = {
         linux = {
-            ["latest"] = { ref = "0.4.10" },
+            ["latest"] = { ref = "0.4.12" },
+            ["0.4.12"] = {
+                url = "https://github.com/d2learn/xlings/releases/download/v0.4.12/xlings-0.4.12-linux-x86_64.tar.gz",
+                sha256 = "efccd525bfc5259a6387c40b523a23c2803678a48ecd4285efa6badac15d6338",
+            },
             ["0.4.10"] = {
                 url = "https://github.com/d2learn/xlings/releases/download/v0.4.10/xlings-0.4.10-linux-x86_64.tar.gz",
                 sha256 = "7308f5d65fb71773f1e3546be86c720e77ee21509b6a66dcee86ebf0239e8faf",
@@ -65,7 +69,11 @@ package = {
             ["0.3.0"] = "XLINGS_RES",
         },
         macosx = {
-            ["latest"] = { ref = "0.4.10" },
+            ["latest"] = { ref = "0.4.12" },
+            ["0.4.12"] = {
+                url = "https://github.com/d2learn/xlings/releases/download/v0.4.12/xlings-0.4.12-macosx-arm64.tar.gz",
+                sha256 = "2350db515e3c326320a3404a36bf2a7b30705d89028e89130b9456d45c6ddf79",
+            },
             ["0.4.10"] = {
                 url = "https://github.com/d2learn/xlings/releases/download/v0.4.10/xlings-0.4.10-macosx-arm64.tar.gz",
                 sha256 = "3b45256592eddf9e47bcaea9e4856183e5d3714fd5684016c04fa7529f889b0f",
@@ -94,7 +102,11 @@ package = {
             ["0.3.0"] = "XLINGS_RES",
         },
         windows = {
-            ["latest"] = { ref = "0.4.10" },
+            ["latest"] = { ref = "0.4.12" },
+            ["0.4.12"] = {
+                url = "https://github.com/d2learn/xlings/releases/download/v0.4.12/xlings-0.4.12-windows-x86_64.zip",
+                sha256 = "9d600b38a8897e772d6c787df95f9e6e0a13bff3f9c3729bf91ed2f6f66f9e62",
+            },
             ["0.4.10"] = {
                 url = "https://github.com/d2learn/xlings/releases/download/v0.4.10/xlings-0.4.10-windows-x86_64.zip",
                 sha256 = "fec7d922d96903b29bfaa59befb241ad87adc059d3f4f3a8dd64fbb46cc532a3",


### PR DESCRIPTION
## Summary
- `pkgs/x/xlings.lua`: add 0.4.12 across linux/macosx/windows; bump `latest` from 0.4.10 → 0.4.12 (same shape as #100)
- `.github/workflows/ci-test.yml` + `ci-xpkg-test.yml`: pin every `quick_install.{sh,ps1}` to `XLINGS_VERSION=v0.4.12` (5 sites total) so CI runs against the version the index targets, not "whatever upstream's `latest` is right now"

## sha256
| platform | sha256 |
|---|---|
| linux-x86_64.tar.gz | `efccd525bfc5259a6387c40b523a23c2803678a48ecd4285efa6badac15d6338` |
| macosx-arm64.tar.gz | `2350db515e3c326320a3404a36bf2a7b30705d89028e89130b9456d45c6ddf79` |
| windows-x86_64.zip  | `9d600b38a8897e772d6c787df95f9e6e0a13bff3f9c3729bf91ed2f6f66f9e62` |

## Verification (local isolated xlings 0.4.9 iso)
- ✅ `xlings install xim:xlings@0.4.12` → `install_dir/bin/xlings`
- ✅ `<install_dir>/bin/xlings --version` → `xlings 0.4.12`
- ✅ sha256 matches the value pinned in lua

## CI pin sites
- `ci-test.yml` line 25 — Linux ubuntu install
- `ci-test.yml` line 80 — Windows pwsh install via ps1
- `ci-test.yml` line 128 — Linux install-test job
- `ci-test.yml` line 170 — xpkg verification job
- `ci-xpkg-test.yml` line 57 — xpkg test job

## Test plan
- [x] Local iso e2e
- [ ] CI green on all 8 checks