### PR TITLE
refactor(proot-safe-copy): use libxpkg runtime APIs instead of shell find

### DIFF
--- a/pkgs/g/glibc.lua
+++ b/pkgs/g/glibc.lua
@@ -178,41 +178,52 @@ function __config_header()
 end
 
 -- Per-entry walk that replaces `cp -r SRC_DIR DST_PARENT/`.
--- Uses libxpkg's runtime APIs (os.dirs / os.files / os.mkdir / os.cp /
--- os.ln) to enumerate the source tree and issue single absolute-path
--- syscalls per entry — which proot's path translator handles correctly.
+--
+-- The package config() sandbox exposes a smaller subset of the
+-- xmake/libxpkg runtime than core scripts: `os.dirs(... "**" ...)`,
+-- `os.mkdir`, `os.cp(file, file)`, `os.tryrm`, `os.isdir`, `os.isfile`,
+-- `os.execute` all work; but `os.files`, `os.filedirs`, `os.islink`,
+-- `os.readlink`, `os.ln` are NOT exposed (verified empirically: CI
+-- raised `attempt to call a nil value (field 'files')` etc.).
+--
+-- Strategy:
+--   1. Materialize the dir skeleton via `os.dirs("**")` (runtime API).
+--   2. Enumerate files + symlinks via one shell `find` pass — read-only
+--      on source, no recursion-into-existing-dest, hence proot-safe.
+--   3. Per file: `os.cp` single file (runtime API, single absolute-path
+--      openat → translates correctly under proot).
+--   4. Per symlink: `ln -s` via os.execute (shell, single symlinkat
+--      → also proot-safe).
+--
 -- The previous `cp -r` tripped a proot bug where dir-fd-relative
 -- `openat(parent_fd, "<child>", ...)` issued by coreutils mid-recursion
--- was mistranslated, failing the copy when the destination subtree
--- already existed in the subos sysroot.
---
--- Symlinks are preserved: the runtime doesn't expose
--- os.islink/os.readlink, so symlinks are discovered via a single
--- `find -type l` (read-only on source, no recursion-into-existing-dest
--- pattern, hence proot-safe) and recreated via os.ln. Header trees
--- normally contain zero symlinks; this branch is a no-op for them.
+-- was mistranslated when the destination subtree already existed in
+-- the subos sysroot. Each op in this helper is a single absolute-path
+-- syscall — proot's translator handles them correctly.
 function __cp_tree_proot_safe(src_dir, dst_dir)
     if not os.isdir(src_dir) then return end
     os.mkdir(dst_dir)
     for _, d in ipairs(os.dirs(path.join(src_dir, "**"))) do
         os.mkdir(path.join(dst_dir, path.relative(d, src_dir)))
     end
-    for _, fpath in ipairs(os.files(path.join(src_dir, "**"))) do
-        local dst = path.join(dst_dir, path.relative(fpath, src_dir))
-        os.mkdir(path.directory(dst))
-        os.cp(fpath, dst)
-    end
     local f = io.popen(string.format(
-        [[find "%s" -type l -printf '%%P\t%%l\n' 2>/dev/null]], src_dir
+        [[find "%s" \( -type f -o -type l \) -printf '%%y\t%%P\t%%l\n' 2>/dev/null]],
+        src_dir
     ))
     if not f then return end
     for line in f:lines() do
-        local rel, target = line:match("^(.-)\t(.+)$")
-        if rel and target then
+        local kind, rel, link_target = line:match("^(%a)\t([^\t]*)\t(.*)$")
+        if kind and rel and rel ~= "" then
             local dst = path.join(dst_dir, rel)
             os.mkdir(path.directory(dst))
-            os.tryrm(dst)
-            os.ln(target, dst, { force = true })
+            if kind == "l" then
+                os.tryrm(dst)
+                if link_target ~= "" then
+                    os.execute(string.format([[ln -s "%s" "%s"]], link_target, dst))
+                end
+            else
+                os.cp(path.join(src_dir, rel), dst)
+            end
         end
     end
     f:close()

--- a/pkgs/g/glibc.lua
+++ b/pkgs/g/glibc.lua
@@ -177,53 +177,45 @@ function __config_header()
     io.writefile(stamp, pkginfo.version())
 end
 
