### PR TITLE
feat(deps): declare runtime deps for 5 dynamic-linked prebuilts (node/cmake/ninja/mdbook/xmake)

### DIFF
--- a/pkgs/c/cmake.lua
+++ b/pkgs/c/cmake.lua
@@ -22,6 +22,13 @@ package = {
 
     xpm = {
         linux = {
+            -- Runtime deps. cmake prebuilt is dynamically linked
+            -- (INTERP=/lib64/ld-linux-x86-64.so.2) and needs
+            -- libc/libdl/librt/libpthread/libm from glibc. No libstdc++
+            -- (statically linked into the binary).
+            deps = {
+                runtime = { "glibc@2.39" },
+            },
             ["latest"] = { ref = "4.0.2" },
             ["4.0.2"] = "XLINGS_RES",
         },

--- a/pkgs/m/mdbook.lua
+++ b/pkgs/m/mdbook.lua
@@ -37,6 +37,14 @@ package = {
             },
         },
         linux = {
+            -- Runtime deps. mdbook prebuilt is dynamically linked
+            -- (INTERP=/lib64/ld-linux-x86-64.so.2) and pulls libc/libdl/
+            -- libpthread/libm from glibc plus libgcc_s.so.1 from gcc's
+            -- runtime libs (Rust statically links libstdc++ but still
+            -- needs libgcc_s for unwind tables).
+            deps = {
+                runtime = { "glibc@2.39", "gcc@15.1.0" },
+            },
             ["latest"] = { ref = "0.5.2" },
             ["0.5.2"] = {
                 url = "https://github.com/rust-lang/mdBook/releases/download/v0.5.2/mdbook-v0.5.2-x86_64-unknown-linux-gnu.tar.gz",

--- a/pkgs/n/ninja.lua
+++ b/pkgs/n/ninja.lua
@@ -21,6 +21,13 @@ package = {
 
     xpm = {
         linux = {
+            -- Runtime deps. ninja prebuilt is dynamically linked
+            -- (INTERP=/lib64/ld-linux-x86-64.so.2) and pulls libc/libm
+            -- from glibc plus libstdc++.so.6 + libgcc_s.so.1 from gcc's
+            -- runtime libs.
+            deps = {
+                runtime = { "glibc@2.39", "gcc@15.1.0" },
+            },
             ["latest"] = { ref = "1.12.1" },
             ["1.12.1"] = "XLINGS_RES",
         },

--- a/pkgs/n/node.lua
+++ b/pkgs/n/node.lua
@@ -40,6 +40,19 @@ package = {
             },
         },
         linux = {
+            -- Runtime deps. The upstream node prebuilt is dynamically linked
+            -- (INTERP=/lib64/ld-linux-x86-64.so.2, RPATH empty) and pulls
+            -- libc/libdl/libpthread/libm from glibc plus libstdc++.so.6 +
+            -- libgcc_s.so.1 from gcc's runtime libs. Without these declared,
+            -- xlings's predicate-driven elfpatch can't rewrite INTERP/RPATH
+            -- to the xpkg-provided libc + libstdc++, and the binary only
+            -- runs on hosts that already have system glibc + a compatible
+            -- libstdc++ (i.e. fails on distroless / Alpine / very old glibc).
+            -- No build deps — install hook is just `os.mv` of the extracted
+            -- prebuilt; nothing is compiled at install time.
+            deps = {
+                runtime = { "glibc@2.39", "gcc@15.1.0" },
+            },
             ["latest"] = { ref = "24.15.0" },
             ["25.9.0"] = _linux_url("25.9.0"),
             ["24.15.0"] = _linux_url("24.15.0"),

--- a/pkgs/x/xmake.lua
+++ b/pkgs/x/xmake.lua
@@ -22,6 +22,18 @@ package = {
 
     xpm = {
         linux = {
+            -- Runtime deps. xmake bundle is dynamically linked
+            -- (INTERP=/lib64/ld-linux-x86-64.so.2) and needs libc/libm
+            -- from glibc plus libncurses.so.6 + libtinfo.so.6 from
+            -- ncurses for its TUI.
+            -- TODO: there is no xim:ncurses prebuilt yet (only
+            -- fromsource:ncurses). Until one is published, falling back
+            -- to the system ncurses works on most distros that have it
+            -- preinstalled. Track the gap separately; declaring
+            -- glibc@2.39 alone is the minimum-viable correct fix.
+            deps = {
+                runtime = { "glibc@2.39" },
+            },
             url_template = "https://github.com/xmake-io/xmake/releases/download/v{version}/xmake-bundle-v{version}.linux.x86_64",
             ["latest"] = { ref = "3.0.8" },
             ["3.0.8"] = {


### PR DESCRIPTION
## Summary
Audit finding: 5 xpkgs ship dynamically-linked prebuilts but declare **zero deps**. Without declared deps, xlings's resolver never activates `glibc` / `gcc` runtime libs in the workspace, and the new predicate-driven elfpatch (post #104 / #106) has no provider to bind to — so INTERP stays at the build-host's `/lib64/ld-linux-x86-64.so.2` and the binary silently leans on whatever libc the user's distro ships.

Fix: use the new build/runtime deps split schema (libxpkg 0.0.33+ / xlings 0.4.11+, see [build-runtime-deps-split design doc](https://github.com/d2learn/xlings/blob/main/docs/plans/2026-05-01-build-runtime-deps-split.md)):

```lua
xpm.linux.deps = {
    runtime = { "glibc@2.39", "gcc@15.1.0" },
}
```

## Per-package picks

| pkg     | runtime deps                  | DT_NEEDED rationale                      |
|---------|-------------------------------|------------------------------------------|
| node    | `glibc@2.39, gcc@15.1.0`      | libc/dl/pthread/m + libstdc++ + libgcc_s |
| cmake   | `glibc@2.39`                  | libc/dl/rt/pthread/m only                |
| ninja   | `glibc@2.39, gcc@15.1.0`      | libc/m + libstdc++ + libgcc_s            |
| mdbook  | `glibc@2.39, gcc@15.1.0`      | libc/dl/pthread + libgcc_s (Rust)        |
| xmake   | `glibc@2.39`                  | libc/m only — libncurses still system    |

`build` slot intentionally empty for all 5: install hook is just `os.mv`, nothing compiled at install time.

## Verification (local isolated xlings 0.4.11 iso)
- ✅ `xlings info <pkg>` displays `runtime deps  glibc@2.39 [...]`
- ✅ `xlings install xim:node@22.12.0` resolves cleanly; `node --version` → `v22.12.0`
- ✅ `xlings remove xim:node` removes node; shared deps (`glibc`, `gcc`) retained for other consumers
- ✅ legacy flat-array `deps = { ... }` form on binutils / openssl / gcc / d2x still works (kept as-is)

## Out of scope
- 24 prebuilt-only xpkgs not on the audit host need a separate extract-and-inspect sweep
- `xim:ncurses` doesn't exist yet; xmake's TUI libs (`libncurses.so.6`, `libtinfo.so.6`) still come from system. Will declare once xim:ncurses is published
- INTERP rewrite via predicate-driven elfpatch is still not triggering consistently (see #106 review thread). Declaring deps is a prerequisite for that path to land

## Test plan
- [x] Iso e2e (info / install / remove)
- [ ] CI: linux-test, static-and-isolation, index-registration, install-tests, windows-test