### PR TITLE
feat(mcpp): add 0.0.1 (modern C++ build tool, static linux x86_64)

### DIFF
--- a/pkgs/m/mcpp.lua
+++ b/pkgs/m/mcpp.lua
@@ -1,0 +1,76 @@
+package = {
+    spec = "1",
+
+    name = "mcpp",
+    description = "A modern C++ build tool with module support, dependency/toolchain management, package indexing, and packaging",
+
+    authors = {"sunrisepeak"},
+    maintainers = {"https://github.com/mcpp-community/mcpp/graphs/contributors"},
+    licenses = {"Apache-2.0"},
+    repo = "https://github.com/mcpp-community/mcpp",
+    homepage = "https://github.com/mcpp-community/mcpp",
+    docs = "https://github.com/mcpp-community/mcpp#readme",
+
+    -- xim pkg info
+    type = "package",
+    archs = {"x86_64"},
+    status = "dev", -- 0.0.x: upstream is pre-1.0, expect breaking changes
+    categories = {"build-tool", "cpp"},
+    keywords = {"cpp", "c++", "build", "module", "package-manager"},
+
+    programs = { "mcpp" },
+
+    xvm_enable = true,
+
+    -- Mirrored at xlings-res/mcpp (byte-identical to upstream
+    -- mcpp-community/mcpp release artifacts, just renamed to
+    -- xlings-res convention `mcpp-<ver>-<platform>-<arch>.<ext>`).
+    --
+    -- XLINGS_RES sentinel resolves to:
+    --   GLOBAL → github.com/xlings-res/mcpp/releases/download/<ver>/...
+    --   CN     → gitcode.com/xlings-res/mcpp/releases/download/<ver>/...
+    --
+    -- The Linux tarball is a fully-static ELF (no .interp, no
+    -- DT_NEEDED) plus a thin shell launcher at the bundle root —
+    -- zero runtime deps. xvm registers `bindir = <install>/bin`
+    -- so the real ELF is invoked directly (the top-level shell
+    -- launcher is only used when running from the bundle root).
+    xpm = {
+        linux = {
+            url_template = "https://github.com/mcpp-community/mcpp/releases/download/v{version}/mcpp-{version}-linux-x86_64.tar.gz",
+            ["latest"] = { ref = "0.0.1" },
+            ["0.0.1"] = "XLINGS_RES",
+        },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+import("xim.libxpkg.system")
+
+function install()
+    -- Tarball top-level layout (no enclosing version-named dir):
+    --   ./mcpp          (POSIX shell launcher → exec bin/mcpp)
+    --   ./bin/mcpp      (static ELF)
+    --   ./LICENSE
+    --   ./README.md
+    -- Extract directly into install_dir so xvm's bindir=<install>/bin
+    -- finds the real binary.
+    os.tryrm(pkginfo.install_dir())
+    os.mkdir(pkginfo.install_dir())
+    system.exec(string.format(
+        [[tar -xzf "%s" -C "%s"]],
+        pkginfo.install_file(), pkginfo.install_dir()
+    ))
+    return true
+end
+
+function config()
+    xvm.add("mcpp", { bindir = path.join(pkginfo.install_dir(), "bin") })
+    return true
+end
+
+function uninstall()
+    xvm.remove("mcpp")
+    return true
+end

--- a/tests/m/test_mcpp.py
+++ b/tests/m/test_mcpp.py
@@ -1,0 +1,80 @@
+"""测试 mcpp 包"""
+import pytest
+from tests.lib.xpkg_parser import parse_xpkg
+from tests.lib.assertions import (
+    assert_required_fields, assert_valid_spec, assert_valid_type,
+    assert_no_typos, assert_no_exec_xvm, assert_no_bashrc_modification,
+    assert_no_direct_path_modification, assert_uses_new_api,
+    assert_xim_add_succeeds, assert_install_succeeds,
+    assert_command_output, assert_xvm_registered,
+)
+from tests.lib.platform_utils import skip_if_not
+
+PKG = "mcpp"
+PKG_FILE = "pkgs/m/mcpp.lua"
+
+
+@pytest.fixture(scope='module')
+def meta():
+    return parse_xpkg(PKG_FILE)
+
+
+class TestStatic:
+    @pytest.mark.static
+    def test_required_fields(self, meta):
+        assert_required_fields(meta)
+
+    @pytest.mark.static
+    def test_valid_spec(self, meta):
+        assert_valid_spec(meta)
+
+    @pytest.mark.static
+    def test_valid_type(self, meta):
+        assert_valid_type(meta)
+
+    @pytest.mark.static
+    def test_no_typos(self):
+        assert_no_typos(PKG_FILE)
+
+
+class TestIndex:
+    @pytest.mark.index
+    def test_xim_add(self):
+        assert_xim_add_succeeds(PKG_FILE)
+
+
+class TestIsolation:
+    @pytest.mark.isolation
+    def test_no_exec_xvm(self):
+        assert_no_exec_xvm(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_no_bashrc(self):
+        assert_no_bashrc_modification(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_no_path_modification(self):
+        assert_no_direct_path_modification(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_new_api(self):
+        assert_uses_new_api(PKG_FILE)
+
+
+class TestLifecycle:
+    @pytest.mark.lifecycle
+    @skip_if_not('linux')
+    def test_install(self):
+        assert_install_succeeds(PKG)
+
+
+class TestVerify:
+    @pytest.mark.verify
+    @skip_if_not('linux')
+    def test_mcpp(self):
+        assert_command_output("mcpp --version", contains="mcpp")
+
+    @pytest.mark.verify
+    @skip_if_not('linux')
+    def test_xvm_mcpp(self):
+        assert_xvm_registered("mcpp")


### PR DESCRIPTION
## Summary
- Adds **mcpp** package — a modern C++ build tool with module support, dependency/toolchain management, package indexing, and packaging (upstream: [mcpp-community/mcpp](https://github.com/mcpp-community/mcpp))
- Linux x86_64 artifact mirrored at [xlings-res/mcpp](https://github.com/xlings-res/mcpp/releases/tag/0.0.1) (byte-identical to upstream, renamed to xlings-res convention `mcpp-<ver>-<platform>-<arch>.<ext>`); also pushed to gitcode mirror for CN users
- xpm uses `XLINGS_RES` sentinel → resolves GLOBAL=github / CN=gitcode automatically
- Tarball is fully static (`readelf -d` empty, no `.interp`) → zero runtime deps
- Bundle ships a top-level shell launcher and real ELF under `bin/`; xvm registers `bindir = <install>/bin` so the binary is invoked directly
- Status `dev` since upstream is 0.0.x and pre-1.0

## Test plan
- [x] static / index / isolation tests pass locally (9/9)
- [x] lifecycle install + `mcpp --version` verify pass locally
- [ ] CI green on linux/macos/windows static + isolation + index-registration
- [ ] CI green on linux-install-test (real install via xim → xvm shim)