### PR TITLE
fix(llvm): point CN url to 20.1.7-fix tag on Gitcode

### DIFF
--- a/pkgs/l/llvm.lua
+++ b/pkgs/l/llvm.lua
@@ -26,10 +26,11 @@ package = {
                 "xim:libxml2@2.13.5",
             },
             ["latest"] = { ref = "20.1.7" },
+            -- Gitcode tag 20.1.7 has corrupted asset; use 20.1.7-fix tag for CN
             ["20.1.7"] = {
                 url = {
                     GLOBAL = "https://github.com/xlings-res/llvm/releases/download/20.1.7/llvm-20.1.7-linux-x86_64.tar.gz",
-                    CN = "https://gitcode.com/xlings-res/llvm/releases/download/20.1.7/llvm-20.1.7-v3-linux-x86_64.tar.gz",
+                    CN = "https://gitcode.com/xlings-res/llvm/releases/download/20.1.7-fix/llvm-20.1.7-linux-x86_64.tar.gz",
                 },
             },
         },


### PR DESCRIPTION
## Summary
- 在 Gitcode 上创建 `20.1.7-fix` tag，上传标准命名的 `llvm-20.1.7-linux-x86_64.tar.gz` (279MB)
- CN URL 从 `20.1.7/llvm-20.1.7-v3-*` 改为 `20.1.7-fix/llvm-20.1.7-linux-x86_64.tar.gz`
- 已验证下载完整性: 279335022 bytes, tar OK

## Why
原 20.1.7 tag 的同名文件损坏且 Gitcode 不支持覆盖，用新 tag 解决。