### PR TITLE
feat(mcpp): add 0.0.2

### DIFF
--- a/pkgs/m/mcpp.lua
+++ b/pkgs/m/mcpp.lua
@@ -42,7 +42,8 @@ package = {
     xpm = {
         linux = {
             url_template = "https://github.com/mcpp-community/mcpp/releases/download/v{version}/mcpp-{version}-linux-x86_64.tar.gz",
-            ["latest"] = { ref = "0.0.1" },
+            ["latest"] = { ref = "0.0.2" },
+            ["0.0.2"] = "XLINGS_RES",
             ["0.0.1"] = "XLINGS_RES",
         },
     },


### PR DESCRIPTION
## Summary
- Mirror mcpp v0.0.2 upstream tarball (byte-identical, layout already matches xlings-res convention) at `xlings-res/mcpp` on GitHub + GitCode
- Add `["0.0.2"] = "XLINGS_RES"` and bump `latest` ref to 0.0.2 in `pkgs/m/mcpp.lua`
- sha256: `8f4884f62ba3d71995705d9bcfcbaf972df14b46aeddedf186cdab19b7dd5319`

## Test plan
- [x] Local isolated env: `XLINGS_HOME=$PWD/.xlings-home-test xlings install xim:mcpp` → `bin/mcpp --version` reports `mcpp 0.0.2` (static ELF)
- [x] Both mirrors return the same sha256
- [ ] CI green