### PR TITLE
feat(openclaw): add brew dep on macOS

### DIFF
--- a/pkgs/o/openclaw.lua
+++ b/pkgs/o/openclaw.lua
@@ -25,7 +25,14 @@ package = {
             ["2026.2.26"] = {},
         },
         macosx = {
-            deps = {"node", "npm"},
+            -- brew is pulled in on macOS because several OpenClaw skills
+            -- (channel daemons, the ffmpeg-backed mlx-tts vendor binary,
+            -- the local podman/docker container runtime that
+            -- `openclaw --container` drives) expect Homebrew-managed
+            -- system libs to be reachable. Linux/Windows users typically
+            -- install those via the distro/winget; macOS is the platform
+            -- where brew is the de-facto answer.
+            deps = {"node", "npm", "brew"},
             ["latest"] = { ref = "2026.5.7" },
             ["2026.5.7"] = {},
             ["2026.2.26"] = {},


### PR DESCRIPTION
## Summary
- Add `brew` to `xpm.macosx.deps` alongside the existing `node` / `npm`.
- Rationale (also captured in an inline comment): on macOS, several OpenClaw skills — channel daemons, the ffmpeg-backed mlx-tts vendor binary, and the local podman/docker runtime that `openclaw --container` drives — expect Homebrew-managed system libs. Linux gets those from the distro and Windows from winget; macOS is the platform where brew is the de-facto answer, so it belongs in the explicit dep list.

No `install()` / `config()` / `uninstall()` changes; behavior is unchanged for users who already have brew, and xlings just adds the brew install step for those who don't.

## Test plan
- [ ] CI green