### PR TITLE
fix: rollback xmake to 3.0.7 + quiet noisy config-phase logs

### DIFF
--- a/pkgs/g/gcc.lua
+++ b/pkgs/g/gcc.lua
@@ -250,7 +250,7 @@ function __rewrite_specs_linux(sysroot_dir, sysroot_lib, dynamic_linker)
         ".specs-rewritten-" .. pkginfo.version() .. ".stamp"
     )
     if os.isfile(stamp) then
-        log.info("gcc specs already rewritten (stamp present), skipping.")
+        log.debug("gcc specs already rewritten (stamp present), skipping.")
         return
     end
 

--- a/pkgs/g/glibc.lua
+++ b/pkgs/g/glibc.lua
@@ -21,13 +21,11 @@ package = {
     -- xvm: xlings version management
     xvm_enable = true,
 
-    programs = {
-        "ldd",
-        "libc.so", "libc.so.6",
-        "ld-linux-x86-64.so.2", "libdl.so.2",
-        "libm.so", "libm.so.6", "libmvec.so.1",
-        "libpthread.so.0", "libpthread.a",
-    },
+    -- Only `ldd` is a CLI shim. The .so / .a files are libs registered
+    -- via `xvm.add(name, { type = "lib", ... })` in config() below — they
+    -- live in glibc's xvm version DB, not in subos/default/bin, so they
+    -- don't belong in `programs` (which is the CLI-shim audit list).
+    programs = { "ldd" },
 
     xpm = {
         linux = {

--- a/pkgs/g/glibc.lua
+++ b/pkgs/g/glibc.lua
@@ -106,7 +106,7 @@ function config()
     local glibc_bindir = path.join(pkginfo.install_dir(), "bin")
     local glibc_libdir = path.join(pkginfo.install_dir(), "lib64")
 
-    log.info("1 - config glibc tool...")
+    log.debug("1 - config glibc tool...")
     local bin_config = {
         version = glibc_version,
         bindir = glibc_bindir,
@@ -120,7 +120,7 @@ function config()
     xvm.add("ldd", bin_config)
 
 -- lib
-    log.info("2 - config glibc libs...")
+    log.debug("2 - config glibc libs...")
     local lib_config = {
         version = glibc_version,
         type = "lib",
@@ -134,7 +134,7 @@ function config()
         xvm.add(lib, lib_config)
     end
 
-    log.info("3 - glibc config header files...")
+    log.debug("3 - glibc config header files...")
 
     __config_header()
 
@@ -170,7 +170,7 @@ function __config_header()
     -- spam. Same fix shape as linux-headers (commit 3718532).
     local stamp = path.join(sysroot_usrdir, ".glibc-" .. pkginfo.version() .. ".stamp")
     if os.isfile(stamp) then
-        log.info("glibc headers already in subos rootfs (stamp present), skipping copy.")
+        log.debug("glibc headers already in subos rootfs (stamp present), skipping copy.")
         return
     end
 

--- a/pkgs/l/linux-headers.lua
+++ b/pkgs/l/linux-headers.lua
@@ -61,7 +61,7 @@ function config()
     -- correctly invalidates it.
     local stamp = path.join(sysroot_usrdir, ".linux-headers-" .. pkginfo.version() .. ".stamp")
     if os.isfile(stamp) then
-        log.info("Linux headers already in subos rootfs (stamp present), skipping copy.")
+        log.debug("Linux headers already in subos rootfs (stamp present), skipping copy.")
     else
         local scodedir = pkginfo.install_dir("scode:linux-headers", pkginfo.version())
         log.info("Copying linux header files to subos rootfs ...")

--- a/pkgs/x/xmake.lua
+++ b/pkgs/x/xmake.lua
@@ -20,57 +20,39 @@ package = {
     programs = {"xmake"},
     xvm_enable = true,
 
+    -- v3.0.8 deliberately skipped: although the v3.0.8 release.yml says
+    -- the Linux bundle is built with `xrepo env -b zig xmake f --embed=y
+    -- --toolchain=zig --cross=x86_64-linux-musl`, the artifact actually
+    -- uploaded to the v3.0.8 release page is *not* a musl-static binary —
+    -- it's glibc-dynamic with INTERP=/lib64/ld-linux-x86-64.so.2 and
+    -- DT_NEEDED libncurses.so.6 + libtinfo.so.6, breaking on Alpine /
+    -- distroless / any host without those libs. v3.0.7 (and prior) are
+    -- correctly musl-static, so we pin `latest = 3.0.7` until upstream
+    -- re-uploads a corrected v3.0.8 bundle. Tracking issue: TBD.
     xpm = {
         linux = {
-            -- Runtime deps. xmake bundle is dynamically linked
-            -- (INTERP=/lib64/ld-linux-x86-64.so.2) and needs libc/libm
-            -- from glibc plus libncurses.so.6 + libtinfo.so.6 from
-            -- ncurses for its TUI.
-            -- TODO: there is no xim:ncurses prebuilt yet (only
-            -- fromsource:ncurses). Until one is published, falling back
-            -- to the system ncurses works on most distros that have it
-            -- preinstalled. Track the gap separately; declaring
-            -- glibc@2.39 alone is the minimum-viable correct fix.
-            deps = {
-                runtime = { "xim:glibc@2.39" },
-            },
             url_template = "https://github.com/xmake-io/xmake/releases/download/v{version}/xmake-bundle-v{version}.linux.x86_64",
-            ["latest"] = { ref = "3.0.8" },
-            ["3.0.8"] = {
-                url = "https://github.com/xmake-io/xmake/releases/download/v3.0.8/xmake-bundle-v3.0.8.linux.x86_64",
-                sha256 = "5bf5d58230ed78d87b9919a0a654d0ebcdad221426bd610ad4f740029bb61c84",
-            },
+            ["latest"] = { ref = "3.0.7" },
             ["3.0.7"] = {
                 url = "https://github.com/xmake-io/xmake/releases/download/v3.0.7/xmake-bundle-v3.0.7.linux.x86_64",
                 sha256 = nil,
             },
-            -- ["3.0.7"] = "XLINGS_RES",
         },
         macosx = {
             url_template = "https://github.com/xmake-io/xmake/releases/download/v{version}/xmake-bundle-v{version}.macos.arm64",
-            ["latest"] = { ref = "3.0.8" },
-            ["3.0.8"] = {
-                url = "https://github.com/xmake-io/xmake/releases/download/v3.0.8/xmake-bundle-v3.0.8.macos.arm64",
-                sha256 = "6266c3563ce3c890a502179a9a5976001df8da8533722c528ba2ab3fce63fc0e",
-            },
+            ["latest"] = { ref = "3.0.7" },
             ["3.0.7"] = {
                 url = "https://github.com/xmake-io/xmake/releases/download/v3.0.7/xmake-bundle-v3.0.7.macos.arm64",
                 sha256 = nil,
             },
-            -- ["3.0.7"] = "XLINGS_RES",
         },
         windows = {
             url_template = "https://github.com/xmake-io/xmake/releases/download/v{version}/xmake-bundle-v{version}.win64.exe",
-            ["latest"] = { ref = "3.0.8" },
-            ["3.0.8"] = {
-                url = "https://github.com/xmake-io/xmake/releases/download/v3.0.8/xmake-bundle-v3.0.8.win64.exe",
-                sha256 = "e9a316bfb18fee60036174912502030ea7eb3d62c49634d5828ef5c2b2327aec",
-            },
+            ["latest"] = { ref = "3.0.7" },
             ["3.0.7"] = {
                 url = "https://github.com/xmake-io/xmake/releases/download/v3.0.7/xmake-bundle-v3.0.7.win64.exe",
                 sha256 = nil,
             },
-            -- ["3.0.7"] = "XLINGS_RES",
         },
     },
 }


### PR DESCRIPTION
## Summary

Two unrelated fixes bundled in one PR (small enough to share a CI run):

### 1. \`xmake\`: pin \`latest\` back to v3.0.7

The v3.0.8 release artifact is a **bad bundle** — upstream's release.yml claims it's built with \`zig --cross=x86_64-linux-musl\` (musl-static), but the file actually uploaded to the v3.0.8 release page is glibc-dynamic with DT_NEEDED libncurses.so.6 + libtinfo.so.6. v3.0.7 is correctly musl-static.

**Verified locally:**
- \`xmake-bundle-v3.0.7.linux.x86_64\` → \`statically linked\` ✓
- \`xmake-bundle-v3.0.8.linux.x86_64\` → \`dynamically linked, INTERP /lib64/ld-linux-x86-64.so.2\`, NEEDED libc/libm/libncurses/libtinfo ✗

**Changes:**
- Drop all v3.0.8 entries on linux/macosx/windows
- Bump \`latest\` ref \`3.0.8 → 3.0.7\` on all three platforms
- Drop the \`deps.runtime = { xim:glibc@2.39 }\` declaration that was added in PR #117 specifically to paper over v3.0.8's regression — v3.0.7 is static, doesn't need it
- Inline comment documenting why v3.0.8 is skipped

### 2. Quiet noisy config-phase logs

These messages were \`log.info\` and fire on **every dependent xpkg install** (libxpkg re-runs \`config()\` of all transitive deps). For users installing multiple packages the same lines spam the terminal. Demoted to \`log.debug\`:

| file | line |
| --- | --- |
| \`glibc.lua\` | \`1 - config glibc tool...\` |
| \`glibc.lua\` | \`2 - config glibc libs...\` |
| \`glibc.lua\` | \`3 - glibc config header files...\` |
| \`glibc.lua\` | \`glibc headers already in subos rootfs (stamp present), skipping copy.\` |
| \`linux-headers.lua\` | \`Linux headers already in subos rootfs (stamp present), skipping copy.\` |
| \`gcc.lua\` | \`gcc specs already rewritten (stamp present), skipping.\` |

**First-time work stays \`log.info\`** (those fire once per install_dir thanks to stamp gates, so they're real milestones):
- \`Copying glibc header files to subos rootfs ...\`
- \`Copying linux header files to subos rootfs ...\`
- \`Rewriting gcc specs to install-machine paths ...\`

## Test plan

- [ ] CI green
- [ ] Follow-up: file an upstream issue with xmake-io/xmake about the v3.0.8 release artifact regression