### PR TITLE
feat: add mcpp 0.0.8

### DIFF
--- a/pkgs/m/mcpp.lua
+++ b/pkgs/m/mcpp.lua
@@ -42,9 +42,10 @@ package = {
     xpm = {
         linux = {
             url_template = "https://github.com/mcpp-community/mcpp/releases/download/v{version}/mcpp-{version}-linux-x86_64.tar.gz",
-            ["latest"] = { ref = "0.0.7" },
+            ["latest"] = { ref = "0.0.8" },
             ["0.0.6"] = "XLINGS_RES",
             ["0.0.7"] = "XLINGS_RES",
+            ["0.0.8"] = "XLINGS_RES",
             ["0.0.5"] = "XLINGS_RES",
             ["0.0.4"] = "XLINGS_RES",
             ["0.0.3"] = "XLINGS_RES",


### PR DESCRIPTION
Adds mcpp 0.0.8. Completes namespace migration support (read_xpkg_lua + install_path both handle old and new index layouts).