### PR TITLE
feat(mcpp): add Windows x86_64 support for 0.0.17 with XLINGS_RES

### DIFF
--- a/pkgs/m/mcpp.lua
+++ b/pkgs/m/mcpp.lua
@@ -62,6 +62,10 @@ package = {
             ["0.0.17"] = "XLINGS_RES",
             ["0.0.16"] = "XLINGS_RES",
         },
+        windows = {
+            ["latest"] = { ref = "0.0.17" },
+            ["0.0.17"] = "XLINGS_RES",
+        },
     },
 }
 
@@ -71,6 +75,7 @@ import("xim.libxpkg.xvm")
 function install()
     local mcpp_dir = pkginfo.install_file()
         :replace(".tar.gz", "")
+        :replace(".zip", "")
     os.tryrm(pkginfo.install_dir())
     os.mv(mcpp_dir, pkginfo.install_dir())
     return true


### PR DESCRIPTION
- Add windows platform with 0.0.17 using XLINGS_RES
- Update install() to handle .zip extension on Windows
- Mirrored mcpp-0.0.17-windows-x86_64.zip to xlings-res/mcpp on GitHub and GitCode