### PR TITLE
feat(mcpp-vscode-clangd): enable clangd experimental modules support

### DIFF
--- a/pkgs/m/mcpp-vscode-clangd.lua
+++ b/pkgs/m/mcpp-vscode-clangd.lua
@@ -44,6 +44,9 @@ function config()
     end
     local settings = os.isfile(settings_file) and json.loadfile(settings_file) or {}
     settings["clangd.path"] = path.join(pkginfo.dep_install_dir("llvm-tools", pkginfo.version()), "bin", "clangd")
+    -- Enable clangd's C++20 modules support so mcpp's `import std;` /
+    -- `import <module>;` projects resolve correctly under the editor.
+    settings["clangd.arguments"] = { "--experimental-modules-support" }
     json.savefile(settings_file, settings, { indent = true })
     system.exec("code --install-extension llvm-vs-code-extensions.vscode-clangd")
     os.cd(root)

--- a/tests/m/test_mcpp_vscode_clangd.py
+++ b/tests/m/test_mcpp_vscode_clangd.py
@@ -97,6 +97,11 @@ class TestStatic:
         assert manifest_check < settings_update
 
     @pytest.mark.static
+    def test_enables_clangd_experimental_modules(self, meta):
+        assert '"clangd.arguments"' in meta.raw_content
+        assert '"--experimental-modules-support"' in meta.raw_content
+
+    @pytest.mark.static
     def test_installs_vscode_clangd_extension(self, meta):
         assert "code --install-extension llvm-vs-code-extensions.vscode-clangd" in meta.raw_content
 


### PR DESCRIPTION
## Summary
给 `mcpp-vscode-clangd` 生成的 `.vscode/settings.json` 加上 `clangd.arguments = [\"--experimental-modules-support\"]`，让用 mcpp 写 C++20 模块（`import std;` / `import <module>;`）的项目在编辑器里能正确解析。

## Diff
- `pkgs/m/mcpp-vscode-clangd.lua`：在 `config()` 里 settings 写入 `clangd.path` 之后追加 `settings["clangd.arguments"] = { "--experimental-modules-support" }`
- `tests/m/test_mcpp_vscode_clangd.py`：新增 `TestStatic::test_enables_clangd_experimental_modules` 断言锁定这两个字符串

## Test plan
- [x] `pytest tests/m/test_mcpp_vscode_clangd.py -m "static or isolation or index"` → 24 passed