### PR TITLE
fix(mcpp): switch macosx 0.0.16 to XLINGS_RES

### DIFF
--- a/pkgs/m/mcpp.lua
+++ b/pkgs/m/mcpp.lua
@@ -58,12 +58,7 @@ package = {
         },
         macosx = {
             ["latest"] = { ref = "0.0.16" },
-            ["0.0.16"] = {
-                url = {
-                    GLOBAL = "https://github.com/xlings-res/mcpp/releases/download/0.0.16/mcpp-0.0.16-macosx-arm64.tar.gz",
-                },
-                sha256 = "9067da8ff79a66d3c40605ca16c1148db651dab46ab1ebecd13f563c543670b6",
-            },
+            ["0.0.16"] = "XLINGS_RES",
         },
     },
 }


### PR DESCRIPTION
## Summary
- Switch macosx 0.0.16 from explicit URL to XLINGS_RES sentinel (gh/gtc mirrors ready)