### PR TITLE
feat(mcpp): bump to 0.0.25 for all platforms

### DIFF
--- a/pkgs/m/mcpp.lua
+++ b/pkgs/m/mcpp.lua
@@ -39,7 +39,8 @@ package = {
     xpm = {
         linux = {
             url_template = "https://github.com/mcpp-community/mcpp/releases/download/v{version}/mcpp-{version}-linux-x86_64.tar.gz",
-            ["latest"] = { ref = "0.0.24" },
+            ["latest"] = { ref = "0.0.25" },
+            ["0.0.25"] = "XLINGS_RES",
             ["0.0.24"] = "XLINGS_RES",
             ["0.0.22"] = "XLINGS_RES",
             ["0.0.21"] = "XLINGS_RES",
@@ -63,7 +64,8 @@ package = {
             ["0.0.1"] = "XLINGS_RES",
         },
         macosx = {
-            ["latest"] = { ref = "0.0.24" },
+            ["latest"] = { ref = "0.0.25" },
+            ["0.0.25"] = "XLINGS_RES",
             ["0.0.24"] = "XLINGS_RES",
             ["0.0.22"] = "XLINGS_RES",
             ["0.0.21"] = "XLINGS_RES",
@@ -73,7 +75,8 @@ package = {
             ["0.0.16"] = "XLINGS_RES",
         },
         windows = {
-            ["latest"] = { ref = "0.0.24" },
+            ["latest"] = { ref = "0.0.25" },
+            ["0.0.25"] = "XLINGS_RES",
             ["0.0.24"] = "XLINGS_RES",
             ["0.0.22"] = "XLINGS_RES",
             ["0.0.21"] = "XLINGS_RES",


### PR DESCRIPTION
- 添加 mcpp 0.0.25 (linux/macosx/windows), latest → 0.0.25
- xlings-res 镜像已上传至 GitHub 和 Gitcode