### PR TITLE
fix(bwrap): add missing log import

### DIFF
--- a/pkgs/b/bwrap.lua
+++ b/pkgs/b/bwrap.lua
@@ -47,6 +47,7 @@ package = {
 
 import("xim.libxpkg.pkginfo")
 import("xim.libxpkg.xvm")
+import("xim.libxpkg.log")
 
 function install()
     os.tryrm(pkginfo.install_dir())


### PR DESCRIPTION
Add missing `import("xim.libxpkg.log")` — the setuid log.info() call needs it.