### PR TITLE
fix(patchelf): switch to xlings-res mirror with top-level dir

### DIFF
--- a/pkgs/p/patchelf.lua
+++ b/pkgs/p/patchelf.lua
@@ -20,15 +20,25 @@ package = {
     aliases = {"elfpatch"},
     xvm_enable = true,
 
+    -- The upstream NixOS/patchelf release tarball
+    -- (`patchelf-<ver>-x86_64.tar.gz`) extracts *flat* — `./bin/`, `./share/`,
+    -- with no top-level directory — so xlings's stock install hook
+    -- (`os.mv(<file-basename>, install_dir)`) cannot find the expected
+    -- `patchelf-<ver>-…/` directory and the install fails.
+    --
+    -- We mirror at xlings-res/patchelf, repackaged with a single
+    -- top-level directory `patchelf-<ver>-linux-x86_64/` matching the
+    -- xlings-res tarball convention `<pkg>-<ver>-<platform>-<arch>/`.
+    -- Binaries inside are byte-identical to upstream.
+    --
+    -- XLINGS_RES sentinel resolves to:
+    --   GLOBAL → github.com/xlings-res/patchelf/releases/download/<ver>/...
+    --   CN     → gitcode.com/xlings-res/patchelf/releases/download/<ver>/...
     xpm = {
         linux = {
+            url_template = "https://github.com/NixOS/patchelf/releases/download/{version}/patchelf-{version}-x86_64.tar.gz",
             ["latest"] = { ref = "0.18.0" },
-            ["0.18.0"] = {
-                url = {
-                    ["GLOBAL"] = "https://github.com/NixOS/patchelf/releases/download/0.18.0/patchelf-0.18.0-x86_64.tar.gz",
-                    ["CN"] = "https://gitcode.com/xlings-res/mirror-cn/releases/download/patchelf/patchelf-0.18.0-x86_64.tar.gz",
-                },
-            },
+            ["0.18.0"] = "XLINGS_RES",
         },
     },
 }


### PR DESCRIPTION
## Summary
- **Bug**: upstream `NixOS/patchelf` release tarball
  (`patchelf-0.18.0-x86_64.tar.gz`) extracts **flat** (`./bin/`,
  `./share/`, no top-level dir), so the stock install hook
  `os.mv("patchelf-0.18.0-x86_64", install_dir())` cannot find the
  expected directory and the install fails.
- **Fix**: repackaged the upstream artifact under a single
  `patchelf-0.18.0-linux-x86_64/` top-level directory (binaries
  byte-identical to upstream) and hosted it at
  [`xlings-res/patchelf`](https://github.com/xlings-res/patchelf/releases/tag/0.18.0)
  on both GitHub and GitCode. The `xpm` entry now uses the
  `XLINGS_RES` sentinel so URLs auto-resolve to both mirrors, and
  `url_template` opts the package in to the weekly version checker.
- Install hook and the rest of the file are unchanged — the
  basename-derived dir lookup now matches because the tarball
  finally has the directory it expected.

## Test plan
- [x] Local isolated env: `XLINGS_HOME=$PWD/.xlings-home-test xlings install xim:patchelf` → `patchelf --version` reports `patchelf 0.18.0`, `bin/patchelf` is the byte-identical static ELF
- [x] Both mirror URLs reachable + sha256 matches:
  - `github.com/xlings-res/patchelf/releases/download/0.18.0/patchelf-0.18.0-linux-x86_64.tar.gz`
  - `gitcode.com/xlings-res/patchelf/releases/download/0.18.0/patchelf-0.18.0-linux-x86_64.tar.gz`
- [ ] CI green