### PR TITLE
feat(zlib): add prebuilt zlib; fix llvm libz.so.1 runtime dep

### DIFF
--- a/pkgs/l/llvm.lua
+++ b/pkgs/l/llvm.lua
@@ -22,6 +22,7 @@ package = {
             deps = {
                 "xim:glibc@2.39",
                 "xim:linux-headers@5.11.1",
+                "xim:zlib@1.3.1",
             },
             ["latest"] = { ref = "20.1.7" },
             ["20.1.7"] = {

--- a/pkgs/z/zlib.lua
+++ b/pkgs/z/zlib.lua
@@ -1,0 +1,93 @@
+package = {
+    spec = "1",
+    homepage = "https://zlib.net",
+
+    name = "zlib",
+    description = "A massively spiffy yet delicately unobtrusive compression library",
+    maintainers = {"Jean-loup Gailly", "Mark Adler"},
+    licenses = {"Zlib"},
+    repo = "https://github.com/madler/zlib",
+
+    type = "package",
+    archs = {"x86_64"},
+    status = "stable",
+    categories = {"compression", "library"},
+    keywords = {"zlib", "compression", "lib"},
+
+    xvm_enable = true,
+
+    xpm = {
+        linux = {
+            ["latest"] = { ref = "1.3.1" },
+            ["1.3.1"] = {
+                url = {
+                    GLOBAL = "https://github.com/xlings-res/zlib/releases/download/1.3.1/zlib-1.3.1-linux-x86_64.tar.gz",
+                    CN = "https://gitcode.com/xlings-res/zlib/releases/download/1.3.1/zlib-1.3.1-linux-x86_64.tar.gz",
+                },
+                sha256 = "bd66d75485ca9d9a949ba5b99733c8ded759a464d1c6172ae26b8a2e176a0e75",
+            },
+        },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.system")
+import("xim.libxpkg.xvm")
+import("xim.libxpkg.log")
+
+local libs = {
+    "libz.so", "libz.so.1",
+}
+
+function install()
+    local srcdir = "zlib-" .. pkginfo.version() .. "-linux-x86_64"
+    os.tryrm(pkginfo.install_dir())
+    os.mv(srcdir, pkginfo.install_dir())
+    return true
+end
+
+function config()
+    local libdir = path.join(pkginfo.install_dir(), "lib")
+    local binding = package.name .. "@" .. pkginfo.version()
+
+    xvm.add(package.name)
+
+    for _, lib in ipairs(libs) do
+        local libpath = path.join(libdir, lib)
+        if os.isfile(libpath) then
+            xvm.add(lib, {
+                type = "lib",
+                bindir = libdir,
+                filename = lib,
+                alias = lib,
+                binding = binding,
+            })
+        end
+    end
+
+    -- Copy headers to sysroot for other packages to find
+    local sys_inc = path.join(system.subos_sysrootdir(), "usr/include")
+    local inc_dir = path.join(pkginfo.install_dir(), "include")
+    if os.isdir(inc_dir) and os.isdir(sys_inc) then
+        local zlib_h = path.join(inc_dir, "zlib.h")
+        local zconf_h = path.join(inc_dir, "zconf.h")
+        if os.isfile(zlib_h) then os.cp(zlib_h, sys_inc) end
+        if os.isfile(zconf_h) then os.cp(zconf_h, sys_inc) end
+    end
+
+    return true
+end
+
+function uninstall()
+    xvm.remove(package.name)
+
+    for _, lib in ipairs(libs) do
+        xvm.remove(lib)
+    end
+
+    local sys_inc = path.join(system.subos_sysrootdir(), "usr/include")
+    os.tryrm(path.join(sys_inc, "zlib.h"))
+    os.tryrm(path.join(sys_inc, "zconf.h"))
+
+    return true
+end

--- a/tests/z/test_zlib.py
+++ b/tests/z/test_zlib.py
@@ -1,0 +1,67 @@
+"""测试 zlib 包"""
+import pytest
+from tests.lib.xpkg_parser import parse_xpkg
+from tests.lib.assertions import (
+    assert_required_fields, assert_valid_spec, assert_valid_type,
+    assert_no_typos, assert_no_exec_xvm, assert_no_bashrc_modification,
+    assert_no_direct_path_modification, assert_uses_new_api,
+    assert_xim_add_succeeds, assert_install_succeeds,
+)
+from tests.lib.platform_utils import skip_if_not
+
+PKG = "zlib"
+PKG_FILE = "pkgs/z/zlib.lua"
+
+
+@pytest.fixture(scope='module')
+def meta():
+    return parse_xpkg(PKG_FILE)
+
+
+class TestStatic:
+    @pytest.mark.static
+    def test_required_fields(self, meta):
+        assert_required_fields(meta)
+
+    @pytest.mark.static
+    def test_valid_spec(self, meta):
+        assert_valid_spec(meta)
+
+    @pytest.mark.static
+    def test_valid_type(self, meta):
+        assert_valid_type(meta)
+
+    @pytest.mark.static
+    def test_no_typos(self):
+        assert_no_typos(PKG_FILE)
+
+
+class TestIndex:
+    @pytest.mark.index
+    def test_xim_add(self):
+        assert_xim_add_succeeds(PKG_FILE)
+
+
+class TestIsolation:
+    @pytest.mark.isolation
+    def test_no_exec_xvm(self):
+        assert_no_exec_xvm(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_no_bashrc(self):
+        assert_no_bashrc_modification(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_no_path_modification(self):
+        assert_no_direct_path_modification(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_new_api(self):
+        assert_uses_new_api(PKG_FILE)
+
+
+class TestLifecycle:
+    @pytest.mark.lifecycle
+    @skip_if_not('linux')
+    def test_install(self):
+        assert_install_succeeds(PKG)


### PR DESCRIPTION
## Problem
After `xlings install llvm`, `clang --version` fails:
```
error while loading shared libraries: libz.so.1: cannot open shared object file
```

clang binary has `NEEDED: libz.so.1`, but after elfpatch rewrites INTERP to xlings glibc, the dynamic linker only searches RPATH paths — none of which contain libz.

## Fix
- Add `zlib` 1.3.1 prebuilt package (built from source via xim-pkgindex-fromsource)
- Add `xim:zlib@1.3.1` as runtime dependency of `llvm` on Linux
- zlib registers `libz.so`/`libz.so.1` with xvm → available in subos lib path

Binary uploaded to xlings-res/zlib on both GitHub and Gitcode.

## Test plan
- [x] Static + isolation tests: 16/16 passed
- [x] zlib binary built from fromsource, verified working