### PR TITLE
feat(pnpm): switch to standalone binary + bump 9.15.0 → 11.0.5

### DIFF
--- a/pkgs/p/pnpm.lua
+++ b/pkgs/p/pnpm.lua
@@ -10,48 +10,101 @@ package = {
 
     -- xim pkg info
     archs = {"x86_64"},
-    status = "stable", -- dev, stable, deprecated
+    status = "stable",
     categories = {"package-manager", "typescript"},
+    keywords = {"pnpm", "javascript", "typescript", "package-manager", "node"},
 
+    programs = { "pnpm" },
+    xvm_enable = true,
+
+    -- Why we ship pnpm's standalone binary instead of the previous
+    -- `npm install -g pnpm` recipe:
+    --   * pnpm-v8+ ships a fully-self-contained binary that bundles the
+    --     Node.js runtime via zig-msvc / posix shims (the `pnpm-linux-x64.tar.gz`
+    --     and friends from the GitHub release page). No external Node
+    --     install needed.
+    --   * Previous recipe required `xim:node` first, doubling install time
+    --     and pulling a ~50 MB Node.js xpkg purely as a build dep, even
+    --     though the resulting pnpm binary doesn't need Node at runtime.
+    --   * Direct binary install removes the layered indirection and makes
+    --     `xlings install pnpm` equivalent to fetching one tarball, same
+    --     shape as xim:bun / xim:codex (who DO still go via npm because
+    --     their upstream wheel layout depends on it) NO — xim:bun and
+    --     xim:codex go via npm because their authors publish on npm
+    --     primarily; pnpm publishes a standalone too, so we use that.
     xpm = {
-        windows = {
-            deps = { "node" },
-            ["latest"] = { ref = "9.15.0"},
-            ["9.15.0"] = { },
-        },
         linux = {
-            deps = { "node" },
-            ["latest"] = { ref = "9.15.0"},
-            ["9.15.0"] = { },
+            -- Runtime deps: pnpm prebuilt is dynamically linked
+            -- against glibc + GCC C++ runtime: NEEDED libc / libdl /
+            -- libm / libpthread / libatomic (glibc) plus libgcc_s /
+            -- libstdc++ (xim:gcc-runtime, since pnpm bundles V8/zig
+            -- which ship C++ panic-unwind + std). Same as xim:node /
+            -- xim:ollama deps shape.
+            deps = {
+                runtime = { "xim:glibc@2.39", "xim:gcc-runtime@15.1.0" },
+            },
+            url_template = "https://github.com/pnpm/pnpm/releases/download/v{version}/pnpm-linux-x64.tar.gz",
+            ["latest"] = { ref = "11.0.5" },
+            ["11.0.5"] = {
+                url = "https://github.com/pnpm/pnpm/releases/download/v11.0.5/pnpm-linux-x64.tar.gz",
+                sha256 = "c1b55f53f5344cf0e26441d97b9ee2ee3b81791503c5cbd4bb93ae1898b8d211",
+            },
         },
         macosx = {
-            deps = { "node" },
-            ["latest"] = { ref = "9.15.0"},
-            ["9.15.0"] = { },
+            url_template = "https://github.com/pnpm/pnpm/releases/download/v{version}/pnpm-darwin-arm64.tar.gz",
+            ["latest"] = { ref = "11.0.5" },
+            ["11.0.5"] = {
+                url = "https://github.com/pnpm/pnpm/releases/download/v11.0.5/pnpm-darwin-arm64.tar.gz",
+                sha256 = "24d412b2d137c6bc91e09c039b0e8ced6b5ac8f1dc9ea1881f0521cdb3bc5318",
+            },
+        },
+        windows = {
+            url_template = "https://github.com/pnpm/pnpm/releases/download/v{version}/pnpm-win32-x64.zip",
+            ["latest"] = { ref = "11.0.5" },
+            ["11.0.5"] = {
+                url = "https://github.com/pnpm/pnpm/releases/download/v11.0.5/pnpm-win32-x64.zip",
+                sha256 = "c79329a48a5e67bbbf73578fe0ddd5ff1fef05ed8c9ce43cfdc675d4d173fa3a",
+            },
         },
     },
 }
 
 import("xim.libxpkg.pkginfo")
 import("xim.libxpkg.xvm")
