### PR TITLE
fix(nvim): switch latest 0.12.2 to xlings-res mirror

### DIFF
--- a/pkgs/n/nvim.lua
+++ b/pkgs/n/nvim.lua
@@ -21,6 +21,22 @@ package = {
     -- xvm: xlings version management
     xvm_enable = true,
 
+    -- Latest version is mirrored at xlings-res/nvim (byte-identical
+    -- to upstream `neovim/neovim` release artifacts, just renamed to
+    -- xlings-res convention `nvim-<ver>-<platform>-<arch>.<ext>`).
+    --
+    -- XLINGS_RES sentinel resolves to:
+    --   GLOBAL → github.com/xlings-res/nvim/releases/download/<ver>/...
+    --   CN     → gitcode.com/xlings-res/nvim/releases/download/<ver>/...
+    --
+    -- The install hook (below) relies on the *internal* tarball dir
+    -- name (`nvim-linux-x86_64/` for linux, `nvim-win64/` for windows)
+    -- which is unchanged by our rename — only the outer filename is
+    -- different.
+    --
+    -- Older versions still pointed at upstream URLs; they're kept for
+    -- users pinning historical builds. New versions go through
+    -- XLINGS_RES.
     xpm = {
         linux = {
             -- Runtime deps. nvim prebuilt (nvim-linux-x86_64.tar.gz)
@@ -33,10 +49,7 @@ package = {
             },
             url_template = "https://github.com/neovim/neovim/releases/download/v{version}/nvim-linux-x86_64.tar.gz",
             ["latest"] = { ref = "0.12.2" },
-            ["0.12.2"] = {
-                url = "https://github.com/neovim/neovim/releases/download/v0.12.2/nvim-linux-x86_64.tar.gz",
-                sha256 = "31cf85945cb600d96cdf69f88bc68bec814acbff50863c5546adef3a1bcef260",
-            },
+            ["0.12.2"] = "XLINGS_RES",
             ["0.11.5"] = {
                 url = "https://github.com/neovim/neovim/releases/download/v0.11.5/nvim-linux-x86_64.tar.gz",
                 sha256 = "b2f91117be5b5ea39edd7297156dc2a4a8df4add6c95a90809a8df19e7ab6f52",
@@ -45,10 +58,7 @@ package = {
         windows = {
             url_template = "https://github.com/neovim/neovim/releases/download/v{version}/nvim-win64.zip",
             ["latest"] = { ref = "0.12.2" },
-            ["0.12.2"] = {
-                url = "https://github.com/neovim/neovim/releases/download/v0.12.2/nvim-win64.zip",
-                sha256 = "23fe150edbcc976eabe55092e1e9d2e5e237afde69553d170e936f776b405d53",
-            },
+            ["0.12.2"] = "XLINGS_RES",
             ["0.11.5"] = {
                 url = "https://github.com/neovim/neovim/releases/download/v0.11.5/nvim-win64.zip",
                 sha256 = "718e731326e7759cf17bbbb33f38975707a2ac85642614686b818ef5fde38f48",


### PR DESCRIPTION
## Summary

Same pattern as #137 (nvm). Switch \`xim:nvim@0.12.2\` from upstream URLs to \`XLINGS_RES\` so CN users get gitcode-served downloads.

## What I did

Created \`xlings-res/nvim\` on both **github** and **gitcode**, uploaded byte-identical copies of upstream neovim release artifacts under the xlings-res naming convention:

| filename | upstream source | sha256 |
| --- | --- | --- |
| \`nvim-0.12.2-linux-x86_64.tar.gz\` | upstream \`nvim-linux-x86_64.tar.gz\` | `31cf85945cb600d96cdf69f88bc68bec814acbff50863c5546adef3a1bcef260` |
| \`nvim-0.12.2-windows-x86_64.zip\` | upstream \`nvim-win64.zip\` | `23fe150edbcc976eabe55092e1e9d2e5e237afde69553d170e936f776b405d53` |

## Files

- \`pkgs/n/nvim.lua\` — Linux + Windows: \`["0.12.2"] = "XLINGS_RES"\`. Older 0.11.5 entries kept on upstream URLs (historical pinning).

## Why mirror this

- CN users hit slow downloads from \`github.com/neovim/neovim/releases/download/...\` from mainland China; \`gitcode.com/xlings-res/nvim/...\` is much faster
- Aligns nvim with the trend most other xim packages already follow (xim:nvm, xim:gcc, xim:openssl, xim:mdbook, ...)
- xlings-res hosts byte-identical copies; no trust delegation, just speed

## Install hook unchanged

The install hook moves the extracted directory `nvim-linux-x86_64/` (linux) or `nvim-win64/` (windows) into install_dir. Those *internal* tarball dir names are unchanged by our outer-filename rename, so install hook keeps working as-is.

## Verified end-to-end (xlings 0.4.16, isolated XLINGS_HOME)

```
$ xlings install nvim   → 3 package(s) installed (deps + nvim)
$ nvim --version        → NVIM v0.12.2
                          Build type: Release
                          LuaJIT 2.1.1774638290
```

## Test plan

- [ ] CI green