### PR TITLE
feat(mcpp): add 0.0.15

### DIFF
--- a/pkgs/m/mcpp.lua
+++ b/pkgs/m/mcpp.lua
@@ -42,7 +42,8 @@ package = {
     xpm = {
         linux = {
             url_template = "https://github.com/mcpp-community/mcpp/releases/download/v{version}/mcpp-{version}-linux-x86_64.tar.gz",
-            ["latest"] = { ref = "0.0.14" },
+            ["latest"] = { ref = "0.0.15" },
+            ["0.0.15"] = "XLINGS_RES",
             ["0.0.14"] = "XLINGS_RES",
             ["0.0.13"] = "XLINGS_RES",
             ["0.0.11"] = "XLINGS_RES",


### PR DESCRIPTION
## Summary
- Add mcpp 0.0.15 entry (XLINGS_RES sentinel, byte-identical mirror of upstream)
- Bump linux `latest` ref to `0.0.15`

Mirror at https://github.com/xlings-res/mcpp/releases/tag/0.0.15 (sha256 `4d8e591f7a9b4ed8c816cbe99a57401fbc9a8ec9c11acb0718380f762c44831e`, matches upstream `mcpp-community/mcpp` v0.0.15).

## Test plan
- [x] Static + isolation tests pass locally (`pytest tests/m/test_mcpp.py -m "static or isolation"`)
- [x] `xlings install mcpp@0.0.15` succeeds in isolated `XLINGS_HOME=.xlings-home-test/`; installed ELF reports `mcpp 0.0.15`
- [ ] CI install-test on linux passes