### PR TITLE
fix(mcpp): update macosx 0.0.16 URL and sha256

### DIFF
--- a/pkgs/m/mcpp.lua
+++ b/pkgs/m/mcpp.lua
@@ -60,9 +60,9 @@ package = {
             ["latest"] = { ref = "0.0.16" },
             ["0.0.16"] = {
                 url = {
-                    GLOBAL = "https://github.com/mcpp-community/mcpp/releases/download/v0.0.16/mcpp-0.0.16-macosx-arm64.tar.gz",
+                    GLOBAL = "https://github.com/xlings-res/mcpp/releases/download/0.0.16/mcpp-0.0.16-macosx-arm64.tar.gz",
                 },
-                sha256 = "86bd16bff530b11e09270d5bbf6d04e5acf55b53453c7a2884d4d2b6fa47b399",
+                sha256 = "d56534c97b40cbc1db474d1c40a8f928908358f9e7efa3fcd1377e391f8d2632",
             },
         },
     },


### PR DESCRIPTION
## Summary
- Switch macosx 0.0.16 URL from upstream direct to xlings-res mirror
- Update sha256 to `d56534c97b40cbc1db474d1c40a8f928908358f9e7efa3fcd1377e391f8d2632`

## Test plan
- [ ] CI macos-install-test passes