### PR TITLE
feat(vc6): add Visual C++ 6.0 portable package

### DIFF
--- a/pkgs/v/vc6.lua
+++ b/pkgs/v/vc6.lua
@@ -30,7 +30,7 @@ import("xim.libxpkg.system")
 import("xim.libxpkg.log")
 
 local SHORTCUT_NAME = "Visual C++ 6.0"
-local MSDEV_REL = path.join("Common", "MSDev98", "Bin", "MSDEV.EXE")
+local MSDEV_REL = path.join("Common", "MSDev98", "BIN", "MSDEV.EXE")
 
 function installed()
     local msdev = path.join(pkginfo.install_dir(), MSDEV_REL)
@@ -55,7 +55,7 @@ function config()
 
     -- Register IDE launcher to xvm
     xvm.add("msdev", {
-        bindir = path.join(pkginfo.install_dir(), "Common", "MSDev98", "Bin"),
+        bindir = path.join(pkginfo.install_dir(), "Common", "MSDev98", "BIN"),
     })
 
     -- Create desktop + start menu shortcut
@@ -90,9 +90,10 @@ function __setup_compat_mode(exe_path)
         [[reg add "HKCU\Software\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Layers" /v "%s" /d "~ WINXPSP3 RUNASADMIN" /f]],
         exe_path
     )
-    try { function() os.run(cmd) end, catch = function(e)
-        log.warn("Failed to set compat mode: %s", tostring(e))
-    end }
+    local ok, err = pcall(os.run, cmd)
+    if not ok then
+        log.warn("Failed to set compat mode: %s", tostring(err))
+    end
 end
 
 function __cleanup_compat_mode(exe_path)
@@ -100,7 +101,8 @@ function __cleanup_compat_mode(exe_path)
         [[reg delete "HKCU\Software\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Layers" /v "%s" /f]],
         exe_path
     )
-    try { function() os.run(cmd) end, catch = function(e)
-        log.warn("Failed to clean compat registry: %s", tostring(e))
-    end }
+    local ok, err = pcall(os.run, cmd)
+    if not ok then
+        log.warn("Failed to clean compat registry: %s", tostring(err))
+    end
 end

--- a/pkgs/v/vc6.lua
+++ b/pkgs/v/vc6.lua
@@ -20,6 +20,13 @@ package = {
             deps = { "shortcut-tool" },
             ["latest"] = { ref = "6.0" },
             ["6.0"] = "XLINGS_RES",
+            -- xim install vc6@chinese  (简体中文版)
+            ["chinese"] = {
+                url = {
+                    GLOBAL = "https://github.com/xlings-res/vc6/releases/download/6.0-chs/vc6-6.0-chs-windows-x86_64.zip",
+                    CN = "https://gitcode.com/xlings-res/vc6/releases/download/6.0-chs/vc6-6.0-chs-windows-x86_64.zip",
+                },
+            },
         },
     },
 }
@@ -29,13 +36,18 @@ import("xim.libxpkg.xvm")
 import("xim.libxpkg.system")
 import("xim.libxpkg.log")
 
-local SHORTCUT_NAME = "Visual C++ 6.0"
+local function __shortcut_name()
+    if pkginfo.version() == "chinese" then
+        return "Visual C++ 6.0 中文版"
+    end
+    return "Visual C++ 6.0"
+end
 local MSDEV_REL = path.join("Common", "MSDev98", "BIN", "MSDEV.EXE")
 
 function installed()
     local msdev = path.join(pkginfo.install_dir(), MSDEV_REL)
     if os.isfile(msdev) then
-        return "6.0"
+        return pkginfo.version()
     end
     return nil
 end
@@ -61,7 +73,7 @@ function config()
     -- Create desktop + start menu shortcut
     system.exec(string.format(
         [[shortcut-tool create --name "%s" --target "%s" --icon "%s"]],
-        SHORTCUT_NAME, msdev_path, msdev_path
+        __shortcut_name(), msdev_path, msdev_path
     ))
 
     log.info("VC++ 6.0 installed with Windows XP SP3 compatibility mode")
