### PR TITLE
feat(mcpp): bump to 0.0.20 for all platforms

### DIFF
--- a/pkgs/m/mcpp.lua
+++ b/pkgs/m/mcpp.lua
@@ -39,7 +39,8 @@ package = {
     xpm = {
         linux = {
             url_template = "https://github.com/mcpp-community/mcpp/releases/download/v{version}/mcpp-{version}-linux-x86_64.tar.gz",
-            ["latest"] = { ref = "0.0.19" },
+            ["latest"] = { ref = "0.0.20" },
+            ["0.0.20"] = "XLINGS_RES",
             ["0.0.19"] = "XLINGS_RES",
             ["0.0.17"] = "XLINGS_RES",
             ["0.0.16"] = "XLINGS_RES",
@@ -59,13 +60,15 @@ package = {
             ["0.0.1"] = "XLINGS_RES",
         },
         macosx = {
-            ["latest"] = { ref = "0.0.19" },
+            ["latest"] = { ref = "0.0.20" },
+            ["0.0.20"] = "XLINGS_RES",
             ["0.0.19"] = "XLINGS_RES",
             ["0.0.17"] = "XLINGS_RES",
             ["0.0.16"] = "XLINGS_RES",
         },
         windows = {
-            ["latest"] = { ref = "0.0.19" },
+            ["latest"] = { ref = "0.0.20" },
+            ["0.0.20"] = "XLINGS_RES",
             ["0.0.19"] = "XLINGS_RES",
             ["0.0.17"] = "XLINGS_RES",
         },


### PR DESCRIPTION
## Summary
- 添加 mcpp 0.0.20 版本支持 (linux/macosx/windows)
- latest 指向 0.0.20
- xlings-res 镜像已上传至 GitHub 和 Gitcode

## Test plan
- [ ] CI 通过