### PR TITLE
feat: add xim:e2fsprogs + xim:syslinux + xlings 0.4.13

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Installation Xlings on Ubuntu
         run: |
           export XLINGS_NON_INTERACTIVE=1
-          export XLINGS_VERSION=v0.4.12
+          export XLINGS_VERSION=v0.4.13
           curl -fsSL https://raw.githubusercontent.com/d2learn/xlings/main/tools/other/quick_install.sh | bash
           echo "XLINGS_HOME=$HOME/.xlings" >> "$GITHUB_ENV"
           echo "PATH=$HOME/.xlings/subos/current/bin:$HOME/.xlings/bin:$PATH" >> "$GITHUB_ENV"
@@ -76,7 +76,7 @@ jobs:
         shell: pwsh
         run: |
           $env:XLINGS_NON_INTERACTIVE = "1"
-          $env:XLINGS_VERSION = "v0.4.12"
+          $env:XLINGS_VERSION = "v0.4.13"
           iex (Invoke-WebRequest `
             -Uri "https://raw.githubusercontent.com/d2learn/xlings/main/tools/other/quick_install.ps1" `
             -UseBasicParsing).Content
@@ -127,7 +127,7 @@ jobs:
       - name: Install xlings on Ubuntu
         run: |
           export XLINGS_NON_INTERACTIVE=1
-          export XLINGS_VERSION=v0.4.12
+          export XLINGS_VERSION=v0.4.13
           curl -fsSL https://raw.githubusercontent.com/d2learn/xlings/main/tools/other/quick_install.sh | bash
           echo "XLINGS_HOME=$HOME/.xlings" >> "$GITHUB_ENV"
           echo "$HOME/.xlings/bin"               >> "$GITHUB_PATH"
@@ -170,7 +170,7 @@ jobs:
       - name: Install xlings on macOS
         run: |
           export XLINGS_NON_INTERACTIVE=1
-          export XLINGS_VERSION=v0.4.12
+          export XLINGS_VERSION=v0.4.13
           curl -fsSL https://raw.githubusercontent.com/d2learn/xlings/main/tools/other/quick_install.sh | bash
           echo "XLINGS_HOME=$HOME/.xlings" >> "$GITHUB_ENV"
           echo "$HOME/.xlings/bin"               >> "$GITHUB_PATH"

--- a/.github/workflows/ci-xpkg-test.yml
+++ b/.github/workflows/ci-xpkg-test.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Install xlings
         run: |
           export XLINGS_NON_INTERACTIVE=1
-          export XLINGS_VERSION=v0.4.12
+          export XLINGS_VERSION=v0.4.13
           curl -fsSL https://raw.githubusercontent.com/d2learn/xlings/main/tools/other/quick_install.sh | bash
           echo "XLINGS_HOME=$HOME/.xlings" >> "$GITHUB_ENV"
           echo "PATH=$HOME/.xlings/subos/current/bin:$HOME/.xlings/bin:$PATH" >> "$GITHUB_ENV"

