### PR TITLE
feat(mcpp): add 0.0.11

### DIFF
--- a/pkgs/m/mcpp.lua
+++ b/pkgs/m/mcpp.lua
@@ -42,7 +42,8 @@ package = {
     xpm = {
         linux = {
             url_template = "https://github.com/mcpp-community/mcpp/releases/download/v{version}/mcpp-{version}-linux-x86_64.tar.gz",
-            ["latest"] = { ref = "0.0.10" },
+            ["latest"] = { ref = "0.0.11" },
+            ["0.0.11"] = "XLINGS_RES",
             ["0.0.10"] = "XLINGS_RES",
             ["0.0.9"] = "XLINGS_RES",
             ["0.0.8"] = "XLINGS_RES",


### PR DESCRIPTION
## Summary
- Mirror mcpp v0.0.11 at `xlings-res/mcpp` on GitHub + GitCode
- Add `["0.0.11"] = "XLINGS_RES"` and bump `latest` ref to 0.0.11
- sha256: `d61d80a9114f4633df09883140c17429add49b58243cf02a8003cba72bbb0f37`

## Test plan
- [x] Both mirrors verified
- [ ] CI green