### PR TITLE
fix: register pkg-name xvm placeholders to fix install detection

### DIFF
--- a/pkgs/c/claude-code.lua
+++ b/pkgs/c/claude-code.lua
@@ -77,10 +77,17 @@ function config()
             --CLAUDE_CONFIG_DIR = path.join(pkginfo.install_dir(), "config"),
         }
     })
+    -- Marker: package name `claude-code` differs from the actual binary
+    -- `claude`. Without this empty placeholder, install detection
+    -- (`xvm info claude-code`) returns nothing, so xlings re-installs
+    -- on every invocation. The marker is metadata-only — no bindir,
+    -- no alias, no shim — and is uninstalled symmetrically below.
+    xvm.add("claude-code", { type = "marker" })
     return true
 end
 
 function uninstall()
     xvm.remove("claude")
+    xvm.remove("claude-code")
     return true
 end

--- a/pkgs/e/e2fsprogs.lua
+++ b/pkgs/e/e2fsprogs.lua
@@ -83,6 +83,12 @@ function config()
         xvm.add(sbin_programs[i], { bindir = bindir, binding = root })
     end
 
+    -- Binding root: `e2fsprogs` is an umbrella package whose programs
+    -- are e2fsck/mke2fs/etc. The package name itself never appears in
+    -- `sbin_programs`, so without this empty placeholder
+    -- `xvm info e2fsprogs` returns nothing on install detection.
+    xvm.add("e2fsprogs", { type = "binding" })
+
     -- mke2fs reads mke2fs.conf at runtime; the static binary has no
     -- compiled-in path that points inside install_dir, so help users
     -- who want non-default fs profiles by exporting MKE2FS_CONFIG.
@@ -96,5 +102,6 @@ function uninstall()
     for _, p in ipairs(sbin_programs) do
         xvm.remove(p)
     end
+    xvm.remove("e2fsprogs")
     return true
 end

--- a/pkgs/m/mingw-w64.lua
+++ b/pkgs/m/mingw-w64.lua
@@ -79,6 +79,12 @@ function config()
     xvm.add("c++", config)
     xvm.add("g++", config)
 
+    -- Binding root: `mingw-w64` is an umbrella toolchain package whose
+    -- registered programs are the gcc/g++/c++ multilib triples.
+    -- Empty placeholder under the package name so install detection
+    -- (`xvm info mingw-w64`) finds an entry.
+    xvm.add("mingw-w64", { type = "binding" })
+
     __config_mingw_bin(mingw_bindir)
 
     return true
@@ -95,6 +101,8 @@ function uninstall()
     xvm.remove("gcc", version)
     xvm.remove("g++", version)
     xvm.remove("c++", version)
+
+    xvm.remove("mingw-w64")
 
     -- TODO: support multi-version (auto switch bin path)
     __config_mingw_bin("")

--- a/pkgs/r/ripgrep.lua
+++ b/pkgs/r/ripgrep.lua
@@ -72,10 +72,15 @@ end
 
 function config()
     xvm.add("rg", { bindir = pkginfo.install_dir() })
+    -- Marker: the binary is `rg` but the package name is `ripgrep`.
+    -- Empty placeholder so install detection (`xvm info ripgrep`)
+    -- finds an entry instead of treating the package as missing.
+    xvm.add("ripgrep", { type = "marker" })
     return true
 end
 
 function uninstall()
     xvm.remove("rg")
+    xvm.remove("ripgrep")
     return true
 end

--- a/pkgs/r/rust.lua
+++ b/pkgs/r/rust.lua
@@ -72,12 +72,18 @@ function config()
     xvm.add("rustfmt", { bindir = cargo_bin, binding = "rustc@" .. "latest" })
     xvm.add("clippy-driver", { bindir = cargo_bin, binding = "rustc@" .. "latest" })
     xvm.add("rust-analyzer", { bindir = cargo_bin, binding = "rustc@" .. "latest" })
+    -- Binding root: `rust` is an umbrella package whose `programs` are
+    -- rustc/cargo/rustup. Empty placeholder under the package name so
+    -- install detection (`xvm info rust`) finds an entry; type
+    -- distinguishes it from concrete program / lib registrations.
+    xvm.add("rust", { type = "binding" })
 
     return true
 end
 
 function uninstall()
     os.exec("rustup self uninstall")
+    xvm.remove("rust")
 end
 
 ---------------------- private

