### PR TITLE
feat(mcpp): bump to 0.0.19 for all platforms

### DIFF
--- a/pkgs/m/mcpp.lua
+++ b/pkgs/m/mcpp.lua
@@ -39,7 +39,8 @@ package = {
     xpm = {
         linux = {
             url_template = "https://github.com/mcpp-community/mcpp/releases/download/v{version}/mcpp-{version}-linux-x86_64.tar.gz",
-            ["latest"] = { ref = "0.0.17" },
+            ["latest"] = { ref = "0.0.19" },
+            ["0.0.19"] = "XLINGS_RES",
             ["0.0.17"] = "XLINGS_RES",
             ["0.0.16"] = "XLINGS_RES",
             ["0.0.15"] = "XLINGS_RES",
@@ -58,12 +59,14 @@ package = {
             ["0.0.1"] = "XLINGS_RES",
         },
         macosx = {
-            ["latest"] = { ref = "0.0.17" },
+            ["latest"] = { ref = "0.0.19" },
+            ["0.0.19"] = "XLINGS_RES",
             ["0.0.17"] = "XLINGS_RES",
             ["0.0.16"] = "XLINGS_RES",
         },
         windows = {
-            ["latest"] = { ref = "0.0.17" },
+            ["latest"] = { ref = "0.0.19" },
+            ["0.0.19"] = "XLINGS_RES",
             ["0.0.17"] = "XLINGS_RES",
         },
     },


### PR DESCRIPTION
## Summary
- Bump mcpp latest to 0.0.19 (linux, macosx, windows)
- Resources mirrored to xlings-res/mcpp on GitHub and GitCode

## Test plan
- [x] Local pytest: static + isolation + index all pass
- [x] CI: awaiting green