### PR TITLE
ci: skip install/uninstall assertion for non-local namespace packages

### DIFF
--- a/.github/scripts/posix-test.sh
+++ b/.github/scripts/posix-test.sh
@@ -166,12 +166,22 @@ for rel_file in "${files[@]}"; do
         log_fail "config --add-xpkg failed"; failures+=("$rel_file (register)"); continue
     fi
 
+    # Packages that declare a non-default namespace (e.g. `namespace = "config"`)
+    # are system-side-effect config helpers — they touch hosts files, fontconfig,
+    # PowerShell policy, .vscode/settings.json, etc. — not real artifact installs.
+    # They also collide with the xim global repo on `<ns>:<name>@<ver>` after
+    # merge (both repos carry the same spec, no way to disambiguate), so the
+    # install/uninstall lifecycle assertion is both not useful and not testable
+    # for them. Register-only is enough; the static/isolation/index suites still
+    # validate their xpkg shape.
+    if [[ "$pkg_ns" != "local" ]]; then
+        info "skip (install/uninstall not asserted for namespace='$pkg_ns')"
+        continue
+    fi
+
     shims_before=$(shim_set)
     info "shims before install: $(printf '%s\n' "$shims_before" | grep -c . || true)"
 
-    # Packages that declare `namespace = "config"` (or any other non-default
-    # namespace) are registered under <namespace>:<name> rather than
-    # local:<name>, so install/remove must address them by that spec.
     pkg_spec="${pkg_ns}:${pkg}"
 
     step "[$pkg] install ($pkg_spec)"

--- a/.github/scripts/windows-test.ps1
+++ b/.github/scripts/windows-test.ps1
@@ -143,13 +143,23 @@ foreach ($relFile in $files) {
         continue
     }
 
+    # Packages that declare a non-default namespace (e.g. `namespace = "config"`)
+    # are system-side-effect config helpers — they touch hosts files, fontconfig,
+    # PowerShell policy, .vscode/settings.json, etc. — not real artifact installs.
+    # They also collide with the xim global repo on <ns>:<name>@<ver> after
+    # merge (both repos carry the same spec, no way to disambiguate), so the
+    # install/uninstall lifecycle assertion is both not useful and not testable
+    # for them. Register-only is enough; the static/isolation/index suites still
+    # validate their xpkg shape.
+    if ($pkgNs -ne "local") {
+        Log-Info "skip (install/uninstall not asserted for namespace='$pkgNs')"
+        continue
+    }
+
     # --- snapshot pre-install state ---
     $shimsBefore = Get-ShimSet
     Log-Info "shims before install: $($shimsBefore.Count)"
 
-    # Packages that declare `namespace = "config"` (or any other non-default
-    # namespace) are registered under <namespace>:<name> rather than
-    # local:<name>, so install/remove must address them by that spec.
     $pkgSpec = "${pkgNs}:${pkg}"
 
     # --- install ---


### PR DESCRIPTION
## Summary
跟进 #242 合入后 main 分支 CI 失败（[run 26359944878](https://github.com/openxlings/xim-pkgindex/actions/runs/26359944878/job/77594683008)）。

## 根因
- 声明 `namespace = "config"` 的包，xlings 用包级 namespace 作为前缀（不是 repo 名），所以 xim global repo 和 local override 里都是 `config:<name>@<ver>`
- xlings 的 spec 是 `<namespace>:<name>@<version>` 两段制，没有第三段做 repo 维度的消歧（这是有意设计 — namespace 已经是二级前缀）
- 之前默认 namespace 的包靠 `xim:` ↔ `local:` 不同 namespace 天然避开了冲突；显式 `config:` 一旦合入 main 就 100% 重复
- 这类 config 包（hosts/fontconfig/vscode/policy/rustup-mirror …）本质上是「写系统配置」的副作用工具，不是真的安装产物，跑 install/uninstall 生命周期断言本来意义就不大

## Fix
`.github/scripts/posix-test.sh` 和 `windows-test.ps1`：解析到 `namespace != "local"` 时，只跑 `config --add-xpkg` 注册，跳过 install/uninstall 段并 `continue`。其他验证（static / isolation / index）仍然完整执行。

## Test plan
- [x] `bash .github/scripts/posix-test.sh "pkgs/m/mcpp-vscode-clangd.lua" "$PWD" linux` → `skip (install/uninstall not asserted for namespace='config')`, failures 0
- [x] `bash .github/scripts/posix-test.sh "pkgs/m/mcpp.lua" "$PWD" linux` → 默认 namespace 包正常 install/use/remove, failures 0
- [ ] CI 实跑两条路径（这个 PR 自身只改脚本，没改包，所以 CI 是自验环境用 xpkg-spec 测试覆盖）