### PR TITLE
feat(ollama,libcuda): sentinel host-link pkg + auto-link cuda backends

### DIFF
--- a/pkgs/l/libcuda-host-link.lua
+++ b/pkgs/l/libcuda-host-link.lua
@@ -1,0 +1,163 @@
+package = {
+    spec = "1",
+
+    name = "libcuda-host-link",
+    description = "Sentinel: stable symlink to host's libcuda.so.1 (NVIDIA driver userspace lib)",
+
+    licenses = {"Apache-2.0"},  -- the package recipe; libcuda.so.1 itself is NVIDIA's
+    repo = "https://github.com/openxlings/xim-pkgindex",
+
+    -- xim pkg info
+    type = "package",
+    archs = {"x86_64"},
+    status = "stable",
+    categories = {"runtime", "lib", "gpu", "nvidia"},
+    keywords = {"cuda", "nvidia", "driver", "host-link", "sentinel"},
+
+    -- ─────────────────────────────────────────────────────────────────────
+    -- What this package does (and what it does NOT do)
+    --
+    -- DOES:
+    --   * Probe the host for an existing `libcuda.so.1`
+    --     (NVIDIA driver userspace lib).
+    --   * Install a single symlink at
+    --       <install_dir>/lib/libcuda.so.1
+    --     pointing to the host file. If host has no driver, the symlink
+    --     points to the canonical /usr/lib/x86_64-linux-gnu/libcuda.so.1
+    --     (or the distro's equivalent), and is intentionally dangling
+    --     until the user installs the driver — at which point GPU-using
+    --     consumer xpkgs auto-resolve.
+    --
+    -- DOES NOT:
+    --   * Redistribute libcuda.so.1. The NVIDIA Driver EULA forbids
+    --     third-party redistribution, and even if it didn't, the
+    --     userspace lib is in strict ABI lockstep with the kernel
+    --     module — versioning it as an xpkg is impossible.
+    --
+    -- Why a sentinel package and not just probe-in-each-consumer:
+    --   * Single source of truth for "where is host libcuda" → all GPU
+    --     xpkgs (ollama / future vllm / jax / cupy / ...) read from
+    --     pkginfo.dep_install_dir("libcuda-host-link").."/lib/libcuda.so.1"
+    --     and don't reimplement ldconfig probing each.
+    --   * Reinstall once → all consumers' transitive symlinks stay
+    --     valid (they link to this package's link, not directly to host).
+    --   * Driver post-install self-heal: install nvidia-driver later →
+    --     re-`xim install libcuda-host-link` → consumer chains auto-fix
+    --     without each consumer reinstall.
+    -- ─────────────────────────────────────────────────────────────────────
+
+    xpm = {
+        linux = {
+            -- Version is the recipe version, not the driver version
+            -- (drivers are owned by the host). Bump on recipe changes.
+            ["latest"] = { ref = "0.0.1" },
+            ["0.0.1"]  = { },  -- no download; install hook does everything
+        },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.log")
+import("xim.libxpkg.system")
+
+-- Probe the host for libcuda.so.1.
+-- Strategy:
+--   1) ldconfig -p | grep libcuda.so.1 → covers properly registered drivers
+--      across distros (Debian/Ubuntu, Fedora/RHEL, Arch, openSUSE).
+--   2) If ldconfig misses (containers without /etc/ld.so.cache populated,
+--      or NixOS-style non-FHS), check the canonical FHS paths directly.
+--   3) Return nil if none found → caller decides what to do.
+local function __probe_host_libcuda()
+    -- Strategy 1: ldconfig cache (works on properly-registered drivers).
+    -- Use try{} to swallow non-zero exits (ldconfig itself, or grep with
+    -- no match). On x86_64-linux-gnu hosts the line shape is:
+    --   "\tlibcuda.so.1 (libc6,x86-64) => /lib/x86_64-linux-gnu/libcuda.so.1"
+    -- (filter for "x86-64" to skip the 32-bit i386 line.)
+    local out = try {
+        function() return os.iorun("ldconfig -p 2>/dev/null") end
+    }
+    if out and out ~= "" then
+        for line in out:gmatch("[^\n]+") do
+            if line:find("libcuda.so.1", 1, true)
+               and line:find("x86-64", 1, true) then
+                local p = line:match("=>%s*(/%S+)")
+                if p and os.isfile(p) then return p end
+            end
+        end
+    end
+    -- Strategy 2: well-known FHS paths (containers without populated
+    -- ld.so.cache, or NixOS-style non-FHS hosts where ldconfig is empty).
+    for _, p in ipairs({
+        "/usr/lib/x86_64-linux-gnu/libcuda.so.1",  -- Debian / Ubuntu / Mint
+        "/usr/lib64/libcuda.so.1",                 -- RHEL / Fedora / openSUSE / Arch
+        "/usr/lib/libcuda.so.1",                   -- Arch (older) / minimal distros
+    }) do
+        if os.isfile(p) then return p end
+    end
+    return nil
+end
+
+-- Choose the symlink target for the "no driver yet" case.
+-- The link target is a path the user's distro WILL provide once the
+-- nvidia-driver package is installed, so the symlink self-heals later
+-- without re-running this package's install hook.
+local function __canonical_path_for_distro()
+    if os.isfile("/etc/os-release") then
+        local content = io.readfile("/etc/os-release") or ""
+        local idl = ((content:match("ID=([^\n]*)") or "") .. " " ..
+                     (content:match("ID_LIKE=([^\n]*)") or "")):lower()
+        idl = idl:gsub('"', '')
+        if idl:find("debian") or idl:find("ubuntu") or idl:find("mint") then
+            return "/usr/lib/x86_64-linux-gnu/libcuda.so.1"
+        elseif idl:find("fedora") or idl:find("rhel") or idl:find("centos")
+            or idl:find("opensuse") or idl:find("suse") then
+            return "/usr/lib64/libcuda.so.1"
+        elseif idl:find("arch") or idl:find("manjaro") then
+            return "/usr/lib/libcuda.so.1"
+        end
+    end
+    -- Default to Debian/Ubuntu layout (most common xim Linux user)
+    return "/usr/lib/x86_64-linux-gnu/libcuda.so.1"
+end
+
+function install()
+    local host_libcuda = __probe_host_libcuda()
+    local target       = host_libcuda or __canonical_path_for_distro()
+
+    -- Always create the symlink, even when the target doesn't exist yet.
+    -- Dangling-but-canonical is intentional: when the user later installs
+    -- nvidia-driver via their distro package manager, the driver will
+    -- materialize at the canonical path, and this symlink (plus all
+    -- transitive consumer symlinks pointing to it) will resolve
+    -- automatically — no xpkg reinstall needed.
+    local link = path.join(pkginfo.install_dir(), "lib", "libcuda.so.1")
+    os.tryrm(pkginfo.install_dir())
+    os.mkdir(path.directory(link))
+    -- Use `ln -sf` rather than os.ln (xmake's lua has no os.ln helper);
+    -- -f is harmless here since we just os.tryrm'd the parent.
+    system.exec(string.format([[ln -sf "%s" "%s"]], target, link))
+
+    if host_libcuda then
+        log.info("libcuda-host-link → %s ✓", host_libcuda)
+    else
+        log.warn("NVIDIA driver not detected on this host.")
+        log.warn("  symlink target: %s (currently dangling)", target)
+        log.warn("  GPU-using xpkgs (ollama / vllm / ...) will fall back")
+        log.warn("  to CPU until you install the NVIDIA driver via your")
+        log.warn("  distro package manager — at which point the link")
+        log.warn("  self-heals and GPU acceleration starts working.")
+    end
+
+    return true
+end
+
+function config()
+    -- Sentinel package: no shim, no xvm registration. Consumers read
+    -- pkginfo.dep_install_dir("libcuda-host-link") + "/lib/libcuda.so.1"
+    -- as the canonical link path.
+    return true
+end
+
+function uninstall()
+    return true
+end

--- a/tests/l/test_libcuda_host_link.py
+++ b/tests/l/test_libcuda_host_link.py
@@ -1,0 +1,85 @@
+"""测试 libcuda-host-link 包"""
+import os
+import pytest
+from tests.lib.xpkg_parser import parse_xpkg
+from tests.lib.assertions import (
+    assert_required_fields, assert_valid_spec, assert_valid_type,
+    assert_no_typos, assert_no_exec_xvm, assert_no_bashrc_modification,
+    assert_no_direct_path_modification, assert_uses_new_api,
+    assert_xim_add_succeeds, assert_install_succeeds,
+)
+from tests.lib.platform_utils import skip_if_not, xpkgs_dir
+
+PKG = "libcuda-host-link"
+PKG_FILE = "pkgs/l/libcuda-host-link.lua"
+
+
+@pytest.fixture(scope='module')
+def meta():
+    return parse_xpkg(PKG_FILE)
+
+
+class TestStatic:
+    @pytest.mark.static
+    def test_required_fields(self, meta):
+        assert_required_fields(meta)
+
+    @pytest.mark.static
+    def test_valid_spec(self, meta):
+        assert_valid_spec(meta)
+
+    @pytest.mark.static
+    def test_valid_type(self, meta):
+        assert_valid_type(meta)
+
+    @pytest.mark.static
+    def test_no_typos(self):
+        assert_no_typos(PKG_FILE)
+
+
+class TestIndex:
+    @pytest.mark.index
+    def test_xim_add(self):
+        assert_xim_add_succeeds(PKG_FILE)
+
+
+class TestIsolation:
+    @pytest.mark.isolation
+    def test_no_exec_xvm(self):
+        assert_no_exec_xvm(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_no_bashrc(self):
+        assert_no_bashrc_modification(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_no_path_modification(self):
+        assert_no_direct_path_modification(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_new_api(self):
+        assert_uses_new_api(PKG_FILE)
+
+
+class TestLifecycle:
+    @pytest.mark.lifecycle
+    @skip_if_not('linux')
+    def test_install(self):
+        # Sentinel package install should always succeed regardless of
+        # whether the host has an NVIDIA driver — the symlink is
+        # intentionally allowed to be dangling so it self-heals on a
+        # later driver install.
+        assert_install_succeeds(PKG)
+
+
+class TestVerify:
+    @pytest.mark.verify
+    @skip_if_not('linux')
+    def test_link_exists(self):
+        # The package should always create the symlink at the canonical
+        # path, regardless of host driver presence.
+        link = os.path.join(
+            xpkgs_dir(), "xim-x-libcuda-host-link", "0.0.1",
+            "lib", "libcuda.so.1",
+        )
+        assert os.path.islink(link), f"sentinel symlink missing: {link}"


### PR DESCRIPTION
## Summary

Adds `xim:libcuda-host-link@0.0.1` (a sentinel package that probes for the host's NVIDIA driver and creates a stable symlink to it) and wires `xim:ollama` to consume it. Fixes the "ollama runs at 100% CPU even on a GPU host" symptom.

## Root cause of the bug

ollama's prebuilt tarball ships its own CUDA backends under `lib/ollama/cuda_v*/`. The backends `dlopen("libcuda.so.1")` at runtime, but `libcuda.so.1` itself is **not redistributable** (NVIDIA EULA + kernel ABI lockstep — only the host's driver package may provide it). The directory has no such symlink, dlopen silently fails, and ollama transparently falls back to CPU.

## Sentinel-package pattern

Rather than each GPU xpkg reimplementing host-driver probing, introduce one tiny "host-link" sentinel:

```lua
xim:libcuda-host-link@0.0.1
  install():
    1. Probe ldconfig + FHS fallback paths
    2. Always create <install>/lib/libcuda.so.1 symlink pointing at
       a canonical host path
    3. Driver missing? → link is dangling to canonical FHS path, so
       it self-heals when user later `apt install nvidia-driver`
```

The package itself ships **zero NVIDIA bytes**, just one symlink, so it sidesteps EULA cleanly.

## ollama wiring

`xim:ollama` adds `xim:libcuda-host-link@0.0.1` as runtime dep. Install hook does `__link_cuda_backends()`: glob `lib/ollama/cuda_v*/` and ln -sf the sentinel into each. Forward-compat with future `cuda_v14` etc.; intentionally excludes `rocm_v*` (AMD GPU, uses libamdhip64).

## Verified end-to-end (xlings 0.4.15 in isolated XLINGS_HOME)

```
$ xlings install ollama
  [xim:xpkg]: libcuda-host-link → /lib/x86_64-linux-gnu/libcuda.so.1 ✓
  [xim:xpkg]: ollama: linked cuda_v12/libcuda.so.1 → <sentinel>
  [xim:xpkg]: ollama: linked cuda_v13/libcuda.so.1 → <sentinel>
  ✓ 4 package(s) installed

$ readlink -f <ollama>/lib/ollama/cuda_v12/libcuda.so.1
  /usr/lib/x86_64-linux-gnu/libcuda.so.550.144.03   ← real driver
```

## Files

- `pkgs/l/libcuda-host-link.lua` — new sentinel package
- `tests/l/test_libcuda_host_link.py` — companion tests (static + index + isolation + lifecycle + verify-link-exists)
- `pkgs/o/ollama.lua` — adds `libcuda-host-link` runtime dep + `__link_cuda_backends()` install-hook helper

## Implementation note

`__link_cuda_backends()` shells out via `os.iorun("ls -d <unquoted-glob>")` rather than `os.dirs()` because libxpkg's prelude `os.dirs` shim double-quotes the pattern, defeating bash glob expansion. Separate libxpkg bug; not blocking this PR but worth a follow-up.

## Out of scope

A hypothetical `xim:nvidia-driver-install` orchestrator package (which would actually `sudo apt install nvidia-driver-XXX`) is intentionally NOT bundled here — sudo + cross-distro complexity make it a poor default dep. If users want one-shot driver setup, that's a separate, opt-in package design.

## Test plan

- [ ] CI green (static + isolation + lifecycle install + verify symlink in xpkgs)