### PR TITLE
fix(llvm): fix broken Gitcode mirror for linux

### DIFF
--- a/pkgs/l/llvm.lua
+++ b/pkgs/l/llvm.lua
@@ -26,7 +26,12 @@ package = {
                 "xim:libxml2@2.13.5",
             },
             ["latest"] = { ref = "20.1.7" },
-            ["20.1.7"] = "XLINGS_RES",
+            ["20.1.7"] = {
+                url = {
+                    GLOBAL = "https://github.com/xlings-res/llvm/releases/download/20.1.7/llvm-20.1.7-linux-x86_64.tar.gz",
+                    CN = "https://gitcode.com/xlings-res/llvm/releases/download/20.1.7/llvm-20.1.7-v3-linux-x86_64.tar.gz",
+                },
+            },
         },
         macosx = {
             ["latest"] = { ref = "20.1.7" },


### PR DESCRIPTION
## Summary
- Gitcode 上 `llvm-20.1.7-linux-x86_64.tar.gz` (279MB) 下载返回 404/截断
- 重新上传为 `llvm-20.1.7-v3-linux-x86_64.tar.gz`，已验证可正常下载
- 从 XLINGS_RES 改为显式 GLOBAL/CN URL

## Root cause
Gitcode 平台对大文件(279MB)的 release asset 存在 bug，原始上传的文件下载链接失效。

## Test plan
- [x] static tests passed
- [x] Gitcode v3 文件下载验证: 279335022 bytes, tar integrity OK
- [ ] CI