### PR TITLE
fix(mcpp): use xlings auto-extract instead of manual tar

### DIFF
--- a/pkgs/m/mcpp.lua
+++ b/pkgs/m/mcpp.lua
@@ -46,22 +46,19 @@ package = {
 
 import("xim.libxpkg.pkginfo")
 import("xim.libxpkg.xvm")
-import("xim.libxpkg.system")
 
 function install()
-    -- Tarball top-level layout (no enclosing version-named dir):
-    --   ./mcpp          (POSIX shell launcher → exec bin/mcpp)
-    --   ./bin/mcpp      (static ELF)
-    --   ./LICENSE
-    --   ./README.md
-    -- Extract directly into install_dir so xvm's bindir=<install>/bin
-    -- finds the real binary.
+    -- xlings auto-extracts the tarball into the runtime workdir.
+    -- Top-level layout (no enclosing version-named dir):
+    --   ./bin/mcpp      (static ELF — the only artifact xvm needs)
+    --   ./mcpp          (POSIX shell launcher, only useful from the
+    --                    bundle root; xvm shim invokes bin/mcpp directly)
+    --   ./LICENSE, ./README.md
+    -- Move just bin/ into install_dir so xvm's bindir=<install>/bin
+    -- resolves the real binary.
     os.tryrm(pkginfo.install_dir())
     os.mkdir(pkginfo.install_dir())
-    system.exec(string.format(
-        [[tar -xzf "%s" -C "%s"]],
-        pkginfo.install_file(), pkginfo.install_dir()
-    ))
+    os.mv("bin", pkginfo.install_dir())
     return true
 end
 


### PR DESCRIPTION
## Summary
- Original recipe called \`tar -xzf install_file()\` inside install(), which is redundant — xlings auto-extracts the tarball into the runtime workdir before install() runs
- Switch to the idiomatic pattern (nvim/node/mdbook): operate on the already-extracted files in cwd
- mcpp's tarball has no enclosing version-named dir; just move \`bin/\` (the only artifact xvm needs) into install_dir
- Drop the top-level shell launcher and LICENSE/README — launcher is only useful from the bundle root, xvm shim invokes \`bin/mcpp\` directly
- (git.lua keeps its manual tar deliberately — see comment there about shared-cache state leakage; mcpp doesn't need that)

## Test plan
- [x] Full local pytest suite: 11/12 pass (the lone fail is \`test_xvm_mcpp\` — a local-env quirk where \`xvm info\` is silenced without sourced PATH; same failure on nvim/xmake locally and passes in CI's clean env)
- [x] \`mcpp --version\` → \`mcpp 0.0.1\` after fresh install
- [x] install_dir contains just \`bin/\` (clean, no double-extracted leftovers)
- [ ] CI green