### PR TITLE
fix(llvm): fix install dir name mismatch causing broken xvm registration

### DIFF
--- a/pkgs/l/llvm.lua
+++ b/pkgs/l/llvm.lua
@@ -87,10 +87,15 @@ local function collect_bin_apps(bindir)
 end
 
 function install()
-    local llvmdir = pkginfo.install_file()
-        :replace(".tar.xz", "")
-        :replace(".tar.gz", "")
-        :replace(".zip", "")
+    -- The inner directory is always llvm-<version>-linux-x86_64 regardless
+    -- of the download filename (which may have a -v2 suffix for mirror reasons).
+    local llvmdir = "llvm-" .. pkginfo.version() .. "-linux-x86_64"
+    if os.host() == "macosx" then
+        llvmdir = pkginfo.install_file()
+            :replace(".tar.xz", "")
+            :replace(".tar.gz", "")
+            :replace(".zip", "")
+    end
     os.tryrm(pkginfo.install_dir())
     os.mv(llvmdir, pkginfo.install_dir())
 


### PR DESCRIPTION
## Problem
After install, all xvm alias registrations fail:
```
[WARN] skip xvm add alias (not found): cc -> clang
[WARN] skip xvm add alias (not found): c++ -> clang++
...
```
Binaries end up at `.../20.1.7/llvm-20.1.7-linux-x86_64/bin/` instead of `.../20.1.7/bin/`.

## Root Cause
`install()` derives the extracted directory name from `pkginfo.install_file()`:
- Download filename: `llvm-20.1.7-v2-linux-x86_64.tar.xz` → derives `llvm-20.1.7-v2-linux-x86_64`
- Actual tarball inner dir: `llvm-20.1.7-linux-x86_64` (no `-v2`)

The `-v2` suffix was added to work around gitcode cache, but the tarball contents don't have it.

## Fix
Use `"llvm-" .. pkginfo.version() .. "-linux-x86_64"` directly on Linux instead of deriving from filename.