### PR TITLE
fix(nvm): bypass install.sh dash bug + bump 0.39.0 → 0.40.4 + xlings-res mirror

### DIFF
--- a/pkgs/n/nvm.lua
+++ b/pkgs/n/nvm.lua
@@ -17,6 +17,10 @@ package = {
 
     xpm = {
         windows = {
+            -- Windows still uses coreybutler/nvm-windows — a separate
+            -- project from POSIX nvm; ships a real .exe installer.
+            -- Not covered by the xlings-res mirror (mirror is for
+            -- POSIX nvm only).
             ["latest"] = { ref = "1.1.11"},
             ["1.1.11"] = {
                 url = "https://github.com/coreybutler/nvm-windows/releases/download/1.1.11/nvm-setup.exe",
@@ -24,11 +28,29 @@ package = {
             }
         },
         linux = {
-            ["latest"] = { ref = "0.39.0"},
-            ["0.39.0"] = {
-                url = "https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh",
-                sha256 = nil,
-            },
+            -- Mirror at xlings-res/nvm (byte-identical to upstream
+            -- nvm-sh/nvm source tarball, just renamed to xlings-res
+            -- convention). XLINGS_RES sentinel resolves to:
+            --   GLOBAL → github.com/xlings-res/nvm/releases/...
+            --   CN     → gitcode.com/xlings-res/nvm/releases/...
+            --
+            -- Why we mirror instead of pointing at upstream:
+            --   * Stable URL shape under xlings-res/<pkg> across both
+            --     GLOBAL and CN mirrors (CN users get gitcode-served
+            --     downloads automatically — important for nvm because
+            --     download speed from raw.githubusercontent.com to
+            --     mainland China is unreliable)
+            --   * upstream `archive/refs/tags/...` URLs are
+            --     auto-generated, theoretically stable but not
+            --     promised stable by GitHub
+            --
+            -- Bumped 0.39.0 → 0.40.4 (latest upstream as of mirror
+            -- creation). Going forward bumps are: download upstream
+            -- source tarball → re-upload as
+            -- nvm-<ver>-{linux-x86_64,macosx-arm64}.tar.gz to
+            -- xlings-res/nvm release page → bump version line here.
+            ["latest"] = { ref = "0.40.4"},
+            ["0.40.4"] = "XLINGS_RES",
         },
     },
 }
@@ -54,7 +76,30 @@ function install()
         os.addenv("PATH", nvm_home)
         os.addenv("PATH", node_home)
     else
-        os.exec("sh " .. pkginfo.install_file())
+        -- Bypass nvm-sh's `install.sh`. The upstream installer ends
+        -- with `for job in $(jobs -p); do wait "$job"; done` — but
+        -- `dash` (Ubuntu/Debian's default `/bin/sh`) does NOT enable
+        -- job control for non-interactive scripts (POSIX), so
+        -- `jobs -p` returns empty, the `for` body never runs, the
+        -- shell exits immediately while three backgrounded `wget &`
+        -- children are still downloading. Net effect from xlings's
+        -- POV is "install ok" while the user terminal hangs at "100%".
+        --
+        -- The installer's only job is laying down 3 files in
+        -- ~/.nvm/. Replacing it with a single `tar xz` of the
+        -- pre-mirrored upstream source tarball is equivalent and
+        -- avoids the dash compat trap entirely.
+        local nvm_home = path.join(os.getenv("HOME"), ".nvm")
+        os.tryrm(nvm_home)
+        os.mkdir(nvm_home)
+        -- Upstream tarball top-level dir is `nvm-<version>/`; flatten
+        -- into ~/.nvm so existing `[ -s "$NVM_DIR/nvm.sh" ] && \. ...`
+        -- profile snippet keeps working unchanged.
+        system.exec(string.format(
+            [[tar -xzf "%s" -C "%s" --strip-components=1]],
+            pkginfo.install_file(), nvm_home
+        ))
+
         system.unix_api().append_to_shell_profile({
             posix = [[
 # nvm config by xlings-xim


### PR DESCRIPTION
## Summary

Three changes in one PR (tightly coupled to the same recipe):

1. **Fix the "100% hang" bug** — bypass `nvm-sh/install.sh`'s `&`+`wait` pattern that's broken under dash
2. **Bump** 0.39.0 → 0.40.4 (latest upstream)
3. **Mirror to xlings-res/nvm** so CN users get gitcode-served downloads

## The dash bug (root cause of users reporting "stuck at 100%")

```sh
# install.sh tail
for job in $(jobs -p); do
    wait "$job"
done
```

dash (Ubuntu/Debian default `/bin/sh`) does NOT enable job control for non-interactive scripts (POSIX). So `jobs -p` returns empty, the `for` body never runs, the script exits immediately while three `wget &` children are still downloading. xlings's `os.exec("sh install.sh")` returns success while the user terminal hangs at "100%".

## Fix: skip install.sh, lay down ~/.nvm via tar

The installer's only job in the non-git path is dropping 3-4 files into ~/.nvm. Replacing with `tar -xzf --strip-components=1` of the upstream source tarball achieves the same end state without hitting any sh/dash compat trap. The shell-profile injection (`. ~/.nvm/nvm.sh`) stays unchanged.

## Mirror

Created **github.com/xlings-res/nvm** + release `0.40.4` with two assets:

| asset | sha256 |
| --- | --- |
| `nvm-0.40.4-linux-x86_64.tar.gz`  | `5949b50e4640f2be2263f963952673d7f1a8745a83f05365e99f032fe78307fd` |
| `nvm-0.40.4-macosx-arm64.tar.gz`  | `5949b50e4640f2be2263f963952673d7f1a8745a83f05365e99f032fe78307fd` |

Both are byte-identical copies of the upstream `nvm-sh/nvm/archive/refs/tags/v0.40.4.tar.gz` — only the filename changes.

**TODO**: gitcode CN mirror needs to be set up separately by maintainer with gitcode credentials. Once that's done, CN users automatically get faster downloads via `XLINGS_RES` resolution.

## Verification (isolated XLINGS_HOME)

```
$ xlings install nvm     → 1 package(s) installed (no 100% hang)
$ ls ~/.nvm/             → nvm.sh, bash_completion, install.sh, README.md, ...
$ . ~/.nvm/nvm.sh && nvm --version
                         → 0.40.4
```

## Files

- `pkgs/n/nvm.lua` — Linux block: URL → `XLINGS_RES`, install hook bypasses `sh install.sh` and uses `tar -xzf --strip-components=1` instead. Windows block (coreybutler/nvm-windows installer) untouched.

## Why didn't you propose using xvm instead

`nvm` is fundamentally a **shell function**, not a binary — it mutates the calling shell's PATH for `nvm use <version>`. xvm shim (subprocess model) can't carry env state back to parent shell. Shell-profile injection is the only viable path for nvm-class tools; xim already manages it via `system.unix_api().append_to_shell_profile`. This PR doesn't change that.

## Test plan

- [ ] CI green