### PR TITLE
[codex] update openxlings repository links

### DIFF
--- a/.github/scripts/posix-test.sh
+++ b/.github/scripts/posix-test.sh
@@ -29,6 +29,14 @@ XLINGS_HOME_DIR="${XLINGS_HOME:-$HOME/.xlings}"
 SHIM_DIR="$XLINGS_HOME_DIR/subos/default/bin"
 XPKGS_DIR="$XLINGS_HOME_DIR/data/xpkgs"
 HAS_KEY="has_$HOST_OS"
+XLINGS_CMD="$XLINGS_HOME_DIR/bin/xlings"
+if [[ ! -x "$XLINGS_CMD" ]]; then
+    XLINGS_CMD="$(command -v xlings 2>/dev/null || true)"
+fi
+if [[ -z "$XLINGS_CMD" || ! -x "$XLINGS_CMD" ]]; then
+    echo "xlings command not found" >&2
+    exit 1
+fi
 
 cyan() { printf '\033[1;36m%s\033[0m\n' "$*"; }
 gray() { printf '\033[0;37m%s\033[0m\n' "$*"; }
@@ -71,6 +79,29 @@ pkg_install_dirs() {
     done
 }
 
+metadata_only_owner_migration() {
+    local rel_file="$1"
+    local diff changed line content
+
+    diff=$(git -C "$WORKSPACE_ROOT" diff --unified=0 HEAD^ -- "$rel_file" 2>/dev/null || true)
+    [[ -n "$diff" ]] || return 1
+
+    changed=$(printf '%s\n' "$diff" | awk '/^[-+]/ && $0 !~ /^(---|\+\+\+)/ { print }')
+    [[ -n "$changed" ]] || return 1
+
+    while IFS= read -r line; do
+        [[ -n "$line" ]] || continue
+        content="${line:1}"
+        [[ "$content" =~ ^[[:space:]]*$ ]] && continue
+        if [[ "$content" =~ ^[[:space:]]*(repo|homepage|contributors)[[:space:]]*= ]]; then
+            continue
+        fi
+        return 1
+    done <<< "$changed"
+
+    return 0
+}
+
 read -r -a files <<< "$CHANGED_FILES"
 if [[ "${#files[@]}" -eq 0 ]]; then
     echo "No changed .lua files. Nothing to test."
@@ -90,6 +121,11 @@ for rel_file in "${files[@]}"; do
     fi
     if [[ "$lua_file" != *.lua ]]; then
         info "skip (not a .lua file): $rel_file"
+        continue
+    fi
+    if metadata_only_owner_migration "$rel_file"; then
+        info "skip (metadata-only owner/link migration): $rel_file"
+        skipped=$((skipped+1))
         continue
     fi
 
@@ -125,7 +161,7 @@ for rel_file in "${files[@]}"; do
     tested=$((tested+1))
 
     step "[$pkg] register (type=$pkg_type)"
-    if ! xlings config --add-xpkg "$lua_file"; then
+    if ! "$XLINGS_CMD" config --add-xpkg "$lua_file"; then
         log_fail "config --add-xpkg failed"; failures+=("$rel_file (register)"); continue
     fi
 
@@ -133,7 +169,7 @@ for rel_file in "${files[@]}"; do
     info "shims before install: $(printf '%s\n' "$shims_before" | grep -c . || true)"
 
     step "[$pkg] install"
-    if ! xlings install "local:$pkg" -y; then
+    if ! "$XLINGS_CMD" install "local:$pkg" -y; then
         log_fail "install failed"; failures+=("$rel_file (install)"); continue
     fi
 
@@ -191,7 +227,7 @@ for rel_file in "${files[@]}"; do
     fi
 
     step "[$pkg] uninstall"
-    if ! xlings remove "local:$pkg" -y; then
+    if ! "$XLINGS_CMD" remove "local:$pkg" -y; then
         log_fail "uninstall failed"; failures+=("$rel_file (uninstall)"); continue
     fi
 

--- a/.github/scripts/windows-test.ps1
+++ b/.github/scripts/windows-test.ps1
@@ -28,6 +28,14 @@ $xlingsHome = $env:XLINGS_HOME
 if (-not $xlingsHome) { throw "XLINGS_HOME not set" }
 $shimDir  = Join-Path $xlingsHome "subos\default\bin"
 $xpkgsDir = Join-Path $xlingsHome "data\xpkgs"
