### PR TITLE
Add mcpp VSCode clangd config package

### DIFF
--- a/.github/scripts/parse-xpkg-meta.py
+++ b/.github/scripts/parse-xpkg-meta.py
@@ -7,6 +7,8 @@ package and what programs to look for afterwards.
 Fields in the output:
   name         package name (string)
   type         package type (e.g. package, app, lib, script, bugfix)
+  namespace    package namespace (defaults to "local" when not declared);
+               install/remove specs must use "<namespace>:<name>"
   programs     list of program names declared by the package
   is_ref       true if this file is a thin ref to another package
   has_linux    true if the package declares a linux branch in xpm
@@ -31,6 +33,7 @@ def main() -> int:
     print(json.dumps({
         "name": meta.name,
         "type": meta.pkg_type,
+        "namespace": meta.namespace or "local",
         "programs": list(meta.programs),
         "is_ref": bool(meta.is_ref),
         "has_linux": bool(meta.platforms.get("linux")),

--- a/.github/scripts/posix-test.sh
+++ b/.github/scripts/posix-test.sh
@@ -137,10 +137,11 @@ for rel_file in "${files[@]}"; do
     fi
     pkg=$(printf '%s' "$meta_json"     | python3 -c "import json,sys; print(json.loads(sys.stdin.read())['name'])")
     pkg_type=$(printf '%s' "$meta_json" | python3 -c "import json,sys; print(json.loads(sys.stdin.read()).get('type','package'))")
+    pkg_ns=$(printf '%s' "$meta_json"   | python3 -c "import json,sys; print(json.loads(sys.stdin.read()).get('namespace','local') or 'local')")
     is_ref=$(printf '%s' "$meta_json"   | python3 -c "import json,sys; print(json.loads(sys.stdin.read())['is_ref'])")
     has_plat=$(printf '%s' "$meta_json" | python3 -c "import json,sys; print(json.loads(sys.stdin.read()).get('$HAS_KEY', False))")
     programs=$(printf '%s' "$meta_json" | python3 -c "import json,sys; print(' '.join(json.loads(sys.stdin.read())['programs']))")
-    info "name=$pkg  type=$pkg_type  programs=[$programs]  is_ref=$is_ref  $HAS_KEY=$has_plat"
+    info "name=$pkg  type=$pkg_type  namespace=$pkg_ns  programs=[$programs]  is_ref=$is_ref  $HAS_KEY=$has_plat"
 
     if [[ "$is_ref" == "True" ]]; then
         info "skip (ref package)"; skipped=$((skipped+1)); continue
@@ -168,8 +169,13 @@ for rel_file in "${files[@]}"; do
     shims_before=$(shim_set)
     info "shims before install: $(printf '%s\n' "$shims_before" | grep -c . || true)"
 
-    step "[$pkg] install"
-    if ! "$XLINGS_CMD" install "local:$pkg" -y; then
+    # Packages that declare `namespace = "config"` (or any other non-default
+    # namespace) are registered under <namespace>:<name> rather than
+    # local:<name>, so install/remove must address them by that spec.
+    pkg_spec="${pkg_ns}:${pkg}"
+
+    step "[$pkg] install ($pkg_spec)"
+    if ! "$XLINGS_CMD" install "$pkg_spec" -y; then
         log_fail "install failed"; failures+=("$rel_file (install)"); continue
     fi
 
@@ -226,8 +232,8 @@ for rel_file in "${files[@]}"; do
         info "no new shim appeared (type='$pkg_type'; programs='$programs' may have been re-pointed)"
     fi
 
-    step "[$pkg] uninstall"
-    if ! "$XLINGS_CMD" remove "local:$pkg" -y; then
+    step "[$pkg] uninstall ($pkg_spec)"
+    if ! "$XLINGS_CMD" remove "$pkg_spec" -y; then
         log_fail "uninstall failed"; failures+=("$rel_file (uninstall)"); continue
     fi
 

--- a/.github/scripts/windows-test.ps1
+++ b/.github/scripts/windows-test.ps1
@@ -105,7 +105,8 @@ foreach ($relFile in $files) {
         continue
     }
     $meta = $metaJson | ConvertFrom-Json
-    Log-Info "name=$($meta.name)  programs=[$($meta.programs -join ',')]  is_ref=$($meta.is_ref)  has_windows=$($meta.has_windows)"
+    $pkgNs = if ($meta.namespace) { $meta.namespace } else { "local" }
+    Log-Info "name=$($meta.name)  namespace=$pkgNs  programs=[$($meta.programs -join ',')]  is_ref=$($meta.is_ref)  has_windows=$($meta.has_windows)"
 
     if ($meta.is_ref) {
         Log-Info "skip (ref package)"
@@ -146,9 +147,14 @@ foreach ($relFile in $files) {
     $shimsBefore = Get-ShimSet
     Log-Info "shims before install: $($shimsBefore.Count)"
 
+    # Packages that declare `namespace = "config"` (or any other non-default
+    # namespace) are registered under <namespace>:<name> rather than
+    # local:<name>, so install/remove must address them by that spec.
+    $pkgSpec = "${pkgNs}:${pkg}"
+
     # --- install ---
-    Log-Step "[$pkg] install"
-    & $xlingsCmd install "local:$pkg" -y 2>&1 | Write-Host
+    Log-Step "[$pkg] install ($pkgSpec)"
+    & $xlingsCmd install $pkgSpec -y 2>&1 | Write-Host
     if ($LASTEXITCODE -ne 0) {
         Log-Fail "install failed"
         $failures += "$relFile (install)"
@@ -207,8 +213,8 @@ foreach ($relFile in $files) {
     }
 
     # --- uninstall ---
-    Log-Step "[$pkg] uninstall"
-    & $xlingsCmd remove "local:$pkg" -y 2>&1 | Write-Host
+    Log-Step "[$pkg] uninstall ($pkgSpec)"
+    & $xlingsCmd remove $pkgSpec -y 2>&1 | Write-Host
     if ($LASTEXITCODE -ne 0) {
         Log-Fail "uninstall failed"
         $failures += "$relFile (uninstall)"

--- a/pkgs/m/mcpp-vscode-clangd.lua
+++ b/pkgs/m/mcpp-vscode-clangd.lua
@@ -1,0 +1,58 @@
+package = {
+    spec = "1",
+    homepage = "https://github.com/openxlings/xim-pkgindex",
+
+    name = "mcpp-vscode-clangd",
+    description = "Configure VSCode clangd support for mcpp LLVM projects",
+    maintainers = {"xim team"},
+    licenses = {"Apache-2.0"},
+
+    type = "config",
+    namespace = "config",
+    status = "dev",
+    categories = {"cpp", "vscode", "config"},
+    keywords = {"mcpp", "vscode", "clangd", "llvm", "cpp-modules", "import-std"},
+
+    xpm = {
+        linux = {
+            deps = { "xim:mcpp", "xim:code", "xim:llvm-tools@20.1.7" },
+            ["latest"] = { ref = "20.1.7" },
+            ["20.1.7"] = {},
+        },
+    },
+}
+
+import("xim.libxpkg.json")
+import("xim.libxpkg.log")
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.system")
+
+function install()
+    return true
+end
+
+function config()
+    local root = system.rundir()
+    if not os.isfile(path.join(root, "mcpp.toml")) then
+        log.warn("mcpp-vscode-clangd skipped: mcpp.toml not found in " .. root)
+        return true
+    end
+    local vscode_dir = path.join(root, ".vscode")
+    local settings_file = path.join(vscode_dir, "settings.json")
+    if not os.isdir(vscode_dir) then
+        os.mkdir(vscode_dir)
+    end
+    local settings = os.isfile(settings_file) and json.loadfile(settings_file) or {}
+    settings["clangd.path"] = path.join(pkginfo.dep_install_dir("llvm-tools", pkginfo.version()), "bin", "clangd")
+    json.savefile(settings_file, settings, { indent = true })
+    system.exec("code --install-extension llvm-vs-code-extensions.vscode-clangd")
+    os.cd(root)
+    system.exec("mcpp toolchain install llvm@" .. pkginfo.version() .. " default")
+    os.tryrm(path.join(root, "compile_commands.json"))
+    system.exec("mcpp build")
+    return true
+end
+
+function uninstall()
+    return true
+end

--- a/tests/lib/xpkg_parser.py
+++ b/tests/lib/xpkg_parser.py
@@ -11,6 +11,7 @@ class XpkgMeta:
     spec: str = ""
     description: str = ""
     pkg_type: str = ""
+    namespace: str = ""
     programs: list = field(default_factory=list)
     platforms: dict = field(default_factory=dict)
     is_ref: bool = False
@@ -48,6 +49,7 @@ def parse_xpkg(lua_path: str) -> XpkgMeta:
     meta.spec = _extract_field(content, "spec") or ""
     meta.description = _extract_field(content, "description") or ""
     meta.pkg_type = _extract_field(content, "type") or ""
+    meta.namespace = _extract_field(content, "namespace") or ""
     meta.has_xvm_enable = "xvm_enable = true" in content
 
     # programs 列表

--- a/tests/m/test_mcpp_vscode_clangd.py
+++ b/tests/m/test_mcpp_vscode_clangd.py
@@ -1,0 +1,157 @@
+"""测试 mcpp-vscode-clangd 配置包"""
+import re
+
+import pytest
+from tests.lib.xpkg_parser import parse_xpkg
+from tests.lib.assertions import (
+    assert_required_fields, assert_valid_spec, assert_valid_type,
+    assert_no_typos, assert_no_exec_xvm, assert_no_bashrc_modification,
+    assert_no_direct_path_modification, assert_uses_new_api,
+    assert_xim_add_succeeds,
+)
+
+PKG_FILE = "pkgs/m/mcpp-vscode-clangd.lua"
+
+
+@pytest.fixture(scope='module')
+def meta():
+    return parse_xpkg(PKG_FILE)
+
+
+class TestStatic:
+    @pytest.mark.static
+    def test_required_fields(self, meta):
+        assert_required_fields(meta)
+
+    @pytest.mark.static
+    def test_valid_spec(self, meta):
+        assert_valid_spec(meta)
+
+    @pytest.mark.static
+    def test_valid_type(self, meta):
+        assert_valid_type(meta)
+
+    @pytest.mark.static
+    def test_is_config_package(self, meta):
+        assert meta.pkg_type == "config"
+
+    @pytest.mark.static
+    def test_name_is_clangd_specific(self, meta):
+        assert meta.name == "mcpp-vscode-clangd"
+
+    @pytest.mark.static
+    def test_lifecycle_hooks_use_config(self, meta):
+        assert not meta.has_installed
+        assert meta.has_install
+        assert meta.has_config
+
+        install_hook = re.search(r"function install\(\)(.*?)\nend", meta.raw_content, re.DOTALL)
+        config_hook = re.search(r"function config\(\)(.*?)\nend", meta.raw_content, re.DOTALL)
+        assert install_hook, "missing install hook"
+        assert config_hook, "missing config hook"
+        assert install_hook.group(1).strip() == "return true"
+        assert "system.rundir()" in config_hook.group(1)
+        assert 'settings["clangd.path"]' in config_hook.group(1)
+
+    @pytest.mark.static
+    def test_no_typos(self):
+        assert_no_typos(PKG_FILE)
+
+    @pytest.mark.static
+    def test_declares_required_deps(self, meta):
+        deps = re.search(r"deps\s*=\s*\{([^}]*)\}", meta.raw_content, re.DOTALL)
+        assert deps, "missing deps declaration"
+        deps_body = deps.group(1)
+        for dep in ("xim:mcpp", "xim:code", "xim:llvm-tools@20.1.7"):
+            assert re.search(rf'["\']{re.escape(dep)}["\']', deps_body), \
+                f"missing dependency: {dep}"
+        for dep in ("mcpp", "code", "llvm-tools@20.1.7"):
+            assert not re.search(rf'["\']{re.escape(dep)}["\']', deps_body), \
+                f"dependency should use xim namespace: {dep}"
+
+    @pytest.mark.static
+    def test_uses_package_version_for_llvm_tools(self, meta):
+        assert "LLVM_TOOLS_VERSION" not in meta.raw_content
+        assert 'pkginfo.dep_install_dir("llvm-tools", pkginfo.version())' in meta.raw_content
+        assert 'mcpp toolchain install llvm@" .. pkginfo.version() .. " default' in meta.raw_content
+
+    @pytest.mark.static
+    def test_configures_clangd_path_only(self, meta):
+        assert '"clangd.path"' in meta.raw_content
+        assert "compile-commands-dir" not in meta.raw_content
+        assert "files.associations" not in meta.raw_content
+
+    @pytest.mark.static
+    def test_uses_system_rundir(self, meta):
+        assert 'import("xim.libxpkg.system")' in meta.raw_content
+        assert "system.rundir()" in meta.raw_content
+
+    @pytest.mark.static
+    def test_skips_when_mcpp_manifest_missing(self, meta):
+        assert 'import("xim.libxpkg.log")' in meta.raw_content
+        assert 'os.isfile(path.join(root, "mcpp.toml"))' in meta.raw_content
+        assert 'log.warn(' in meta.raw_content
+        assert "mcpp-vscode-clangd skipped" in meta.raw_content
+        manifest_check = meta.raw_content.index('os.isfile(path.join(root, "mcpp.toml"))')
+        settings_update = meta.raw_content.index('settings["clangd.path"]')
+        assert manifest_check < settings_update
+
+    @pytest.mark.static
+    def test_installs_vscode_clangd_extension(self, meta):
+        assert "code --install-extension llvm-vs-code-extensions.vscode-clangd" in meta.raw_content
+
+    @pytest.mark.static
+    def test_triggers_mcpp_build(self, meta):
+        toolchain_install = meta.raw_content.index('mcpp toolchain install llvm@" .. pkginfo.version() .. " default')
+        build = meta.raw_content.index("mcpp build")
+        assert toolchain_install < build
+
+    @pytest.mark.static
+    def test_removes_cdb_before_build(self, meta):
+        remove_cdb = meta.raw_content.index('os.tryrm(path.join(root, "compile_commands.json"))')
+        build = meta.raw_content.index("mcpp build")
+        assert remove_cdb < build
+
+    @pytest.mark.static
+    def test_does_not_mutate_tool_homes(self, meta):
+        assert "MCPP_HOME" not in meta.raw_content
+        assert "XLINGS_HOME" not in meta.raw_content
+        assert ".xlings" not in meta.raw_content
+
+    @pytest.mark.static
+    def test_install_hook_stays_small(self, meta):
+        hook = re.search(r"function install\(\)(.*?)\nend", meta.raw_content, re.DOTALL)
+        assert hook, "missing install hook"
+        lines = [line for line in hook.group(1).splitlines() if line.strip()]
+        assert len(lines) == 1
+
+    @pytest.mark.static
+    def test_no_custom_project_dir_helpers(self, meta):
+        assert "shell_quote" not in meta.raw_content
+        assert "read_file" not in meta.raw_content
+        assert "project_dir" not in meta.raw_content
+        assert "ensure_mcpp_project" not in meta.raw_content
+
+
+class TestIndex:
+    @pytest.mark.index
+    def test_xim_add(self):
+        assert_xim_add_succeeds(PKG_FILE)
+
+
+class TestIsolation:
+    @pytest.mark.isolation
+    def test_no_exec_xvm(self):
+        assert_no_exec_xvm(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_no_bashrc(self):
+        assert_no_bashrc_modification(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_no_path_modification(self):
+        assert_no_direct_path_modification(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_new_api(self):
+        assert_uses_new_api(PKG_FILE)


### PR DESCRIPTION
## Summary
- add mcpp-vscode xpkg config package for mcpp LLVM + VSCode clangd workflow
- declare deps on mcpp, code, and llvm-tools@20.1.7
- generate .vscode/settings.json with clangd.path, install VSCode clangd extension, and run mcpp build

## Tests
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/m/test_mcpp_vscode.py
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/m/test_mcpp_vscode.py tests/m/test_mcpp.py tests/l/test_llvm_tools.py tests/c/test_code.py -m "static or index or isolation"