### PR TITLE
feat(vim): add vim 8.1.1045 (truly-static x86_64 prebuilt)

### DIFF
--- a/pkgs/v/vim.lua
+++ b/pkgs/v/vim.lua
@@ -1,0 +1,66 @@
+package = {
+    spec = "1",
+
+    name = "vim",
+    description = "The classic Vi IMproved text editor (statically linked, hermetic)",
+
+    contributors = "https://github.com/vim/vim/graphs/contributors",
+    licenses = {"Vim"},
+    repo = "https://github.com/vim/vim",
+    docs = "https://www.vim.org/docs.php",
+
+    type = "package",
+    archs = {"x86_64"},
+    status = "stable",
+    categories = {"vim", "editor"},
+    keywords = {"vim", "editor", "vi"},
+
+    programs = { "vim" },
+
+    xvm_enable = true,
+
+    -- Why dtschan/vim-static rather than vim/vim-appimage:
+    --   * dtschan ships a single ELF, `static-pie linked` with no
+    --     NEEDED entries — runs on Alpine / distroless / any x86_64
+    --     host without a libc on disk.
+    --   * vim-appimage is glibc-2.34+ AND requires fuse; both
+    --     defeat the hermetic-prebuilt goal.
+    -- Tradeoff: dtschan only publishes v8.1.1045 (2019). Vim 8.1 is
+    -- still highly capable (Huge variant, no GUI), and there is no
+    -- newer truly-static x86_64 vim build out there. Bumping requires
+    -- finding (or producing) a newer static binary; track separately.
+    xpm = {
+        linux = {
+            ["latest"] = { ref = "8.1.1045" },
+            ["8.1.1045"] = {
+                url = "https://github.com/dtschan/vim-static/releases/download/v8.1.1045/vim",
+                sha256 = "376d7044d00cfc02bcad0570af7ff543ebd46d95175f82b8102a7ca1e9f75a71",
+            },
+        },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+
+function install()
+    -- Single-file binary download. Move it into install_dir/bin/ so
+    -- xvm's standard `bindir` registration in config() picks it up
+    -- the same way nvim/khistory/etc. do.
+    os.tryrm(pkginfo.install_dir())
+    os.mkdir(path.join(pkginfo.install_dir(), "bin"))
+    local dst = path.join(pkginfo.install_dir(), "bin", "vim")
+    os.mv(pkginfo.install_file(), dst)
+    os.exec("chmod +x " .. dst)
+    return true
+end
+
+function config()
+    xvm.add("vim", { bindir = path.join(pkginfo.install_dir(), "bin") })
+    return true
+end
+
+function uninstall()
+    xvm.remove("vim")
+    return true
+end

--- a/tests/v/test_vim.py
+++ b/tests/v/test_vim.py
@@ -1,0 +1,80 @@
+"""测试 vim 包"""
+import pytest
+from tests.lib.xpkg_parser import parse_xpkg
+from tests.lib.assertions import (
+    assert_required_fields, assert_valid_spec, assert_valid_type,
+    assert_no_typos, assert_no_exec_xvm, assert_no_bashrc_modification,
+    assert_no_direct_path_modification, assert_uses_new_api,
+    assert_xim_add_succeeds, assert_install_succeeds,
+    assert_command_output, assert_xvm_registered,
+)
+from tests.lib.platform_utils import skip_if_not
+
+PKG = "vim"
+PKG_FILE = "pkgs/v/vim.lua"
+
+
+@pytest.fixture(scope='module')
+def meta():
+    return parse_xpkg(PKG_FILE)
+
+
+class TestStatic:
+    @pytest.mark.static
+    def test_required_fields(self, meta):
+        assert_required_fields(meta)
+
+    @pytest.mark.static
+    def test_valid_spec(self, meta):
+        assert_valid_spec(meta)
+
+    @pytest.mark.static
+    def test_valid_type(self, meta):
+        assert_valid_type(meta)
+
+    @pytest.mark.static
+    def test_no_typos(self):
+        assert_no_typos(PKG_FILE)
+
+
+class TestIndex:
+    @pytest.mark.index
+    def test_xim_add(self):
+        assert_xim_add_succeeds(PKG_FILE)
+
+
+class TestIsolation:
+    @pytest.mark.isolation
+    def test_no_exec_xvm(self):
+        assert_no_exec_xvm(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_no_bashrc(self):
+        assert_no_bashrc_modification(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_no_path_modification(self):
+        assert_no_direct_path_modification(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_new_api(self):
+        assert_uses_new_api(PKG_FILE)
+
+
+class TestLifecycle:
+    @pytest.mark.lifecycle
+    @skip_if_not('linux')
+    def test_install(self):
+        assert_install_succeeds(PKG)
+
+
+class TestVerify:
+    @pytest.mark.verify
+    @skip_if_not('linux')
+    def test_vim(self):
+        assert_command_output("vim --version | head -1", contains="VIM")
+
+    @pytest.mark.verify
+    @skip_if_not('linux')
+    def test_xvm_vim(self):
+        assert_xvm_registered("vim")


### PR DESCRIPTION
## Summary

Add \`xim:vim@8.1.1045\` from \`dtschan/vim-static\`. Selected this source over \`vim/vim-appimage\` because the user request was **"prefer minimal-deps / static if available"** and dtschan's binary is the only currently-existing **truly static** Linux x86_64 vim build.

| candidate | linkage | NEEDED | runs on Alpine? |
| --- | --- | --- | --- |
| \`dtschan/vim-static@v8.1.1045\` (chosen) | static-pie | (none) | yes |
| \`vim/vim-appimage@v9.2.0437\` | dynamic, AppImage | requires glibc 2.34+ + fuse | no |

The tradeoff is version: dtschan stopped publishing in 2019 at v8.1.1045. Vim 8.1 (Huge variant, no GUI) is still highly capable for editing — patches 1-1045 cover ~5 years of vim improvements over 8.0.

## Verified locally

Inside an isolated \`XLINGS_HOME=.xlings-home-test\`:

```
$ xlings install vim                          → 1 package(s) installed
$ readelf -d \$(which vim) | grep NEEDED      → (none, static)
$ vim --version | head -1                     → VIM - Vi IMproved 8.1
$ vim -es -c '%s/smoke/works/g | wq' /tmp/x   → file actually edited (smoke→works)
```

## Files

- \`pkgs/v/vim.lua\` — single-file binary download, registers vim shim via xvm.add
- \`tests/v/test_vim.py\` — static + index + isolation + lifecycle + verify, mirroring tests/n/test_nvim.py

## Test plan

- [ ] CI green (static + isolation + lifecycle install + verify \`vim --version\` contains "VIM")

## Future bump

If a newer truly-static vim becomes available (e.g. someone publishes a 9.x static build, or we produce one in-repo), bump \`latest\`. Until then, 8.1.1045 is documented in the lua comment as the deliberate ceiling.