### PR TITLE
feat(mcpp): add 0.0.3

### DIFF
--- a/pkgs/m/mcpp.lua
+++ b/pkgs/m/mcpp.lua
@@ -42,7 +42,8 @@ package = {
     xpm = {
         linux = {
             url_template = "https://github.com/mcpp-community/mcpp/releases/download/v{version}/mcpp-{version}-linux-x86_64.tar.gz",
-            ["latest"] = { ref = "0.0.2" },
+            ["latest"] = { ref = "0.0.3" },
+            ["0.0.3"] = "XLINGS_RES",
             ["0.0.2"] = "XLINGS_RES",
             ["0.0.1"] = "XLINGS_RES",
         },


### PR DESCRIPTION
## Summary
- Mirror mcpp v0.0.3 upstream tarball (byte-identical, layout already matches xlings-res convention) at `xlings-res/mcpp` on GitHub + GitCode
- Add `["0.0.3"] = "XLINGS_RES"` and bump `latest` ref to 0.0.3 in `pkgs/m/mcpp.lua`
- sha256: `f7a5c4357a3d1bc1c63e289daeedd7b9ea1826b2b8aa57dae8f42cc3108f1369` (matches upstream SHA256SUMS)

## Test plan
- [x] Local isolated env: `xlings install xim:mcpp` → `bin/mcpp --version` reports `mcpp 0.0.3`; installed binary sha256 byte-identical to upstream tarball content
- [x] Both mirrors (GitHub + GitCode) return the same sha256
- [ ] CI green