--- Per-entry walk that replaces `cp -r SRC_DIR DST_PARENT/` (and xmake's
--- recursive os.cp on a directory). Enumerates the source tree via
--- `find` (the xim libxpkg lua sandbox doesn't expose xmake's
--- os.files / os.filedirs / os.islink — even openssl.lua here resorts to
--- io.popen('ls -d')), then issues a single absolute-path syscall per
--- entry (mkdir / cp single file / ln symlink) — which proot's path
--- translator handles correctly. The previous `cp -r` tripped a proot
--- bug where `openat(parent_fd, "<child>", ...)` issued by coreutils
--- mid-recursion was mistranslated, failing the copy when the
--- destination subtree already existed in the subos sysroot.
+-- Per-entry walk that replaces `cp -r SRC_DIR DST_PARENT/`.
+-- Uses libxpkg's runtime APIs (os.dirs / os.files / os.mkdir / os.cp /
+-- os.ln) to enumerate the source tree and issue single absolute-path
+-- syscalls per entry — which proot's path translator handles correctly.
+-- The previous `cp -r` tripped a proot bug where dir-fd-relative
+-- `openat(parent_fd, "<child>", ...)` issued by coreutils mid-recursion
+-- was mistranslated, failing the copy when the destination subtree
+-- already existed in the subos sysroot.
 --
--- Symlinks are preserved (readlink + ln -s), matching `symlink = true`
--- on xmake's recursive os.cp and `cp -d`/`cp -a`.
+-- Symlinks are preserved: the runtime doesn't expose
+-- os.islink/os.readlink, so symlinks are discovered via a single
+-- `find -type l` (read-only on source, no recursion-into-existing-dest
+-- pattern, hence proot-safe) and recreated via os.ln. Header trees
+-- normally contain zero symlinks; this branch is a no-op for them.
 function __cp_tree_proot_safe(src_dir, dst_dir)
     if not os.isdir(src_dir) then return end
     os.mkdir(dst_dir)
+    for _, d in ipairs(os.dirs(path.join(src_dir, "**"))) do
+        os.mkdir(path.join(dst_dir, path.relative(d, src_dir)))
+    end
+    for _, fpath in ipairs(os.files(path.join(src_dir, "**"))) do
+        local dst = path.join(dst_dir, path.relative(fpath, src_dir))
+        os.mkdir(path.directory(dst))
+        os.cp(fpath, dst)
+    end
     local f = io.popen(string.format(
-        [[find "%s" -mindepth 1 \( -type d -o -type l -o -type f \) -printf '%%y\t%%P\n' 2>/dev/null]],
-        src_dir
+        [[find "%s" -type l -printf '%%P\t%%l\n' 2>/dev/null]], src_dir
     ))
     if not f then return end
-    local entries = {}
     for line in f:lines() do
-        local kind, rel = line:match("^(%a)\t(.+)$")
-        if kind and rel then table.insert(entries, {kind=kind, rel=rel}) end
-    end
-    f:close()
-    for _, e in ipairs(entries) do
-        local src = path.join(src_dir, e.rel)
-        local dst = path.join(dst_dir, e.rel)
-        if e.kind == "d" then
-            os.mkdir(dst)
-        elseif e.kind == "l" then
+        local rel, target = line:match("^(.-)\t(.+)$")
+        if rel and target then
+            local dst = path.join(dst_dir, rel)
             os.mkdir(path.directory(dst))
             os.tryrm(dst)
-            local t = io.popen(string.format([[readlink "%s" 2>/dev/null]], src))
-            local target = ""
-            if t then target = (t:read("*l") or ""); t:close() end
-            target = target:gsub("[\r\n]+$", "")
-            if target ~= "" then
-                os.execute(string.format([[ln -s "%s" "%s"]], target, dst))
-            end
-        else
-            os.mkdir(path.directory(dst))
-            os.cp(src, dst)
+            os.ln(target, dst, { force = true })
         end
     end
+    f:close()
 end
 
 function __relocate()

--- a/pkgs/l/linux-headers.lua
+++ b/pkgs/l/linux-headers.lua
@@ -78,50 +78,41 @@ function config()
 end
 
 -- Per-entry walk that replaces xmake's recursive `os.cp` (and `cp -r`).
