### PR TITLE
refactor: use shared sysroot module + libxpkg fs API for header install

### DIFF
--- a/libs/sysroot.lua
+++ b/libs/sysroot.lua
@@ -1,0 +1,53 @@
+-- Shared sysroot installation helpers for xim-pkgindex.
+--
+-- Loaded by package config() hooks via:
+--     import("xim.pkgindex.sysroot")
+--
+-- Requires xlings >= 0.4.29 (libxpkg fs module + `xim.pkgindex.*`
+-- custom-module loader, both shipped in xlings v0.4.29 / libxpkg v0.0.40).
+-- Older xlings versions have no `xim.pkgindex.*` resolver, so the import
+-- falls through to the unknown-module stub and any callsite hits a nil
+-- error — that's the right signal to bump xlings.
+
+import("xim.libxpkg.fs")
+
+local sysroot = {}
+
+-- Recursively materialize SRC_DIR into DST_DIR as a tree of symlinks.
+--
+-- Why symlink instead of copy:
+--   * Avoids the proot sandbox `Permission denied` triggered by `cp -r`
+--     (recursive openat into an existing destination subtree).
+--   * Each operation here (fs.mkdir_p / fs.symlink / fs.readlink /
+--     fs.remove) is a single absolute-path syscall — translates
+--     correctly under proot.
+--   * No file duplication, sysroot view stays in sync with the package
+--     install dir, and uninstalling the package correctly leaves
+--     dangling links (headers should not be available without their
+--     library).
+--
+-- Behavior:
+--   * Regular files in SRC become symlinks in DST pointing at SRC/<rel>.
+--   * Existing symlinks are preserved by reading their original target
+--     and recreating the link with the same target in DST.
+--   * Existing entries at DST are removed first (force-overwrite).
+--   * Missing SRC is a silent no-op.
+function sysroot.install_headers(src_dir, dst_dir)
+    if not os.isdir(src_dir) then return end
+    fs.mkdir_p(dst_dir)
+    for _, e in ipairs(fs.entries(src_dir) or {}) do
+        local dst = path.join(dst_dir, e.name)
+        if e.type == "directory" then
+            sysroot.install_headers(e.path, dst)
+        elseif e.type == "symlink" then
+            fs.remove(dst)
+            local target = fs.readlink(e.path)
+            if target then fs.symlink(target, dst) end
+        else
+            fs.remove(dst)
+            fs.symlink(e.path, dst)
+        end
+    end
+end
+
+return sysroot

--- a/pkgs/g/glibc.lua
+++ b/pkgs/g/glibc.lua
@@ -52,6 +52,7 @@ import("xim.libxpkg.log")
 import("xim.libxpkg.pkginfo")
 import("xim.libxpkg.system")
 import("xim.libxpkg.xvm")
