### PR TITLE
fix(openclaw): warm up proot path cache + --ignore-scripts for sandbox

### DIFF
--- a/pkgs/o/openclaw.lua
+++ b/pkgs/o/openclaw.lua
@@ -53,8 +53,16 @@ function install()
     os.tryrm(pkginfo.install_dir())
     os.mkdir(pkginfo.install_dir())
 
+    -- Warm up proot's internal path-resolution state before the heavy
+    -- npm install. Without this, the first large fork+exec burst
+    -- (npm unpacking 559 packages) in a fresh proot sandbox triggers
+    -- `double free or corruption` in proot's talloc pool. A single
+    -- PATH-traversing command (`node --version`) initializes proot's
+    -- path cache and prevents the crash. This is a no-op outside proot.
+    os.execute("node --version > /dev/null 2>&1")
+
     local npm_install = string.format(
-        [[npm install --prefix "%s" --no-fund --no-audit "openclaw@%s"]],
+        [[npm install --prefix "%s" --no-fund --no-audit --ignore-scripts "openclaw@%s"]],
         pkginfo.install_dir(),
         pkginfo.version()
     )


### PR DESCRIPTION
## Root cause

In a fresh proot sandbox, the first large fork+exec burst (npm unpacking 559 packages) triggers `double free or corruption` in proot's talloc pool. This is a proot v5.4.0 bug in its PATH resolution initialization — the first command that traverses PATH via fork+exec initializes internal state that subsequent fork+exec operations depend on.

**Proven by controlled experiment** (all in fresh subos sandbox):

| sequence | result |
|---|---|
| bare `npm install openclaw` | ❌ `double free or corruption` |
| `which node` → `npm install openclaw` | ✅ success |
| `node --version` → `npm install openclaw` | ✅ success |
| `xlings install glibc` → `npm install openclaw` | ✅ success |
| `ls /usr; ls /tmp; ls /home` → `npm install openclaw` | ❌ crash (ls doesn't traverse PATH) |

## Fix

1. **`os.execute("node --version > /dev/null 2>&1")`** before npm install — warms up proot's path cache. No-op outside proot.
2. **`--ignore-scripts`** — openclaw's deps include native-addon packages (koffi, tree-sitter-bash) whose install scripts fork compiler processes, adding extra ptrace pressure. Safe because openclaw works without compiled native addons.

## Test plan
- [x] Real system: fresh subos `oc-real`, openclaw not installed anywhere, `xlings install openclaw -y` → glibc headers ✅ → npm install 559 packages ✅ → `openclaw --version` = `OpenClaw 2026.5.7` ✅
- [ ] CI green