### PR TITLE
feat(deps): switch ninja/node/mdbook from xim:gcc to xim:gcc-runtime

### DIFF
--- a/pkgs/m/mdbook.lua
+++ b/pkgs/m/mdbook.lua
@@ -39,11 +39,11 @@ package = {
         linux = {
             -- Runtime deps. mdbook prebuilt is dynamically linked
             -- (INTERP=/lib64/ld-linux-x86-64.so.2) and pulls libc/libdl/
-            -- libpthread/libm from glibc plus libgcc_s.so.1 from gcc's
-            -- runtime libs (Rust statically links libstdc++ but still
-            -- needs libgcc_s for unwind tables).
+            -- libpthread/libm from glibc plus libgcc_s.so.1 from
+            -- xim:gcc-runtime (Rust statically links libstdc++ but
+            -- still needs libgcc_s for unwind tables).
             deps = {
-                runtime = { "xim:glibc@2.39", "xim:gcc@15.1.0" },
+                runtime = { "xim:glibc@2.39", "xim:gcc-runtime@15.1.0" },
             },
             ["latest"] = { ref = "0.5.2" },
             ["0.5.2"] = {

--- a/pkgs/n/ninja.lua
+++ b/pkgs/n/ninja.lua
@@ -23,10 +23,10 @@ package = {
         linux = {
             -- Runtime deps. ninja prebuilt is dynamically linked
             -- (INTERP=/lib64/ld-linux-x86-64.so.2) and pulls libc/libm
-            -- from glibc plus libstdc++.so.6 + libgcc_s.so.1 from gcc's
-            -- runtime libs.
+            -- from glibc plus libstdc++.so.6 + libgcc_s.so.1 from
+            -- xim:gcc-runtime (the runtime libs split out of xim:gcc).
             deps = {
-                runtime = { "xim:glibc@2.39", "xim:gcc@15.1.0" },
+                runtime = { "xim:glibc@2.39", "xim:gcc-runtime@15.1.0" },
             },
             ["latest"] = { ref = "1.12.1" },
             ["1.12.1"] = "XLINGS_RES",

--- a/pkgs/n/node.lua
+++ b/pkgs/n/node.lua
@@ -43,15 +43,16 @@ package = {
             -- Runtime deps. The upstream node prebuilt is dynamically linked
             -- (INTERP=/lib64/ld-linux-x86-64.so.2, RPATH empty) and pulls
             -- libc/libdl/libpthread/libm from glibc plus libstdc++.so.6 +
-            -- libgcc_s.so.1 from gcc's runtime libs. Without these declared,
-            -- xlings's predicate-driven elfpatch can't rewrite INTERP/RPATH
-            -- to the xpkg-provided libc + libstdc++, and the binary only
+            -- libgcc_s.so.1 from xim:gcc-runtime (the runtime libs split
+            -- out of xim:gcc). Without these declared, xlings's
+            -- predicate-driven elfpatch can't rewrite INTERP/RPATH to
+            -- the xpkg-provided libc + libstdc++, and the binary only
             -- runs on hosts that already have system glibc + a compatible
             -- libstdc++ (i.e. fails on distroless / Alpine / very old glibc).
             -- No build deps — install hook is just `os.mv` of the extracted
             -- prebuilt; nothing is compiled at install time.
             deps = {
-                runtime = { "xim:glibc@2.39", "xim:gcc@15.1.0" },
+                runtime = { "xim:glibc@2.39", "xim:gcc-runtime@15.1.0" },
             },
             ["latest"] = { ref = "24.15.0" },
             ["25.9.0"] = _linux_url("25.9.0"),


### PR DESCRIPTION
## What

Follow-up to #116. Switches three xpkgs from \`xim:gcc@15.1.0\` (1.1 GB compiler) to \`xim:gcc-runtime@15.1.0\` (26 MB runtime-only):

- \`pkgs/n/ninja.lua\`
- \`pkgs/n/node.lua\`
- \`pkgs/m/mdbook.lua\`

These three only need \`libstdc++.so.6\` / \`libgcc_s.so.1\` at runtime; they don't need \`cc1plus\` / headers / \`*.a\` static libs. Saves ~1.07 GB per install.

## Verified locally (iso env, no xim:gcc pre-installed)

\`\`\`
$ xlings install xim:ninja -y
✓ xim:gcc-runtime@15.1.0  done   # 26 MB, NOT xim:gcc
✓ xim:ninja@1.12.1        done

$ ldd \$XLINGS_HOME/data/xpkgs/xim-x-ninja/1.12.1/ninja
  libstdc++.so.6 => …/xim-x-gcc-runtime/15.1.0/lib64/libstdc++.so.6
  libgcc_s.so.1  => …/xim-x-gcc-runtime/15.1.0/lib64/libgcc_s.so.1
\`\`\`

Same result for \`xim:node@22.17.1\` and \`xim:mdbook@0.4.43\`.

## Test plan

- [ ] CI: \`xpkg test\`
- [ ] CI: \`pkgindex test\` linux-install-test on the 3 changed packages