### PR TITLE
feat(libxml2): add prebuilt libxml2; fix llvm lld runtime dep

### DIFF
--- a/pkgs/l/libxml2.lua
+++ b/pkgs/l/libxml2.lua
@@ -1,0 +1,88 @@
+package = {
+    spec = "1",
+    homepage = "https://gitlab.gnome.org/GNOME/libxml2",
+
+    name = "libxml2",
+    description = "XML C parser and toolkit",
+    maintainers = {"GNOME"},
+    licenses = {"MIT"},
+    repo = "https://gitlab.gnome.org/GNOME/libxml2",
+
+    type = "package",
+    archs = {"x86_64"},
+    status = "stable",
+    categories = {"xml", "parsing", "library"},
+    keywords = {"libxml2", "xml", "parser", "lib"},
+
+    xvm_enable = true,
+
+    xpm = {
+        linux = {
+            ["latest"] = { ref = "2.13.5" },
+            ["2.13.5"] = {
+                url = {
+                    GLOBAL = "https://github.com/xlings-res/libxml2/releases/download/2.13.5/libxml2-2.13.5-linux-x86_64.tar.gz",
+                    CN = "https://gitcode.com/xlings-res/libxml2/releases/download/2.13.5/libxml2-2.13.5-linux-x86_64.tar.gz",
+                },
+                sha256 = "f963896ed90c4599d06786f86203620e937a746a6be246065d7a3b01af2a7ed1",
+            },
+        },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.system")
+import("xim.libxpkg.xvm")
+
+local libs = {
+    "libxml2.so", "libxml2.so.2",
+}
+
+function install()
+    local srcdir = "libxml2-" .. pkginfo.version() .. "-linux-x86_64"
+    os.tryrm(pkginfo.install_dir())
+    os.mv(srcdir, pkginfo.install_dir())
+    return true
+end
+
+function config()
+    local libdir = path.join(pkginfo.install_dir(), "lib")
+    local binding = package.name .. "@" .. pkginfo.version()
+
+    xvm.add(package.name)
+
+    for _, lib in ipairs(libs) do
+        local libpath = path.join(libdir, lib)
+        if os.isfile(libpath) then
+            xvm.add(lib, {
+                type = "lib",
+                bindir = libdir,
+                filename = lib,
+                alias = lib,
+                binding = binding,
+            })
+        end
+    end
+
+    -- Copy headers to sysroot
+    local sys_inc = path.join(system.subos_sysrootdir(), "usr/include")
+    local inc_dir = path.join(pkginfo.install_dir(), "include", "libxml2")
+    if os.isdir(inc_dir) and os.isdir(sys_inc) then
+        os.cp(inc_dir, sys_inc)
+    end
+
+    return true
+end
+
+function uninstall()
+    xvm.remove(package.name)
+
+    for _, lib in ipairs(libs) do
+        xvm.remove(lib)
+    end
+
+    local sys_inc = path.join(system.subos_sysrootdir(), "usr/include")
+    os.tryrm(path.join(sys_inc, "libxml2"))
+
+    return true
+end

--- a/pkgs/l/llvm.lua
+++ b/pkgs/l/llvm.lua
@@ -23,6 +23,7 @@ package = {
                 "xim:glibc@2.39",
                 "xim:linux-headers@5.11.1",
                 "xim:zlib@1.3.1",
+                "xim:libxml2@2.13.5",
             },
             ["latest"] = { ref = "20.1.7" },
             ["20.1.7"] = {

--- a/tests/l/test_libxml2.py
+++ b/tests/l/test_libxml2.py
@@ -1,0 +1,67 @@
+"""测试 libxml2 包"""
+import pytest
+from tests.lib.xpkg_parser import parse_xpkg
+from tests.lib.assertions import (
+    assert_required_fields, assert_valid_spec, assert_valid_type,
+    assert_no_typos, assert_no_exec_xvm, assert_no_bashrc_modification,
+    assert_no_direct_path_modification, assert_uses_new_api,
+    assert_xim_add_succeeds, assert_install_succeeds,
+)
+from tests.lib.platform_utils import skip_if_not
+
+PKG = "libxml2"
+PKG_FILE = "pkgs/l/libxml2.lua"
+
+
+@pytest.fixture(scope='module')
+def meta():
+    return parse_xpkg(PKG_FILE)
+
+
+class TestStatic:
+    @pytest.mark.static
+    def test_required_fields(self, meta):
+        assert_required_fields(meta)
+
+    @pytest.mark.static
+    def test_valid_spec(self, meta):
+        assert_valid_spec(meta)
+
+    @pytest.mark.static
+    def test_valid_type(self, meta):
+        assert_valid_type(meta)
+
+    @pytest.mark.static
+    def test_no_typos(self):
+        assert_no_typos(PKG_FILE)
+
+
+class TestIndex:
+    @pytest.mark.index
+    def test_xim_add(self):
+        assert_xim_add_succeeds(PKG_FILE)
+
+
+class TestIsolation:
+    @pytest.mark.isolation
+    def test_no_exec_xvm(self):
+        assert_no_exec_xvm(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_no_bashrc(self):
+        assert_no_bashrc_modification(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_no_path_modification(self):
+        assert_no_direct_path_modification(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_new_api(self):
+        assert_uses_new_api(PKG_FILE)
+
+
+class TestLifecycle:
+    @pytest.mark.lifecycle
+    @skip_if_not('linux')
+    def test_install(self):
+        assert_install_succeeds(PKG)


### PR DESCRIPTION
lld requires libxml2.so.2. Add prebuilt libxml2 2.13.5 and declare as llvm dep. Uploaded to xlings-res (GitHub + Gitcode).