### PR TITLE
feat(mcpp): add 0.0.6

### DIFF
--- a/pkgs/m/mcpp.lua
+++ b/pkgs/m/mcpp.lua
@@ -42,7 +42,8 @@ package = {
     xpm = {
         linux = {
             url_template = "https://github.com/mcpp-community/mcpp/releases/download/v{version}/mcpp-{version}-linux-x86_64.tar.gz",
-            ["latest"] = { ref = "0.0.5" },
+            ["latest"] = { ref = "0.0.6" },
+            ["0.0.6"] = "XLINGS_RES",
             ["0.0.5"] = "XLINGS_RES",
             ["0.0.4"] = "XLINGS_RES",
             ["0.0.3"] = "XLINGS_RES",


### PR DESCRIPTION
## Summary
- Mirror mcpp v0.0.6 upstream tarball (byte-identical, layout already matches xlings-res convention) at `xlings-res/mcpp` on GitHub + GitCode
- Add `["0.0.6"] = "XLINGS_RES"` and bump `latest` ref to 0.0.6 in `pkgs/m/mcpp.lua`
- sha256: `21de9d47aedd5ecb0e9279afe611ceb80fcb7e912e2699a9ae667c28c095a831` (matches upstream SHA256SUMS)

## Test plan
- [x] Local isolated env: `xlings install xim:mcpp` → `bin/mcpp --version` reports `mcpp 0.0.6`
- [x] Both mirrors return the same sha256
- [ ] CI green