### PR TITLE
fix(gcc-runtime): use `libdirs` (not `abi`) for lib dir export

### DIFF
--- a/pkgs/g/gcc-runtime.lua
+++ b/pkgs/g/gcc-runtime.lua
@@ -19,7 +19,7 @@ package = {
     -- Pure runtime library bundle: no executables to shim, so no
     -- `programs` and no `xvm_enable`. Consumers (ninja, cmake, node, ...)
     -- pick up the lib64 dir via xlings predicate-driven elfpatch — see
-    -- `exports.runtime.abi` below.
+    -- `exports.runtime.libdirs` below.
     --
     -- Why a separate package instead of leaving callers depending on
     -- xim:gcc:
@@ -46,8 +46,14 @@ package = {
                     -- xlings install-time elfpatch reads this and
                     -- appends `<install_dir>/lib64` to consumers' RPATH
                     -- so libstdc++.so.6 / libgcc_s.so.1 / ... resolve
-                    -- without the consumer hardcoding paths.
-                    abi = { "lib64" },
+                    -- without the consumer hardcoding paths. Per the
+                    -- libxpkg ExportsRuntime schema (xpkg.cppm), the
+                    -- field for lib search dirs is `libdirs` (string
+                    -- list). `abi` is reserved for a single-string ABI
+                    -- disambiguation tag (e.g. "linux-x86_64-glibc"),
+                    -- only meaningful when multiple libc providers
+                    -- coexist — gcc-runtime doesn't need it.
+                    libdirs = { "lib64" },
                 },
             },
         },
@@ -60,7 +66,7 @@ function install()
     -- Tarball extracts to gcc-runtime-<ver>-linux-x86_64/lib64/. Move
     -- the whole tree to install_dir as-is; the .so RPATHs were stripped
     -- at build time, so the consumer's RPATH (set by elfpatch via
-    -- exports.runtime.abi) is what ld.so uses to resolve transitive
+    -- exports.runtime.libdirs) is what ld.so uses to resolve transitive
     -- deps (libc/libm via xim:glibc).
     local srcdir = pkginfo.install_file():replace(".tar.gz", "")
     os.tryrm(pkginfo.install_dir())


### PR DESCRIPTION
## Summary

`pkgs/g/gcc-runtime.lua` declares its lib search dir under the wrong field:

```lua
exports = {
    runtime = {
        abi = { "lib64" },     -- wrong field + wrong type
    },
},
```

Per the libxpkg `ExportsRuntime` schema (`src/xpkg.cppm`):

| field     | type                       | meaning                                        |
| --------- | -------------------------- | ---------------------------------------------- |
| `loader`  | `string`                   | dynamic linker path (libc-class providers only) |
| `libdirs` | `vector<string>`           | lib search dirs (RPATH closure)                 |
| `abi`     | `string`                   | ABI disambiguation tag (e.g. `"linux-x86_64-glibc"`) |

So `lib64` belongs in `libdirs`, and `abi` is a single string, never a list.

## Why CI doesn't catch this today

The C++ loader (`xpkg-loader.cppm:266-292`) does soft type-checks: a value with the wrong type is silently dropped. So gcc-runtime's `exports.runtime` block parses with all three sub-fields **empty**. Consumers (ninja / node / mdbook) then go through `closure_lib_paths`, which falls back to the `{lib64, lib}` convention per dep. Since gcc-runtime ships a `lib64/`, the fallback finds the libs by accident — the declaration is functionally a no-op.

Fix: declare `libdirs = { "lib64" }`, matching the schema and the original author's intent.

## Test plan

- [ ] CI green on this PR (parses unchanged, no behavior change for current consumers)
- [ ] Follow-up: bump `XIM_PKGINDEX_REF` in xlings CI to include this commit + #116/#117 and verify E2E-05 passes end-to-end with the corrected schema