### PR TITLE
feat(gcc): rewrite specs at install-time so direct binary invocation works

### DIFF
--- a/pkgs/g/gcc.lua
+++ b/pkgs/g/gcc.lua
@@ -36,6 +36,14 @@ package = {
                 -- fix xmake project --project=.  -k compile_commands
                 -- home/xlings/.xlings_data/subos/linux/usr/include/bits/errno.h:26:11: fatal error: linux/errno.h: No such file or directory
                 "linux-headers@5.11.1",
+                -- gcc-specs-config rewrites gcc's specs at install-time so
+                -- the install-machine's xim:glibc loader path / lib64 are
+                -- baked in. Without this, direct-invocation of
+                -- <install_dir>/bin/gcc (bypassing the xvm shim's flag
+                -- injection) emits binaries with INTERP=/lib64/... and
+                -- RPATH empty, leaning on system glibc and breaking on
+                -- distroless / Alpine / different glibc version.
+                "gcc-specs-config@0.0.1",
             },
             ["latest"] = { ref = "16.1.0" },
             ["16.1.0"] = "XLINGS_RES",
@@ -163,6 +171,25 @@ function __config_linux()
             ' --sysroot=%s -Wl,--dynamic-linker=%s -Wl,--enable-new-dtags,-rpath,%s -Wl,-rpath-link,%s',
             sysroot_dir, dynamic_linker, sysroot_lib, sysroot_lib
         )
+
+        -- Rewrite gcc's specs file in-place so direct invocation of
+        -- <install_dir>/bin/gcc (without the xvm shim's flag injection
+        -- via alias_args above) emits binaries with the correct
+        -- install-machine INTERP / RPATH. Specs is rewritten on every
+        -- install on every machine — this is the install-time-realign
+        -- pattern that handles all the cases the prebuilt-tarball-baked
+        -- specs don't (different XLINGS_HOME, container, fresh box,
+        -- moved subos).
+        --
+        -- Invoke via absolute shim path because the config phase doesn't
+        -- prepend subos/default/bin to PATH (unlike the install phase).
+        local gcc_bin = path.join(pkginfo.install_dir(), "bin/gcc")
+        local specs_config_bin = path.join(system.bindir(), "gcc-specs-config")
+        log.info("Rewriting gcc specs to install-machine paths via gcc-specs-config...")
+        system.exec(string.format(
+            "%s %s --dynamic-linker %s --rpath %s --linker-type gnu",
+            specs_config_bin, gcc_bin, dynamic_linker, sysroot_lib
+        ))
     else
         log.warn("subos dir is empty, skip alias linker/sysroot injection")
     end


### PR DESCRIPTION
## Summary
Wire `gcc-specs-config` (existing xscript) into `xim:gcc.lua`'s `__config_linux()` so each install on each machine rewrites gcc's specs file with that machine's actual xim:glibc loader path + lib64. Closes the "direct invocation of `<install_dir>/bin/gcc` bypasses the xvm shim, gcc emits INTERP=/lib64/... → broken in container/distroless" gap.

## Why this is the architectural fix
- **PT_INTERP can never be relocatable**: kernel reads it literally in `execve()`. No $ORIGIN, no env expansion. ELF spec hard rule.
- **The only correct answer is "rewrite at every install so paths match the machine"**, which fits xlings's per-install hook model exactly.
- Until now: xim:gcc relied on xvm shim's alias_args injecting `-Wl,...` flags at invocation time. This works for `gcc` calls through PATH but fails the moment any tool resolves and stores `<install_dir>/bin/gcc` and calls it directly later (cmake / autotools cache / IDE script).

## Two changes in `pkgs/g/gcc.lua`
1. `xpm.linux.deps` += `gcc-specs-config@0.0.1` (guarantees the script is on disk before config phase runs)
2. `__config_linux()` execs `<system.bindir()>/gcc-specs-config <gcc> --dynamic-linker ... --rpath ...` with install-machine-actual paths. Uses absolute shim path because config-phase doesn't auto-prepend `subos/default/bin` to PATH (unlike install-phase)

## Verification (local isolated xlings 0.4.11 iso)

| invocation | INTERP | runs? |
|---|---|---|
| `<subos>/bin/gcc` (xvm shim) — was OK before | iso `subos/default/lib/...` | ✅ |
| `<install_dir>/bin/gcc` (direct) — **was broken** | **iso `subos/default/lib/...`** ← fix | **✅** |

specs file evidence:
```
[xim:xpkg]: Replacing dynamic linker in specs:
            /lib64/ld-linux-x86-64.so.2 → /home/speak/.../iso/.../subos/default/lib/ld-linux-x86-64.so.2
[xim:xpkg]: Adding rpath to specs: /home/speak/.../iso/.../subos/default/lib
[xim:xpkg]: Specs file updated.
```

Shim alias_args left in place as defense-in-depth.

## Test plan
- [x] iso e2e (install / both invocation paths produce same correct ELF / both run)
- [ ] CI: linux-test, static-and-isolation, index-registration, install-tests, windows-test