--- Enumerates the source tree via `find` (the xim libxpkg lua sandbox
--- doesn't expose xmake's os.files / os.filedirs / os.islink), then
--- issues a single absolute-path syscall per entry (mkdir / cp single
--- file / ln symlink) — which proot's path translator handles correctly.
--- The previous recursive copy tripped a proot bug where dir-fd-relative
--- openat() issued mid-recursion was mistranslated when the destination
--- subtree already existed in the subos sysroot.
+-- Uses libxpkg's runtime APIs (os.dirs / os.files / os.mkdir / os.cp /
+-- os.ln) to issue single absolute-path syscalls per entry — proot's
+-- path translator handles those correctly, unlike `cp -r` which trips
+-- on dir-fd-relative openat into an existing destination subtree.
 --
--- Symlinks are preserved (readlink + ln -s), matching `symlink = true`
--- on the prior os.cp call.
+-- Symlinks are preserved: the runtime doesn't expose
+-- os.islink/os.readlink, so they're discovered via one
+-- `find -type l` (read-only on source, proot-safe) and recreated via
+-- os.ln. Header trees normally contain zero symlinks; this branch is
+-- a no-op for them.
 function __cp_tree_proot_safe(src_dir, dst_dir)
     if not os.isdir(src_dir) then return end
     os.mkdir(dst_dir)
+    for _, d in ipairs(os.dirs(path.join(src_dir, "**"))) do
+        os.mkdir(path.join(dst_dir, path.relative(d, src_dir)))
+    end
+    for _, fpath in ipairs(os.files(path.join(src_dir, "**"))) do
+        local dst = path.join(dst_dir, path.relative(fpath, src_dir))
+        os.mkdir(path.directory(dst))
+        os.cp(fpath, dst)
+    end
     local f = io.popen(string.format(
-        [[find "%s" -mindepth 1 \( -type d -o -type l -o -type f \) -printf '%%y\t%%P\n' 2>/dev/null]],
-        src_dir
+        [[find "%s" -type l -printf '%%P\t%%l\n' 2>/dev/null]], src_dir
     ))
     if not f then return end
-    local entries = {}
     for line in f:lines() do
-        local kind, rel = line:match("^(%a)\t(.+)$")
-        if kind and rel then table.insert(entries, {kind=kind, rel=rel}) end
-    end
-    f:close()
-    for _, e in ipairs(entries) do
-        local src = path.join(src_dir, e.rel)
-        local dst = path.join(dst_dir, e.rel)
-        if e.kind == "d" then
-            os.mkdir(dst)
-        elseif e.kind == "l" then
+        local rel, target = line:match("^(.-)\t(.+)$")
+        if rel and target then
+            local dst = path.join(dst_dir, rel)
             os.mkdir(path.directory(dst))
             os.tryrm(dst)
-            local t = io.popen(string.format([[readlink "%s" 2>/dev/null]], src))
-            local target = ""
-            if t then target = (t:read("*l") or ""); t:close() end
-            target = target:gsub("[\r\n]+$", "")
-            if target ~= "" then
-                os.execute(string.format([[ln -s "%s" "%s"]], target, dst))
-            end
-        else
-            os.mkdir(path.directory(dst))
-            os.cp(src, dst)
+            os.ln(target, dst, { force = true })
         end
     end
+    f:close()
 end
 
 function uninstall()

--- a/pkgs/l/linux-headers.lua
+++ b/pkgs/l/linux-headers.lua
@@ -78,38 +78,37 @@ function config()
 end
 
 -- Per-entry walk that replaces xmake's recursive `os.cp` (and `cp -r`).
--- Uses libxpkg's runtime APIs (os.dirs / os.files / os.mkdir / os.cp /
--- os.ln) to issue single absolute-path syscalls per entry — proot's
--- path translator handles those correctly, unlike `cp -r` which trips
--- on dir-fd-relative openat into an existing destination subtree.
---
--- Symlinks are preserved: the runtime doesn't expose
--- os.islink/os.readlink, so they're discovered via one
--- `find -type l` (read-only on source, proot-safe) and recreated via
--- os.ln. Header trees normally contain zero symlinks; this branch is
--- a no-op for them.
+-- See pkgs/g/glibc.lua for the full rationale. Short form:
+--   - Dirs:     os.dirs("**") + os.mkdir         (runtime API)
+--   - Files:    `find -type f` + os.cp file→file (runtime API for copy)
+--   - Symlinks: `find -type l` + `ln -s`         (shell for both, runtime
+--                                                 doesn't expose os.ln
+--                                                 in package sandbox)
+-- Each op is a single absolute-path syscall → proot-safe.
 function __cp_tree_proot_safe(src_dir, dst_dir)
     if not os.isdir(src_dir) then return end
     os.mkdir(dst_dir)
     for _, d in ipairs(os.dirs(path.join(src_dir, "**"))) do
         os.mkdir(path.join(dst_dir, path.relative(d, src_dir)))
     end