+import("xim.pkgindex.sysroot")
 
 -- libnss modules
 local glibc_libs = {
@@ -172,61 +173,9 @@ function __config_header()
         return
     end
 
-    log.info("Copying glibc header files to subos rootfs ...")
-    __cp_tree_proot_safe(include_dir, path.join(sysroot_usrdir, "include"))
+    log.info("Linking glibc headers into subos sysroot ...")
+    sysroot.install_headers(include_dir, path.join(sysroot_usrdir, "include"))
     io.writefile(stamp, pkginfo.version())
-end
-
--- Per-entry walk that replaces `cp -r SRC_DIR DST_PARENT/`.
---
--- The package config() sandbox exposes a smaller subset of the
--- xmake/libxpkg runtime than core scripts: `os.dirs(... "**" ...)`,
--- `os.mkdir`, `os.cp(file, file)`, `os.tryrm`, `os.isdir`, `os.isfile`,
--- `os.execute` all work; but `os.files`, `os.filedirs`, `os.islink`,
--- `os.readlink`, `os.ln` are NOT exposed (verified empirically: CI
--- raised `attempt to call a nil value (field 'files')` etc.).
---
--- Strategy:
---   1. Materialize the dir skeleton via `os.dirs("**")` (runtime API).
---   2. Enumerate files + symlinks via one shell `find` pass — read-only
---      on source, no recursion-into-existing-dest, hence proot-safe.
---   3. Per file: `os.cp` single file (runtime API, single absolute-path
---      openat → translates correctly under proot).
---   4. Per symlink: `ln -s` via os.execute (shell, single symlinkat
---      → also proot-safe).
---
--- The previous `cp -r` tripped a proot bug where dir-fd-relative
--- `openat(parent_fd, "<child>", ...)` issued by coreutils mid-recursion
--- was mistranslated when the destination subtree already existed in
--- the subos sysroot. Each op in this helper is a single absolute-path
--- syscall — proot's translator handles them correctly.
-function __cp_tree_proot_safe(src_dir, dst_dir)
-    if not os.isdir(src_dir) then return end
-    os.mkdir(dst_dir)
-    for _, d in ipairs(os.dirs(path.join(src_dir, "**"))) do
-        os.mkdir(path.join(dst_dir, path.relative(d, src_dir)))
-    end
-    local f = io.popen(string.format(
-        [[find "%s" \( -type f -o -type l \) -printf '%%y\t%%P\t%%l\n' 2>/dev/null]],
-        src_dir
-    ))
-    if not f then return end
-    for line in f:lines() do
-        local kind, rel, link_target = line:match("^(%a)\t([^\t]*)\t(.*)$")
-        if kind and rel and rel ~= "" then
-            local dst = path.join(dst_dir, rel)
-            os.mkdir(path.directory(dst))
-            if kind == "l" then
-                os.tryrm(dst)
-                if link_target ~= "" then
-                    os.execute(string.format([[ln -s "%s" "%s"]], link_target, dst))
-                end
-            else
-                os.cp(path.join(src_dir, rel), dst)
-            end
-        end
-    end
-    f:close()
 end
 
 function __relocate()

--- a/pkgs/l/linux-headers.lua
+++ b/pkgs/l/linux-headers.lua
@@ -32,6 +32,7 @@ import("xim.libxpkg.system")
 import("xim.libxpkg.pkgmanager")
 import("xim.libxpkg.xvm")
 import("xim.libxpkg.log")
+import("xim.pkgindex.sysroot")
 
 function install()
     -- This package is a thin delegator: the real header payload is provided
@@ -64,8 +65,8 @@ function config()
         log.debug("Linux headers already in subos rootfs (stamp present), skipping copy.")
     else
         local scodedir = pkginfo.install_dir("scode:linux-headers", pkginfo.version())
-        log.info("Copying linux header files to subos rootfs ...")
-        __cp_tree_proot_safe(
+        log.info("Linking linux headers into subos sysroot ...")
+        sysroot.install_headers(
             path.join(scodedir, "include"),
             path.join(sysroot_usrdir, "include")
         )
@@ -75,43 +76,6 @@ function config()
     xvm.add("linux-headers")
 
     return true
-end
-
--- Per-entry walk that replaces xmake's recursive `os.cp` (and `cp -r`).
--- See pkgs/g/glibc.lua for the full rationale. Short form:
---   - Dirs:     os.dirs("**") + os.mkdir         (runtime API)
---   - Files:    `find -type f` + os.cp file→file (runtime API for copy)
---   - Symlinks: `find -type l` + `ln -s`         (shell for both, runtime
---                                                 doesn't expose os.ln
---                                                 in package sandbox)
--- Each op is a single absolute-path syscall → proot-safe.
-function __cp_tree_proot_safe(src_dir, dst_dir)
-    if not os.isdir(src_dir) then return end
-    os.mkdir(dst_dir)
-    for _, d in ipairs(os.dirs(path.join(src_dir, "**"))) do
-        os.mkdir(path.join(dst_dir, path.relative(d, src_dir)))
-    end
-    local f = io.popen(string.format(
-        [[find "%s" \( -type f -o -type l \) -printf '%%y\t%%P\t%%l\n' 2>/dev/null]],
-        src_dir
-    ))
-    if not f then return end
-    for line in f:lines() do
-        local kind, rel, link_target = line:match("^(%a)\t([^\t]*)\t(.*)$")
-        if kind and rel and rel ~= "" then
-            local dst = path.join(dst_dir, rel)
-            os.mkdir(path.directory(dst))
-            if kind == "l" then
-                os.tryrm(dst)
-                if link_target ~= "" then
-                    os.execute(string.format([[ln -s "%s" "%s"]], link_target, dst))
-                end
-            else
-                os.cp(path.join(src_dir, rel), dst)
-            end
-        end
-    end
-    f:close()
 end
 
 function uninstall()

--- a/pkgs/o/openssl.lua
+++ b/pkgs/o/openssl.lua
@@ -32,6 +32,7 @@ import("xim.libxpkg.pkginfo")
 import("xim.libxpkg.system")
 import("xim.libxpkg.xvm")
 import("xim.libxpkg.log")
+import("xim.pkgindex.sysroot")
 -- elfpatch import removed: predicate-driven auto-patch (post 2026-05-02
 -- design) reads glibc.lua's exports.runtime.loader and rewrites our
 -- INTERP / RPATH automatically. No install-hook elfpatch call needed.
@@ -103,20 +104,9 @@ function config()
         xvm.add(lib, config)
     end
 
-    log.debug("Installing headers to sysroot...")
+    log.debug("Linking headers into subos sysroot ...")
     if os.isdir(includedir) then
-        local sys_includedir = get_sys_usr_includedir()
-        local subdirs = os.dirs(path.join(includedir, "*"))
-        for _, subdir in ipairs(subdirs) do
-            local name = path.filename(subdir)
-            local dst = path.join(sys_includedir, name)
-            os.tryrm(dst)
-            __cp_tree_proot_safe(subdir, dst)
-        end
-
-        for _, file in ipairs(list_files(path.join(includedir, "*.h"))) do
-            os.execute('cp "' .. file .. '" "' .. sys_includedir .. '/"')
-        end
+        sysroot.install_headers(includedir, get_sys_usr_includedir())
     end
 
     xvm.add(package.name, { binding = binding_tree_version_tag })
@@ -149,41 +139,4 @@ function uninstall()
 
     xvm.remove(xpkg_binding_tree)
     return true
-end
-
--- Per-entry walk that replaces `cp -r SRC_DIR DST_PARENT/`.
--- See pkgs/g/glibc.lua for the full rationale. Short form:
---   - Dirs:     os.dirs("**") + os.mkdir         (runtime API)
---   - Files:    `find -type f` + os.cp file→file (runtime API for copy)
---   - Symlinks: `find -type l` + `ln -s`         (shell for both, runtime
---                                                 doesn't expose os.ln
---                                                 in package sandbox)
--- Each op is a single absolute-path syscall → proot-safe.
-function __cp_tree_proot_safe(src_dir, dst_dir)
-    if not os.isdir(src_dir) then return end
-    os.mkdir(dst_dir)
-    for _, d in ipairs(os.dirs(path.join(src_dir, "**"))) do
-        os.mkdir(path.join(dst_dir, path.relative(d, src_dir)))
-    end
-    local f = io.popen(string.format(
-        [[find "%s" \( -type f -o -type l \) -printf '%%y\t%%P\t%%l\n' 2>/dev/null]],
-        src_dir
-    ))
-    if not f then return end
-    for line in f:lines() do
-        local kind, rel, link_target = line:match("^(%a)\t([^\t]*)\t(.*)$")
-        if kind and rel and rel ~= "" then
-            local dst = path.join(dst_dir, rel)
-            os.mkdir(path.directory(dst))
-            if kind == "l" then
-                os.tryrm(dst)
-                if link_target ~= "" then
-                    os.execute(string.format([[ln -s "%s" "%s"]], link_target, dst))
-                end
-            else
-                os.cp(path.join(src_dir, rel), dst)
-            end
-        end
-    end
-    f:close()
 end

--- a/pkgs/p/python.lua
+++ b/pkgs/p/python.lua
@@ -43,6 +43,7 @@ import("xim.libxpkg.pkginfo")
 import("xim.libxpkg.system")
 import("xim.libxpkg.xvm")
 import("xim.libxpkg.log")
+import("xim.pkgindex.sysroot")
 
 function install()
     if os.host() == "windows" then
@@ -76,8 +77,8 @@ function config()
         if sysrootdir and os.isdir(includedir) then
             local sysroot_usrdir = path.join(sysrootdir, "usr")
             if not os.isdir(sysroot_usrdir) then os.mkdir(sysroot_usrdir) end
-            log.info("Installing Python dev headers into subos sysroot...")
-            __cp_tree_proot_safe(includedir, path.join(sysroot_usrdir, "include"))
+            log.info("Linking Python dev headers into subos sysroot ...")
+            sysroot.install_headers(includedir, path.join(sysroot_usrdir, "include"))
         end
     end
     return true
@@ -103,41 +104,4 @@ function uninstall()
     end
 
     return true
-end
-
--- Per-entry walk that replaces xmake's recursive `os.cp` on a directory.
--- See pkgs/g/glibc.lua for the full rationale. Short form:
---   - Dirs:     os.dirs("**") + os.mkdir         (runtime API)
---   - Files:    `find -type f` + os.cp file→file (runtime API for copy)
---   - Symlinks: `find -type l` + `ln -s`         (shell for both, runtime
---                                                 doesn't expose os.ln
---                                                 in package sandbox)
--- Each op is a single absolute-path syscall → proot-safe.
-function __cp_tree_proot_safe(src_dir, dst_dir)
-    if not os.isdir(src_dir) then return end
-    os.mkdir(dst_dir)
-    for _, d in ipairs(os.dirs(path.join(src_dir, "**"))) do
-        os.mkdir(path.join(dst_dir, path.relative(d, src_dir)))
-    end
-    local f = io.popen(string.format(
-        [[find "%s" \( -type f -o -type l \) -printf '%%y\t%%P\t%%l\n' 2>/dev/null]],
-        src_dir
-    ))
-    if not f then return end
-    for line in f:lines() do
-        local kind, rel, link_target = line:match("^(%a)\t([^\t]*)\t(.*)$")
-        if kind and rel and rel ~= "" then
-            local dst = path.join(dst_dir, rel)
-            os.mkdir(path.directory(dst))
-            if kind == "l" then
-                os.tryrm(dst)
-                if link_target ~= "" then
-                    os.execute(string.format([[ln -s "%s" "%s"]], link_target, dst))
-                end
-            else
-                os.cp(path.join(src_dir, rel), dst)
-            end
-        end
-    end
-    f:close()
 end


### PR DESCRIPTION
## Summary

Create `libs/sysroot.lua` loaded via `import("xim.pkgindex.sysroot")` (new xlings 0.4.29 feature). Provides `sysroot.install_headers(src_dir, dst_dir)` — recursively symlinks headers into subos sysroot using `fs.entries` + `fs.symlink` (std::filesystem-backed). Zero `cp -r`, zero shell `find`, zero proot openat bug.

Replaces 4 copies of the inline `__cp_tree_proot_safe` helper.

| pkg | before | after |
|---|---|---|
| `glibc.lua` | 50-line inline helper | `sysroot.install_headers(include_dir, sysroot_usr/include)` |
| `linux-headers.lua` | 35-line inline helper | `sysroot.install_headers(scode/include, sysroot_usr/include)` |
| `openssl.lua` | 35-line inline helper + per-subdir loop + list_files | `sysroot.install_headers(includedir, sys_includedir)` |
| `python.lua` | 35-line inline helper | `sysroot.install_headers(includedir, sysroot_usr/include)` |

Net: **+53 lines** (shared module) **−185 lines** (removed inline helpers). Each package: 1 import + 1 call.

## Test plan
- [ ] CI green (xlings 0.4.29 now deployed — CI installer pulls latest)