### PR TITLE
feat(mcpp): bump to 0.0.27 for all platforms

### DIFF
--- a/pkgs/m/mcpp.lua
+++ b/pkgs/m/mcpp.lua
@@ -39,7 +39,8 @@ package = {
     xpm = {
         linux = {
             url_template = "https://github.com/mcpp-community/mcpp/releases/download/v{version}/mcpp-{version}-linux-x86_64.tar.gz",
-            ["latest"] = { ref = "0.0.26" },
+            ["latest"] = { ref = "0.0.27" },
+            ["0.0.27"] = "XLINGS_RES",
             ["0.0.26"] = "XLINGS_RES",
             ["0.0.25"] = "XLINGS_RES",
             ["0.0.24"] = "XLINGS_RES",
@@ -65,7 +66,8 @@ package = {
             ["0.0.1"] = "XLINGS_RES",
         },
         macosx = {
-            ["latest"] = { ref = "0.0.26" },
+            ["latest"] = { ref = "0.0.27" },
+            ["0.0.27"] = "XLINGS_RES",
             ["0.0.26"] = "XLINGS_RES",
             ["0.0.25"] = "XLINGS_RES",
             ["0.0.24"] = "XLINGS_RES",
@@ -77,7 +79,8 @@ package = {
             ["0.0.16"] = "XLINGS_RES",
         },
         windows = {
-            ["latest"] = { ref = "0.0.26" },
+            ["latest"] = { ref = "0.0.27" },
+            ["0.0.27"] = "XLINGS_RES",
             ["0.0.26"] = "XLINGS_RES",
             ["0.0.25"] = "XLINGS_RES",
             ["0.0.24"] = "XLINGS_RES",


### PR DESCRIPTION
## Summary
- 升级 mcpp 到 0.0.27（linux / macosx / windows 三平台同步）
- 资源延续 `XLINGS_RES` 约定，镜像到 `xlings-res/mcpp@0.0.27`（GitHub + GitCode 均已上传）

## Mirrors
- GitHub: https://github.com/xlings-res/mcpp/releases/tag/0.0.27
- GitCode: https://gitcode.com/xlings-res/mcpp/releases/tag/0.0.27

## Test plan
- [x] `pytest tests/m/test_mcpp.py -m "static or isolation"` → 8 passed
- [x] `pytest tests/m/test_mcpp.py -m index` → 1 passed
- [x] `xlings install local:mcpp@0.0.27` → success
- [x] `xlings use mcpp@0.0.27` + `mcpp --version` → `mcpp 0.0.27`
- [x] `xlings remove local:mcpp@0.0.27` → clean
- [ ] CI 上 lifecycle / verify（依赖远端拉取 xlings-res 资源）