### PR TITLE
feat(mcpp): add Windows x86_64 support for 0.0.17

### DIFF
--- a/pkgs/m/mcpp.lua
+++ b/pkgs/m/mcpp.lua
@@ -62,6 +62,10 @@ package = {
             ["0.0.17"] = "XLINGS_RES",
             ["0.0.16"] = "XLINGS_RES",
         },
+        windows = {
+            ["latest"] = { ref = "0.0.17" },
+            ["0.0.17"] = "XLINGS_RES",
+        },
     },
 }
 
@@ -71,6 +75,7 @@ import("xim.libxpkg.xvm")
 function install()
     local mcpp_dir = pkginfo.install_file()
         :replace(".tar.gz", "")
+        :replace(".zip", "")
     os.tryrm(pkginfo.install_dir())
     os.mv(mcpp_dir, pkginfo.install_dir())
     return true


### PR DESCRIPTION
## Summary
- Add Windows x86_64 platform support for mcpp 0.0.17 using XLINGS_RES
- Update `install()` to handle `.zip` extension (Windows uses zip, Linux/macOS use tar.gz)
- Mirrored `mcpp-0.0.17-windows-x86_64.zip` to xlings-res/mcpp on both GitHub and GitCode

## Mirrors
- GitHub: https://github.com/xlings-res/mcpp/releases/tag/0.0.17
- GitCode: https://gitcode.com/xlings-res/mcpp/releases/tag/0.0.17

## XLINGS_RES URL Resolution
xlings engine generates: `{server}/mcpp/releases/download/0.0.17/mcpp-0.0.17-windows-x86_64.zip`
(confirmed from source: Windows platform uses `.zip` extension automatically)

## Test plan
- [x] L0 static + L2 isolation tests pass locally
- [x] `has_windows: true` verified via parse-xpkg-meta.py
- [ ] CI: windows-test (install/uninstall cycle)
- [ ] CI: linux/macos tests (no regression)