### PR TITLE
feat(mcpp): bump to 0.0.21 for all platforms

### DIFF
--- a/pkgs/m/mcpp.lua
+++ b/pkgs/m/mcpp.lua
@@ -39,7 +39,8 @@ package = {
     xpm = {
         linux = {
             url_template = "https://github.com/mcpp-community/mcpp/releases/download/v{version}/mcpp-{version}-linux-x86_64.tar.gz",
-            ["latest"] = { ref = "0.0.20" },
+            ["latest"] = { ref = "0.0.21" },
+            ["0.0.21"] = "XLINGS_RES",
             ["0.0.20"] = "XLINGS_RES",
             ["0.0.19"] = "XLINGS_RES",
             ["0.0.17"] = "XLINGS_RES",
@@ -60,14 +61,16 @@ package = {
             ["0.0.1"] = "XLINGS_RES",
         },
         macosx = {
-            ["latest"] = { ref = "0.0.20" },
+            ["latest"] = { ref = "0.0.21" },
+            ["0.0.21"] = "XLINGS_RES",
             ["0.0.20"] = "XLINGS_RES",
             ["0.0.19"] = "XLINGS_RES",
             ["0.0.17"] = "XLINGS_RES",
             ["0.0.16"] = "XLINGS_RES",
         },
         windows = {
-            ["latest"] = { ref = "0.0.20" },
+            ["latest"] = { ref = "0.0.21" },
+            ["0.0.21"] = "XLINGS_RES",
             ["0.0.20"] = "XLINGS_RES",
             ["0.0.19"] = "XLINGS_RES",
             ["0.0.17"] = "XLINGS_RES",


### PR DESCRIPTION
## Summary
- 添加 mcpp 0.0.21 (linux/macosx/windows)，latest 指向 0.0.21
- xlings-res 镜像已上传至 GitHub 和 Gitcode

## Test plan
- [x] static tests passed
- [ ] CI