### PR TITLE
feat(mcpp): add 0.0.13

### DIFF
--- a/pkgs/m/mcpp.lua
+++ b/pkgs/m/mcpp.lua
@@ -42,7 +42,8 @@ package = {
     xpm = {
         linux = {
             url_template = "https://github.com/mcpp-community/mcpp/releases/download/v{version}/mcpp-{version}-linux-x86_64.tar.gz",
-            ["latest"] = { ref = "0.0.11" },
+            ["latest"] = { ref = "0.0.13" },
+            ["0.0.13"] = "XLINGS_RES",
             ["0.0.11"] = "XLINGS_RES",
             ["0.0.10"] = "XLINGS_RES",
             ["0.0.9"] = "XLINGS_RES",


### PR DESCRIPTION
## Summary
- Add mcpp 0.0.13 version support
- Update latest ref from 0.0.11 to 0.0.13
- Binary mirrored to xlings-res/mcpp

## Test plan
- [x] Static tests pass
- [x] Isolation tests pass