### PR TITLE
feat(claude): rename package from claude-code to claude

### DIFF
--- a/pkgs/c/claude.lua
+++ b/pkgs/c/claude.lua
@@ -1,7 +1,7 @@
 package = {
     spec = "1",
 
-    name = "claude-code",
+    name = "claude",
     description = "Claude Code CLI from Anthropic",
     homepage = "https://github.com/anthropics/claude-code",
     licenses = {"MIT"},
@@ -102,17 +102,10 @@ function config()
             --CLAUDE_CONFIG_DIR = path.join(pkginfo.install_dir(), "config"),
         }
     })
-    -- Marker: package name `claude-code` differs from the actual binary
-    -- `claude`. Without this empty placeholder, install detection
-    -- (`xvm info claude-code`) returns nothing, so xlings re-installs
-    -- on every invocation. The marker is metadata-only — no bindir,
-    -- no alias, no shim — and is uninstalled symmetrically below.
-    xvm.add("claude-code", { type = "marker" })
     return true
 end
 
 function uninstall()
     xvm.remove("claude")
-    xvm.remove("claude-code")
     return true
 end

--- a/tests/c/test_claude.py
+++ b/tests/c/test_claude.py
@@ -10,8 +10,8 @@ from tests.lib.assertions import (
 )
 from tests.lib.platform_utils import skip_if_not
 
-PKG = "claude-code"
-PKG_FILE = "pkgs/c/claude-code.lua"
+PKG = "claude"
+PKG_FILE = "pkgs/c/claude.lua"
 
 
 @pytest.fixture(scope='module')


### PR DESCRIPTION
## Summary
- 把 xpkg 文件 `pkgs/c/claude-code.lua` 重命名为 `pkgs/c/claude.lua`
- 同步把 `package.name` 从 `claude-code` 改为 `claude`
- 与可执行命令 `claude` 对齐，使用方写法更直观（`xlings install claude` 即可）
- 删除 `xvm.add(\"claude-code\", { type = \"marker\" })` 占位：这个 marker 之前是为了让 `xvm info claude-code` 能识别已安装态（因为包名与二进制不一致）；改名后包名本身就是 `claude`，主 `xvm.add(\"claude\", ...)` 已足够，对称的 `xvm.remove(\"claude-code\")` 也一并去掉
- 测试文件同名重命名为 `tests/c/test_claude.py`，更新 `PKG`/`PKG_FILE` 常量

## Breaking change
- `xlings install claude-code` 不再可用，需要改成 `xlings install claude`
- 已安装的 `xim:claude-code@x.y.z` 在 xvm 中残留的 marker 不会自动清理；如需可 `xlings remove claude-code` 再装新名

## Test plan
- [x] `pytest tests/c/test_claude.py -m \"static or isolation or index\"` → 11 passed
- [x] `xlings install local:claude@2.1.142` → 干净 install
- [x] `claude --version` → `2.1.142 (Claude Code)`
- [x] `xlings list claude` → `◆ local:claude@2.1.142  Claude Code CLI from Anthropic`
- [x] `xlings remove local:claude@2.1.142` → 干净卸载