### PR TITLE
fix(sysroot): use shell ls + os.isdir instead of fs.entries/fs.is_*

### DIFF
--- a/libs/sysroot.lua
+++ b/libs/sysroot.lua
@@ -38,21 +38,38 @@ local sysroot = {}
 function sysroot.install_headers(src_dir, dst_dir)
     if not os.isdir(src_dir) then return end
     fs.mkdir_p(dst_dir)
-    for _, e in ipairs(fs.entries(src_dir) or {}) do
-        local dst = path.join(dst_dir, e.name)
-
-        -- Skip if anything already exists at dst — host bind-mount,
-        -- prior package symlink, or promoted dir. Don't touch it.
-        if fs.is_symlink(dst) or fs.is_file(dst) or fs.is_directory(dst) then
+    -- Enumerate source entries via a single shell `ls` (one fork, one
+    -- readdir — proot-safe). Then for each name, use `os.isdir` /
+    -- `os.isfile` (the old runtime APIs that proot translates correctly)
+    -- to test existence. Only entries that don't already exist in dst
+    -- get a single `fs.symlink` call.
+    --
+    -- Why not fs.entries: even read-only fs.entries + fs.is_symlink +
+    -- fs.is_file + fs.is_directory on 130 entries under proot is ~400+
+    -- C++ std::filesystem stat() calls that proot traces via ptrace —
+    -- enough to poison the talloc pool on some kernel/proot combos.
+    -- The shell `ls` + Lua `os.isdir`/`os.isfile` path uses ~2N
+    -- syscalls total (one readdir + one stat per entry) and goes
+    -- through proot's simpler absolute-path translation, not the
+    -- dir-fd-relative openat path.
+    local f = io.popen(string.format([[ls -1 "%s" 2>/dev/null]], src_dir))
+    if not f then return end
+    local names = {}
+    for line in f:lines() do
+        local name = line:gsub("[\r\n]+$", "")
+        if name ~= "" then table.insert(names, name) end
+    end
+    f:close()
+    for _, name in ipairs(names) do
+        local dst = path.join(dst_dir, name)
+        -- Skip if anything already exists at dst (host bind-mount,
+        -- prior package, or prior install). os.isdir/os.isfile cover
+        -- real entries + symlinks that resolve to dirs/files.
+        if os.isdir(dst) or os.isfile(dst) then
             -- already present, skip
         else
-            -- Entry doesn't exist yet → symlink it
-            if e.type == "symlink" then
-                local target = fs.readlink(e.path)
-                if target then fs.symlink(target, dst) end
-            else
-                fs.symlink(e.path, dst)
-            end
+            local src = path.join(src_dir, name)
+            fs.symlink(src, dst)
         end
     end
 end


### PR DESCRIPTION
## Root cause

Even after #174 (skip-if-exists), proot crashed on real systems. The fs module's C++ `std::filesystem` stat calls (`fs.entries()`, `fs.is_symlink()`, `fs.is_file()`, `fs.is_directory()`) are each ptrace-traced by proot. 130 glibc entries × (1 readdir + 3 stat checks) = **~520 ptrace ops** — enough to corrupt talloc, even though we never call `fs.symlink` on existing entries.

## Fix

Replace `fs.entries()` + `fs.is_*()` with:
- **`io.popen('ls -1')`** for enumeration (1 fork + 1 readdir → proot-safe)
- **`os.isdir()` / `os.isfile()`** for existence check (old runtime APIs, simpler absolute-path stat → proot-safe)
- **`fs.symlink()`** only for the ~2 entries that don't already exist

Total proot pressure: ~2N syscalls vs ~4N+.

## Verified on real system

Completely fresh subos, openclaw not installed **anywhere** (all xpkgs/state nuked):

```
xlings subos new final-test
echo 'xlings install openclaw -y; openclaw --version' \
  | xlings subos use final-test --sandbox
```

- `Linking glibc headers into subos sysroot ...` ✅ no crash
- npm install 559 packages ✅ no crash
- `OpenClaw 2026.5.7 (eeef486)` ✅