### PR TITLE
feat: add proot 5.4.0 + bwrap 0.11.2 (musl-static prebuilt)

### DIFF
--- a/pkgs/b/bwrap.lua
+++ b/pkgs/b/bwrap.lua
@@ -1,0 +1,71 @@
+package = {
+    spec = "1",
+
+    name = "bwrap",
+    description = "Bubblewrap — unprivileged sandboxing tool (setuid-less namespace sandbox)",
+
+    homepage = "https://github.com/containers/bubblewrap",
+    contributors = "https://github.com/containers/bubblewrap/graphs/contributors",
+    licenses = {"LGPL-2.0-or-later"},
+    repo = "https://github.com/containers/bubblewrap",
+    docs = "https://github.com/containers/bubblewrap#readme",
+
+    type = "package",
+    archs = {"x86_64"},
+    status = "stable",
+    categories = {"sandbox", "container", "tool"},
+    keywords = {"bwrap", "bubblewrap", "sandbox", "namespace", "rootless"},
+
+    -- `bubblewrap` is the canonical upstream name; `bwrap` is the
+    -- compiled binary. We expose both — alias `bubblewrap → bwrap`.
+    programs = {"bwrap", "bubblewrap"},
+    aliases = {"bubblewrap"},
+    xvm_enable = true,
+
+    -- Mirrored at xlings-res/bwrap, built from upstream
+    -- containers/bubblewrap v0.11.2 source in Alpine 3.20
+    -- (musl 1.2.5, gcc 13.2, libcap 2.78). Single statically-linked
+    -- ELF (`bin/bwrap`, ~137 KB stripped). Upstream releases source
+    -- only — no prebuilt artifact ships for bwrap, hence the mirror.
+    --
+    -- Runtime requirement (kernel side, not packaged here): bwrap
+    -- needs unprivileged user namespaces enabled
+    -- (`/proc/sys/kernel/unprivileged_userns_clone=1` on kernels that
+    -- gate it), or to run setuid. The package does not setuid the
+    -- binary — that's a deployment decision left to the user.
+    --
+    -- XLINGS_RES sentinel resolves to:
+    --   GLOBAL → github.com/xlings-res/bwrap/releases/download/<ver>/...
+    --   CN     → gitcode.com/xlings-res/bwrap/releases/download/<ver>/...
+    xpm = {
+        linux = {
+            url_template = "https://github.com/containers/bubblewrap/releases/download/v{version}/bubblewrap-{version}.tar.xz",
+            ["latest"] = { ref = "0.11.2" },
+            ["0.11.2"] = "XLINGS_RES",
+        },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+
+function install()
+    os.tryrm(pkginfo.install_dir())
+    local bwrapdir = pkginfo.install_file()
+        :replace(".zip", "")
+        :replace(".tar.gz", "")
+    os.mv(bwrapdir, pkginfo.install_dir())
+    return true
+end
+
+function config()
+    xvm.add("bwrap", { bindir = path.join(pkginfo.install_dir(), "bin") })
+    xvm.add("bubblewrap", { bindir = path.join(pkginfo.install_dir(), "bin"), alias = "bwrap" })
+    return true
+end
+
+function uninstall()
+    xvm.remove("bwrap")
+    xvm.remove("bubblewrap")
+    return true
+end

--- a/pkgs/p/proot.lua
+++ b/pkgs/p/proot.lua
@@ -1,0 +1,60 @@
+package = {
+    spec = "1",
+
+    name = "proot",
+    description = "Userspace chroot, mount --bind, and binfmt_misc — no root required",
+
+    homepage = "https://proot-me.github.io",
+    contributors = "https://github.com/proot-me/proot/graphs/contributors",
+    licenses = {"GPL-2.0-or-later"},
+    repo = "https://github.com/proot-me/proot",
+    docs = "https://proot-me.github.io",
+
+    type = "package",
+    archs = {"x86_64"},
+    status = "stable",
+    categories = {"sandbox", "container", "tool"},
+    keywords = {"proot", "chroot", "sandbox", "userspace", "rootless"},
+
+    programs = {"proot"},
+    xvm_enable = true,
+
+    -- Mirrored at xlings-res/proot, built from upstream proot-me/proot
+    -- v5.4.0 source in Alpine 3.20 (musl 1.2.5, gcc 13.2). Single
+    -- statically-linked ELF (`bin/proot`) — zero runtime deps. Upstream
+    -- ships no v5.4.0 prebuilt; the only release-attached artifact for
+    -- proot is the v5.3.0 glibc-static binary, which is why we mirror.
+    --
+    -- XLINGS_RES sentinel resolves to:
+    --   GLOBAL → github.com/xlings-res/proot/releases/download/<ver>/...
+    --   CN     → gitcode.com/xlings-res/proot/releases/download/<ver>/...
+    xpm = {
+        linux = {
+            url_template = "https://github.com/proot-me/proot/archive/v{version}/proot-{version}.tar.gz",
+            ["latest"] = { ref = "5.4.0" },
+            ["5.4.0"] = "XLINGS_RES",
+        },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+
+function install()
+    os.tryrm(pkginfo.install_dir())
+    local prootdir = pkginfo.install_file()
+        :replace(".zip", "")
+        :replace(".tar.gz", "")
+    os.mv(prootdir, pkginfo.install_dir())
+    return true
+end
+
+function config()
+    xvm.add("proot", { bindir = path.join(pkginfo.install_dir(), "bin") })
+    return true
+end
+
+function uninstall()
+    xvm.remove("proot")
+    return true
+end


### PR DESCRIPTION
## Summary

Add two sandboxing primitives to the index, both shipped as fully-static
musl prebuilts mirrored at xlings-res:

- **`xim:proot`** — userspace chroot/mount/binfmt_misc, single 247 KB ELF.
  Upstream proot-me/proot ships no v5.4.0 prebuilt at all, only a v5.3.0
  glibc-static binary. We build from v5.4.0 source in Alpine 3.20
  (musl 1.2.5 + gcc 13.2 + talloc-static) following the Alpine APKBUILD's
  static target.
- **`xim:bwrap`** — unprivileged userns sandbox (bubblewrap), single
  137 KB ELF with libcap statically linked. Upstream
  containers/bubblewrap releases source only, so we build v0.11.2 in
  Alpine 3.20 with `meson --prefer-static -Dc_link_args=-static`.
  Aliased as `bubblewrap`. Runtime requires unprivileged user namespaces
  enabled on the host kernel.

Both packages use the `XLINGS_RES` sentinel + `url_template`, follow the
`<pkg>-<ver>-linux-x86_64/bin/<pkg>` tarball convention, and live at:

- `github.com/xlings-res/{proot,bwrap}` (GLOBAL)
- `gitcode.com/xlings-res/{proot,bwrap}` (CN)

All four mirror URLs verified — sha256 sums match across both hosts:
- proot: `f9f4e866fa6ddb09039bed0ae679ab73da9c59086ced57ae132d838033d9f73e`
- bwrap: `9dd724029012676e0ff500a0607567af33ca9481501b9a81f73737d1a873455b`

## Test plan
- [x] `XLINGS_HOME=$PWD/.xlings-home-test xlings install xim:proot` → `proot --version` reports `5.4.0`; `proot -r / -b /etc /usr/bin/whoami` runs sandboxed
- [x] `XLINGS_HOME=$PWD/.xlings-home-test xlings install xim:bwrap` → `bwrap --version` reports `bubblewrap 0.11.2`; `--help` parses
- [x] Both binaries verified statically-linked (`file` confirms; no glibc/musl runtime needed)
- [ ] CI green