### PR TITLE
feat(media-crawler): add MediaCrawler package

### DIFF
--- a/pkgs/m/media-crawler.lua
+++ b/pkgs/m/media-crawler.lua
@@ -31,7 +31,6 @@ package = {
             },
         },
         macosx = {
-            deps = {"python", "uv"},
             ["latest"] = { ref = "2026.4.30" },
             ["2026.4.30"] = {
                 url = "https://github.com/NanmiCoder/MediaCrawler/archive/f328ee35b55e25e8aaeb9c847fe8b622e3f3447f.tar.gz",

--- a/pkgs/m/media-crawler.lua
+++ b/pkgs/m/media-crawler.lua
@@ -2,7 +2,7 @@ package = {
     spec = "1",
 
     name = "media-crawler",
-    description = "Multi-platform social media scraper (XHS, Douyin, Kuaishou, Bilibili, Weibo, Tieba, Zhihu) using Playwright",
+    description = "Multi-platform social media crawler (XHS, Douyin, Kuaishou, Bilibili, Weibo, Tieba, Zhihu) using Playwright",
 
     authors = {"NanmiCoder"},
     maintainers = {"NanmiCoder"},
@@ -23,7 +23,7 @@ package = {
     -- Requires Python >= 3.11 and Node.js >= 16 at runtime.
     xpm = {
         linux = {
-            deps = {"python"},
+            deps = {"python", "uv"},
             ["latest"] = { ref = "2026.4.30" },
             ["2026.4.30"] = {
                 url = "https://github.com/NanmiCoder/MediaCrawler/archive/f328ee35b55e25e8aaeb9c847fe8b622e3f3447f.tar.gz",
@@ -31,7 +31,7 @@ package = {
             },
         },
         macosx = {
-            deps = {"python"},
+            deps = {"python", "uv"},
             ["latest"] = { ref = "2026.4.30" },
             ["2026.4.30"] = {
                 url = "https://github.com/NanmiCoder/MediaCrawler/archive/f328ee35b55e25e8aaeb9c847fe8b622e3f3447f.tar.gz",
@@ -48,38 +48,27 @@ import("xim.libxpkg.system")
 function __source_dir()
     local archive = pkginfo.install_file()
     local dir = path.directory(archive)
-    -- GitHub archive extracts to <repo>-<full_sha>/
     return path.join(dir, "MediaCrawler-f328ee35b55e25e8aaeb9c847fe8b622e3f3447f")
 end
 
 function install()
     os.tryrm(pkginfo.install_dir())
+    os.cp(__source_dir(), pkginfo.install_dir())
 
-    -- Create venv and install dependencies
-    system.exec(string.format([[python3 -m venv "%s"]], pkginfo.install_dir()))
-    local venv_pip = path.join(pkginfo.install_dir(), "bin", "pip")
-    if os.host() == "windows" then
-        venv_pip = path.join(pkginfo.install_dir(), "Scripts", "pip.exe")
-    end
+    -- Use uv to create venv and sync dependencies
+    system.exec(string.format([[cd "%s" && uv venv && uv sync]], pkginfo.install_dir()))
 
-    system.exec(string.format([["%s" install --upgrade pip]], venv_pip))
-    system.exec(string.format([["%s" install -r "%s/requirements.txt"]], venv_pip, __source_dir()))
-
-    -- Copy source into install dir
-    os.cp(path.join(__source_dir(), "*"), path.join(pkginfo.install_dir(), "src"))
-
-    -- Install playwright browsers
-    local venv_playwright = path.join(pkginfo.install_dir(), "bin", "playwright")
-    system.exec(string.format([["%s" install chromium]], venv_playwright))
+    -- Install playwright chromium browser
+    system.exec(string.format([[cd "%s" && uv run playwright install chromium]], pkginfo.install_dir()))
 
     -- Create launcher script
-    local launcher = path.join(pkginfo.install_dir(), "bin", "media-crawler")
-    local venv_python = path.join(pkginfo.install_dir(), "bin", "python")
-    local src_dir = path.join(pkginfo.install_dir(), "src")
+    local bindir = path.join(pkginfo.install_dir(), "bin")
+    os.mkdir(bindir)
+    local launcher = path.join(bindir, "media-crawler")
     io.writefile(launcher, string.format([[#!/bin/bash
 cd "%s"
-exec "%s" main.py "$@"
-]], src_dir, venv_python))
+exec uv run main.py "$@"
+]], pkginfo.install_dir()))
     os.exec(string.format([[chmod +x "%s"]], launcher))
 
     return true

--- a/pkgs/m/media-crawler.lua
+++ b/pkgs/m/media-crawler.lua
@@ -1,0 +1,98 @@
+package = {
+    spec = "1",
+
+    name = "media-crawler",
+    description = "Multi-platform social media scraper (XHS, Douyin, Kuaishou, Bilibili, Weibo, Tieba, Zhihu) using Playwright",
+
+    authors = {"NanmiCoder"},
+    maintainers = {"NanmiCoder"},
+    licenses = {"MIT"},
+    repo = "https://github.com/NanmiCoder/MediaCrawler",
+    homepage = "https://github.com/NanmiCoder/MediaCrawler",
+
+    type = "package",
+    archs = {"x86_64", "arm64"},
+    status = "dev",
+    categories = {"tools", "crawler", "data"},
+    keywords = {"crawler", "scraper", "social-media", "xiaohongshu", "douyin", "bilibili", "weibo", "playwright"},
+
+    programs = {"media-crawler"},
+    xvm_enable = true,
+
+    -- Source archive from GitHub (pinned to commit).
+    -- Requires Python >= 3.11 and Node.js >= 16 at runtime.
+    xpm = {
+        linux = {
+            deps = {"python"},
+            ["latest"] = { ref = "2026.4.30" },
+            ["2026.4.30"] = {
+                url = "https://github.com/NanmiCoder/MediaCrawler/archive/f328ee35b55e25e8aaeb9c847fe8b622e3f3447f.tar.gz",
+                sha256 = "f11b00a9425cc89488054a395e27fc86d846372854b2d5d684cec6b5ce6576b2",
+            },
+        },
+        macosx = {
+            deps = {"python"},
+            ["latest"] = { ref = "2026.4.30" },
+            ["2026.4.30"] = {
+                url = "https://github.com/NanmiCoder/MediaCrawler/archive/f328ee35b55e25e8aaeb9c847fe8b622e3f3447f.tar.gz",
+                sha256 = "f11b00a9425cc89488054a395e27fc86d846372854b2d5d684cec6b5ce6576b2",
+            },
+        },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+import("xim.libxpkg.system")
+
+function __source_dir()
+    local archive = pkginfo.install_file()
+    local dir = path.directory(archive)
+    -- GitHub archive extracts to <repo>-<full_sha>/
+    return path.join(dir, "MediaCrawler-f328ee35b55e25e8aaeb9c847fe8b622e3f3447f")
+end
+
+function install()
+    os.tryrm(pkginfo.install_dir())
+
+    -- Create venv and install dependencies
+    system.exec(string.format([[python3 -m venv "%s"]], pkginfo.install_dir()))
+    local venv_pip = path.join(pkginfo.install_dir(), "bin", "pip")
+    if os.host() == "windows" then
+        venv_pip = path.join(pkginfo.install_dir(), "Scripts", "pip.exe")
+    end
+
+    system.exec(string.format([["%s" install --upgrade pip]], venv_pip))
+    system.exec(string.format([["%s" install -r "%s/requirements.txt"]], venv_pip, __source_dir()))
+
+    -- Copy source into install dir
+    os.cp(path.join(__source_dir(), "*"), path.join(pkginfo.install_dir(), "src"))
+
+    -- Install playwright browsers
+    local venv_playwright = path.join(pkginfo.install_dir(), "bin", "playwright")
+    system.exec(string.format([["%s" install chromium]], venv_playwright))
+
+    -- Create launcher script
+    local launcher = path.join(pkginfo.install_dir(), "bin", "media-crawler")
+    local venv_python = path.join(pkginfo.install_dir(), "bin", "python")
+    local src_dir = path.join(pkginfo.install_dir(), "src")
+    io.writefile(launcher, string.format([[#!/bin/bash
+cd "%s"
+exec "%s" main.py "$@"
+]], src_dir, venv_python))
+    os.exec(string.format([[chmod +x "%s"]], launcher))
+
+    return true
+end
+
+function config()
+    xvm.add("media-crawler", {
+        bindir = path.join(pkginfo.install_dir(), "bin"),
+    })
+    return true
+end
+
+function uninstall()
+    xvm.remove("media-crawler")
+    return true
+end

--- a/tests/m/test_media_crawler.py
+++ b/tests/m/test_media_crawler.py
@@ -1,0 +1,59 @@
+"""测试 media-crawler 包"""
+import pytest
+from tests.lib.xpkg_parser import parse_xpkg
+from tests.lib.assertions import (
+    assert_required_fields, assert_valid_spec, assert_valid_type,
+    assert_no_typos, assert_no_exec_xvm, assert_no_bashrc_modification,
+    assert_no_direct_path_modification, assert_uses_new_api,
+    assert_xim_add_succeeds,
+)
+
+PKG = "media-crawler"
+PKG_FILE = "pkgs/m/media-crawler.lua"
+
+
+@pytest.fixture(scope='module')
+def meta():
+    return parse_xpkg(PKG_FILE)
+
+
+class TestStatic:
+    @pytest.mark.static
+    def test_required_fields(self, meta):
+        assert_required_fields(meta)
+
+    @pytest.mark.static
+    def test_valid_spec(self, meta):
+        assert_valid_spec(meta)
+
+    @pytest.mark.static
+    def test_valid_type(self, meta):
+        assert_valid_type(meta)
+
+    @pytest.mark.static
+    def test_no_typos(self):
+        assert_no_typos(PKG_FILE)
+
+
+class TestIndex:
+    @pytest.mark.index
+    def test_xim_add(self):
+        assert_xim_add_succeeds(PKG_FILE)
+
+
+class TestIsolation:
+    @pytest.mark.isolation
+    def test_no_exec_xvm(self):
+        assert_no_exec_xvm(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_no_bashrc(self):
+        assert_no_bashrc_modification(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_no_path_modification(self):
+        assert_no_direct_path_modification(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_new_api(self):
+        assert_uses_new_api(PKG_FILE)


### PR DESCRIPTION
## Summary
- Add [MediaCrawler](https://github.com/NanmiCoder/MediaCrawler) package support
- Multi-platform social media scraper (XHS, Douyin, Kuaishou, Bilibili, Weibo, Tieba, Zhihu)
- Uses Playwright browser automation, Python venv installation
- Pinned to latest commit f328ee3 (2026-04-30), versioned as `2026.4.30`
- Supports linux and macosx

## Installation model
- Downloads source tarball from GitHub
- Creates Python venv, installs requirements.txt
- Installs Playwright chromium browser
- Creates `media-crawler` launcher script
- Registers via xvm

## Dependencies
- Python >= 3.11 (declared as `deps = {"python"}`)
- Node.js >= 16 (runtime dependency for pyexecjs)

## Test plan
- [x] Static + isolation tests pass (8/8)
- [ ] CI static-and-isolation checks pass