### PR TITLE
fix(media-crawler): graceful uv→pip fallback

### DIFF
--- a/pkgs/m/media-crawler.lua
+++ b/pkgs/m/media-crawler.lua
@@ -50,24 +50,54 @@ function __source_dir()
     return path.join(dir, "MediaCrawler-f328ee35b55e25e8aaeb9c847fe8b622e3f3447f")
 end
 
+function __has_uv()
+    return os.iorun("uv --version") ~= nil
+end
+
 function install()
     os.tryrm(pkginfo.install_dir())
     os.cp(__source_dir(), pkginfo.install_dir())
 
-    -- Use uv to create venv and sync dependencies
-    system.exec(string.format([[cd "%s" && uv venv && uv sync]], pkginfo.install_dir()))
+    local installdir = pkginfo.install_dir()
 
-    -- Install playwright chromium browser
-    system.exec(string.format([[cd "%s" && uv run playwright install chromium]], pkginfo.install_dir()))
+    -- Try uv first; fall back to pip if uv fails or is absent
+    local use_uv = __has_uv()
+    if use_uv then
+        local ok = os.exec(string.format(
+            [[cd "%s" && UV_INDEX_URL=https://pypi.org/simple/ uv venv && UV_INDEX_URL=https://pypi.org/simple/ uv sync]],
+            installdir), {try = true})
+        if not ok then use_uv = false end
+    end
+
+    if not use_uv then
+        system.exec(string.format([[cd "%s" && python3 -m venv .venv]], installdir))
+        local pip = path.join(installdir, ".venv", "bin", "pip")
+        system.exec(string.format([["%s" install --upgrade pip]], pip))
+        system.exec(string.format([["%s" install -r "%s/requirements.txt"]], pip, installdir))
+    end
+
+    -- Install playwright chromium
+    if use_uv then
+        system.exec(string.format([[cd "%s" && uv run playwright install chromium]], installdir))
+    else
+        system.exec(string.format([[cd "%s" && .venv/bin/playwright install chromium]], installdir))
+    end
 
     -- Create launcher script
-    local bindir = path.join(pkginfo.install_dir(), "bin")
+    local bindir = path.join(installdir, "bin")
     os.mkdir(bindir)
     local launcher = path.join(bindir, "media-crawler")
-    io.writefile(launcher, string.format([[#!/bin/bash
+    if use_uv then
+        io.writefile(launcher, string.format([[#!/bin/bash
 cd "%s"
 exec uv run main.py "$@"
-]], pkginfo.install_dir()))
+]], installdir))
+    else
+        io.writefile(launcher, string.format([[#!/bin/bash
+cd "%s"
+exec .venv/bin/python main.py "$@"
+]], installdir))
+    end
     os.exec(string.format([[chmod +x "%s"]], launcher))
 
     return true


### PR DESCRIPTION
## Summary
- Try `uv venv && uv sync` first with PyPI index override
- If uv fails (e.g. missing/incompatible), automatically fall back to `python3 -m venv` + `pip install -r requirements.txt`
- Remove macosx deps to avoid catalog resolution issues on older xlings CI
- Fixes macos-install-test failure from PR #206

## Test plan
- [x] Static + isolation tests pass (8/8)
- [x] linux-install-test passed with uv path
- [x] macos-install-test passed with pip fallback path