### PR TITLE
fix(vc6): revert to simple install, fix zip folder name

### DIFF
--- a/pkgs/v/vc6.lua
+++ b/pkgs/v/vc6.lua
@@ -31,8 +31,8 @@ package = {
             ["latest"] = { ref = "chinese" },
             ["chinese"] = {
                 url = {
-                    GLOBAL = "https://github.com/xlings-res/vc6/releases/download/6.0-chs/vc6-6.0-chinese-windows-x86_64.zip",
-                    CN = "https://gitcode.com/xlings-res/vc6/releases/download/6.0-chs/vc6-6.0-chs-v2-windows-x86_64.zip",
+                    GLOBAL = "https://github.com/xlings-res/vc6/releases/download/6.0-chs/vc6-chinese-windows-x86_64.zip",
+                    CN = "https://gitcode.com/xlings-res/vc6/releases/download/6.0-chs/vc6-chinese-windows-x86_64.zip",
                 },
             },
             ["english"] = "XLINGS_RES",
@@ -65,35 +65,9 @@ end
 
 function install()
     os.tryrm(pkginfo.install_dir())
-    -- xlings may rename the downloaded file, so the extracted folder name
-    -- (from zip internal structure) may not match install_file():replace(".zip","").
-    -- Scan for the extracted folder containing MSDEV.EXE instead.
-    local install_file = pkginfo.install_file()
-    local extract_dir = path.directory(install_file)
-
-    -- Try direct name match first (works for XLINGS_RES convention)
-    local guessed = install_file:replace(".zip", "")
-    if os.isdir(guessed) then
-        os.mv(guessed, pkginfo.install_dir())
-        return true
-    end
-
-    -- Fallback: find the extracted folder by looking for MSDEV.EXE
-    for _, entry in ipairs(os.dirs(path.join(extract_dir, "vc6-*"))) do
-        if os.isfile(path.join(entry, MSDEV_REL)) then
-            os.mv(entry, pkginfo.install_dir())
-            return true
-        end
-    end
-
-    -- Last resort: try any directory starting with "vc6"
-    for _, entry in ipairs(os.dirs(path.join(extract_dir, "vc6*"))) do
-        os.mv(entry, pkginfo.install_dir())
-        return true
-    end
-
-    log.error("install failed: could not find extracted VC6 directory")
-    return false
+    local extracted = pkginfo.install_file():replace(".zip", "")
+    os.mv(extracted, pkginfo.install_dir())
+    return true
 end
 
 function config()


### PR DESCRIPTION
## Summary
- 恢复原版简单 install 函数（`install_file():replace(".zip","")` + `os.mv`）
- 根因修复：重新打包 zip，内部目录名改为 `vc6-chinese-windows-x86_64/` 匹配 xlings 命名规范
- URL 更新为正确的文件名
- GitHub + Gitcode 的 release 资源已同步替换

## Test plan
- [x] static tests passed
- [ ] CI
- [ ] Windows 安装验证