-import("xim.libxpkg.log")
+import("xim.libxpkg.system")
 
+-- Tarball / zip layouts (verified via tar -tzf / unzip -l):
+--   linux/macos: `pnpm` binary at top level + `dist/` directory of
+--                supporting JS modules. Both must end up in install_dir.
+--   windows:     `pnpm.exe` at top level + `dist/`.
+--
+-- xlings auto-extracts the archive into a runtime working directory
+-- whose contents we then move into install_dir wholesale. The shape
+-- is intentionally flat (binary at install_dir root, NOT install_dir/bin)
+-- because the `dist/` sibling needs to be findable relative to the
+-- binary at runtime — pnpm uses argv[0] resolution to locate dist/.
 function install()
-    local pnpm_installcmd_template = "npm install -g pnpm@%s --prefix %s"
-    os.iorun(string.format(pnpm_installcmd_template, pkginfo.version(), pkginfo.install_dir()))
+    os.tryrm(pkginfo.install_dir())
+    os.mkdir(pkginfo.install_dir())
+
+    if is_host("windows") then
+        for _, entry in ipairs({"pnpm.exe", "dist"}) do
+            os.trymv(entry, path.join(pkginfo.install_dir(), entry))
+        end
+    else
+        for _, entry in ipairs({"pnpm", "dist"}) do
+            os.trymv(entry, path.join(pkginfo.install_dir(), entry))
+        end
+    end
+
     return true
 end
 
 function config()
-    log.debug("config xvm...")
-    local bindir = pkginfo.install_dir()
-    local cfg = {}
-    if os.host() == "windows" then
-        cfg.alias = "pnpm.cmd"
-    else
-        bindir = path.join(pkginfo.install_dir(), "bin")
+    local cfg = { bindir = pkginfo.install_dir() }
+    if is_host("windows") then
+        cfg.alias = "pnpm.exe"
     end
-    cfg.bindir = bindir
     xvm.add("pnpm", cfg)
     return true
 end


### PR DESCRIPTION
## Summary

Two changes in one PR (tightly coupled):

1. **Switch artifact source** — npm-install pattern → standalone GitHub-release binary
2. **Bump latest** — 9.15.0 → 11.0.5

## Why

Previous recipe used `npm install -g pnpm@<ver>` which required `xim:node` as a build dep. pnpm v8+ ships a fully-self-contained standalone binary with the JS runtime bundled in (via zig+v8). No external Node needed.

Direct binary install:
- Drops `xim:node` build dep (saves ~50 MB extra install when user only wants pnpm)
- One tarball per platform, deterministic sha256 pinning
- Same shape as xim:bun (which uses npm because the bun npm package is the canonical channel) — pnpm has its own GitHub-release standalone, so we use that

## Linkage / deps

pnpm prebuilt is **dynamically linked** (NEEDED libc/libdl/libm/libpthread/libatomic + libgcc_s/libstdc++), so deps:

```lua
deps.runtime = { "xim:glibc@2.39", "xim:gcc-runtime@15.1.0" }
```

Upstream also publishes `pnpm-linux-x64-musl.tar.gz` but it's **musl-dynamic** (NEEDED libc.musl-x86_64), same situation as xim:node — switching to musl trades glibc deps for a musl libc xim doesn't ship as a runtime package. Net-zero.

## Files changed

- `pkgs/p/pnpm.lua` — three platforms (linux-x64 / darwin-arm64 / win32-x64), each pinned with sha256; install() extracts `pnpm` (or `pnpm.exe`) + `dist/` into install_dir; config() registers shim with bindir = install_dir (not install_dir/bin) so dist/ stays sibling to binary.

## Test plan

- [ ] CI green (static + isolation + lifecycle install + verify `pnpm --version`)