### PR TITLE
feat(mcpp): add 0.0.10

### DIFF
--- a/pkgs/m/mcpp.lua
+++ b/pkgs/m/mcpp.lua
@@ -42,7 +42,8 @@ package = {
     xpm = {
         linux = {
             url_template = "https://github.com/mcpp-community/mcpp/releases/download/v{version}/mcpp-{version}-linux-x86_64.tar.gz",
-            ["latest"] = { ref = "0.0.9" },
+            ["latest"] = { ref = "0.0.10" },
+            ["0.0.10"] = "XLINGS_RES",
             ["0.0.9"] = "XLINGS_RES",
             ["0.0.8"] = "XLINGS_RES",
             ["0.0.7"] = "XLINGS_RES",


### PR DESCRIPTION
## Summary
- Mirror mcpp v0.0.10 at `xlings-res/mcpp` on GitHub + GitCode
- Add `["0.0.10"] = "XLINGS_RES"` and bump `latest` ref to 0.0.10
- sha256: `5f6674993ca139a068811111e1779bdf9447126363e3fca3a93da13cf6c83a61`

## Test plan
- [x] Both mirrors verified
- [ ] CI green