--- a/pkgs/r/rust.lua
+++ b/pkgs/r/rust.lua
@@ -83,6 +83,12 @@ end
 
 function uninstall()
     os.exec("rustup self uninstall")
+    xvm.remove("rustc")
+    xvm.remove("cargo")
+    xvm.remove("rustup")
+    xvm.remove("rustfmt")
+    xvm.remove("clippy-driver")
+    xvm.remove("rust-analyzer")
     xvm.remove("rust")
 end
 

--- a/pkgs/r/rustup.lua
+++ b/pkgs/r/rustup.lua
@@ -69,10 +69,15 @@ end
 
 function config()
     xvm.add("rustup-init")
+    -- Marker: the package ships only the `rustup-init` bootstrap
+    -- binary, but xlings searches for a `rustup` entry on `xim:rustup`
+    -- install detection. Empty placeholder so the lookup succeeds.
+    xvm.add("rustup", { type = "marker" })
     return true
 end
 
 function uninstall()
     xvm.remove("rustup-init")
+    xvm.remove("rustup")
     return true
 end

--- a/pkgs/v/vcstool.lua
+++ b/pkgs/v/vcstool.lua
@@ -96,10 +96,15 @@ end
 
 function config()
     xvm.add("vcs", { bindir = __venv_bindir() })
+    -- Marker: the binary is `vcs` (upstream's CLI command) but the
+    -- package name is `vcstool`. Empty placeholder so install
+    -- detection (`xvm info vcstool`) finds an entry.
+    xvm.add("vcstool", { type = "marker" })
     return true
 end
 
 function uninstall()
     xvm.remove("vcs")
+    xvm.remove("vcstool")
     return true
 end


### PR DESCRIPTION
## Summary

When a package's name differs from its registered xvm program names,
`xvm info <pkgname>` returned nothing, so xlings treated the package
as not-installed and **re-ran install on every invocation** (the
claude-code symptom that motivated this).

Fix: add an empty xvm entry under the package name with two new
`type` values to make install detection deterministic and to
distinguish placeholder-only entries from real `program`/`lib`
registrations:

| type | meaning |
|------|---------|
| `marker` | pkg name is just an alias for a single upstream binary with a different name (no umbrella semantics) |
| `binding` | pkg name is a binding root for an umbrella package whose registered programs don't include the package name |

xvm core already accepts arbitrary `--type` strings via `xvm.add()`
(see `xim/base/xvm.lua` — `bin`/`lib` are pre-existing values), so
**no core changes needed** — these are pure metadata tags.

## Coverage

| pkg | type | reason |
|-----|------|--------|
| `claude-code` | marker | binary is `claude` (npm `@anthropic-ai/claude-code` exposes `claude`) |
| `ripgrep` | marker | binary is `rg` |
| `vcstool` | marker | binary is `vcs` (ROS upstream CLI name) |
| `rustup` | marker | only ships the `rustup-init` bootstrap binary |
| `rust` | binding | umbrella for rustc/cargo/rustup/rustfmt/clippy-driver/rust-analyzer |
| `mingw-w64` | binding | umbrella toolchain registering x86_64-w64-mingw32-{gcc,g++,c++} + gcc/g++/c++ |
| `e2fsprogs` | binding | umbrella for fsck/mke2fs/tune2fs/resize2fs/debugfs/etc. |

## Test plan

Verified end-to-end in a local isolated `XLINGS_HOME` for claude-code, ripgrep, e2fsprogs (covers npm-install / binary-install / multi-program-binding paths):

- [x] 1st `xlings install xim:<pkg>` → installs cleanly
- [x] `xlings info xim:<pkg>` → `installed: yes`, `active: <ver>`
- [x] 2nd `xlings install xim:<pkg>` → reports `xim:<pkg>@<ver> is already installed` *(was: re-downloaded + re-installed every time)*
- [x] Registered binaries still execute (`rg --version` → `ripgrep 15.1.0`, `mke2fs -V` → `mke2fs 1.47.3`, claude-code reachable via xvm)
- [ ] CI green

## Note (gcc)

Initial scan flagged `gcc` as missing because the regex only matched literal-string `xvm.add(...)` calls and missed the `for _, prog in ipairs(linux_programs) do xvm.add(prog, ...) end` loop that already registers the `gcc` name on linux. gcc is intentionally **skipped** from this PR.