### PR TITLE
Revert #113: keep xim:e2fsprogs on XLINGS_RES (mirror works)

### DIFF
--- a/pkgs/e/e2fsprogs.lua
+++ b/pkgs/e/e2fsprogs.lua
@@ -16,19 +16,15 @@ package = {
     categories = {"system", "filesystem", "utilities"},
     keywords = {"ext2", "ext3", "ext4", "fsck", "mke2fs", "resize2fs", "tune2fs"},
 
-    -- Tarball ships statically-linked ELF binaries (built by
-    -- github.com/ronpscg/e2fsprogs-static-builds): no glibc / musl
-    -- runtime dep, no INTERP/RPATH to patch. Programs we expose via
-    -- xvm shims:
+    -- The xlings-res tarball ships statically-linked ELF binaries
+    -- (built by github.com/ronpscg/e2fsprogs-static-builds): no glibc /
+    -- musl runtime dep, no INTERP/RPATH to patch. Programs we expose
+    -- via xvm shims:
     --   sbin/      core fsck/mkfs/tune family
     --   usr/sbin/  ext4 helpers (e4crypt, e4defrag, filefrag)
     -- `mklost+found` is omitted from the program list because the `+`
     -- in its name isn't xvm-shim friendly; it remains accessible via
     -- the install dir if needed.
-    --
-    -- The artefact lives in the xlings-res/e2fsprogs mirror but is
-    -- referenced as a direct URL (rather than the XLINGS_RES sentinel),
-    -- to match the rest of the recently-added prebuilt packages.
     programs = {
         "badblocks", "debugfs", "dumpe2fs", "e2fsck", "e2image", "e2label",
         "e2mmpstatus", "e2undo", "fsck", "fsck.ext2", "fsck.ext3", "fsck.ext4",
@@ -41,10 +37,7 @@ package = {
     xpm = {
         linux = {
             ["latest"] = { ref = "1.47.3" },
-            ["1.47.3"] = {
-                url = "https://github.com/xlings-res/e2fsprogs/releases/download/1.47.3/e2fsprogs-1.47.3-linux-x86_64.tar.gz",
-                sha256 = "fa3211e05885ba44fe412017c67e95a0d0cf10c690766ce85a5d77ad7010edf4",
-            },
+            ["1.47.3"] = "XLINGS_RES",
         },
     },
 }
@@ -63,9 +56,9 @@ local sbin_programs = {
 }
 
 function install()
-    -- Tarball extracts to e2fsprogs-<ver>-linux-x86_64/ with layout:
-    -- sbin/ usr/sbin/ etc/. Move the whole tree to install_dir, then
-    -- collapse usr/sbin into sbin so a single bindir covers every
+    -- XLINGS_RES tarball extracts to e2fsprogs-<ver>-linux-x86_64/ with
+    -- layout: sbin/ usr/sbin/ etc/. Move the whole tree to install_dir,
+    -- then collapse usr/sbin into sbin so a single bindir covers every
     -- shimmed program.
     local srcdir = pkginfo.install_file():replace(".tar.gz", "")
     os.tryrm(pkginfo.install_dir())


### PR DESCRIPTION
## Why

Reverts #113. Empirical verification on a fresh local cache (mirror=CN, gitcode):

```
$ curl -fsSL https://gitcode.com/xlings-res/e2fsprogs/releases/download/1.47.3/e2fsprogs-1.47.3-linux-x86_64.tar.gz | sha256sum
fa3211e05885ba44fe412017c67e95a0d0cf10c690766ce85a5d77ad7010edf4  # ✓ matches upload

$ xlings install local:e2fsprogs -y     # via XLINGS_RES + CN mirror, no cache
✓ local:e2fsprogs@1.47.3  done
```

The asset name `e2fsprogs-1.47.3-linux-x86_64.tar.gz` matches the
XLINGS_RES URL template (`<pkg>-<ver>-<os>-<arch>.<ext>`) on both the
GitHub and gitcode mirrors, and end-to-end install through the
sentinel succeeds.

## Test plan

- [x] `xlings install local:e2fsprogs` clean (CN mirror) → 23 shims, `mke2fs -V` smoke ✓
- [x] `xlings remove local:e2fsprogs` clean → all shims removed