### PR TITLE
fix(deps): namespace remaining bare-name deps on gcc/binutils/openssl/d2x

### DIFF
--- a/pkgs/b/binutils.lua
+++ b/pkgs/b/binutils.lua
@@ -30,7 +30,7 @@ package = {
 
     xpm = {
         linux = {
-            deps = { "glibc@2.39" },
+            deps = { "xim:glibc@2.39" },
             ["latest"] = { ref = "2.42" },
             ["2.42"] = "XLINGS_RES",
         },

--- a/pkgs/d/d2x.lua
+++ b/pkgs/d/d2x.lua
@@ -31,7 +31,7 @@ package = {
             ["0.1.1"] = "XLINGS_RES",
         },
         linux = {
-            deps = { "glibc@2.39", "openssl@3.1.5" },
+            deps = { "xim:glibc@2.39", "xim:openssl@3.1.5" },
             ["latest"] = { ref = "0.1.4" },
             ["0.1.4"] = "XLINGS_RES",
             ["0.1.3"] = "XLINGS_RES",

--- a/pkgs/g/gcc.lua
+++ b/pkgs/g/gcc.lua
@@ -32,10 +32,10 @@ package = {
     xpm = {
         linux = {
             deps = {
-                "glibc@2.39", "binutils@2.42",
+                "xim:glibc@2.39", "xim:binutils@2.42",
                 -- fix xmake project --project=.  -k compile_commands
                 -- home/xlings/.xlings_data/subos/linux/usr/include/bits/errno.h:26:11: fatal error: linux/errno.h: No such file or directory
-                "linux-headers@5.11.1",
+                "xim:linux-headers@5.11.1",
                 -- gcc-specs-config rewrites gcc's specs at install-time so
                 -- the install-machine's xim:glibc loader path / lib64 are
                 -- baked in. Without this, direct-invocation of
@@ -43,7 +43,7 @@ package = {
                 -- injection) emits binaries with INTERP=/lib64/... and
                 -- RPATH empty, leaning on system glibc and breaking on
                 -- distroless / Alpine / different glibc version.
-                "gcc-specs-config@0.0.1",
+                "xim:gcc-specs-config@0.0.1",
             },
             ["latest"] = { ref = "16.1.0" },
             ["16.1.0"] = "XLINGS_RES",

--- a/pkgs/o/openssl.lua
+++ b/pkgs/o/openssl.lua
@@ -21,7 +21,7 @@ package = {
 
     xpm = {
         linux = {
-            deps = { "glibc@2.39" },
+            deps = { "xim:glibc@2.39" },
             ["latest"] = { ref = "3.1.5" },
             ["3.1.5"] = "XLINGS_RES",
         },


### PR DESCRIPTION
Follow-up to #110: those 5 packages got fixed but gcc/binutils/openssl/d2x still have bare-name deps that trigger the same ambiguity error in xlings PR #257's E2E-05.

```
[error] package 'glibc@2.39' is ambiguous, candidates:
  1. projectrepo:glibc@2.39
  2. xim:glibc@2.39
[error] package 'binutils@2.42' is ambiguous
[error] package 'linux-headers@5.11.1' is ambiguous
[error] package 'gcc-specs-config@0.0.1' is ambiguous
```

All these come from gcc.lua's deps + transitive (binutils → glibc, openssl → glibc, d2x → glibc/openssl).

Fix: prefix with `xim:` namespace, same approach as #110.

Unblocks: d2learn/xlings PR #257.