### PR TITLE
feat(gcc-runtime): split GCC runtime libs into a standalone xpkg

### DIFF
--- a/pkgs/g/gcc-runtime.lua
+++ b/pkgs/g/gcc-runtime.lua
@@ -1,0 +1,77 @@
+package = {
+    spec = "1",
+
+    homepage = "https://gcc.gnu.org",
+    name = "gcc-runtime",
+    description = "GCC runtime libraries (libstdc++, libgcc_s, libgomp, libatomic, libitm, libquadmath, libssp) — required by virtually every C++ binary on Linux, including Clang-built ones",
+
+    authors = {"GNU"},
+    licenses = {"GPL-3.0-with-GCC-exception", "LGPL-2.1+"},
+    repo = "https://gcc.gnu.org/git/?p=gcc.git",
+    docs = "https://gcc.gnu.org/onlinedocs/libstdc++/",
+
+    type = "package",
+    archs = {"x86_64"},
+    status = "stable",
+    categories = {"libc++", "runtime", "lib"},
+    keywords = {"libstdc++", "libgcc", "gcc-runtime", "cxx-runtime"},
+
+    -- Pure runtime library bundle: no executables to shim, so no
+    -- `programs` and no `xvm_enable`. Consumers (ninja, cmake, node, ...)
+    -- pick up the lib64 dir via xlings predicate-driven elfpatch — see
+    -- `exports.runtime.abi` below.
+    --
+    -- Why a separate package instead of leaving callers depending on
+    -- xim:gcc:
+    --   * xim:gcc is the full compiler (~1.1 GB)
+    --   * The runtime libs are ~25 MB
+    --   * Tools that only need to *run* C++ binaries (ninja, cmake,
+    --     node, mdbook, fd, ...) don't need cc1/cc1plus/headers/*.a
+    --   * libstdc++ is forward-compatible; one gcc-runtime version
+    --     covers every binary built against an equal-or-older GCC
+
+    xpm = {
+        linux = {
+            -- Tracks GCC main version. libstdc++ ABI is forward-
+            -- compatible (versioned symbols GLIBCXX_3.4.x), so a single
+            -- modern gcc-runtime covers all consumers.
+            ["latest"] = { ref = "15.1.0" },
+            ["15.1.0"] = "XLINGS_RES",
+
+            deps = {
+                runtime = { "xim:glibc@2.39" },
+            },
+            exports = {
+                runtime = {
+                    -- xlings install-time elfpatch reads this and
+                    -- appends `<install_dir>/lib64` to consumers' RPATH
+                    -- so libstdc++.so.6 / libgcc_s.so.1 / ... resolve
+                    -- without the consumer hardcoding paths.
+                    abi = { "lib64" },
+                },
+            },
+        },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+
+function install()
+    -- Tarball extracts to gcc-runtime-<ver>-linux-x86_64/lib64/. Move
+    -- the whole tree to install_dir as-is; the .so RPATHs were stripped
+    -- at build time, so the consumer's RPATH (set by elfpatch via
+    -- exports.runtime.abi) is what ld.so uses to resolve transitive
+    -- deps (libc/libm via xim:glibc).
+    local srcdir = pkginfo.install_file():replace(".tar.gz", "")
+    os.tryrm(pkginfo.install_dir())
+    os.mv(srcdir, pkginfo.install_dir())
+    return true
+end
+
+function config()
+    return true
+end
+
+function uninstall()
+    return true
+end

--- a/pkgs/m/mdbook.lua
+++ b/pkgs/m/mdbook.lua
@@ -39,11 +39,11 @@ package = {
         linux = {
             -- Runtime deps. mdbook prebuilt is dynamically linked
             -- (INTERP=/lib64/ld-linux-x86-64.so.2) and pulls libc/libdl/
-            -- libpthread/libm from glibc plus libgcc_s.so.1 from gcc's
-            -- runtime libs (Rust statically links libstdc++ but still
-            -- needs libgcc_s for unwind tables).
+            -- libpthread/libm from glibc plus libgcc_s.so.1 from
+            -- xim:gcc-runtime (Rust statically links libstdc++ but
+            -- still needs libgcc_s for unwind tables).
             deps = {
-                runtime = { "xim:glibc@2.39", "xim:gcc@15.1.0" },
+                runtime = { "xim:glibc@2.39", "xim:gcc-runtime@15.1.0" },
             },
             ["latest"] = { ref = "0.5.2" },
             ["0.5.2"] = {

--- a/pkgs/n/ninja.lua
+++ b/pkgs/n/ninja.lua
@@ -23,10 +23,10 @@ package = {
         linux = {
             -- Runtime deps. ninja prebuilt is dynamically linked
             -- (INTERP=/lib64/ld-linux-x86-64.so.2) and pulls libc/libm
-            -- from glibc plus libstdc++.so.6 + libgcc_s.so.1 from gcc's
-            -- runtime libs.
+            -- from glibc plus libstdc++.so.6 + libgcc_s.so.1 from
+            -- xim:gcc-runtime (the runtime libs split out of xim:gcc).
             deps = {
-                runtime = { "xim:glibc@2.39", "xim:gcc@15.1.0" },
+                runtime = { "xim:glibc@2.39", "xim:gcc-runtime@15.1.0" },
             },
             ["latest"] = { ref = "1.12.1" },
             ["1.12.1"] = "XLINGS_RES",

--- a/pkgs/n/node.lua
+++ b/pkgs/n/node.lua
@@ -43,15 +43,16 @@ package = {
             -- Runtime deps. The upstream node prebuilt is dynamically linked
             -- (INTERP=/lib64/ld-linux-x86-64.so.2, RPATH empty) and pulls
             -- libc/libdl/libpthread/libm from glibc plus libstdc++.so.6 +
-            -- libgcc_s.so.1 from gcc's runtime libs. Without these declared,
-            -- xlings's predicate-driven elfpatch can't rewrite INTERP/RPATH
-            -- to the xpkg-provided libc + libstdc++, and the binary only
+            -- libgcc_s.so.1 from xim:gcc-runtime (the runtime libs split
+            -- out of xim:gcc). Without these declared, xlings's
+            -- predicate-driven elfpatch can't rewrite INTERP/RPATH to
+            -- the xpkg-provided libc + libstdc++, and the binary only
             -- runs on hosts that already have system glibc + a compatible
             -- libstdc++ (i.e. fails on distroless / Alpine / very old glibc).
             -- No build deps — install hook is just `os.mv` of the extracted
             -- prebuilt; nothing is compiled at install time.
             deps = {
-                runtime = { "xim:glibc@2.39", "xim:gcc@15.1.0" },
+                runtime = { "xim:glibc@2.39", "xim:gcc-runtime@15.1.0" },
             },
             ["latest"] = { ref = "24.15.0" },
             ["25.9.0"] = _linux_url("25.9.0"),


### PR DESCRIPTION
## What

Adds **xim:gcc-runtime** — a 26 MB bundle of GCC's runtime shared libraries (libstdc++, libgcc_s, libgomp, libatomic, libitm, libquadmath, libssp), extracted from the xim:gcc 15.1.0 tarball with RPATHs stripped. Consumers (ninja, node, mdbook) switch their runtime dep from \`xim:gcc@15.1.0\` (1.1 GB compiler) to \`xim:gcc-runtime@15.1.0\` (26 MB runtime-only).

xim:gcc **is unchanged** — it keeps its own lib64 so users who actually want the compiler still get a self-contained install. gcc-runtime is purely a consumer-side optimization for tools that only need to *run* C++ binaries.

## Why

Ran across this when noticing that \`xlings install xim:ninja\` pulls down 1.1 GB of GCC just to get \`libstdc++.so.6\` + \`libgcc_s.so.1\`. The runtime libs are designed to be independently distributable (GCC Runtime Library Exception, plus libstdc++'s versioned-symbol forward-compat guarantee), and other distros (Debian, Arch, Fedora, conda-forge) all split them out.

Naming: chose \`gcc-runtime\` over \`libstdc++\` (too narrow — bundle has 7 lib families) or \`gcc-libs\` (the \`-libs\` suffix collides with Debian/Fedora convention for \`.a\` static-link packages). Leaves namespace open for a future \`llvm-runtime\` to mirror libc++/compiler-rt.

## Mirror

Tarball published to **xlings-res/gcc-runtime** on both github + gitcode under tag \`15.1.0\`. Asset name follows the XLINGS_RES convention (\`gcc-runtime-15.1.0-linux-x86_64.tar.gz\`); installs through the \`XLINGS_RES\` sentinel resolve correctly on both GLOBAL and CN mirrors.

## Verified locally (iso env, no xim:gcc pre-installed)

\`\`\`
$ xlings install xim:ninja -y
✓ xim:gcc-runtime@15.1.0  done   (~26MB, NOT xim:gcc)
✓ xim:ninja@1.12.1        done

$ ls /home/speak/.xlings/data/xpkgs/ | grep gcc
xim-x-gcc-runtime          # ← only the runtime, not the full compiler

$ ldd \$XLINGS_HOME/data/xpkgs/xim-x-ninja/1.12.1/ninja
  libstdc++.so.6 => …/xim-x-gcc-runtime/15.1.0/lib64/libstdc++.so.6
  libgcc_s.so.1  => …/xim-x-gcc-runtime/15.1.0/lib64/libgcc_s.so.1
  libm.so.6 / libc.so.6 / ld-linux-x86-64.so.2 → xim-x-glibc/2.39/lib64

$ ninja --version
1.12.1
\`\`\`

Same outcome verified for \`xim:node@22.17.1\` and \`xim:mdbook@0.4.43\`.

## Disk impact

| consumer install | before | after | delta |
|---|---|---|---|
| ninja, node, mdbook (each) | pulls xim:gcc 1.1 GB | pulls xim:gcc-runtime 26 MB | **−1074 MB** |

## Test plan

- [ ] CI: \`xpkg test\` (static + isolation + index-registration)
- [ ] CI: \`pkgindex test\` (linux/macos/windows install lifecycle on changed packages)
- [ ] Iso install \`xim:ninja\` from clean state pulls gcc-runtime (NOT xim:gcc) ✓ already verified
- [ ] Iso install \`xim:node@22.17.1\` from clean state pulls gcc-runtime ✓ already verified
- [ ] Iso install \`xim:mdbook\` from clean state pulls gcc-runtime ✓ already verified