### PR TITLE
fix(vc6): robust install path detection for custom URL downloads

### DIFF
--- a/pkgs/v/vc6.lua
+++ b/pkgs/v/vc6.lua
@@ -69,9 +69,35 @@ end
 
 function install()
     os.tryrm(pkginfo.install_dir())
-    local extracted = pkginfo.install_file():replace(".zip", "")
-    os.mv(extracted, pkginfo.install_dir())
-    return true
+    -- xlings may rename the downloaded file, so the extracted folder name
+    -- (from zip internal structure) may not match install_file():replace(".zip","").
+    -- Scan for the extracted folder containing MSDEV.EXE instead.
+    local install_file = pkginfo.install_file()
+    local extract_dir = path.directory(install_file)
+
+    -- Try direct name match first (works for XLINGS_RES convention)
+    local guessed = install_file:replace(".zip", "")
+    if os.isdir(guessed) then
+        os.mv(guessed, pkginfo.install_dir())
+        return true
+    end
+
+    -- Fallback: find the extracted folder by looking for MSDEV.EXE
+    for _, entry in ipairs(os.dirs(path.join(extract_dir, "vc6-*"))) do
+        if os.isfile(path.join(entry, MSDEV_REL)) then
+            os.mv(entry, pkginfo.install_dir())
+            return true
+        end
+    end
+
+    -- Last resort: try any directory starting with "vc6"
+    for _, entry in ipairs(os.dirs(path.join(extract_dir, "vc6*"))) do
+        os.mv(entry, pkginfo.install_dir())
+        return true
+    end
+
+    log.error("install failed: could not find extracted VC6 directory")
+    return false
 end
 
 function config()


### PR DESCRIPTION
## Summary
修复中文版安装失败 (target not found + shortcut-tool 报错)

**根因**: xlings 下载自定义 URL 时可能重命名文件，导致 `install_file():replace(".zip","")` 
与 zip 内部目录名不匹配。例如：
- zip 内部: `vc6-6.0-chinese-windows-x86_64/`
- xlings 本地: `vc6-chinese-windows-x86_64.zip` → replace 后 `vc6-chinese-windows-x86_64`
- `os.mv` 找不到源目录 → install_dir 为空 → MSDEV.EXE 不存在 → shortcut-tool target not found

**修复**: 三级 fallback 查找解压目录
1. 直接名字匹配（XLINGS_RES 标准命名）
2. 扫描 `vc6-*` 目录找包含 MSDEV.EXE 的
3. 兜底匹配 `vc6*` 目录

## Test plan
- [x] static tests passed
- [ ] CI
- [ ] Windows 实际安装验证