### PR TITLE
fix(license): correct media-crawler and add rustup license

### DIFF
--- a/pkgs/m/media-crawler.lua
+++ b/pkgs/m/media-crawler.lua
@@ -6,7 +6,7 @@ package = {
 
     authors = {"NanmiCoder"},
     maintainers = {"NanmiCoder"},
-    licenses = {"MIT"},
+    licenses = {"NON-COMMERCIAL LEARNING LICENSE 1.1"},
     repo = "https://github.com/NanmiCoder/MediaCrawler",
     homepage = "https://github.com/NanmiCoder/MediaCrawler",
 

--- a/pkgs/r/rustup.lua
+++ b/pkgs/r/rustup.lua
@@ -9,6 +9,7 @@ package = {
     name = "rustup",
     description = "An installer init tool for Rustup, the Rust toolchain installer",
 
+    licenses = {"MIT", "Apache-2.0"},
     repo = "https://github.com/rust-lang/rustup",
     docs = "https://rust-lang.github.io/rustup/installation/other.html",
 


### PR DESCRIPTION
## Summary
- **media-crawler**: license was incorrectly declared as `MIT`, actual upstream license is `NON-COMMERCIAL LEARNING LICENSE 1.1`
- **rustup**: added missing `MIT, Apache-2.0` license field

## Notes
- seeme-server/seeme-report: upstream repo has no LICENSE file (`license: null` via GitHub API), kept as-is
- Microsoft packages (msvc, vs-buildtools, wsl-ubuntu): proprietary/unknown, not modified

## Test plan
- [x] Verified media-crawler license against https://github.com/NanmiCoder/MediaCrawler/blob/main/LICENSE
- [x] Verified rustup license against https://github.com/rust-lang/rustup (MIT/Apache-2.0 dual license)