### PR TITLE
fix(llvm): add std module sources and clang-scan-deps for import std

### DIFF
--- a/pkgs/l/llvm.lua
+++ b/pkgs/l/llvm.lua
@@ -29,7 +29,7 @@ package = {
                     GLOBAL = "https://github.com/xlings-res/llvm/releases/download/20.1.7/llvm-20.1.7-linux-x86_64.tar.xz",
                     CN = "https://gitcode.com/xlings-res/llvm/releases/download/20.1.7/llvm-20.1.7-linux-x86_64.tar.xz",
                 },
-                sha256 = "ac9e4665368a52e03209a206a276a887a2019e64b9870cb93e59c5638d235130",
+                sha256 = "11cedefe2a36b73abe42f9e1bd31cc1551e0bb4f7763b7c5944d4e9e1febc312",
             },
         },
         macosx = {


### PR DESCRIPTION
## Problem
`import std;` was not working because the split package was missing:
- `share/libc++/v1/std.cppm` and `std.compat.cppm` (module interface sources)
- `share/libc++/v1/std/*.inc` (~110 files) and `std.compat/*.inc` (~21 files)
- `bin/clang-scan-deps` (module dependency scanner, needed by build systems like mcpp)

`libc++.modules.json` existed but pointed to non-existent paths.

## Fix
Repackaged `llvm-20.1.7-linux-x86_64.tar.xz` with the missing files.
Package size: 133MB -> 168MB.

## Verification
```
$ clang++ -std=c++23 -fexperimental-library -x c++-module --precompile share/libc++/v1/std.cppm -o std.pcm  ✓
$ clang++ -std=c++23 -fexperimental-library -fmodule-file=std=std.pcm test.cpp -o test  ✓
$ clang-scan-deps --version  ✓
```

## Test plan
- [x] Static + isolation tests pass (8/8)
- [x] `import std;` compiles and links successfully
- [x] `clang-scan-deps` works
- [x] Binary uploaded to xlings-res/llvm (GitHub)