### PR TITLE
ci: scope lifecycle skip to namespace='config' only

### DIFF
--- a/.github/scripts/posix-test.sh
+++ b/.github/scripts/posix-test.sh
@@ -166,16 +166,16 @@ for rel_file in "${files[@]}"; do
         log_fail "config --add-xpkg failed"; failures+=("$rel_file (register)"); continue
     fi
 
-    # Packages that declare a non-default namespace (e.g. `namespace = "config"`)
-    # are system-side-effect config helpers — they touch hosts files, fontconfig,
-    # PowerShell policy, .vscode/settings.json, etc. — not real artifact installs.
-    # They also collide with the xim global repo on `<ns>:<name>@<ver>` after
-    # merge (both repos carry the same spec, no way to disambiguate), so the
-    # install/uninstall lifecycle assertion is both not useful and not testable
-    # for them. Register-only is enough; the static/isolation/index suites still
-    # validate their xpkg shape.
-    if [[ "$pkg_ns" != "local" ]]; then
-        info "skip (install/uninstall not asserted for namespace='$pkg_ns')"
+    # `namespace = "config"` is not a package — it's a bundle of system-side
+    # configuration steps (hosts files, fontconfig, PowerShell policy,
+    # .vscode/settings.json, mirror endpoints, etc.). The install/uninstall
+    # lifecycle assertion is not the right shape for it, and it also collides
+    # with the xim global repo on `config:<name>@<ver>` after merge (both repos
+    # carry the same spec, no way to disambiguate by repo). Register-only is
+    # enough; the static/isolation/index suites still validate the xpkg shape.
+    # Other namespaces remain full lifecycle tests.
+    if [[ "$pkg_ns" == "config" ]]; then
+        info "skip (install/uninstall not asserted for namespace='config')"
         continue
     fi
 

--- a/.github/scripts/windows-test.ps1
+++ b/.github/scripts/windows-test.ps1
@@ -143,16 +143,16 @@ foreach ($relFile in $files) {
         continue
     }
 
-    # Packages that declare a non-default namespace (e.g. `namespace = "config"`)
-    # are system-side-effect config helpers — they touch hosts files, fontconfig,
-    # PowerShell policy, .vscode/settings.json, etc. — not real artifact installs.
-    # They also collide with the xim global repo on <ns>:<name>@<ver> after
-    # merge (both repos carry the same spec, no way to disambiguate), so the
-    # install/uninstall lifecycle assertion is both not useful and not testable
-    # for them. Register-only is enough; the static/isolation/index suites still
-    # validate their xpkg shape.
-    if ($pkgNs -ne "local") {
-        Log-Info "skip (install/uninstall not asserted for namespace='$pkgNs')"
+    # `namespace = "config"` is not a package — it's a bundle of system-side
+    # configuration steps (hosts files, fontconfig, PowerShell policy,
+    # .vscode/settings.json, mirror endpoints, etc.). The install/uninstall
+    # lifecycle assertion is not the right shape for it, and it also collides
+    # with the xim global repo on config:<name>@<ver> after merge (both repos
+    # carry the same spec, no way to disambiguate by repo). Register-only is
+    # enough; the static/isolation/index suites still validate the xpkg shape.
+    # Other namespaces remain full lifecycle tests.
+    if ($pkgNs -eq "config") {
+        Log-Info "skip (install/uninstall not asserted for namespace='config')"
         continue
     }
 


### PR DESCRIPTION
## Summary
跟进 #243：把 install/uninstall skip 的范围从「所有非 local namespace」收窄到「仅 namespace='config'」。

## 为什么收窄
- `config` namespace 本质不是一个 package，而是一组系统侧配置（hosts/fontconfig/PowerShell policy/.vscode/settings.json/镜像端点 …），跑 install/uninstall 生命周期断言没意义
- 但其他可能出现的自定义 namespace 还是有可能装真实的产物，应该走完整流程
- #243 一刀切，覆盖面过大，会让未来其他自定义 namespace 的真包绕过 lifecycle 验证

## Fix
`.github/scripts/posix-test.sh` 和 `windows-test.ps1` 把判定从 `pkg_ns != "local"` 改为 `pkg_ns == "config"`。

## Test plan
- [x] `bash .github/scripts/posix-test.sh "pkgs/m/mcpp-vscode-clangd.lua" "$PWD" linux` → skip, failures 0
- [x] `bash .github/scripts/posix-test.sh "pkgs/m/mcpp.lua" "$PWD" linux` → 默认 namespace 完整 install/use/remove, failures 0