### PR TITLE
fix(deps): namespace runtime deps on prebuilt packages

### DIFF
--- a/pkgs/c/cmake.lua
+++ b/pkgs/c/cmake.lua
@@ -27,7 +27,7 @@ package = {
             -- libc/libdl/librt/libpthread/libm from glibc. No libstdc++
             -- (statically linked into the binary).
             deps = {
-                runtime = { "glibc@2.39" },
+                runtime = { "xim:glibc@2.39" },
             },
             ["latest"] = { ref = "4.0.2" },
             ["4.0.2"] = "XLINGS_RES",

--- a/pkgs/m/mdbook.lua
+++ b/pkgs/m/mdbook.lua
@@ -43,7 +43,7 @@ package = {
             -- runtime libs (Rust statically links libstdc++ but still
             -- needs libgcc_s for unwind tables).
             deps = {
-                runtime = { "glibc@2.39", "gcc@15.1.0" },
+                runtime = { "xim:glibc@2.39", "xim:gcc@15.1.0" },
             },
             ["latest"] = { ref = "0.5.2" },
             ["0.5.2"] = {

--- a/pkgs/n/ninja.lua
+++ b/pkgs/n/ninja.lua
@@ -26,7 +26,7 @@ package = {
             -- from glibc plus libstdc++.so.6 + libgcc_s.so.1 from gcc's
             -- runtime libs.
             deps = {
-                runtime = { "glibc@2.39", "gcc@15.1.0" },
+                runtime = { "xim:glibc@2.39", "xim:gcc@15.1.0" },
             },
             ["latest"] = { ref = "1.12.1" },
             ["1.12.1"] = "XLINGS_RES",

--- a/pkgs/n/node.lua
+++ b/pkgs/n/node.lua
@@ -51,7 +51,7 @@ package = {
             -- No build deps — install hook is just `os.mv` of the extracted
             -- prebuilt; nothing is compiled at install time.
             deps = {
-                runtime = { "glibc@2.39", "gcc@15.1.0" },
+                runtime = { "xim:glibc@2.39", "xim:gcc@15.1.0" },
             },
             ["latest"] = { ref = "24.15.0" },
             ["25.9.0"] = _linux_url("25.9.0"),

--- a/pkgs/x/xmake.lua
+++ b/pkgs/x/xmake.lua
@@ -32,7 +32,7 @@ package = {
             -- preinstalled. Track the gap separately; declaring
             -- glibc@2.39 alone is the minimum-viable correct fix.
             deps = {
-                runtime = { "glibc@2.39" },
+                runtime = { "xim:glibc@2.39" },
             },
             url_template = "https://github.com/xmake-io/xmake/releases/download/v{version}/xmake-bundle-v{version}.linux.x86_64",
             ["latest"] = { ref = "3.0.8" },


### PR DESCRIPTION
## Summary

PR #108 declared bare-name runtime deps (\`glibc@2.39\`, \`gcc@15.1.0\`) on cmake / mdbook / ninja / node / xmake. This causes the resolver to fail with **"package is ambiguous"** in any setup where multiple repos see the same package — including:

- xlings's E2E-05 test (\`fixed project scenarios\`) which mounts the fixture as both \`projectrepo\` and \`xim\`
- Production users with both project-local and global indexes (the intended dual-repo deployment)

## Repro

\`\`\`
[error] package 'glibc@2.39' is ambiguous, candidates:
1. projectrepo:glibc@2.39   from project repo 'projectrepo'
2. xim:glibc@2.39   from global repo 'xim'

use one of:
  xlings install projectrepo:glibc@2.39
  xlings install xim:glibc@2.39
\`\`\`

## Fix

Prefix runtime deps with \`xim:\` namespace. Since these packages are only published in xim, this is the canonical resolution.

\`\`\`diff
- runtime = { "glibc@2.39", "gcc@15.1.0" },
+ runtime = { "xim:glibc@2.39", "xim:gcc@15.1.0" },
\`\`\`

Affected:
- \`cmake.lua\`: \`xim:glibc@2.39\`
- \`mdbook.lua\`: \`xim:glibc@2.39\`, \`xim:gcc@15.1.0\`
- \`ninja.lua\`: \`xim:glibc@2.39\`, \`xim:gcc@15.1.0\`
- \`node.lua\`: \`xim:glibc@2.39\`, \`xim:gcc@15.1.0\`
- \`xmake.lua\`: \`xim:glibc@2.39\`

## Test plan

- [x] xlings PR #257 CI re-run after this merges → E2E-05 should pass

## Related

- Unblocks: d2learn/xlings PR #257 (release: 0.4.13 elfpatch order fix)
- Predecessor: #108 (introduced the bare-name deps)