@@ -72,7 +84,7 @@ end
 function uninstall()
     -- Remove shortcut
     system.exec(string.format(
-        [[shortcut-tool remove --name "%s"]], SHORTCUT_NAME
+        [[shortcut-tool remove --name "%s"]], __shortcut_name()
     ))
 
     -- Unregister from xvm

--- a/pkgs/v/vc6.lua
+++ b/pkgs/v/vc6.lua
@@ -102,7 +102,7 @@ function __setup_compat_mode(exe_path)
         [[reg add "HKCU\Software\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Layers" /v "%s" /d "~ WINXPSP3 RUNASADMIN" /f]],
         exe_path
     )
-    local ok, err = pcall(os.run, cmd)
+    local ok, err = pcall(system.exec, cmd)
     if not ok then
         log.warn("Failed to set compat mode: %s", tostring(err))
     end
@@ -113,7 +113,7 @@ function __cleanup_compat_mode(exe_path)
         [[reg delete "HKCU\Software\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Layers" /v "%s" /f]],
         exe_path
     )
-    local ok, err = pcall(os.run, cmd)
+    local ok, err = pcall(system.exec, cmd)
     if not ok then
         log.warn("Failed to clean compat registry: %s", tostring(err))
     end

--- a/pkgs/v/vc6.lua
+++ b/pkgs/v/vc6.lua
@@ -1,0 +1,106 @@
+package = {
+    spec = "1",
+
+    name = "vc6",
+    description = "Visual C++ 6.0: Classic C/C++ IDE (portable for Windows 10/11)",
+    homepage = "https://en.wikipedia.org/wiki/Visual_C%2B%2B#32-bit_versions",
+    licenses = {"Proprietary"},
+
+    -- xim pkg info
+    type = "package",
+    archs = {"x86_64"},
+    status = "stable",
+    categories = {"ide", "c", "c++"},
+    keywords = {"visual-c++", "vc6", "msvc6", "vc++6.0"},
+
+    programs = { "msdev" },
+
+    xpm = {
+        windows = {
+            deps = { "shortcut-tool" },
+            ["latest"] = { ref = "6.0" },
+            ["6.0"] = "XLINGS_RES",
+        },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+import("xim.libxpkg.system")
+import("xim.libxpkg.log")
+
+local SHORTCUT_NAME = "Visual C++ 6.0"
+local MSDEV_REL = path.join("Common", "MSDev98", "Bin", "MSDEV.EXE")
+
+function installed()
+    local msdev = path.join(pkginfo.install_dir(), MSDEV_REL)
+    if os.isfile(msdev) then
+        return "6.0"
+    end
+    return nil
+end
+
+function install()
+    os.tryrm(pkginfo.install_dir())
+    local extracted = pkginfo.install_file():replace(".zip", "")
+    os.mv(extracted, pkginfo.install_dir())
+    return true
+end
+
+function config()
+    local msdev_path = path.join(pkginfo.install_dir(), MSDEV_REL)
+
+    -- Set Windows XP SP3 compatibility mode + RunAsAdmin via registry
+    __setup_compat_mode(msdev_path)
+
+    -- Register IDE launcher to xvm
+    xvm.add("msdev", {
+        bindir = path.join(pkginfo.install_dir(), "Common", "MSDev98", "Bin"),
+    })
+
+    -- Create desktop + start menu shortcut
+    system.exec(string.format(
+        [[shortcut-tool create --name "%s" --target "%s" --icon "%s"]],
+        SHORTCUT_NAME, msdev_path, msdev_path
+    ))
+
+    log.info("VC++ 6.0 installed with Windows XP SP3 compatibility mode")
+
+    return true
+end
+
+function uninstall()
+    -- Remove shortcut
+    system.exec(string.format(
+        [[shortcut-tool remove --name "%s"]], SHORTCUT_NAME
+    ))
+
+    -- Unregister from xvm
+    xvm.remove("msdev")
+
+    -- Clean up compatibility registry entry
+    local msdev_path = path.join(pkginfo.install_dir(), MSDEV_REL)
+    __cleanup_compat_mode(msdev_path)
+
+    return true
+end
+
+function __setup_compat_mode(exe_path)
+    local cmd = string.format(
+        [[reg add "HKCU\Software\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Layers" /v "%s" /d "~ WINXPSP3 RUNASADMIN" /f]],
+        exe_path
+    )
+    try { function() os.run(cmd) end, catch = function(e)
+        log.warn("Failed to set compat mode: %s", tostring(e))
+    end }
+end
+
+function __cleanup_compat_mode(exe_path)
+    local cmd = string.format(
+        [[reg delete "HKCU\Software\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Layers" /v "%s" /f]],
+        exe_path
+    )
+    try { function() os.run(cmd) end, catch = function(e)
+        log.warn("Failed to clean compat registry: %s", tostring(e))
+    end }
+end

--- a/tests/v/test_vc6.py
+++ b/tests/v/test_vc6.py
@@ -1,0 +1,61 @@
+"""测试 vc6 包"""
+import pytest
+from tests.lib.xpkg_parser import parse_xpkg
+from tests.lib.assertions import (
+    assert_required_fields, assert_valid_spec, assert_valid_type,
+    assert_no_typos, assert_no_exec_xvm, assert_no_bashrc_modification,
+    assert_no_direct_path_modification, assert_uses_new_api,
+    assert_xim_add_succeeds, assert_install_succeeds,
+    assert_command_output, assert_xvm_registered,
+)
+from tests.lib.platform_utils import skip_if_not
+
+PKG = "vc6"
+PKG_FILE = "pkgs/v/vc6.lua"
+
+
+@pytest.fixture(scope='module')
+def meta():
+    return parse_xpkg(PKG_FILE)
+
+
+class TestStatic:
+    @pytest.mark.static
+    def test_required_fields(self, meta):
+        assert_required_fields(meta)
+
+    @pytest.mark.static
+    def test_valid_spec(self, meta):
+        assert_valid_spec(meta)
+
+    @pytest.mark.static
+    def test_valid_type(self, meta):
+        assert_valid_type(meta)
+
+    @pytest.mark.static
+    def test_no_typos(self):
+        assert_no_typos(PKG_FILE)
+
+
+class TestIndex:
+    @pytest.mark.index
+    def test_xim_add(self):
+        assert_xim_add_succeeds(PKG_FILE)
+
+
+class TestIsolation:
+    @pytest.mark.isolation
+    def test_no_exec_xvm(self):
+        assert_no_exec_xvm(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_no_bashrc(self):
+        assert_no_bashrc_modification(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_no_path_modification(self):
+        assert_no_direct_path_modification(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_new_api(self):
+        assert_uses_new_api(PKG_FILE)


### PR DESCRIPTION
## Summary
- Add `vc6` package: portable Visual C++ 6.0 IDE for Windows 10/11
- Two versions: `xim install vc6` (English) / `xim install vc6@chinese` (简体中文)
- Auto-sets XP SP3 compatibility mode via registry `AppCompatFlags`
- Creates desktop + start menu shortcuts via `shortcut-tool`
- Clean uninstall: shortcuts + xvm + registry entries
- Resources hosted on xlings-res (GitHub + GitCode), ~49MB per version

## Test plan
- [x] Local pytest: 9/9 passed (static + isolation + index)
- [x] CI pkgindex test: all 4 jobs green (linux, windows, macos, linux-install)
- [x] CI xpkg test: passed
- [x] Windows install/uninstall lifecycle: PASS (msdev.exe shim created, all shims cleaned)