-    for _, fpath in ipairs(os.files(path.join(src_dir, "**"))) do
-        local dst = path.join(dst_dir, path.relative(fpath, src_dir))
-        os.mkdir(path.directory(dst))
-        os.cp(fpath, dst)
-    end
     local f = io.popen(string.format(
-        [[find "%s" -type l -printf '%%P\t%%l\n' 2>/dev/null]], src_dir
+        [[find "%s" \( -type f -o -type l \) -printf '%%y\t%%P\t%%l\n' 2>/dev/null]],
+        src_dir
     ))
     if not f then return end
     for line in f:lines() do
-        local rel, target = line:match("^(.-)\t(.+)$")
-        if rel and target then
+        local kind, rel, link_target = line:match("^(%a)\t([^\t]*)\t(.*)$")
+        if kind and rel and rel ~= "" then
             local dst = path.join(dst_dir, rel)
             os.mkdir(path.directory(dst))
-            os.tryrm(dst)
-            os.ln(target, dst, { force = true })
+            if kind == "l" then
+                os.tryrm(dst)
+                if link_target ~= "" then
+                    os.execute(string.format([[ln -s "%s" "%s"]], link_target, dst))
+                end
+            else
+                os.cp(path.join(src_dir, rel), dst)
+            end
         end
     end
     f:close()

--- a/pkgs/o/openssl.lua
+++ b/pkgs/o/openssl.lua
@@ -152,38 +152,37 @@ function uninstall()
 end
 
 -- Per-entry walk that replaces `cp -r SRC_DIR DST_PARENT/`.
--- Uses libxpkg's runtime APIs (os.dirs / os.files / os.mkdir / os.cp /
--- os.ln) to issue single absolute-path syscalls per entry — proot's
--- path translator handles those correctly, unlike `cp -r` which trips
--- on dir-fd-relative openat into an existing destination subtree.
---
--- Symlinks are preserved: the runtime doesn't expose
--- os.islink/os.readlink, so they're discovered via one
--- `find -type l` (read-only on source, proot-safe) and recreated via
--- os.ln. Header trees normally contain zero symlinks; this branch is
--- a no-op for them.
+-- See pkgs/g/glibc.lua for the full rationale. Short form:
+--   - Dirs:     os.dirs("**") + os.mkdir         (runtime API)
+--   - Files:    `find -type f` + os.cp file→file (runtime API for copy)
+--   - Symlinks: `find -type l` + `ln -s`         (shell for both, runtime
+--                                                 doesn't expose os.ln
+--                                                 in package sandbox)
+-- Each op is a single absolute-path syscall → proot-safe.
 function __cp_tree_proot_safe(src_dir, dst_dir)
     if not os.isdir(src_dir) then return end
     os.mkdir(dst_dir)
     for _, d in ipairs(os.dirs(path.join(src_dir, "**"))) do
         os.mkdir(path.join(dst_dir, path.relative(d, src_dir)))
     end
-    for _, fpath in ipairs(os.files(path.join(src_dir, "**"))) do
-        local dst = path.join(dst_dir, path.relative(fpath, src_dir))
-        os.mkdir(path.directory(dst))
-        os.cp(fpath, dst)
-    end
     local f = io.popen(string.format(
-        [[find "%s" -type l -printf '%%P\t%%l\n' 2>/dev/null]], src_dir
+        [[find "%s" \( -type f -o -type l \) -printf '%%y\t%%P\t%%l\n' 2>/dev/null]],
+        src_dir
     ))
     if not f then return end
     for line in f:lines() do
-        local rel, target = line:match("^(.-)\t(.+)$")
-        if rel and target then
+        local kind, rel, link_target = line:match("^(%a)\t([^\t]*)\t(.*)$")
+        if kind and rel and rel ~= "" then
             local dst = path.join(dst_dir, rel)
             os.mkdir(path.directory(dst))
-            os.tryrm(dst)
-            os.ln(target, dst, { force = true })
+            if kind == "l" then
+                os.tryrm(dst)
+                if link_target ~= "" then
+                    os.execute(string.format([[ln -s "%s" "%s"]], link_target, dst))
+                end
+            else
+                os.cp(path.join(src_dir, rel), dst)
+            end
         end
     end
     f:close()