--- a/pkgs/e/e2fsprogs.lua
+++ b/pkgs/e/e2fsprogs.lua
@@ -1,0 +1,100 @@
+package = {
+    spec = "1",
+
+    name = "e2fsprogs",
+    description = "ext2/ext3/ext4 filesystem utilities (mke2fs, e2fsck, tune2fs, resize2fs, debugfs)",
+
+    homepage = "https://e2fsprogs.sourceforge.net/",
+    authors = {"Theodore Ts'o"},
+    licenses = {"GPL-2.0-only", "LGPL-2.0-only", "BSD-3-Clause", "MIT"},
+    repo = "https://git.kernel.org/pub/scm/fs/ext2/e2fsprogs.git",
+    docs = "https://www.man7.org/linux/man-pages/man8/mke2fs.8.html",
+
+    type = "package",
+    archs = {"x86_64"},
+    status = "stable",
+    categories = {"system", "filesystem", "utilities"},
+    keywords = {"ext2", "ext3", "ext4", "fsck", "mke2fs", "resize2fs", "tune2fs"},
+
+    -- The xlings-res tarball ships statically-linked ELF binaries
+    -- (built by github.com/ronpscg/e2fsprogs-static-builds): no glibc /
+    -- musl runtime dep, no INTERP/RPATH to patch. Programs we expose
+    -- via xvm shims:
+    --   sbin/      core fsck/mkfs/tune family
+    --   usr/sbin/  ext4 helpers (e4crypt, e4defrag, filefrag)
+    -- `mklost+found` is omitted from the program list because the `+`
+    -- in its name isn't xvm-shim friendly; it remains accessible via
+    -- the install dir if needed.
+    programs = {
+        "badblocks", "debugfs", "dumpe2fs", "e2fsck", "e2image", "e2label",
+        "e2mmpstatus", "e2undo", "fsck", "fsck.ext2", "fsck.ext3", "fsck.ext4",
+        "logsave", "mke2fs", "mkfs.ext2", "mkfs.ext3", "mkfs.ext4",
+        "resize2fs", "tune2fs",
+        "e4crypt", "e4defrag", "filefrag",
+    },
+    xvm_enable = true,
+
+    xpm = {
+        linux = {
+            ["latest"] = { ref = "1.47.3" },
+            ["1.47.3"] = "XLINGS_RES",
+        },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+import("xim.libxpkg.log")
+
+-- Programs we ship and shim. Ordered to match the `programs` field above.
+local sbin_programs = {
+    "badblocks", "debugfs", "dumpe2fs", "e2fsck", "e2image", "e2label",
+    "e2mmpstatus", "e2undo", "fsck", "fsck.ext2", "fsck.ext3", "fsck.ext4",
+    "logsave", "mke2fs", "mkfs.ext2", "mkfs.ext3", "mkfs.ext4",
+    "resize2fs", "tune2fs",
+    "e4crypt", "e4defrag", "filefrag",
+}
+
+function install()
+    -- XLINGS_RES tarball extracts to e2fsprogs-<ver>-linux-x86_64/ with
+    -- layout: sbin/ usr/sbin/ etc/. Move the whole tree to install_dir,
+    -- then collapse usr/sbin into sbin so a single bindir covers every
+    -- shimmed program.
+    local srcdir = pkginfo.install_file():replace(".tar.gz", "")
+    os.tryrm(pkginfo.install_dir())
+    os.mv(srcdir, pkginfo.install_dir())
+
+    local sbin = path.join(pkginfo.install_dir(), "sbin")
+    local usr_sbin = path.join(pkginfo.install_dir(), "usr", "sbin")
+    if os.isdir(usr_sbin) then
+        os.execute(string.format('mv "%s"/* "%s"/', usr_sbin, sbin))
+        os.tryrm(path.join(pkginfo.install_dir(), "usr"))
+    end
+    return true
+end
+
+function config()
+    local bindir = path.join(pkginfo.install_dir(), "sbin")
+    local root = "e2fsprogs@" .. pkginfo.version()
+    -- First program owns the version slot; the rest bind their lifecycle
+    -- to it via `binding`, so removing e2fsprogs cleans every shim.
+    xvm.add(sbin_programs[1], { bindir = bindir })
+    for i = 2, #sbin_programs do
+        xvm.add(sbin_programs[i], { bindir = bindir, binding = root })
+    end
+
+    -- mke2fs reads mke2fs.conf at runtime; the static binary has no
+    -- compiled-in path that points inside install_dir, so help users
+    -- who want non-default fs profiles by exporting MKE2FS_CONFIG.
+    log.info("e2fsprogs config files at %s/etc/", pkginfo.install_dir())
+    log.info("If mke2fs warns about a missing mke2fs.conf, run:")
+    log.info("  export MKE2FS_CONFIG=%s/etc/mke2fs.conf", pkginfo.install_dir())
+    return true
+end
+
+function uninstall()
+    for _, p in ipairs(sbin_programs) do
+        xvm.remove(p)
+    end
+    return true
+end

--- a/pkgs/s/syslinux.lua
+++ b/pkgs/s/syslinux.lua
@@ -1,0 +1,96 @@
+package = {
+    spec = "1",
+
+    name = "syslinux",
+    description = "SYSLINUX bootloader collection (isolinux, pxelinux, extlinux + EFI loaders)",
+
+    homepage = "https://www.syslinux.org",
+    authors = {"H. Peter Anvin"},
+    licenses = {"GPL-2.0+"},
+    repo = "https://git.kernel.org/pub/scm/boot/syslinux/syslinux.git",
+    docs = "https://wiki.syslinux.org",
+
+    type = "package",
+    archs = {"x86_64"},
+    status = "stable",
+    categories = {"system", "boot", "bootloader"},
+    keywords = {"syslinux", "isolinux", "pxelinux", "extlinux", "bootloader", "iso"},
+
+    -- Upstream's tarball is a prebuilt distribution: bootloader stub
+    -- modules (`*.c32`, `*.bin`, EFI loaders) ship as binary blobs that
+    -- get written to boot media by mkisofs / xorriso / dd, plus three
+    -- host-side installer ELFs:
+    --
+    --     bios/extlinux/extlinux              -> install onto ext/btrfs/xfs/fat
+    --     bios/linux/syslinux                 -> install onto fat (uses mtools)
+    --     bios/linux/syslinux-nomtools        -> install onto fat (no mtools)
+    --
+    -- Caveat: those installer ELFs are i386 (`/lib/ld-linux.so.2`),
+    -- which means a pure 64-bit host without i386 multilib can't
+    -- launch them (`exec format error`). Most of the package's value
+    -- — the `.c32`/`.bin`/EFI artefacts used to build bootable
+    -- images — does not need the installer ELFs to run, so we still
+    -- ship them and surface the constraint in `config()` log output.
+    programs = { "extlinux", "syslinux", "syslinux-nomtools" },
+    xvm_enable = true,
+
+    xpm = {
+        linux = {
+            ["latest"] = { ref = "6.03" },
+            ["6.03"] = {
+                url = "https://www.kernel.org/pub/linux/utils/boot/syslinux/syslinux-6.03.tar.xz",
+                sha256 = "26d3986d2bea109d5dc0e4f8c4822a459276cf021125e8c9f23c3cca5d8c850e",
+            },
+        },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+import("xim.libxpkg.log")
+
+local host_installers = { "extlinux", "syslinux", "syslinux-nomtools" }
+
+function install()
+    -- Tarball extracts to syslinux-<ver>/ at the runtime download dir.
+    local srcdir = pkginfo.install_file():replace(".tar.xz", "")
+    os.tryrm(pkginfo.install_dir())
+    os.mv(srcdir, pkginfo.install_dir())
+
+    -- Surface the three host installer ELFs under a single bindir so
+    -- xvm can shim them — upstream parks them under bios/extlinux/ and
+    -- bios/linux/, neither of which is conventional.
+    local bindir = path.join(pkginfo.install_dir(), "bin")
+    os.mkdir(bindir)
+    os.cp(path.join(pkginfo.install_dir(), "bios/extlinux/extlinux"),     path.join(bindir, "extlinux"))
+    os.cp(path.join(pkginfo.install_dir(), "bios/linux/syslinux"),         path.join(bindir, "syslinux"))
+    os.cp(path.join(pkginfo.install_dir(), "bios/linux/syslinux-nomtools"), path.join(bindir, "syslinux-nomtools"))
+    for _, p in ipairs(host_installers) do
+        os.execute('chmod +x "' .. path.join(bindir, p) .. '"')
+    end
+    return true
+end
+
+function config()
+    local bindir = path.join(pkginfo.install_dir(), "bin")
+    local root = "syslinux@" .. pkginfo.version()
+    xvm.add(host_installers[1], { bindir = bindir })
+    for i = 2, #host_installers do
+        xvm.add(host_installers[i], { bindir = bindir, binding = root })
+    end
+
+    log.info("syslinux installed to %s", pkginfo.install_dir())
+    log.info("BIOS modules:    %s/bios/   (isolinux.bin, ldlinux.c32, menu.c32, mbr/*.bin, ...)", pkginfo.install_dir())
+    log.info("EFI64 loaders:   %s/efi64/", pkginfo.install_dir())
+    log.info("EFI32 loaders:   %s/efi32/", pkginfo.install_dir())
+    log.info("Host installers (extlinux/syslinux/syslinux-nomtools) are i386 ELFs;")
+    log.info("running them on a 64-bit host requires i386 multilib (e.g. libc6-i386).")
+    return true
+end
+
+function uninstall()
+    for _, p in ipairs(host_installers) do
+        xvm.remove(p)
+    end
+    return true
+end

--- a/pkgs/x/xlings.lua
+++ b/pkgs/x/xlings.lua
@@ -36,7 +36,11 @@ package = {
     -- one version at a time.
     xpm = {
         linux = {
-            ["latest"] = { ref = "0.4.12" },
+            ["latest"] = { ref = "0.4.13" },
+            ["0.4.13"] = {
+                url = "https://github.com/d2learn/xlings/releases/download/v0.4.13/xlings-0.4.13-linux-x86_64.tar.gz",
+                sha256 = "74be30e988c82b9f2f3c44a48df2ae736aec6ad9ee05558351c3e37ee73088ec",
+            },
             ["0.4.12"] = {
                 url = "https://github.com/d2learn/xlings/releases/download/v0.4.12/xlings-0.4.12-linux-x86_64.tar.gz",
                 sha256 = "efccd525bfc5259a6387c40b523a23c2803678a48ecd4285efa6badac15d6338",
@@ -69,7 +73,11 @@ package = {
             ["0.3.0"] = "XLINGS_RES",
         },
         macosx = {
-            ["latest"] = { ref = "0.4.12" },
+            ["latest"] = { ref = "0.4.13" },
+            ["0.4.13"] = {
+                url = "https://github.com/d2learn/xlings/releases/download/v0.4.13/xlings-0.4.13-macosx-arm64.tar.gz",
+                sha256 = "d64625801bba3a6895b3f61b9dd3e4fecac67d2fecfac7379693bf1f2298864d",
+            },
             ["0.4.12"] = {
                 url = "https://github.com/d2learn/xlings/releases/download/v0.4.12/xlings-0.4.12-macosx-arm64.tar.gz",
                 sha256 = "2350db515e3c326320a3404a36bf2a7b30705d89028e89130b9456d45c6ddf79",
@@ -102,7 +110,11 @@ package = {
             ["0.3.0"] = "XLINGS_RES",
         },
         windows = {
-            ["latest"] = { ref = "0.4.12" },
+            ["latest"] = { ref = "0.4.13" },
+            ["0.4.13"] = {
+                url = "https://github.com/d2learn/xlings/releases/download/v0.4.13/xlings-0.4.13-windows-x86_64.zip",
+                sha256 = "6953fc974d241e72de0625d80b15b7250cb071a906a500da5b3c6b410c9df878",
+            },
             ["0.4.12"] = {
                 url = "https://github.com/d2learn/xlings/releases/download/v0.4.12/xlings-0.4.12-windows-x86_64.zip",
                 sha256 = "9d600b38a8897e772d6c787df95f9e6e0a13bff3f9c3729bf91ed2f6f66f9e62",


### PR DESCRIPTION
## Summary

- **xim:e2fsprogs@1.47.3** — ext2/3/4 utilities. Static x86_64 prebuilds republished to `xlings-res/e2fsprogs` (sourced from [ronpscg/e2fsprogs-static-builds](https://github.com/ronpscg/e2fsprogs-static-builds)) so the binaries have no glibc / musl runtime dependency. The xpkg shims the full `sbin/` set (`mke2fs`, `e2fsck`, `tune2fs`, `resize2fs`, `debugfs`, the `fsck.ext{2,3,4}` family, …) plus `usr/sbin/` ext4 helpers (`e4crypt`, `e4defrag`, `filefrag`).

- **xim:syslinux@6.03** — bootloader collection (isolinux, pxelinux, extlinux + EFI loaders) installed straight from the upstream `kernel.org` tarball. The `.c32` / `.bin` / EFI artefacts that get written to boot media are kept under the upstream layout (`bios/`, `efi32/`, `efi64/`); the three host installer ELFs (`extlinux`, `syslinux`, `syslinux-nomtools`) are surfaced via a single `bin/` so xvm can shim them. Caveat: those installer ELFs are i386 — `config()` logs the i386-multilib requirement for hosts that want to run them.

- **xim:xlings@0.4.13** — `linux` / `macosx` / `windows` entries with sha256s, `latest` bumped 0.4.12 → 0.4.13, and CI pinned to `v0.4.13` across `ci-test.yml` (3 bash sites + 1 pwsh) and `ci-xpkg-test.yml` (1 site).

## Verification (host xlings 0.4.13)

For each new xpkg:

```
xlings config --add-xpkg pkgs/<X>/<pkg>.lua    # registered ✓
xlings install local:<pkg> -y                  # install hook ran clean ✓
ls $XLINGS_HOME/data/xpkgs/local-x-<pkg>/<ver> # expected layout ✓
mke2fs -V / e4crypt / filefrag                 # smoke (e2fsprogs)    ✓
$XLINGS_HOME/data/xpkgs/.../bios/mbr/isohdpfx.bin
$XLINGS_HOME/data/xpkgs/.../efi64/efi/syslinux.efi  # syslinux artefacts present ✓
xlings remove local:<pkg> -y                   # shims cleaned ✓
xlings install local:xlings@0.4.13 -y          # ↳ `xlings --version` → 0.4.13 ✓
```

## Test plan

- [ ] `xpkg test` workflow (ci-xpkg-test.yml): static + isolation + index registration green
- [ ] `pkgindex test` workflow (ci-test.yml): linux-test (lint), linux-install-test, macos-install-test
- [ ] windows-test: only relevant for changed `.lua` with a `windows` xpm branch — none of the three new files have one, so windows-test will skip the install/uninstall pass for them