### PR TITLE
feat(claude-code): bump to 2.1.142 and support new native binary layout

### DIFF
--- a/pkgs/c/claude-code.lua
+++ b/pkgs/c/claude-code.lua
@@ -20,19 +20,22 @@ package = {
     xpm = {
         linux = {
             deps = {"node", "npm"},
-            ["latest"] = { ref = "2.1.90" },
+            ["latest"] = { ref = "2.1.142" },
+            ["2.1.142"] = { ref = "2.1.142" },
             ["2.1.90"] = { ref = "2.1.90" },
             ["2.1.63"] = {},
         },
         macosx = {
             deps = {"node", "npm"},
-            ["latest"] = { ref = "2.1.90" },
+            ["latest"] = { ref = "2.1.142" },
+            ["2.1.142"] = { ref = "2.1.142" },
             ["2.1.90"] = { ref = "2.1.90" },
             ["2.1.63"] = {},
         },
         windows = {
             deps = {"node", "npm"},
-            ["latest"] = { ref = "2.1.90" },
+            ["latest"] = { ref = "2.1.142" },
+            ["2.1.142"] = { ref = "2.1.142" },
             ["2.1.90"] = { ref = "2.1.90" },
             ["2.1.63"] = {},
         },
@@ -44,11 +47,26 @@ import("xim.libxpkg.xvm")
 
 
 -- 结构说明（基于 npm 包元数据 + 本地安装校验）:
---   1) 包自身入口由 package.json 的 bin.claude = "cli.js" 定义
---   2) 安装后主入口位于: <install>/node_modules/@anthropic-ai/claude-code/cli.js
---   3) npm .bin 包装脚本在不同 OS 的形态可能不同（如 .cmd/.ps1），这里不依赖它
-function __claude_cli()
-    return path.join(pkginfo.install_dir(), "node_modules", "@anthropic-ai", "claude-code", "cli.js")
+--   1) 旧版（<= 2.1.100）：package.json 的 bin.claude = "cli.js"，
+--      主入口位于 <install>/node_modules/@anthropic-ai/claude-code/cli.js，
+--      需要通过 node 解释器执行。
+--   2) 新版（>= 2.1.120）：package.json 的 bin.claude = "bin/claude.exe"，
+--      install.cjs 在 postinstall 把对应平台的原生二进制覆盖到
+--      <install>/node_modules/@anthropic-ai/claude-code/bin/claude.exe，
+--      可直接执行（即使在 linux/macos 文件名也是 claude.exe）。
+--   3) 这里运行时探测，向后兼容历史版本。npm .bin 包装在不同 OS 形态不同，
+--      不直接依赖。
+function __claude_entry()
+    local pkg_root = path.join(pkginfo.install_dir(), "node_modules", "@anthropic-ai", "claude-code")
+    local native = path.join(pkg_root, "bin", "claude.exe")
+    if os.isfile(native) then
+        return { path = native, mode = "native" }
+    end
+    local js = path.join(pkg_root, "cli.js")
+    if os.isfile(js) then
+        return { path = js, mode = "node" }
+    end
+    return nil
 end
 
 function install()
@@ -62,16 +80,23 @@ function install()
     )
     os.exec(npm_install)
 
-    if not os.isfile(__claude_cli()) then
-        raise("claude cli.js not found after npm install")
+    if not __claude_entry() then
+        raise("claude entry (bin/claude.exe or cli.js) not found after npm install")
     end
 
     return true
 end
 
 function config()
+    local entry = __claude_entry()
+    local alias
+    if entry.mode == "native" then
+        alias = string.format([["%s"]], entry.path)
+    else
+        alias = string.format([[node "%s"]], entry.path)
+    end
     xvm.add("claude", {
-        alias = string.format([[node "%s"]], __claude_cli()),
+        alias = alias,
         envs = {
             -- should be set by user, not hardcoded here
             --CLAUDE_CONFIG_DIR = path.join(pkginfo.install_dir(), "config"),

--- a/tests/c/test_claude_code.py
+++ b/tests/c/test_claude_code.py
@@ -63,10 +63,11 @@ class TestIsolation:
 
 class TestDesign:
     @pytest.mark.static
-    def test_runtime_entry_uses_cli_js(self):
+    def test_runtime_entry_supports_both_layouts(self):
         content = open(PKG_FILE, encoding='utf-8').read()
-        assert "function __claude_cli()" in content
+        assert "function __claude_entry()" in content
         assert "@anthropic-ai" in content
+        assert "claude.exe" in content
         assert "cli.js" in content
         assert "node \"%s\"" in content
 


### PR DESCRIPTION
## Summary
- 升级 claude-code 到 **2.1.142**（Anthropic 在 npm 上显式标记的 `stable` dist-tag；`latest` 当前是 2.1.150，但官方另起 `stable` tag 指向 2.1.142，按 xpkg-updater 默认 stable 规则选 2.1.142）
- **同时适配上游 2.1.120+ 的新二进制布局**：
  - 旧版（≤ 2.1.100）：`cli.js`，需 `node` 解释器
  - 新版（≥ 2.1.120）：`bin/claude.exe`（即使 linux/macos 文件名也是 `claude.exe`），是原生单文件可执行（ELF/Mach-O/PE），由 install.cjs postinstall 覆盖到位
- hooks 改为运行时探测，向后兼容老版本，避免 `claude cli.js not found after npm install` 安装失败
- 同步更新 `tests/c/test_claude_code.py::TestDesign::test_runtime_entry_supports_both_layouts`：要求新 helper `__claude_entry()` 同时引用 `claude.exe` 与 `cli.js`，并保留 `node \"%s\"` 老路径断言

## Test plan
- [x] `pytest tests/c/test_claude_code.py -m \"static or isolation or index\"` → 11 passed
- [x] `xlings install local:claude-code@2.1.142` → success
- [x] `xlings use claude@2.1.142` + `claude --version` → `2.1.142 (Claude Code)`
- [x] `which claude` 指向 xvm shim，底层走 `bin/claude.exe` 原生二进制
- [ ] CI 上 lifecycle / verify（依赖 node/npm 远端拉取）