--- a/pkgs/o/openssl.lua
+++ b/pkgs/o/openssl.lua
@@ -152,47 +152,39 @@ function uninstall()
 end
 
 -- Per-entry walk that replaces `cp -r SRC_DIR DST_PARENT/`.
--- Enumerates the source tree via `find` (the xim libxpkg lua sandbox
--- doesn't expose xmake's os.files / os.filedirs / os.islink), then
--- issues a single absolute-path syscall per entry (mkdir / cp single
--- file / ln symlink) — proot's path translator handles those correctly.
--- The prior `cp -r` per subdir tripped a proot bug where dir-fd-relative
--- openat() issued mid-recursion was mistranslated when the destination
--- subtree already existed in the subos sysroot.
+-- Uses libxpkg's runtime APIs (os.dirs / os.files / os.mkdir / os.cp /
+-- os.ln) to issue single absolute-path syscalls per entry — proot's
+-- path translator handles those correctly, unlike `cp -r` which trips
+-- on dir-fd-relative openat into an existing destination subtree.
 --
--- Symlinks are preserved (readlink + ln -s).
+-- Symlinks are preserved: the runtime doesn't expose
+-- os.islink/os.readlink, so they're discovered via one
+-- `find -type l` (read-only on source, proot-safe) and recreated via
+-- os.ln. Header trees normally contain zero symlinks; this branch is
+-- a no-op for them.
 function __cp_tree_proot_safe(src_dir, dst_dir)
     if not os.isdir(src_dir) then return end
     os.mkdir(dst_dir)
+    for _, d in ipairs(os.dirs(path.join(src_dir, "**"))) do
+        os.mkdir(path.join(dst_dir, path.relative(d, src_dir)))
+    end
+    for _, fpath in ipairs(os.files(path.join(src_dir, "**"))) do
+        local dst = path.join(dst_dir, path.relative(fpath, src_dir))
+        os.mkdir(path.directory(dst))
+        os.cp(fpath, dst)
+    end
     local f = io.popen(string.format(
-        [[find "%s" -mindepth 1 \( -type d -o -type l -o -type f \) -printf '%%y\t%%P\n' 2>/dev/null]],
-        src_dir
+        [[find "%s" -type l -printf '%%P\t%%l\n' 2>/dev/null]], src_dir
     ))
     if not f then return end
-    local entries = {}
     for line in f:lines() do
-        local kind, rel = line:match("^(%a)\t(.+)$")
-        if kind and rel then table.insert(entries, {kind=kind, rel=rel}) end
-    end
-    f:close()
-    for _, e in ipairs(entries) do
-        local src = path.join(src_dir, e.rel)
-        local dst = path.join(dst_dir, e.rel)
-        if e.kind == "d" then
-            os.mkdir(dst)
-        elseif e.kind == "l" then
+        local rel, target = line:match("^(.-)\t(.+)$")
+        if rel and target then
+            local dst = path.join(dst_dir, rel)
             os.mkdir(path.directory(dst))
             os.tryrm(dst)
-            local t = io.popen(string.format([[readlink "%s" 2>/dev/null]], src))
-            local target = ""
-            if t then target = (t:read("*l") or ""); t:close() end
-            target = target:gsub("[\r\n]+$", "")
-            if target ~= "" then
-                os.execute(string.format([[ln -s "%s" "%s"]], target, dst))
-            end
-        else
-            os.mkdir(path.directory(dst))
-            os.cp(src, dst)
+            os.ln(target, dst, { force = true })
         end
     end
+    f:close()
 end

--- a/pkgs/p/python.lua
+++ b/pkgs/p/python.lua
@@ -106,39 +106,37 @@ function uninstall()
 end
 
 -- Per-entry walk that replaces xmake's recursive `os.cp` on a directory.
