### PR TITLE
fix(mcpp): mv whole extracted dir into install_dir (full bundle)

### DIFF
--- a/pkgs/m/mcpp.lua
+++ b/pkgs/m/mcpp.lua
@@ -30,11 +30,15 @@ package = {
     --   GLOBAL → github.com/xlings-res/mcpp/releases/download/<ver>/...
     --   CN     → gitcode.com/xlings-res/mcpp/releases/download/<ver>/...
     --
-    -- The Linux tarball is a fully-static ELF (no .interp, no
-    -- DT_NEEDED) plus a thin shell launcher at the bundle root —
-    -- zero runtime deps. xvm registers `bindir = <install>/bin`
-    -- so the real ELF is invoked directly (the top-level shell
-    -- launcher is only used when running from the bundle root).
+    -- The Linux tarball ships under `mcpp-<ver>-linux_x86_64/`
+    -- (note: upstream uses underscore in the inner dir name).
+    -- It contains:
+    --   bin/mcpp        — fully-static ELF (no .interp, empty
+    --                      DT_NEEDED — zero runtime deps)
+    --   mcpp            — POSIX shell launcher → exec bin/mcpp
+    --   LICENSE, README.md
+    -- xvm registers `bindir = <install>/bin` so the ELF is invoked
+    -- directly; the shell launcher is only useful from the bundle root.
     xpm = {
         linux = {
             url_template = "https://github.com/mcpp-community/mcpp/releases/download/v{version}/mcpp-{version}-linux-x86_64.tar.gz",
@@ -48,17 +52,12 @@ import("xim.libxpkg.pkginfo")
 import("xim.libxpkg.xvm")
 
 function install()
-    -- xlings auto-extracts the tarball into the runtime workdir.
-    -- Top-level layout (no enclosing version-named dir):
-    --   ./bin/mcpp      (static ELF — the only artifact xvm needs)
-    --   ./mcpp          (POSIX shell launcher, only useful from the
-    --                    bundle root; xvm shim invokes bin/mcpp directly)
-    --   ./LICENSE, ./README.md
-    -- Move just bin/ into install_dir so xvm's bindir=<install>/bin
-    -- resolves the real binary.
+    -- xlings auto-extracts the tarball into the runtime workdir;
+    -- the bundle is wrapped in `mcpp-<ver>-linux_x86_64/` so just
+    -- rename that dir into install_dir (same shape as nvim/node).
+    local mcpp_dir = "mcpp-" .. pkginfo.version() .. "-linux_x86_64"
     os.tryrm(pkginfo.install_dir())
-    os.mkdir(pkginfo.install_dir())
-    os.mv("bin", pkginfo.install_dir())
+    os.mv(mcpp_dir, pkginfo.install_dir())
     return true
 end
 


### PR DESCRIPTION
## Summary
- Upstream re-published the mcpp 0.0.1 tarball with a wrapping \`mcpp-0.0.1-linux_x86_64/\` top-level dir (underscore in inner dir name)
- Switch to the nvim/node pattern: single \`os.mv\` of the auto-extracted dir into \`install_dir\`
- Result: full bundle (\`bin/\`, \`LICENSE\`, \`mcpp\` launcher, \`README.md\`) lives inside \`install_dir\` instead of plucking out just \`bin/\`
- xvm still registers \`bindir = <install>/bin\` — invokes ELF directly; launcher + license stay alongside

## xlings-res mirror status
- ✅ **GitHub** (\`xlings-res/mcpp@0.0.1\`): re-uploaded with new tarball, sha256 \`4fa704351b29f9cda719f6db12fe5157a5319d07a1f52c01256d359004bad01f\`, verified 200/4936446 bytes
- ⚠️ **GitCode** (\`xlings-res/mcpp@0.0.1\`): asset upload reports success via API but file 404s on the serving CDN. Reproduces on every retry, even after delete-and-recreate of the repo. **Tested isolation**: a fresh \`xlings-res/mcpp-uploadtest\` repo created from scratch had a working asset upload — so the issue appears to be repo-path-level state poisoning at gitcode that doesn't clear on repo recreation. CN users will fall back to upstream github until gitcode reaper unsticks the path. Not blocking — same package files are fine on github.

## Test plan
- [x] Local \`xlings install local:mcpp@0.0.1\` succeeds (with mirror=GLOBAL to dodge the gitcode 404)
- [x] \`mcpp --version\` → \`mcpp 0.0.1\` after install
- [x] install_dir contains full bundle: \`bin/ LICENSE mcpp README.md\`
- [x] static + index + isolation tests: 9/9 pass
- [ ] CI green