### PR TITLE
fix(llvm): switch to XLINGS_RES naming, remove sha256

### DIFF
--- a/pkgs/l/llvm-tools.lua
+++ b/pkgs/l/llvm-tools.lua
@@ -21,20 +21,20 @@ package = {
             ["latest"] = { ref = "20.1.7" },
             ["20.1.7"] = {
                 url = {
-                    GLOBAL = "https://github.com/xlings-res/llvm/releases/download/20.1.7/llvm-tools-20.1.7-linux-x86_64.tar.xz",
-                    CN = "https://gitcode.com/xlings-res/llvm/releases/download/20.1.7/llvm-tools-20.1.7-linux-x86_64.tar.xz",
+                    GLOBAL = "https://github.com/xlings-res/llvm/releases/download/20.1.7/llvm-tools-20.1.7-linux-x86_64.tar.gz",
+                    CN = "https://gitcode.com/xlings-res/llvm/releases/download/20.1.7/llvm-tools-20.1.7-linux-x86_64.tar.gz",
                 },
-                sha256 = "c438945f6fc10dafc539158ef8c93684fef1f2d88dee864396f88557d4a460c0",
+                sha256 = nil,
             },
         },
         windows = {
             ["latest"] = { ref = "20.1.7" },
             ["20.1.7"] = {
                 url = {
-                    GLOBAL = "https://github.com/xlings-res/llvm/releases/download/20.1.7/llvm-tools-20.1.7-windows-x86_64.tar.xz",
-                    CN = "https://gitcode.com/xlings-res/llvm/releases/download/20.1.7/llvm-tools-20.1.7-windows-x86_64.tar.xz",
+                    GLOBAL = "https://github.com/xlings-res/llvm/releases/download/20.1.7/llvm-tools-20.1.7-windows-x86_64.zip",
+                    CN = "https://gitcode.com/xlings-res/llvm/releases/download/20.1.7/llvm-tools-20.1.7-windows-x86_64.zip",
                 },
-                sha256 = "021047864f767747e4131a716357472e4a8343f11957c34c2a41d56a227d35f4",
+                sha256 = nil,
             },
         },
     },

--- a/pkgs/l/llvm.lua
+++ b/pkgs/l/llvm.lua
@@ -26,13 +26,7 @@ package = {
                 "xim:libxml2@2.13.5",
             },
             ["latest"] = { ref = "20.1.7" },
-            ["20.1.7"] = {
-                url = {
-                    GLOBAL = "https://github.com/xlings-res/llvm/releases/download/20.1.7/llvm-20.1.7-linux-x86_64.tar.xz",
-                    CN = "https://gitcode.com/xlings-res/llvm/releases/download/20.1.7/llvm-20.1.7-linux-x86_64.tar.xz",
-                },
-                sha256 = "b28ff325888d45f81cf76cd92655aabcc000235c6e89c34d5a6bb73bf5865fb2",
-            },
+            ["20.1.7"] = "XLINGS_RES",
         },
         macosx = {
             ["latest"] = { ref = "20.1.7" },
@@ -43,13 +37,7 @@ package = {
         },
         windows = {
             ["latest"] = { ref = "20.1.7" },
-            ["20.1.7"] = {
-                url = {
-                    GLOBAL = "https://github.com/xlings-res/llvm/releases/download/20.1.7/llvm-20.1.7-windows-x86_64.tar.xz",
-                    CN = "https://gitcode.com/xlings-res/llvm/releases/download/20.1.7/llvm-20.1.7-windows-x86_64.tar.xz",
-                },
-                sha256 = "1900412c31f1ab4165fefc31460623031d0ee4f8f1c03072b8026d1f04f656b9",
-            },
+            ["20.1.7"] = "XLINGS_RES",
         },
     },
 }


### PR DESCRIPTION
## Summary
- **llvm**: Linux/Windows switched to `XLINGS_RES` (auto URL resolution, no sha256)
- **llvm-tools**: URLs updated to `.tar.gz`/`.zip` format, sha256 removed
  - Cannot use XLINGS_RES directly (package name `llvm-tools` ≠ repo name `llvm`)
- **macOS**: unchanged (custom `LLVM-20.1.7-macOS-ARM64.tar.xz` naming)

## xlings-res Assets
All repacked from `.tar.xz` to XLINGS_RES convention:
- `llvm-20.1.7-linux-x86_64.tar.gz` (267MB)
- `llvm-20.1.7-windows-x86_64.zip` (222MB, includes clang-scan-deps.exe)
- `llvm-tools-20.1.7-linux-x86_64.tar.gz` (108MB)
- `llvm-tools-20.1.7-windows-x86_64.zip` (54MB)

Uploaded to both GitHub and GitCode xlings-res/llvm.