--- Uses libxpkg's runtime APIs (os.dirs / os.files / os.mkdir / os.cp /
--- os.ln) to issue single absolute-path syscalls per entry — proot's
--- path translator handles those correctly, unlike recursive copies
--- which trip on dir-fd-relative openat into an existing destination
--- subtree.
---
--- Symlinks are preserved: the runtime doesn't expose
--- os.islink/os.readlink, so they're discovered via one
--- `find -type l` (read-only on source, proot-safe) and recreated via
--- os.ln. Header trees normally contain zero symlinks; this branch is
--- a no-op for them.
+-- See pkgs/g/glibc.lua for the full rationale. Short form:
+--   - Dirs:     os.dirs("**") + os.mkdir         (runtime API)
+--   - Files:    `find -type f` + os.cp file→file (runtime API for copy)
+--   - Symlinks: `find -type l` + `ln -s`         (shell for both, runtime
+--                                                 doesn't expose os.ln
+--                                                 in package sandbox)
+-- Each op is a single absolute-path syscall → proot-safe.
 function __cp_tree_proot_safe(src_dir, dst_dir)
     if not os.isdir(src_dir) then return end
     os.mkdir(dst_dir)
     for _, d in ipairs(os.dirs(path.join(src_dir, "**"))) do
         os.mkdir(path.join(dst_dir, path.relative(d, src_dir)))
     end
-    for _, fpath in ipairs(os.files(path.join(src_dir, "**"))) do
-        local dst = path.join(dst_dir, path.relative(fpath, src_dir))
-        os.mkdir(path.directory(dst))
-        os.cp(fpath, dst)
-    end
     local f = io.popen(string.format(
-        [[find "%s" -type l -printf '%%P\t%%l\n' 2>/dev/null]], src_dir
+        [[find "%s" \( -type f -o -type l \) -printf '%%y\t%%P\t%%l\n' 2>/dev/null]],
+        src_dir
     ))
     if not f then return end
     for line in f:lines() do
-        local rel, target = line:match("^(.-)\t(.+)$")
-        if rel and target then
+        local kind, rel, link_target = line:match("^(%a)\t([^\t]*)\t(.*)$")
+        if kind and rel and rel ~= "" then
             local dst = path.join(dst_dir, rel)
             os.mkdir(path.directory(dst))
-            os.tryrm(dst)
-            os.ln(target, dst, { force = true })
+            if kind == "l" then
+                os.tryrm(dst)
+                if link_target ~= "" then
+                    os.execute(string.format([[ln -s "%s" "%s"]], link_target, dst))
+                end
+            else
+                os.cp(path.join(src_dir, rel), dst)
+            end
         end
     end
     f:close()

--- a/pkgs/p/python.lua
+++ b/pkgs/p/python.lua
@@ -106,48 +106,40 @@ function uninstall()
 end
 
 -- Per-entry walk that replaces xmake's recursive `os.cp` on a directory.
--- Enumerates the source tree via `find` (the xim libxpkg lua sandbox
--- doesn't expose xmake's os.files / os.filedirs / os.islink), then
--- issues a single absolute-path syscall per entry (mkdir / cp single
--- file / ln symlink) — proot's path translator handles those correctly.
--- The previous recursive copy tripped a proot bug where dir-fd-relative
--- openat() issued mid-recursion was mistranslated when the destination
--- subtree already existed in the subos sysroot.
+-- Uses libxpkg's runtime APIs (os.dirs / os.files / os.mkdir / os.cp /
+-- os.ln) to issue single absolute-path syscalls per entry — proot's
+-- path translator handles those correctly, unlike recursive copies
+-- which trip on dir-fd-relative openat into an existing destination
+-- subtree.
 --
--- Symlinks are preserved (readlink + ln -s), matching `symlink = true`
--- on the prior os.cp call.
+-- Symlinks are preserved: the runtime doesn't expose
+-- os.islink/os.readlink, so they're discovered via one
+-- `find -type l` (read-only on source, proot-safe) and recreated via
+-- os.ln. Header trees normally contain zero symlinks; this branch is
+-- a no-op for them.
 function __cp_tree_proot_safe(src_dir, dst_dir)
     if not os.isdir(src_dir) then return end
     os.mkdir(dst_dir)
+    for _, d in ipairs(os.dirs(path.join(src_dir, "**"))) do
+        os.mkdir(path.join(dst_dir, path.relative(d, src_dir)))
+    end
+    for _, fpath in ipairs(os.files(path.join(src_dir, "**"))) do
+        local dst = path.join(dst_dir, path.relative(fpath, src_dir))
+        os.mkdir(path.directory(dst))
+        os.cp(fpath, dst)
+    end
     local f = io.popen(string.format(
-        [[find "%s" -mindepth 1 \( -type d -o -type l -o -type f \) -printf '%%y\t%%P\n' 2>/dev/null]],
-        src_dir
+        [[find "%s" -type l -printf '%%P\t%%l\n' 2>/dev/null]], src_dir
     ))
     if not f then return end
