### PR TITLE
fix(llvm): restore CN url to standard 20.1.7 tag

### DIFF
--- a/pkgs/l/llvm.lua
+++ b/pkgs/l/llvm.lua
@@ -26,13 +26,7 @@ package = {
                 "xim:libxml2@2.13.5",
             },
             ["latest"] = { ref = "20.1.7" },
-            -- Gitcode tag 20.1.7 has corrupted asset; use 20.1.7-fix tag for CN
-            ["20.1.7"] = {
-                url = {
-                    GLOBAL = "https://github.com/xlings-res/llvm/releases/download/20.1.7/llvm-20.1.7-linux-x86_64.tar.gz",
-                    CN = "https://gitcode.com/xlings-res/llvm/releases/download/20.1.7-fix/llvm-20.1.7-linux-x86_64.tar.gz",
-                },
-            },
+            ["20.1.7"] = "XLINGS_RES",
         },
         macosx = {
             ["latest"] = { ref = "20.1.7" },


### PR DESCRIPTION
## Summary
- Gitcode 上以标准命名重新上传 `llvm-20.1.7-linux-x86_64.tar.gz` (279MB) 到 `20.1.7` tag
- llvm.lua 恢复使用 `XLINGS_RES`，不再需要显式 GLOBAL/CN URL
- 下载验证: 279335022 bytes, tar OK

## Why
将正确文件放回标准 tag (`20.1.7`)，移除 `-fix` 临时方案。