### PR TITLE
fix(e2fsprogs): use direct mirror URL instead of XLINGS_RES

### DIFF
--- a/pkgs/e/e2fsprogs.lua
+++ b/pkgs/e/e2fsprogs.lua
@@ -16,15 +16,19 @@ package = {
     categories = {"system", "filesystem", "utilities"},
     keywords = {"ext2", "ext3", "ext4", "fsck", "mke2fs", "resize2fs", "tune2fs"},
 
-    -- The xlings-res tarball ships statically-linked ELF binaries
-    -- (built by github.com/ronpscg/e2fsprogs-static-builds): no glibc /
-    -- musl runtime dep, no INTERP/RPATH to patch. Programs we expose
-    -- via xvm shims:
+    -- Tarball ships statically-linked ELF binaries (built by
+    -- github.com/ronpscg/e2fsprogs-static-builds): no glibc / musl
+    -- runtime dep, no INTERP/RPATH to patch. Programs we expose via
+    -- xvm shims:
     --   sbin/      core fsck/mkfs/tune family
     --   usr/sbin/  ext4 helpers (e4crypt, e4defrag, filefrag)
     -- `mklost+found` is omitted from the program list because the `+`
     -- in its name isn't xvm-shim friendly; it remains accessible via
     -- the install dir if needed.
+    --
+    -- The artefact lives in the xlings-res/e2fsprogs mirror but is
+    -- referenced as a direct URL (rather than the XLINGS_RES sentinel),
+    -- to match the rest of the recently-added prebuilt packages.
     programs = {
         "badblocks", "debugfs", "dumpe2fs", "e2fsck", "e2image", "e2label",
         "e2mmpstatus", "e2undo", "fsck", "fsck.ext2", "fsck.ext3", "fsck.ext4",
@@ -37,7 +41,10 @@ package = {
     xpm = {
         linux = {
             ["latest"] = { ref = "1.47.3" },
-            ["1.47.3"] = "XLINGS_RES",
+            ["1.47.3"] = {
+                url = "https://github.com/xlings-res/e2fsprogs/releases/download/1.47.3/e2fsprogs-1.47.3-linux-x86_64.tar.gz",
+                sha256 = "fa3211e05885ba44fe412017c67e95a0d0cf10c690766ce85a5d77ad7010edf4",
+            },
         },
     },
 }
@@ -56,9 +63,9 @@ local sbin_programs = {
 }
 
 function install()
-    -- XLINGS_RES tarball extracts to e2fsprogs-<ver>-linux-x86_64/ with
-    -- layout: sbin/ usr/sbin/ etc/. Move the whole tree to install_dir,
-    -- then collapse usr/sbin into sbin so a single bindir covers every
+    -- Tarball extracts to e2fsprogs-<ver>-linux-x86_64/ with layout:
+    -- sbin/ usr/sbin/ etc/. Move the whole tree to install_dir, then
+    -- collapse usr/sbin into sbin so a single bindir covers every
     -- shimmed program.
     local srcdir = pkginfo.install_file():replace(".tar.gz", "")
     os.tryrm(pkginfo.install_dir())


### PR DESCRIPTION
## Summary

`xim:e2fsprogs@1.47.3` was added in #112 with `XLINGS_RES` sentinel resolution. Switching to a direct URL (pointing at the same artefact in `xlings-res/e2fsprogs`) for two reasons:

- the maintainer reports the `XLINGS_RES` sentinel doesn't work reliably for this package;
- it matches the shape of the other prebuilt packages added in the same PR (`xim:xlings@0.4.13` and `xim:syslinux@6.03`), which are both direct URLs.

The artefact, sha256, naming, and install/uninstall semantics are all unchanged.

## Verification (local iso, fresh cache)

- `xlings install local:e2fsprogs -y` → ✓ done
- `ls $XPKG_DIR/sbin` → 23 entries (full sbin + usr/sbin merged)
- `mke2fs -V` → `mke2fs 1.47.3 (8-Jul-2025)`
- `xlings remove local:e2fsprogs -y` → ✓ all shims cleaned

## Test plan

- [ ] `pkgindex test` linux-install-test repeats the lifecycle pass on the runner