### PR TITLE
feat(mcpp): add 0.0.9

### DIFF
--- a/pkgs/m/mcpp.lua
+++ b/pkgs/m/mcpp.lua
@@ -42,10 +42,11 @@ package = {
     xpm = {
         linux = {
             url_template = "https://github.com/mcpp-community/mcpp/releases/download/v{version}/mcpp-{version}-linux-x86_64.tar.gz",
-            ["latest"] = { ref = "0.0.8" },
-            ["0.0.6"] = "XLINGS_RES",
-            ["0.0.7"] = "XLINGS_RES",
+            ["latest"] = { ref = "0.0.9" },
+            ["0.0.9"] = "XLINGS_RES",
             ["0.0.8"] = "XLINGS_RES",
+            ["0.0.7"] = "XLINGS_RES",
+            ["0.0.6"] = "XLINGS_RES",
             ["0.0.5"] = "XLINGS_RES",
             ["0.0.4"] = "XLINGS_RES",
             ["0.0.3"] = "XLINGS_RES",


### PR DESCRIPTION
## Summary
- Mirror mcpp v0.0.9 at `xlings-res/mcpp` on GitHub + GitCode
- Add `["0.0.9"] = "XLINGS_RES"` and bump `latest` ref to 0.0.9
- sha256: `904037996f74979951f9d295b6268607f78b0af505ff37b058c7f380562c1f62` (matches upstream SHA256SUMS)

## Test plan
- [x] Both mirrors verified (sha256 match)
- [ ] CI green