### PR TITLE
feat(mcpp): add 0.0.17 version support

### DIFF
--- a/pkgs/m/mcpp.lua
+++ b/pkgs/m/mcpp.lua
@@ -39,7 +39,8 @@ package = {
     xpm = {
         linux = {
             url_template = "https://github.com/mcpp-community/mcpp/releases/download/v{version}/mcpp-{version}-linux-x86_64.tar.gz",
-            ["latest"] = { ref = "0.0.16" },
+            ["latest"] = { ref = "0.0.17" },
+            ["0.0.17"] = "XLINGS_RES",
             ["0.0.16"] = "XLINGS_RES",
             ["0.0.15"] = "XLINGS_RES",
             ["0.0.14"] = "XLINGS_RES",
@@ -57,7 +58,8 @@ package = {
             ["0.0.1"] = "XLINGS_RES",
         },
         macosx = {
-            ["latest"] = { ref = "0.0.16" },
+            ["latest"] = { ref = "0.0.17" },
+            ["0.0.17"] = "XLINGS_RES",
             ["0.0.16"] = "XLINGS_RES",
         },
     },


### PR DESCRIPTION
## Summary
- Add mcpp 0.0.17 to linux and macosx platforms using XLINGS_RES mode
- Release artifacts mirrored to xlings-res/mcpp on both GitHub and GitCode

## Assets
- `mcpp-0.0.17-linux-x86_64.tar.gz` (sha256: `4305fba40b538d8d6045551d8ff40ceb6bcce4bddca7133bd37fe2e26bf2bc69`)
- `mcpp-0.0.17-macosx-arm64.tar.gz` (sha256: `7acf32d37d83b6a605662c53231667831ddfb6548785319d810ec64604dce04c`)

## Mirrors
- GitHub: https://github.com/xlings-res/mcpp/releases/tag/0.0.17
- GitCode: https://gitcode.com/xlings-res/mcpp/releases/tag/0.0.17