### PR TITLE
feat(go): add Go 1.26.2 (truly-static x86_64 prebuilt)

### DIFF
--- a/pkgs/g/go.lua
+++ b/pkgs/g/go.lua
@@ -1,0 +1,83 @@
+package = {
+    spec = "1",
+
+    name = "go",
+    description = "The Go programming language",
+    homepage = "https://go.dev",
+
+    authors = {"Google"},
+    contributors = "https://github.com/golang/go/graphs/contributors",
+    licenses = {"BSD-3-Clause"},
+    repo = "https://github.com/golang/go",
+    docs = "https://go.dev/doc",
+
+    type = "package",
+    archs = {"x86_64"},
+    status = "stable",
+    categories = {"language", "compiler", "tools"},
+    keywords = {"go", "golang", "language", "compiler"},
+
+    -- Go ships gofmt, go test, go run, etc. via the same `go` driver,
+    -- but `gofmt` is also exposed as a standalone binary in bin/.
+    programs = { "go", "gofmt" },
+
+    xvm_enable = true,
+
+    -- Why direct download from go.dev rather than a tarball mirror:
+    --   * Linux x86_64 binary is `statically linked` with empty
+    --     DT_NEEDED (verified locally with readelf) — runs hermetically
+    --     on Alpine / distroless / any x86_64 host without a libc on
+    --     disk, so no runtime deps declaration needed.
+    --   * go.dev publishes per-version hashes via the dl JSON API,
+    --     letting us pin sha256 deterministically.
+    xpm = {
+        linux = {
+            url_template = "https://go.dev/dl/go{version}.linux-amd64.tar.gz",
+            ["latest"] = { ref = "1.26.2" },
+            ["1.26.2"] = {
+                url = "https://go.dev/dl/go1.26.2.linux-amd64.tar.gz",
+                sha256 = "990e6b4bbba816dc3ee129eaeaf4b42f17c2800b88a2166c265ac1a200262282",
+            },
+        },
+        macosx = {
+            url_template = "https://go.dev/dl/go{version}.darwin-arm64.tar.gz",
+            ["latest"] = { ref = "1.26.2" },
+            ["1.26.2"] = {
+                url = "https://go.dev/dl/go1.26.2.darwin-arm64.tar.gz",
+                sha256 = "32af1522bf3e3ff3975864780a429cc0b41d190ec7bf90faa661d6d64566e7af",
+            },
+        },
+        windows = {
+            url_template = "https://go.dev/dl/go{version}.windows-amd64.zip",
+            ["latest"] = { ref = "1.26.2" },
+            ["1.26.2"] = {
+                url = "https://go.dev/dl/go1.26.2.windows-amd64.zip",
+                sha256 = "98eb3570bade15cb826b0909338df6cc6d2cf590bc39c471142002db3832b708",
+            },
+        },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+
+function install()
+    -- Tarball / zip extracts to a `go/` directory containing bin/, src/,
+    -- pkg/, lib/, etc. Move the whole tree into install_dir as-is.
+    os.tryrm(pkginfo.install_dir())
+    os.mv("go", pkginfo.install_dir())
+    return true
+end
+
+function config()
+    local bindir = path.join(pkginfo.install_dir(), "bin")
+    xvm.add("go",    { bindir = bindir })
+    xvm.add("gofmt", { bindir = bindir })
+    return true
+end
+
+function uninstall()
+    xvm.remove("go")
+    xvm.remove("gofmt")
+    return true
+end

--- a/tests/g/test_go.py
+++ b/tests/g/test_go.py
@@ -1,0 +1,91 @@
+"""测试 go 包"""
+import pytest
+from tests.lib.xpkg_parser import parse_xpkg
+from tests.lib.assertions import (
+    assert_required_fields, assert_valid_spec, assert_valid_type,
+    assert_no_typos, assert_no_exec_xvm, assert_no_bashrc_modification,
+    assert_no_direct_path_modification, assert_uses_new_api,
+    assert_xim_add_succeeds, assert_install_succeeds,
+    assert_command_output, assert_xvm_registered,
+)
+from tests.lib.platform_utils import skip_if_not
+
+PKG = "go"
+PKG_FILE = "pkgs/g/go.lua"
+
+
+@pytest.fixture(scope='module')
+def meta():
+    return parse_xpkg(PKG_FILE)
+
+
+class TestStatic:
+    @pytest.mark.static
+    def test_required_fields(self, meta):
+        assert_required_fields(meta)
+
+    @pytest.mark.static
+    def test_valid_spec(self, meta):
+        assert_valid_spec(meta)
+
+    @pytest.mark.static
+    def test_valid_type(self, meta):
+        assert_valid_type(meta)
+
+    @pytest.mark.static
+    def test_no_typos(self):
+        assert_no_typos(PKG_FILE)
+
+
+class TestIndex:
+    @pytest.mark.index
+    def test_xim_add(self):
+        assert_xim_add_succeeds(PKG_FILE)
+
+
+class TestIsolation:
+    @pytest.mark.isolation
+    def test_no_exec_xvm(self):
+        assert_no_exec_xvm(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_no_bashrc(self):
+        assert_no_bashrc_modification(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_no_path_modification(self):
+        assert_no_direct_path_modification(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_new_api(self):
+        assert_uses_new_api(PKG_FILE)
+
+
+class TestLifecycle:
+    @pytest.mark.lifecycle
+    @skip_if_not('linux')
+    def test_install(self):
+        assert_install_succeeds(PKG)
+
+
+class TestVerify:
+    @pytest.mark.verify
+    @skip_if_not('linux')
+    def test_go(self):
+        assert_command_output("go version", contains="go1.")
+
+    @pytest.mark.verify
+    @skip_if_not('linux')
+    def test_gofmt(self):
+        # gofmt prints help/version on stderr; check it's runnable
+        assert_command_output("gofmt -h 2>&1 | head -1", contains="usage: gofmt")
+
+    @pytest.mark.verify
+    @skip_if_not('linux')
+    def test_xvm_go(self):
+        assert_xvm_registered("go")
+
+    @pytest.mark.verify
+    @skip_if_not('linux')
+    def test_xvm_gofmt(self):
+        assert_xvm_registered("gofmt")


### PR DESCRIPTION
## Summary

Add \`xim:go@1.26.2\` from go.dev's official distribution. Linux x86_64 binary is **truly static** (statically linked, empty DT_NEEDED — verified locally with readelf), so no runtime deps declaration needed.

| platform | artifact | size |
| --- | --- | --- |
| linux-amd64 | \`go1.26.2.linux-amd64.tar.gz\` | 66 MB |
| darwin-arm64 | \`go1.26.2.darwin-arm64.tar.gz\` | - |
| windows-amd64 | \`go1.26.2.windows-amd64.zip\` | - |

sha256 sourced from \`https://go.dev/dl/?mode=json\` — pinned per version.

## Verification

\`\`\`
$ readelf -d go/bin/go    | grep NEEDED   → (none)
$ readelf -d go/bin/gofmt | grep NEEDED   → (none)
$ file go/bin/go    → ELF 64-bit LSB executable, statically linked
$ ./go/bin/go version  →  go version go1.26.2 linux/amd64
\`\`\`

## Files

- \`pkgs/g/go.lua\` — three platforms; install() extracts \`go/\` directory and moves into install_dir as-is; config() registers \`go\` and \`gofmt\` shims.
- \`tests/g/test_go.py\` — static / index / isolation / lifecycle / verify layers, matching tests/v/test_vim.py.

## Test plan

- [ ] CI green (static + isolation + lifecycle install + verify \`go version\` contains "go1.")