### PR TITLE
feat(mcpp): add 0.0.5

### DIFF
--- a/pkgs/m/mcpp.lua
+++ b/pkgs/m/mcpp.lua
@@ -42,7 +42,8 @@ package = {
     xpm = {
         linux = {
             url_template = "https://github.com/mcpp-community/mcpp/releases/download/v{version}/mcpp-{version}-linux-x86_64.tar.gz",
-            ["latest"] = { ref = "0.0.4" },
+            ["latest"] = { ref = "0.0.5" },
+            ["0.0.5"] = "XLINGS_RES",
             ["0.0.4"] = "XLINGS_RES",
             ["0.0.3"] = "XLINGS_RES",
             ["0.0.2"] = "XLINGS_RES",


### PR DESCRIPTION
## Summary
- Mirror mcpp v0.0.5 upstream tarball (byte-identical, layout already matches xlings-res convention) at `xlings-res/mcpp` on GitHub + GitCode
- Add `["0.0.5"] = "XLINGS_RES"` and bump `latest` ref to 0.0.5 in `pkgs/m/mcpp.lua`
- sha256: `d545912d13bb72fb724a6f7b97687c3932984ba70e5681e671098f4abf5cc456` (matches upstream SHA256SUMS)

## Test plan
- [x] Local isolated env: `xlings install xim:mcpp` → `bin/mcpp --version` reports `mcpp 0.0.5`
- [x] Both mirrors return the same sha256
- [ ] CI green