### PR TITLE
feat(git): add Linux x86_64 support (static prebuilt)

### DIFF
--- a/pkgs/g/git.lua
+++ b/pkgs/g/git.lua
@@ -25,7 +25,31 @@ package = {
             deps = { "shortcut-tool" },
             ["latest"] = { ref = "2.51.1" },
             ["2.51.1"] = "XLINGS_RES",
-        }
+        },
+        linux = {
+            -- TODO(self-build): migrate to xlings-res official mirror.
+            -- Currently sourced from the community project
+            -- supriyo-biswas/static-builds, which ships a fully
+            -- statically-linked git tarball (verified via readelf:
+            -- empty DT_NEEDED, no .interp section). Pros: zero deps,
+            -- single download, currently tracks upstream within days
+            -- (git-2.53.0 published 2026-03-19). Cons: single
+            -- maintainer, no SLA, build environment opaque.
+            --
+            -- Plan: once the xim-pkgindex-build self-build pipeline
+            -- (alpine + musl, similar to scode:gcc → xlings-res/gcc
+            -- chain) is in place, switch this to:
+            --   url = ...xlings-res/git/<ver>/git-<ver>-linux-x86_64.tar.gz
+            -- so xim owns the build chain end-to-end and removes the
+            -- community-source dependency. Same migration applies to
+            -- xim:vim (currently dtschan/vim-static, 2019 stale) and
+            -- any future T2 pkgs.
+            ["latest"] = { ref = "2.53.0" },
+            ["2.53.0"] = {
+                url = "https://github.com/supriyo-biswas/static-builds/releases/download/git-2.53.0/git-2.53.0-linux-x86_64.tar.gz",
+                sha256 = "948a9bb92e74e9a5e5bdd6d8a19e49712f46d9709ddcda924bf17828a794d297",
+            },
+        },
     },
 }
 
@@ -35,33 +59,58 @@ import("xim.libxpkg.system")
 import("xim.libxpkg.log")
 
 function install()
-    os.tryrm(pkginfo.install_dir())
-    local git_dir = pkginfo.install_file()
-        :replace(".zip", "")
-    os.mv(git_dir, pkginfo.install_dir())
+    if is_host("windows") then
+        -- Windows: PortableGit zip extracts to a `PortableGit/` sibling
+        -- dir; old recipe relied on the file-name prefix matching.
+        os.tryrm(pkginfo.install_dir())
+        local git_dir = pkginfo.install_file():replace(".zip", "")
+        os.mv(git_dir, pkginfo.install_dir())
+    else
+        -- Linux: static-builds tarball has `bin/`, `libexec/`, `share/`
+        -- at its top level (no enclosing version-named subdir, despite
+        -- the tarball filename). Extract directly into install_dir so
+        -- git can find libexec/git-core helpers via its argv[0]-relative
+        -- resolution. Use explicit `tar -xzf -C` (same shape as
+        -- ollama.lua) rather than relying on xlings's implicit
+        -- pre-extract behavior, which can leak runtimedir state into
+        -- this package's install_dir on shared-cache hosts.
+        os.tryrm(pkginfo.install_dir())
+        os.mkdir(pkginfo.install_dir())
+        system.exec(string.format(
+            [[tar -xzf "%s" -C "%s"]],
+            pkginfo.install_file(), pkginfo.install_dir()
+        ))
+    end
     return true
 end
 
 function config()
+    if is_host("windows") then
+        xvm.add("git", {
+            bindir = path.join(pkginfo.install_dir(), "cmd")
+        })
 
-    xvm.add("git", {
-        bindir = path.join(pkginfo.install_dir(), "cmd")
-    })
-
-    system.exec(string.format(
-        [[shortcut-tool create --name "Git Bash" --target "%s" --icon "%s" --args "%s"]],
-        path.join(pkginfo.install_dir(), "git-bash.exe"),
-        path.join(pkginfo.install_dir(), "git-bash.exe"),
-        "--cd-to-home"
-    ))
+        system.exec(string.format(
+            [[shortcut-tool create --name "Git Bash" --target "%s" --icon "%s" --args "%s"]],
+            path.join(pkginfo.install_dir(), "git-bash.exe"),
+            path.join(pkginfo.install_dir(), "git-bash.exe"),
+            "--cd-to-home"
+        ))
+    else
+        xvm.add("git", {
+            bindir = path.join(pkginfo.install_dir(), "bin")
+        })
+    end
 
     return true
 end
 
 function uninstall()
     xvm.remove("git")
-    system.exec(string.format(
-        [[shortcut-tool remove --name "Git Bash"]]
-    ))
+    if is_host("windows") then
+        system.exec(string.format(
+            [[shortcut-tool remove --name "Git Bash"]]
+        ))
+    end
     return true
 end

--- a/tests/g/test_git.py
+++ b/tests/g/test_git.py
@@ -59,3 +59,22 @@ class TestIsolation:
     @pytest.mark.isolation
     def test_new_api(self):
         assert_uses_new_api(PKG_FILE)
+
+
+class TestLifecycle:
+    @pytest.mark.lifecycle
+    @skip_if_not('linux')
+    def test_install(self):
+        assert_install_succeeds(PKG)
+
+
+class TestVerify:
+    @pytest.mark.verify
+    @skip_if_not('linux')
+    def test_git(self):
+        assert_command_output("git --version", contains="git version")
+
+    @pytest.mark.verify
+    @skip_if_not('linux')
+    def test_xvm_git(self):
+        assert_xvm_registered("git")


### PR DESCRIPTION
## Summary

Adds the Linux platform to the existing \`xim:git\` package (previously Windows-only). Sourced from \`supriyo-biswas/static-builds\` which ships a single 24 MB tarball with `bin/git` **statically linked** (verified via readelf: empty DT_NEEDED, no `.interp` section).

## Why this source

| candidate | linkage | freshness | risk |
| --- | --- | --- | --- |
| **supriyo-biswas/static-builds** (chosen) | static | git-2.53.0 within days of upstream | single maintainer, no SLA |
| build from source via xim scode | static-when-musl | depends on us | requires adding ~6 dep packages first (libcurl/openssl/libpcre2/libz/expat/gettext) |
| upstream `git/git` releases | source-only, no binaries | n/a | n/a |
| distro packages (apt/dnf) | dynamic glibc | distro-pinned | not hermetic |

## TODO: migrate to self-built mirror

The community source works but is a single point of failure. Long-term plan (captured in `TODO(self-build):` comment in lua):

> Once a self-build pipeline modeled on the existing `scode:gcc → xlings-res/gcc` chain is in place (alpine + musl + Dockerfile per pkg), switch this URL to `xlings-res/git/<ver>/...` so xim owns the build end-to-end. Same migration applies to xim:vim.

## Verified locally

```
$ readelf -d <tarball>/bin/git | grep NEEDED   → (none)
$ file <tarball>/bin/git → ELF 64-bit LSB executable, statically linked, stripped
$ <tarball>/bin/git --version → git version 2.53.0
```

## Files

- `pkgs/g/git.lua` — added linux platform; install() splits windows / linux paths
- `tests/g/test_git.py` — adds Lifecycle (install) + Verify (`git --version`, xvm registered) tests on linux

## Test plan

- [ ] CI green