### PR TITLE
fix(mcpp): use upstream direct URL for macosx 0.0.16

### DIFF
--- a/pkgs/m/mcpp.lua
+++ b/pkgs/m/mcpp.lua
@@ -58,7 +58,12 @@ package = {
         },
         macosx = {
             ["latest"] = { ref = "0.0.16" },
-            ["0.0.16"] = "XLINGS_RES",
+            ["0.0.16"] = {
+                url = {
+                    GLOBAL = "https://github.com/mcpp-community/mcpp/releases/download/v0.0.16/mcpp-0.0.16-macosx-arm64.tar.gz",
+                },
+                sha256 = "86bd16bff530b11e09270d5bbf6d04e5acf55b53453c7a2884d4d2b6fa47b399",
+            },
         },
     },
 }


### PR DESCRIPTION
## Summary
- Replace `XLINGS_RES` sentinel with upstream direct URL + sha256 for macosx 0.0.16
- Transitional approach until gitcode mirror is set up

## Test plan
- [x] Static + isolation tests pass (8/8)
- [ ] CI macos-install-test passes with new URL