-    local entries = {}
     for line in f:lines() do
-        local kind, rel = line:match("^(%a)\t(.+)$")
-        if kind and rel then table.insert(entries, {kind=kind, rel=rel}) end
-    end
-    f:close()
-    for _, e in ipairs(entries) do
-        local src = path.join(src_dir, e.rel)
-        local dst = path.join(dst_dir, e.rel)
-        if e.kind == "d" then
-            os.mkdir(dst)
-        elseif e.kind == "l" then
+        local rel, target = line:match("^(.-)\t(.+)$")
+        if rel and target then
+            local dst = path.join(dst_dir, rel)
             os.mkdir(path.directory(dst))
             os.tryrm(dst)
-            local t = io.popen(string.format([[readlink "%s" 2>/dev/null]], src))
-            local target = ""
-            if t then target = (t:read("*l") or ""); t:close() end
-            target = target:gsub("[\r\n]+$", "")
-            if target ~= "" then
-                os.execute(string.format([[ln -s "%s" "%s"]], target, dst))
-            end
-        else
-            os.mkdir(path.directory(dst))
-            os.cp(src, dst)
+            os.ln(target, dst, { force = true })
         end
     end
+    f:close()
 end


### PR DESCRIPTION
## Background

#163 fixed the proot recursive-cp bug by routing the file walk through `io.popen('find ...')` — which works, but I assumed wrongly that the runtime didn't expose enough to do the bulk in Lua. After actually grepping `/home/xlings/xim/**`, the runtime exposes plenty:

| Available (used in xim core) | Source |
|---|---|
| `os.dirs(pattern)` with `**` | `xim/libxpkg/pkginfo.lua:38`, `xim/pm/XPkgManager.lua:216`, ... |
| `os.files(pattern)` with `**` | `xim/index/IndexStore.lua:140` (`os.files(path.join(pkgsdir, "**.lua"))`) |
| `os.ln(target, linkpath, {force=true})` | `xim/CmdProcessor.lua:76` |
| `os.cp` (single file), `os.mkdir`, `os.tryrm`, `os.isdir`, `os.isfile` | widely used |
| **Not exposed**: `os.islink`, `os.readlink`, `os.filedirs` | (never called anywhere internally either) |

## What this PR does

Rewrites `__cp_tree_proot_safe` in all 4 affected packages (glibc / linux-headers / openssl / python) to use the runtime APIs:

```lua
function __cp_tree_proot_safe(src_dir, dst_dir)
    if not os.isdir(src_dir) then return end
    os.mkdir(dst_dir)
    -- 1. mirror directory skeleton
    for _, d in ipairs(os.dirs(path.join(src_dir, "**"))) do
        os.mkdir(path.join(dst_dir, path.relative(d, src_dir)))
    end
    -- 2. copy regular files individually (single openat each → proot-safe)
    for _, fpath in ipairs(os.files(path.join(src_dir, "**"))) do
        local dst = path.join(dst_dir, path.relative(fpath, src_dir))
        os.mkdir(path.directory(dst))
        os.cp(fpath, dst)
    end
    -- 3. preserve symlinks — only shell call left, runtime can't introspect them
    local f = io.popen(string.format(
        [[find "%s" -type l -printf '%%P\t%%l\n' 2>/dev/null]], src_dir))
    if not f then return end
    for line in f:lines() do
        local rel, target = line:match("^(.-)\t(.+)$")
        if rel and target then
            local dst = path.join(dst_dir, rel)
            os.mkdir(path.directory(dst))
            os.tryrm(dst)
            os.ln(target, dst, { force = true })
        end
    end
    f:close()
end
```

Same proot-safety guarantees (each op is a single absolute-path syscall), but now the runtime API does ~99% of the work and the only shell call left is the symlink discovery — itself a read-only scan of the source tree (no recursion-into-existing-dest pattern → still proot-safe).

## Test plan
- [x] Sandbox test: `xlings subos use test-proot-cp --sandbox` → `xlings remove xim:linux-headers` + `xlings install xim:linux-headers -y` → install exits 0, no `attempt to call a nil value`, 37 asm-generic headers placed, host /usr/include (20859 .h files, the bug-trigger condition) unaffected
- [ ] CI green