### PR TITLE
feat(gcc-runtime): add xim:gcc-runtime — runtime libs split out of xim:gcc

### DIFF
--- a/pkgs/g/gcc-runtime.lua
+++ b/pkgs/g/gcc-runtime.lua
@@ -1,0 +1,77 @@
+package = {
+    spec = "1",
+
+    homepage = "https://gcc.gnu.org",
+    name = "gcc-runtime",
+    description = "GCC runtime libraries (libstdc++, libgcc_s, libgomp, libatomic, libitm, libquadmath, libssp) — required by virtually every C++ binary on Linux, including Clang-built ones",
+
+    authors = {"GNU"},
+    licenses = {"GPL-3.0-with-GCC-exception", "LGPL-2.1+"},
+    repo = "https://gcc.gnu.org/git/?p=gcc.git",
+    docs = "https://gcc.gnu.org/onlinedocs/libstdc++/",
+
+    type = "package",
+    archs = {"x86_64"},
+    status = "stable",
+    categories = {"libc++", "runtime", "lib"},
+    keywords = {"libstdc++", "libgcc", "gcc-runtime", "cxx-runtime"},
+
+    -- Pure runtime library bundle: no executables to shim, so no
+    -- `programs` and no `xvm_enable`. Consumers (ninja, cmake, node, ...)
+    -- pick up the lib64 dir via xlings predicate-driven elfpatch — see
+    -- `exports.runtime.abi` below.
+    --
+    -- Why a separate package instead of leaving callers depending on
+    -- xim:gcc:
+    --   * xim:gcc is the full compiler (~1.1 GB)
+    --   * The runtime libs are ~25 MB
+    --   * Tools that only need to *run* C++ binaries (ninja, cmake,
+    --     node, mdbook, fd, ...) don't need cc1/cc1plus/headers/*.a
+    --   * libstdc++ is forward-compatible; one gcc-runtime version
+    --     covers every binary built against an equal-or-older GCC
+
+    xpm = {
+        linux = {
+            -- Tracks GCC main version. libstdc++ ABI is forward-
+            -- compatible (versioned symbols GLIBCXX_3.4.x), so a single
+            -- modern gcc-runtime covers all consumers.
+            ["latest"] = { ref = "15.1.0" },
+            ["15.1.0"] = "XLINGS_RES",
+
+            deps = {
+                runtime = { "xim:glibc@2.39" },
+            },
+            exports = {
+                runtime = {
+                    -- xlings install-time elfpatch reads this and
+                    -- appends `<install_dir>/lib64` to consumers' RPATH
+                    -- so libstdc++.so.6 / libgcc_s.so.1 / ... resolve
+                    -- without the consumer hardcoding paths.
+                    abi = { "lib64" },
+                },
+            },
+        },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+
+function install()
+    -- Tarball extracts to gcc-runtime-<ver>-linux-x86_64/lib64/. Move
+    -- the whole tree to install_dir as-is; the .so RPATHs were stripped
+    -- at build time, so the consumer's RPATH (set by elfpatch via
+    -- exports.runtime.abi) is what ld.so uses to resolve transitive
+    -- deps (libc/libm via xim:glibc).
+    local srcdir = pkginfo.install_file():replace(".tar.gz", "")
+    os.tryrm(pkginfo.install_dir())
+    os.mv(srcdir, pkginfo.install_dir())
+    return true
+end
+
+function config()
+    return true
+end
+
+function uninstall()
+    return true
+end


### PR DESCRIPTION
## What

Adds **xim:gcc-runtime@15.1.0** — a 26 MB bundle of GCC's runtime shared libraries (libstdc++, libgcc_s, libgomp, libatomic, libitm, libquadmath, libssp), extracted from the xim:gcc 15.1.0 tarball with RPATHs stripped at build time.

Pure runtime library bundle: no executables, no \`xvm.add\`, no \`programs\` field. Consumers (will be ninja/node/mdbook in follow-up PR) pick up the lib64 dir via xlings predicate-driven elfpatch through \`exports.runtime.abi\`.

xim:gcc **is unchanged** — it keeps its own lib64 so users who actually want the compiler still get a self-contained install. gcc-runtime is purely a consumer-side optimization for tools that only need to *run* C++ binaries.

## Mirror

Published to **xlings-res/gcc-runtime** on github + gitcode under tag \`15.1.0\`. Asset name follows the XLINGS_RES convention:

    gcc-runtime-15.1.0-linux-x86_64.tar.gz

Resolves correctly through the \`XLINGS_RES\` sentinel on both GLOBAL (github) and CN (gitcode) mirrors; sha256 matches the upload.

## Naming rationale

Chose \`gcc-runtime\` over alternatives:

- \`libstdc++\` — too narrow (bundle has 7 lib families)
- \`gcc-libs\` — \`-libs\` suffix collides with Debian/Fedora convention for \`.a\` static-link packages
- \`libc++\` — different project entirely (LLVM's C++ stdlib)

Leaves namespace open for a future \`llvm-runtime\` covering libc++/compiler-rt.

## This PR + follow-up

This PR adds **only** the new \`gcc-runtime\` package. A follow-up PR will switch \`ninja\` / \`node\` / \`mdbook\` from \`xim:gcc@15.1.0\` (1.1 GB compiler) to \`xim:gcc-runtime@15.1.0\` (26 MB runtime).

Splitting the work because CI's \`xim\` namespace cache is built from \`main\` — if consumer xpkgs already reference \`xim:gcc-runtime\` in the same PR that introduces it, install tests fail with \`package 'xim:gcc-runtime@15.1.0' not found\`. Land this first; consumer switch lands second.

## Verified locally

\`\`\`
$ xlings install local:gcc-runtime -y
✓ local:gcc-runtime@15.1.0  done   (26 MB)

$ ls /home/speak/.xlings/data/xpkgs/local-x-gcc-runtime/15.1.0/lib64/
libstdc++.so.6.0.34 libgcc_s.so.1 libgomp.so.1.0.0 libatomic.so.1.2.0
libitm.so.1.0.0 libquadmath.so.0.0.0 libssp.so.0.0.0 (+ symlinks)

$ patchelf --print-rpath libstdc++.so.6.0.34
(empty — stripped at build time, consumer's RPATH governs)
\`\`\`

## Test plan

- [ ] CI: \`xpkg test\` (static + isolation + index-registration on the new file)
- [ ] CI: \`pkgindex test\` linux-install-test exercises \`xlings install local:gcc-runtime\` lifecycle