### PR TITLE
feat(vc6): Chinese version as default, fix uninstall

### DIFF
--- a/pkgs/v/vc6.lua
+++ b/pkgs/v/vc6.lua
@@ -18,15 +18,17 @@ package = {
     xpm = {
         windows = {
             deps = { "shortcut-tool" },
-            ["latest"] = { ref = "6.0" },
-            ["6.0"] = "XLINGS_RES",
-            -- xim install vc6@chinese  (简体中文版)
+            -- default: Chinese simplified; use vc6@english for English
+            ["latest"] = { ref = "chinese" },
             ["chinese"] = {
                 url = {
-                    GLOBAL = "https://github.com/xlings-res/vc6/releases/download/6.0-chs/vc6-6.0-chs-windows-x86_64.zip",
-                    CN = "https://gitcode.com/xlings-res/vc6/releases/download/6.0-chs/vc6-6.0-chs-windows-x86_64.zip",
+                    GLOBAL = "https://github.com/xlings-res/vc6/releases/download/6.0-chs/vc6-6.0-chinese-windows-x86_64.zip",
+                    CN = "https://gitcode.com/xlings-res/vc6/releases/download/6.0-chs/vc6-6.0-chinese-windows-x86_64.zip",
                 },
             },
+            ["english"] = "XLINGS_RES",
+            -- keep "6.0" as alias for english (backward compat)
+            ["6.0"] = "XLINGS_RES",
         },
     },
 }
@@ -37,10 +39,10 @@ import("xim.libxpkg.system")
 import("xim.libxpkg.log")
 
 local function __shortcut_name()
-    if pkginfo.version() == "chinese" then
-        return "Visual C++ 6.0 中文版"
+    if pkginfo.version() == "english" or pkginfo.version() == "6.0" then
+        return "Visual C++ 6.0"
     end
-    return "Visual C++ 6.0"
+    return "Visual C++ 6.0 中文版"
 end
 local MSDEV_REL = path.join("Common", "MSDev98", "BIN", "MSDEV.EXE")
 
@@ -65,9 +67,13 @@ function config()
     -- Set Windows XP SP3 compatibility mode + RunAsAdmin via registry
     __setup_compat_mode(msdev_path)
 
+    -- Register package.name as binding root
+    xvm.add(package.name)
+
     -- Register IDE launcher to xvm
     xvm.add("msdev", {
         bindir = path.join(pkginfo.install_dir(), "Common", "MSDev98", "BIN"),
+        binding = package.name .. "@" .. pkginfo.version(),
     })
 
     -- Create desktop + start menu shortcut
@@ -82,17 +88,24 @@ function config()
 end
 
 function uninstall()
-    -- Remove shortcut
-    system.exec(string.format(
-        [[shortcut-tool remove --name "%s"]], __shortcut_name()
+    -- Remove shortcut (try both names in case version changed)
+    pcall(system.exec, string.format(
+        [[shortcut-tool remove --name "%s"]], "Visual C++ 6.0 中文版"
+    ))
+    pcall(system.exec, string.format(
+        [[shortcut-tool remove --name "%s"]], "Visual C++ 6.0"
     ))
 
     -- Unregister from xvm
+    xvm.remove(package.name)
     xvm.remove("msdev")
 
     -- Clean up compatibility registry entry
     local msdev_path = path.join(pkginfo.install_dir(), MSDEV_REL)
     __cleanup_compat_mode(msdev_path)
+
+    -- Remove install directory
+    os.tryrm(pkginfo.install_dir())
 
     return true
 end

--- a/pkgs/v/vc6.lua
+++ b/pkgs/v/vc6.lua
@@ -15,10 +15,23 @@ package = {
 
     programs = { "msdev" },
 
+    -- 中文版制作流程 (基于英文版 6.0 自动生成):
+    --   1. LIEF (Python) 从英文版 14 个 PE 文件 (DLL/PKG/EXE) 中
+    --      提取 RT_STRING 资源段的 3528 条 String Table 字符串
+    --   2. LLM 批量翻译为简体中文 (保留格式符 %s/%d、快捷键 \tCtrl+X、
+    --      热键标记 & 等), 共翻译 3024 条
+    --   3. LIEF 将中文 UTF-16LE 字符串回写到 PE 资源段
+    --   4. 打包为 zip 上传至 GitHub/Gitcode xlings-res/vc6@6.0-chs
+    --
+    -- 涉及的 PE 文件: DEVSHL.DLL, MSDEV.EXE, DEVEDIT.PKG,
+    --   IDE/DEVRES.PKG, IDE/DEVBLD.PKG, IDE/DEVDBG.PKG, IDE/DEVCPP.PKG,
+    --   IDE/DEVCLVW.PKG, IDE/DEVDTG.PKG, IDE/DEVAUT1.PKG, IDE/DEVGAL.PKG,
+    --   IDE/DEVTOOL.PKG, IDE/DEVBIED.PKG, IDE/DEVHTMX.PKG
+
     xpm = {
         windows = {
             deps = { "shortcut-tool" },
-            -- default: Chinese simplified; use vc6@english for English
+            -- 默认安装简体中文版; 英文版: xlings install vc6@english
             ["latest"] = { ref = "chinese" },
             ["chinese"] = {
                 url = {
@@ -27,7 +40,7 @@ package = {
                 },
             },
             ["english"] = "XLINGS_RES",
-            -- keep "6.0" as alias for english (backward compat)
+            -- "6.0" 作为英文版别名 (向后兼容)
             ["6.0"] = "XLINGS_RES",
         },
     },


### PR DESCRIPTION
## Summary

- 默认版本改为简体中文版（基于英文版 6.0，通过 LIEF + LLM 自动翻译 14 个 PE 文件的 3024 条 String Table 字符串）
- 英文版仍可通过 `xlings install vc6@english` 安装
- 修复卸载问题：注册 package.name 为 binding root、清理 install_dir、双快捷方式名删除
- 中文版 zip 已上传至 GitHub/Gitcode xlings-res/vc6@6.0-chs

## 中文版制作流程
1. LIEF 提取英文版 PE 资源段 String Table（3528 条）
2. LLM 批量翻译为简体中文（保留 %s/%d、\tCtrl+X、& 热键等）
3. LIEF 回写 UTF-16LE 中文字符串到 PE 文件
4. 打包上传

## Test plan
- [x] spec D1 检测通过
- [x] static + isolation 全部通过
- [ ] CI 通过
- [ ] Windows 实际安装/卸载测试