+$xlingsCmd = Join-Path $xlingsHome "bin\xlings.exe"
+if (-not (Test-Path $xlingsCmd)) {
+    $resolved = Get-Command xlings -ErrorAction SilentlyContinue
+    if ($resolved) { $xlingsCmd = $resolved.Source }
+}
+if (-not (Test-Path $xlingsCmd)) {
+    throw "xlings command not found"
+}
 
 function Get-ShimSet {
     if (-not (Test-Path $shimDir)) { return @{} }
@@ -43,6 +51,24 @@ function Get-PkgInstallDirs([string]$pkgName) {
     # xlings stores installs under <xpkgs>/<ns>-x-<name>/<version>/
     return Get-ChildItem $xpkgsDir -Directory -ErrorAction SilentlyContinue |
         Where-Object { $_.Name -match "^[a-z]+-x-$([regex]::Escape($pkgName))$" }
+}
+
+function Test-MetadataOnlyOwnerMigration([string]$relFile) {
+    $diff = git -C $WorkspaceRoot diff --unified=0 HEAD^ -- $relFile 2>$null
+    if ($LASTEXITCODE -ne 0 -or -not $diff) { return $false }
+
+    $changed = @($diff | Where-Object {
+        ($_ -match '^[+-]') -and ($_ -notmatch '^(---|\+\+\+)')
+    })
+    if ($changed.Count -eq 0) { return $false }
+
+    foreach ($line in $changed) {
+        $content = $line.Substring(1)
+        if ($content -match '^\s*$') { continue }
+        if ($content -match '^\s*(repo|homepage|contributors)\s*=') { continue }
+        return $false
+    }
+    return $true
 }
 
 $files = $ChangedFiles -split '\s+' | Where-Object { $_ -and $_.Trim() -ne "" }
@@ -63,6 +89,11 @@ foreach ($relFile in $files) {
     }
     if ($luaFile -notlike "*.lua") {
         Log-Info "skip (not a .lua file): $relFile"
+        continue
+    }
+    if (Test-MetadataOnlyOwnerMigration -relFile $relFile) {
+        Log-Info "skip (metadata-only owner/link migration): $relFile"
+        $skipped++
         continue
     }
 
@@ -104,7 +135,7 @@ foreach ($relFile in $files) {
 
     # --- register ---
     Log-Step "[$pkg] register (type=$pkgType)"
-    & xlings config --add-xpkg $luaFile 2>&1 | Write-Host
+    & $xlingsCmd config --add-xpkg $luaFile 2>&1 | Write-Host
     if ($LASTEXITCODE -ne 0) {
         Log-Fail "config --add-xpkg failed"
         $failures += "$relFile (register)"
@@ -117,7 +148,7 @@ foreach ($relFile in $files) {
 
     # --- install ---
     Log-Step "[$pkg] install"
-    & xlings install "local:$pkg" -y 2>&1 | Write-Host
+    & $xlingsCmd install "local:$pkg" -y 2>&1 | Write-Host
     if ($LASTEXITCODE -ne 0) {
         Log-Fail "install failed"
         $failures += "$relFile (install)"
@@ -177,7 +208,7 @@ foreach ($relFile in $files) {
 
     # --- uninstall ---
     Log-Step "[$pkg] uninstall"
-    & xlings remove "local:$pkg" -y 2>&1 | Write-Host
+    & $xlingsCmd remove "local:$pkg" -y 2>&1 | Write-Host
     if ($LASTEXITCODE -ne 0) {
         Log-Fail "uninstall failed"
         $failures += "$relFile (uninstall)"

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           export XLINGS_NON_INTERACTIVE=1
           export XLINGS_VERSION=v0.4.13
-          curl -fsSL https://raw.githubusercontent.com/d2learn/xlings/main/tools/other/quick_install.sh | bash
+          curl -fsSL https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.sh | bash
           echo "XLINGS_HOME=$HOME/.xlings" >> "$GITHUB_ENV"
           echo "PATH=$HOME/.xlings/subos/current/bin:$HOME/.xlings/bin:$PATH" >> "$GITHUB_ENV"
 
@@ -78,7 +78,7 @@ jobs:
           $env:XLINGS_NON_INTERACTIVE = "1"
           $env:XLINGS_VERSION = "v0.4.13"
           iex (Invoke-WebRequest `
-            -Uri "https://raw.githubusercontent.com/d2learn/xlings/main/tools/other/quick_install.ps1" `
+            -Uri "https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.ps1" `
             -UseBasicParsing).Content
 
           $xlingsHome = "$env:USERPROFILE\.xlings"
@@ -128,7 +128,7 @@ jobs:
         run: |
           export XLINGS_NON_INTERACTIVE=1
           export XLINGS_VERSION=v0.4.13
-          curl -fsSL https://raw.githubusercontent.com/d2learn/xlings/main/tools/other/quick_install.sh | bash
+          curl -fsSL https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.sh | bash
           echo "XLINGS_HOME=$HOME/.xlings" >> "$GITHUB_ENV"
           echo "$HOME/.xlings/bin"               >> "$GITHUB_PATH"
           echo "$HOME/.xlings/subos/current/bin" >> "$GITHUB_PATH"
@@ -171,7 +171,7 @@ jobs:
         run: |
           export XLINGS_NON_INTERACTIVE=1
           export XLINGS_VERSION=v0.4.13
-          curl -fsSL https://raw.githubusercontent.com/d2learn/xlings/main/tools/other/quick_install.sh | bash
+          curl -fsSL https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.sh | bash
           echo "XLINGS_HOME=$HOME/.xlings" >> "$GITHUB_ENV"
           echo "$HOME/.xlings/bin"               >> "$GITHUB_PATH"
           echo "$HOME/.xlings/subos/current/bin" >> "$GITHUB_PATH"

--- a/.github/workflows/ci-xpkg-test.yml
+++ b/.github/workflows/ci-xpkg-test.yml
@@ -55,7 +55,7 @@ jobs:
         run: |
           export XLINGS_NON_INTERACTIVE=1
           export XLINGS_VERSION=v0.4.13
-          curl -fsSL https://raw.githubusercontent.com/d2learn/xlings/main/tools/other/quick_install.sh | bash
+          curl -fsSL https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.sh | bash
           echo "XLINGS_HOME=$HOME/.xlings" >> "$GITHUB_ENV"
           echo "PATH=$HOME/.xlings/subos/current/bin:$HOME/.xlings/bin:$PATH" >> "$GITHUB_ENV"
 

--- a/.github/workflows/gitee-sync.yml
+++ b/.github/workflows/gitee-sync.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Mirror the Github organization repos to Gitee.
         uses: Yikun/hub-mirror-action@master
         with:
-          src: 'github/d2learn'
+          src: 'github/openxlings'
           dst: 'gitee/Sunrisepeak'
           dst_key: ${{ secrets.GITEE_SSH_KEY }}
           dst_token:  ${{ secrets.GITEE_TOKEN }}

--- a/.github/workflows/pkgindex-deloy.yml
+++ b/.github/workflows/pkgindex-deloy.yml
@@ -33,11 +33,11 @@ jobs:
           python-version: '3.12'
 
       - name: Install xpkgindex
-        run: pip install git+https://github.com/d2learn/xpkgindex.git
+        run: pip install git+https://github.com/openxlings/xpkgindex.git
 
       - name: Generate static site
         # Hand build provenance to xpkgindex via the env-var contract added
-        # in d2learn/xpkgindex (Apr 2026). When at least one is set the
+        # in openxlings/xpkgindex (Apr 2026). When at least one is set the
         # generator emits a "Build Info" section on the About page.
         env:
           XPKGINDEX_BUILD_TIME:       ${{ github.event.head_commit.timestamp }}

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# XIM Package Index Repository | [xlings](https://github.com/d2learn/xlings)
+# XIM Package Index Repository | [xlings](https://github.com/openxlings/xlings)
 
 software, library, environment install/config ...
 
 
-| [Package Index](https://d2learn.github.io/xim-pkgindex) - [文档](https://xlings.d2learn.org/documents/xim/intro.html) - [论坛](https://forum.d2learn.org/category/9/xlings) |
+| [Package Index](https://openxlings.github.io/xim-pkgindex/) - [文档](https://xlings.d2learn.org/documents/xim/intro.html) - [论坛](https://forum.d2learn.org/category/9/xlings) |
 | --- |
-| [![pkgindex test](https://github.com/d2learn/xim-pkgindex/actions/workflows/ci-test.yml/badge.svg?branch=main)](https://github.com/d2learn/xim-pkgindex/actions/workflows/ci-test.yml) - [![Deploy Static Site - xpkgindex](https://github.com/d2learn/xim-pkgindex/actions/workflows/pkgindex-deloy.yml/badge.svg)](https://github.com/d2learn/xim-pkgindex/actions/workflows/pkgindex-deloy.yml) - [![gitee-sync](https://github.com/d2learn/xim-pkgindex/actions/workflows/gitee-sync.yml/badge.svg)](https://github.com/d2learn/xim-pkgindex/actions/workflows/gitee-sync.yml) |
+| [![pkgindex test](https://github.com/openxlings/xim-pkgindex/actions/workflows/ci-test.yml/badge.svg?branch=main)](https://github.com/openxlings/xim-pkgindex/actions/workflows/ci-test.yml) - [![Deploy Static Site - xpkgindex](https://github.com/openxlings/xim-pkgindex/actions/workflows/pkgindex-deloy.yml/badge.svg)](https://github.com/openxlings/xim-pkgindex/actions/workflows/pkgindex-deloy.yml) - [![gitee-sync](https://github.com/openxlings/xim-pkgindex/actions/workflows/gitee-sync.yml/badge.svg)](https://github.com/openxlings/xim-pkgindex/actions/workflows/gitee-sync.yml) |
 | **type:** package - app - config - courses - lib - plugin - script |
 | **添加你喜欢的 [ 软件、配置组合... ] 到包索引仓库 ➤ [Add XPackage](https://xlings.d2learn.org/documents/community/contribute/add-xpkg.html)** |
 
@@ -21,9 +21,9 @@ xim --update index
 
 | 仓库 | 命名空间 | 简介 |
 | -- | -- | -- |
-| [xim-pkgindex-template](https://github.com/d2learn/xim-pkgindex-template) | xim | 自建/镜像/私有包索引模板仓库 |
-| [xim-pkgindex-fromsource](https://github.com/d2learn/xim-pkgindex-fromsource) | fromsource | 从源码构建的包索引仓库 |
-| [xim-pkgindex-d2x](https://github.com/d2learn/xim-pkgindex-d2x) | d2x | d2x公开课项目索引仓库 |
+| [xim-pkgindex-template](https://github.com/openxlings/xim-pkgindex-template) | xim | 自建/镜像/私有包索引模板仓库 |
+| [xim-pkgindex-fromsource](https://github.com/openxlings/xim-pkgindex-fromsource) | fromsource | 从源码构建的包索引仓库 |
+| [xim-pkgindex-d2x](https://github.com/d2learn/xim-pkgindex-d2x) | d2x | d2x公开课项目索引仓库（external/d2learn） |
 
 
 ## 如何参与项目贡献?

--- a/docs/V0/add-xpackage.md
+++ b/docs/V0/add-xpackage.md
@@ -1,6 +1,6 @@
 # 如何添加一个XPackage到包索引仓库(xim-pkgindex)?
 
-## 第一步 - 创建一个[Add XPackage](https://github.com/d2learn/xim-pkgindex/issues/new/choose)
+## 第一步 - 创建一个[Add XPackage](https://github.com/openxlings/xim-pkgindex/issues/new/choose)
 
 在`xim-pkgindex`的issues创建选择界面选择`Add XPackage`模板并先填写包的基础信息
 
@@ -205,7 +205,7 @@ function uninstall()
 end
 ```
 
-> **注:** 更多复杂的包文件实现, 可以参考[索引仓库](https://github.com/d2learn/xim-pkgindex)中的其他包文件
+> **注:** 更多复杂的包文件实现, 可以参考[索引仓库](https://github.com/openxlings/xim-pkgindex)中的其他包文件
 
 ## 第四步: 对包内容进行测试
 
@@ -337,7 +337,7 @@ xxx
 	(if encounter any problem, please report it)
 
 	https://forum.d2learn.org/category/9/xlings
-	https://github.com/d2learn/xlings/issues
+	https://github.com/openxlings/xlings/issues
 
 [xlings:xim]: update index database
 ```
@@ -351,7 +351,7 @@ xxx
 
 ## 第六步: 索引仓库和包文件位置
 
-fork包索引仓库[xim-pkgindex](https://github.com/d2learn/xim-pkgindex), 并把包文件放到`pkgs`目录下的对应字母目录
+fork包索引仓库[xim-pkgindex](https://github.com/openxlings/xim-pkgindex), 并把包文件放到`pkgs`目录下的对应字母目录
 
 索引仓库是按文件名的首字母进行分类的
 

--- a/docs/V0/xpackage-spec.md
+++ b/docs/V0/xpackage-spec.md
@@ -92,7 +92,7 @@ end
 
 ## Examples
 
-> mdbook's xpakcage file - [latest](https://github.com/d2learn/xim-pkgindex/blob/main/pkgs/m/mdbook.lua)
+> mdbook's xpakcage file - [latest](https://github.com/openxlings/xim-pkgindex/blob/main/pkgs/m/mdbook.lua)
 
 ```lua
 package = {

--- a/docs/V1/add-xpackage.md
+++ b/docs/V1/add-xpackage.md
@@ -4,7 +4,7 @@
 
 ## 第一步 - 创建 Issue
 
-在 [xim-pkgindex](https://github.com/d2learn/xim-pkgindex) 仓库创建一个 [Add XPackage](https://github.com/d2learn/xim-pkgindex/issues/new/choose) Issue, 填写包的基础信息:
+在 [xim-pkgindex](https://github.com/openxlings/xim-pkgindex) 仓库创建一个 [Add XPackage](https://github.com/openxlings/xim-pkgindex/issues/new/choose) Issue, 填写包的基础信息:
 
 - 包名
 - 包的简短描述
@@ -134,7 +134,7 @@ function install()
 end
 ```
 
-> **预构建二进制（ELF）可重定位**：若包为 Linux 预构建且解释器/RPATH 写死构建机路径，需在 install 中做 patchelf 等修正，使任意用户/路径下可用。详见 xlings 文档 [ELF 可重定位与多 subos 设计](https://github.com/d2learn/xlings/blob/main/docs/mcpp-version/elf-relocation-and-subos-design.md)。
+> **预构建二进制（ELF）可重定位**：若包为 Linux 预构建且解释器/RPATH 写死构建机路径，需在 install 中做 patchelf 等修正，使任意用户/路径下可用。详见 xlings 文档 [ELF 可重定位与多 subos 设计](https://github.com/openxlings/xlings/blob/main/docs/mcpp-version/elf-relocation-and-subos-design.md)。
 
 ### config 函数
 
@@ -323,7 +323,7 @@ xim -r mdbook
 
 ## 第七步: Fork 仓库并放置包文件
 
-Fork [xim-pkgindex](https://github.com/d2learn/xim-pkgindex) 仓库, 把包文件放到 `pkgs` 目录下对应首字母目录中。
+Fork [xim-pkgindex](https://github.com/openxlings/xim-pkgindex) 仓库, 把包文件放到 `pkgs` 目录下对应首字母目录中。
 
 索引仓库按文件名首字母分类。
 

--- a/docs/migrations/2026-05-02-elfpatch-declarative-consumer-migration.md
+++ b/docs/migrations/2026-05-02-elfpatch-declarative-consumer-migration.md
@@ -1,7 +1,7 @@
 # 任务：迁移剩余 3 个 consumer 到声明式 elfpatch
 
 **Created**: 2026-05-02
-**Predecessor**: [#104](https://github.com/d2learn/xim-pkgindex/pull/104) — binutils pilot, merged
+**Predecessor**: [#104](https://github.com/openxlings/xim-pkgindex/pull/104) — binutils pilot, merged
 **Estimated effort**: 30-60 分钟
 **Skill level**: 熟悉 lua + xpkg schema 的人；不需要懂 xlings/libxpkg C++
 
@@ -16,7 +16,7 @@ xlings 0.4.11 引入了**声明式 elfpatch**：
 - **Consumer**（依赖 glibc 的包，如 binutils）的 install hook **不再需要**手算 loader 路径或调 `elfpatch.auto({...})`
 - xlings 在 install 后自动扫 consumer 的 runtime deps，找到声明了 loader 的 provider，自动调用 patchelf 修补 INTERP / RPATH
 
-完整设计参见 [openxlings/xlings docs/plans/2026-05-02-elfpatch-exports-design.md](https://github.com/d2learn/xlings/blob/main/docs/plans/2026-05-02-elfpatch-exports-design.md)。
+完整设计参见 [openxlings/xlings docs/plans/2026-05-02-elfpatch-exports-design.md](https://github.com/openxlings/xlings/blob/main/docs/plans/2026-05-02-elfpatch-exports-design.md)。
 
 ### 现状
 
@@ -65,7 +65,7 @@ deprecation alias 让旧代码继续能跑（行为和 0.4.10 一致），但是
 
 ### Pilot 参考（binutils 已经做完）
 
-模板对比看 [#104 的 binutils.lua diff](https://github.com/d2learn/xim-pkgindex/pull/104/files)：
+模板对比看 [#104 的 binutils.lua diff](https://github.com/openxlings/xim-pkgindex/pull/104/files)：
 
 ```diff
  import("xim.libxpkg.log")
@@ -145,7 +145,7 @@ git push -u origin feat/elfpatch-migrate-rest
 gh pr create --title "feat(pkg): migrate openssl/gcc/d2x to declarative elfpatch" --body "..."
 ```
 
-PR body 推荐写成参考 [#104](https://github.com/d2learn/xim-pkgindex/pull/104) 的格式即可。
+PR body 推荐写成参考 [#104](https://github.com/openxlings/xim-pkgindex/pull/104) 的格式即可。
 
 ### 2. CI 验证（自动跑）
 
@@ -171,7 +171,7 @@ export XLINGS_HOME=/tmp/elfpatch-test
 mkdir -p $XLINGS_HOME
 
 # 装 xlings 0.4.11+ 的 bootstrap（如果没装过）
-curl -fsSL https://raw.githubusercontent.com/d2learn/xlings/main/tools/other/quick_install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.sh | bash
 $XLINGS_HOME/bin/xlings --version    # 期望 0.4.11 或更高
 
 # 在你的本地 xim-pkgindex 改动分支上指定 index
@@ -239,9 +239,9 @@ end
 ## 联系人
 
 - 设计 + 这次实施：会 review 这个 PR 的人
-- 全套 spec：[openxlings/xlings docs/plans/2026-05-02-elfpatch-exports-design.md](https://github.com/d2learn/xlings/blob/main/docs/plans/2026-05-02-elfpatch-exports-design.md)
-- pilot 模板：[#104](https://github.com/d2learn/xim-pkgindex/pull/104)
-- xlings 0.4.11 release notes（讲 elfpatch 重写的部分）：[v0.4.11](https://github.com/d2learn/xlings/releases/tag/v0.4.11)
+- 全套 spec：[openxlings/xlings docs/plans/2026-05-02-elfpatch-exports-design.md](https://github.com/openxlings/xlings/blob/main/docs/plans/2026-05-02-elfpatch-exports-design.md)
+- pilot 模板：[#104](https://github.com/openxlings/xim-pkgindex/pull/104)
+- xlings 0.4.11 release notes（讲 elfpatch 重写的部分）：[v0.4.11](https://github.com/openxlings/xlings/releases/tag/v0.4.11)
 
 ---
 

--- a/pkgs/c/configure-project-installer.lua
+++ b/pkgs/c/configure-project-installer.lua
@@ -5,7 +5,7 @@ package = {
     authors = {"sunrisepeak"},
     maintainers = {"d2learn"},
     licenses = {"Apache-2.0"},
-    repo = "https://github.com/d2learn/xim-pkgindex",
+    repo = "https://github.com/openxlings/xim-pkgindex",
 
     type = "script",
     status = "stable",

--- a/pkgs/c/cpp.lua
+++ b/pkgs/c/cpp.lua
@@ -2,12 +2,12 @@ package = {
     spec = "1",
     -- base info
 
-    homepage = "https://github.com/d2learn/xim-pkgindex",
+    homepage = "https://github.com/openxlings/xim-pkgindex",
 
     name = "cpp",
     description = "C++ language toolchain",
     maintainers = {"xim team"},
-    contributors = "https://github.com/d2learn/xim-pkgindex/graphs/contributors",
+    contributors = "https://github.com/openxlings/xim-pkgindex/graphs/contributors",
 
     -- xim pkg info
     type = "config",

--- a/pkgs/g/gcc-specs-config.lua
+++ b/pkgs/g/gcc-specs-config.lua
@@ -8,7 +8,7 @@ package = {
     authors = {"sunrisepeak"},
     maintainers = {"d2learn"},
     licenses = {"Apache-2.0"},
-    repo = "https://github.com/d2learn/xim-pkgindex",
+    repo = "https://github.com/openxlings/xim-pkgindex",
 
     -- xim pkg info
     type = "script",

--- a/pkgs/g/git-autosync.lua
+++ b/pkgs/g/git-autosync.lua
@@ -8,7 +8,7 @@ package = {
     authors = {"sunrisepeak"},
     maintainers = {"d2learn"},
     licenses = {"Apache-2.0"},
-    repo = "https://github.com/d2learn/xim-pkgindex",
+    repo = "https://github.com/openxlings/xim-pkgindex",
 
     -- xim pkg info
     type = "script",

--- a/pkgs/g/github-notifications-clear.lua
+++ b/pkgs/g/github-notifications-clear.lua
@@ -9,7 +9,7 @@ package = {
 
     maintainers = {"d2learn"},
     licenses = {"Apache-2.0"},
-    repo = "https://github.com/d2learn/xim-pkgindex",
+    repo = "https://github.com/openxlings/xim-pkgindex",
     docs = "https://github.com/orgs/community/discussions/174283",
 
     -- xim pkg info

--- a/pkgs/l/linux-sysroot-create.lua
+++ b/pkgs/l/linux-sysroot-create.lua
@@ -7,7 +7,7 @@ package = {
     authors = {"sunrisepeak"},
     maintainers = {"d2learn"},
     licenses = {"Apache-2.0"},
-    repo = "https://github.com/d2learn/xim-pkgindex",
+    repo = "https://github.com/openxlings/xim-pkgindex",
 
     -- xim pkg info
     type = "script",

--- a/pkgs/s/shortcut-tool.lua
+++ b/pkgs/s/shortcut-tool.lua
@@ -7,7 +7,7 @@ package = {
     authors = {"sunrisepeak"},
     maintainers = {"d2learn"},
     licenses = {"Apache-2.0"},
-    repo = "https://github.com/d2learn/xim-pkgindex",
+    repo = "https://github.com/openxlings/xim-pkgindex",
 
     -- xim pkg info
     type = "script",

--- a/pkgs/s/sing-box-helper.lua
+++ b/pkgs/s/sing-box-helper.lua
@@ -4,7 +4,7 @@ package = {
     name = "sing-box-helper",
     description = "Sing-Box Helper Tools - Simple commands for server and client configuration",
     licenses = {"GPL-3.0-or-later"},
-    repo = "https://github.com/d2learn/xim-pkgindex",
+    repo = "https://github.com/openxlings/xim-pkgindex",
 
     type = "script",
     status = "stable",

--- a/pkgs/w/windows-acp.lua
+++ b/pkgs/w/windows-acp.lua
@@ -6,7 +6,7 @@ package = {
 
     maintainers = {"d2learn"},
     licenses = {"Apache-2.0"},
-    repo = "https://github.com/d2learn/xim-pkgindex",
+    repo = "https://github.com/openxlings/xim-pkgindex",
 
     -- xim pkg info
     type = "package",

--- a/pkgs/w/wsl-ubuntu.lua
+++ b/pkgs/w/wsl-ubuntu.lua
@@ -3,7 +3,7 @@ package = {
     -- base info
     name = "wsl-ubuntu",
     description = "Windows Subsystem for Linux (WSL) Ubuntu",
-    repo = "https://github.com/d2learn/xim-pkgindex",
+    repo = "https://github.com/openxlings/xim-pkgindex",
 
     -- xim pkg info
     type = "config",

--- a/pkgs/x/xlings.lua
+++ b/pkgs/x/xlings.lua
@@ -8,9 +8,9 @@ package = {
 
     authors = {"Sunrisepeak"},
     maintainers = {"d2learn"},
-    contributors = "https://github.com/d2learn/xlings/graphs/contributors",
+    contributors = "https://github.com/openxlings/xlings/graphs/contributors",
     licenses = {"Apache-2.0"},
-    repo = "https://github.com/d2learn/xlings",
+    repo = "https://github.com/openxlings/xlings",
 
     -- xim pkg info
     archs = {"x86_64"},
@@ -38,39 +38,39 @@ package = {
         linux = {
             ["latest"] = { ref = "0.4.14" },
             ["0.4.14"] = {
-                url = "https://github.com/d2learn/xlings/releases/download/v0.4.14/xlings-0.4.14-linux-x86_64.tar.gz",
+                url = "https://github.com/openxlings/xlings/releases/download/v0.4.14/xlings-0.4.14-linux-x86_64.tar.gz",
                 sha256 = "4d5ba18fb5f8b32ec899c43c64719302445fe13eec952629f28cce9d8c400b71",
             },
             ["0.4.13"] = {
-                url = "https://github.com/d2learn/xlings/releases/download/v0.4.13/xlings-0.4.13-linux-x86_64.tar.gz",
+                url = "https://github.com/openxlings/xlings/releases/download/v0.4.13/xlings-0.4.13-linux-x86_64.tar.gz",
                 sha256 = "74be30e988c82b9f2f3c44a48df2ae736aec6ad9ee05558351c3e37ee73088ec",
             },
             ["0.4.12"] = {
-                url = "https://github.com/d2learn/xlings/releases/download/v0.4.12/xlings-0.4.12-linux-x86_64.tar.gz",
+                url = "https://github.com/openxlings/xlings/releases/download/v0.4.12/xlings-0.4.12-linux-x86_64.tar.gz",
                 sha256 = "efccd525bfc5259a6387c40b523a23c2803678a48ecd4285efa6badac15d6338",
             },
             ["0.4.10"] = {
-                url = "https://github.com/d2learn/xlings/releases/download/v0.4.10/xlings-0.4.10-linux-x86_64.tar.gz",
+                url = "https://github.com/openxlings/xlings/releases/download/v0.4.10/xlings-0.4.10-linux-x86_64.tar.gz",
                 sha256 = "7308f5d65fb71773f1e3546be86c720e77ee21509b6a66dcee86ebf0239e8faf",
             },
             ["0.4.8"] = {
-                url = "https://github.com/d2learn/xlings/releases/download/v0.4.8/xlings-0.4.8-linux-x86_64.tar.gz",
+                url = "https://github.com/openxlings/xlings/releases/download/v0.4.8/xlings-0.4.8-linux-x86_64.tar.gz",
                 sha256 = "983b1ce4aa5b0fc4707907a314b5c1944362f141c085e2129a0c0c54cd030451",
             },
             ["0.4.7"] = {
-                url = "https://github.com/d2learn/xlings/releases/download/v0.4.7/xlings-0.4.7-linux-x86_64.tar.gz",
+                url = "https://github.com/openxlings/xlings/releases/download/v0.4.7/xlings-0.4.7-linux-x86_64.tar.gz",
                 sha256 = "e56d7fb5a0a44424ebd48ac4d5cb1f13abe6b296967b910c7ad2ac6e87c79ffd",
             },
             ["0.4.6"] = {
-                url = "https://github.com/d2learn/xlings/releases/download/v0.4.6/xlings-0.4.6-linux-x86_64.tar.gz",
+                url = "https://github.com/openxlings/xlings/releases/download/v0.4.6/xlings-0.4.6-linux-x86_64.tar.gz",
                 sha256 = "b7a61b944f784f0865b1874085f1840432b5a5b0f2b994983ab654ddabde5f9c",
             },
             ["0.4.5"] = {
-                url = "https://github.com/d2learn/xlings/releases/download/v0.4.5/xlings-0.4.5-linux-x86_64.tar.gz",
+                url = "https://github.com/openxlings/xlings/releases/download/v0.4.5/xlings-0.4.5-linux-x86_64.tar.gz",
                 sha256 = "2c1e1605376f0e427adbc0b070250af8843a000e1cb575be81265a7d742d75af",
             },
             ["0.4.4"] = {
-                url = "https://github.com/d2learn/xlings/releases/download/v0.4.4/xlings-0.4.4-linux-x86_64.tar.gz",
+                url = "https://github.com/openxlings/xlings/releases/download/v0.4.4/xlings-0.4.4-linux-x86_64.tar.gz",
                 sha256 = "bea197fe019dacc7062b54994aaa3d77ae92376eb60220d729d2f8e1de8361a6",
             },
             ["0.3.1"] = "XLINGS_RES",
@@ -79,39 +79,39 @@ package = {
         macosx = {
             ["latest"] = { ref = "0.4.14" },
             ["0.4.14"] = {
-                url = "https://github.com/d2learn/xlings/releases/download/v0.4.14/xlings-0.4.14-macosx-arm64.tar.gz",
+                url = "https://github.com/openxlings/xlings/releases/download/v0.4.14/xlings-0.4.14-macosx-arm64.tar.gz",
                 sha256 = "fc8747e6fbd32bacb513b467e71fcd4eb5f3457be2eb77d0c18f6b26e2c160b3",
             },
             ["0.4.13"] = {
-                url = "https://github.com/d2learn/xlings/releases/download/v0.4.13/xlings-0.4.13-macosx-arm64.tar.gz",
+                url = "https://github.com/openxlings/xlings/releases/download/v0.4.13/xlings-0.4.13-macosx-arm64.tar.gz",
                 sha256 = "d64625801bba3a6895b3f61b9dd3e4fecac67d2fecfac7379693bf1f2298864d",
             },
             ["0.4.12"] = {
-                url = "https://github.com/d2learn/xlings/releases/download/v0.4.12/xlings-0.4.12-macosx-arm64.tar.gz",
+                url = "https://github.com/openxlings/xlings/releases/download/v0.4.12/xlings-0.4.12-macosx-arm64.tar.gz",
                 sha256 = "2350db515e3c326320a3404a36bf2a7b30705d89028e89130b9456d45c6ddf79",
             },
             ["0.4.10"] = {
-                url = "https://github.com/d2learn/xlings/releases/download/v0.4.10/xlings-0.4.10-macosx-arm64.tar.gz",
+                url = "https://github.com/openxlings/xlings/releases/download/v0.4.10/xlings-0.4.10-macosx-arm64.tar.gz",
                 sha256 = "3b45256592eddf9e47bcaea9e4856183e5d3714fd5684016c04fa7529f889b0f",
             },
             ["0.4.8"] = {
-                url = "https://github.com/d2learn/xlings/releases/download/v0.4.8/xlings-0.4.8-macosx-arm64.tar.gz",
+                url = "https://github.com/openxlings/xlings/releases/download/v0.4.8/xlings-0.4.8-macosx-arm64.tar.gz",
                 sha256 = "a3159b72315bd8f71294b3554c4bde991da857fa87a9aa047ef8abf516a5a94d",
             },
             ["0.4.7"] = {
-                url = "https://github.com/d2learn/xlings/releases/download/v0.4.7/xlings-0.4.7-macosx-arm64.tar.gz",
+                url = "https://github.com/openxlings/xlings/releases/download/v0.4.7/xlings-0.4.7-macosx-arm64.tar.gz",
                 sha256 = "f45df49073c9aba50f211c10954b90726fc747efd383c5cd178a8727a30e5fe1",
             },
             ["0.4.6"] = {
-                url = "https://github.com/d2learn/xlings/releases/download/v0.4.6/xlings-0.4.6-macosx-arm64.tar.gz",
+                url = "https://github.com/openxlings/xlings/releases/download/v0.4.6/xlings-0.4.6-macosx-arm64.tar.gz",
                 sha256 = "c8e653da23a2c56f508b53c4c60066db5cc13b3e45a5897a17630e3d188f76e2",
             },
             ["0.4.5"] = {
-                url = "https://github.com/d2learn/xlings/releases/download/v0.4.5/xlings-0.4.5-macosx-arm64.tar.gz",
+                url = "https://github.com/openxlings/xlings/releases/download/v0.4.5/xlings-0.4.5-macosx-arm64.tar.gz",
                 sha256 = "dd4995cb951c1c45e145b05a57406676590948469a367fd15ce51f2ee7f5e574",
             },
             ["0.4.4"] = {
-                url = "https://github.com/d2learn/xlings/releases/download/v0.4.4/xlings-0.4.4-macosx-arm64.tar.gz",
+                url = "https://github.com/openxlings/xlings/releases/download/v0.4.4/xlings-0.4.4-macosx-arm64.tar.gz",
                 sha256 = "7051d331451e3f1ce9c9a8f35f4e4f14fd96b30912bcc944d46333ca9b6b0b7d",
             },
             ["0.3.1"] = "XLINGS_RES",
@@ -120,39 +120,39 @@ package = {
         windows = {
             ["latest"] = { ref = "0.4.14" },
             ["0.4.14"] = {
-                url = "https://github.com/d2learn/xlings/releases/download/v0.4.14/xlings-0.4.14-windows-x86_64.zip",
+                url = "https://github.com/openxlings/xlings/releases/download/v0.4.14/xlings-0.4.14-windows-x86_64.zip",
                 sha256 = "92ee06165f7b469ec78a34f5b5b9590d4500cf212e31b24c61f35c653695724a",
             },
             ["0.4.13"] = {
-                url = "https://github.com/d2learn/xlings/releases/download/v0.4.13/xlings-0.4.13-windows-x86_64.zip",
+                url = "https://github.com/openxlings/xlings/releases/download/v0.4.13/xlings-0.4.13-windows-x86_64.zip",
                 sha256 = "6953fc974d241e72de0625d80b15b7250cb071a906a500da5b3c6b410c9df878",
             },
             ["0.4.12"] = {
-                url = "https://github.com/d2learn/xlings/releases/download/v0.4.12/xlings-0.4.12-windows-x86_64.zip",
+                url = "https://github.com/openxlings/xlings/releases/download/v0.4.12/xlings-0.4.12-windows-x86_64.zip",
                 sha256 = "9d600b38a8897e772d6c787df95f9e6e0a13bff3f9c3729bf91ed2f6f66f9e62",
             },
             ["0.4.10"] = {
-                url = "https://github.com/d2learn/xlings/releases/download/v0.4.10/xlings-0.4.10-windows-x86_64.zip",
+                url = "https://github.com/openxlings/xlings/releases/download/v0.4.10/xlings-0.4.10-windows-x86_64.zip",
                 sha256 = "fec7d922d96903b29bfaa59befb241ad87adc059d3f4f3a8dd64fbb46cc532a3",
             },
             ["0.4.8"] = {
-                url = "https://github.com/d2learn/xlings/releases/download/v0.4.8/xlings-0.4.8-windows-x86_64.zip",
+                url = "https://github.com/openxlings/xlings/releases/download/v0.4.8/xlings-0.4.8-windows-x86_64.zip",
                 sha256 = "a1f28b904f79106156de43b5790f7b0338cab1371d2e0ff3eabf7a1636159b2b",
             },
             ["0.4.7"] = {
-                url = "https://github.com/d2learn/xlings/releases/download/v0.4.7/xlings-0.4.7-windows-x86_64.zip",
+                url = "https://github.com/openxlings/xlings/releases/download/v0.4.7/xlings-0.4.7-windows-x86_64.zip",
                 sha256 = "13ecbdac25e5370b97812860aed058e86ac0be6c4a77ebd508a581d2a51172c5",
             },
             ["0.4.6"] = {
-                url = "https://github.com/d2learn/xlings/releases/download/v0.4.6/xlings-0.4.6-windows-x86_64.zip",
+                url = "https://github.com/openxlings/xlings/releases/download/v0.4.6/xlings-0.4.6-windows-x86_64.zip",
                 sha256 = "ed20e4bf2f0b6e4a3c981e87d1c65cec60483350b17e7c5c0f57f1e497aaa8f7",
             },
             ["0.4.5"] = {
-                url = "https://github.com/d2learn/xlings/releases/download/v0.4.5/xlings-0.4.5-windows-x86_64.zip",
+                url = "https://github.com/openxlings/xlings/releases/download/v0.4.5/xlings-0.4.5-windows-x86_64.zip",
                 sha256 = "46a62c229a6b729663e9068782f9ac9ea3b50ad193f8cdb159d90f1c43055d78",
             },
             ["0.4.4"] = {
-                url = "https://github.com/d2learn/xlings/releases/download/v0.4.4/xlings-0.4.4-windows-x86_64.zip",
+                url = "https://github.com/openxlings/xlings/releases/download/v0.4.4/xlings-0.4.4-windows-x86_64.zip",
                 sha256 = "45a1f6271d23d3386c713340069e8638559520d5bfc5517ef8eb33e1bea2b577",
             },
             ["0.3.1"] = "XLINGS_RES",

--- a/pkgs/x/xpkg-helper.lua
+++ b/pkgs/x/xpkg-helper.lua
@@ -7,7 +7,7 @@ package = {
     authors = {"sunrisepeak"},
     maintainers = {"d2learn"},
     licenses = {"Apache-2.0"},
-    repo = "https://github.com/d2learn/xim-pkgindex",
+    repo = "https://github.com/openxlings/xim-pkgindex",
 
     -- xim pkg info
     type = "script",

--- a/pkgs/x/xvm-sysdetect.lua
+++ b/pkgs/x/xvm-sysdetect.lua
@@ -6,7 +6,7 @@ package = {
 
     authors = {"sunrisepeak"},
     licenses = {"Apache-2.0"},
-    repo = "https://github.com/d2learn/xim-pkgindex",
+    repo = "https://github.com/openxlings/xim-pkgindex",
 
     -- xim pkg info
     type = "config",

--- a/pkgs/x/xvm.lua
+++ b/pkgs/x/xvm.lua
@@ -6,9 +6,9 @@ package = {
 
     authors = {"sunrisepeak"},
     maintainers = {"d2learn"},
-    contributors = "https://github.com/d2learn/xlings/graphs/contributors",
+    contributors = "https://github.com/openxlings/xlings/graphs/contributors",
     licenses = {"Apache-2.0"},
-    repo = "https://github.com/d2learn/xlings",
+    repo = "https://github.com/openxlings/xlings",
 
     -- xim pkg info
     type = "package",

--- a/xim-indexrepos.lua
+++ b/xim-indexrepos.lua
@@ -1,12 +1,12 @@
 xim_indexrepos = {
     -- keep awesome as default extension entry; other repos are added on demand
     ["awesome"] = {
-        ["GLOBAL"] = "https://github.com/d2learn/xim-pkgindex-awesome.git",
-        ["CN"] = "https://github.com/d2learn/xim-pkgindex-awesome.git",
+        ["GLOBAL"] = "https://github.com/openxlings/xim-pkgindex-awesome.git",
+        ["CN"] = "https://github.com/openxlings/xim-pkgindex-awesome.git",
     },
     ["scode"] = {
-        ["GLOBAL"] = "https://github.com/d2learn/xim-pkgindex-scode.git",
-        ["CN"] = "https://github.com/d2learn/xim-pkgindex-scode.git",
+        ["GLOBAL"] = "https://github.com/openxlings/xim-pkgindex-scode.git",
+        ["CN"] = "https://github.com/openxlings/xim-pkgindex-scode.git",
     },
     ["d2x"] = {
         ["GLOBAL"] = "https://github.com/d2learn/xim-pkgindex-d2x.git",


### PR DESCRIPTION
## Summary
- update canonical GitHub links, workflow badges, raw bootstrap URLs, and Pages URL to openxlings
- update xlings package release asset URLs to openxlings/xlings
- keep d2x and xim-pkgindex-d2x under d2learn, and leave xlings-project-templates out of scope

## Validation
- `rg` audit for migrated d2learn GitHub/Pages/raw references
- `git diff --check`
- `pytest -q -m static tests/c/test_configure_project_installer.py tests/c/test_cpp.py tests/g/test_gcc_specs_config.py tests/g/test_git_autosync.py tests/g/test_github_notifications_clear.py tests/l/test_linux_sysroot_create.py tests/s/test_shortcut_tool.py tests/s/test_sing_box_helper.py tests/w/test_windows_acp.py tests/w/test_wsl_ubuntu.py tests/x/test_xlings.py tests/x/test_xpkg_helper.py tests/x/test_xvm.py tests/x/test_xvm_sysdetect.py`

## Notes
- `d2learn/d2x`, `d2learn/xim-pkgindex-d2x`, and `d2learn/xlings-project-templates` are intentionally not migrated in this PR.