### PR TITLE
feat(xlings): bump to 0.4.41

### DIFF
--- a/pkgs/x/xlings.lua
+++ b/pkgs/x/xlings.lua
@@ -36,7 +36,11 @@ package = {
     -- one version at a time.
     xpm = {
         linux = {
-            ["latest"] = { ref = "0.4.40" },
+            ["latest"] = { ref = "0.4.41" },
+            ["0.4.41"] = {
+                url = "https://github.com/openxlings/xlings/releases/download/v0.4.41/xlings-0.4.41-linux-x86_64.tar.gz",
+                sha256 = "196ffcdc19611808198ea6f43a6ce03061c56e712418ec267499b4727d56e876",
+            },
             ["0.4.40"] = {
                 url = "https://github.com/openxlings/xlings/releases/download/v0.4.40/xlings-0.4.40-linux-x86_64.tar.gz",
                 sha256 = "02e47440aae74f8a8f6d32e001001aedc9742c36af048a3af604b1ae450257c4",
@@ -173,7 +177,11 @@ package = {
             ["0.3.0"] = "XLINGS_RES",
         },
         macosx = {
-            ["latest"] = { ref = "0.4.40" },
+            ["latest"] = { ref = "0.4.41" },
+            ["0.4.41"] = {
+                url = "https://github.com/openxlings/xlings/releases/download/v0.4.41/xlings-0.4.41-macosx-arm64.tar.gz",
+                sha256 = "105f0fbb43d523c875e6221f26446e535f704532604849d43725a24af8745bcd",
+            },
             ["0.4.40"] = {
                 url = "https://github.com/openxlings/xlings/releases/download/v0.4.40/xlings-0.4.40-macosx-arm64.tar.gz",
                 sha256 = "25589957250cb0be51a22ee2cea4615a3665c5fed257c1e1568f4d7be5b81e75",
@@ -310,7 +318,11 @@ package = {
             ["0.3.0"] = "XLINGS_RES",
         },
         windows = {
-            ["latest"] = { ref = "0.4.40" },
+            ["latest"] = { ref = "0.4.41" },
+            ["0.4.41"] = {
+                url = "https://github.com/openxlings/xlings/releases/download/v0.4.41/xlings-0.4.41-windows-x86_64.zip",
+                sha256 = "7ccfdea68a64587f8e8b2e5b7128f98a55e1eba7fdab451a2d5998017799bf8e",
+            },
             ["0.4.40"] = {
                 url = "https://github.com/openxlings/xlings/releases/download/v0.4.40/xlings-0.4.40-windows-x86_64.zip",
                 sha256 = "92afb39331eb406b15ea96b727f5ade53d05205e1afe6b72d442e4607c3f3aee",

--- a/pkgs/x/xlings.lua
+++ b/pkgs/x/xlings.lua
@@ -318,11 +318,7 @@ package = {
             ["0.3.0"] = "XLINGS_RES",
         },
         windows = {
-            ["latest"] = { ref = "0.4.41" },
-            ["0.4.41"] = {
-                url = "https://github.com/openxlings/xlings/releases/download/v0.4.41/xlings-0.4.41-windows-x86_64.zip",
-                sha256 = "7ccfdea68a64587f8e8b2e5b7128f98a55e1eba7fdab451a2d5998017799bf8e",
-            },
+            ["latest"] = { ref = "0.4.40" },
             ["0.4.40"] = {
                 url = "https://github.com/openxlings/xlings/releases/download/v0.4.40/xlings-0.4.40-windows-x86_64.zip",
                 sha256 = "92afb39331eb406b15ea96b727f5ade53d05205e1afe6b72d442e4607c3f3aee",


### PR DESCRIPTION
## Summary
- update `xlings` Linux and macOS latest refs from 0.4.40 to 0.4.41
- add Linux and macOS v0.4.41 release asset URLs with sha256 checksums
- keep Windows latest at 0.4.40 for now because the v0.4.41 Windows zip currently fails xlings package-index auto-extraction on Windows with `empty pathname`

## Install/uninstall behavior
- Linux/macOS install behavior is unchanged; the package extracts the official xlings release asset and registers `xlings` through xvm
- Windows remains on the existing 0.4.40 package-index entry until the xlings Windows archive extraction issue is fixed
- uninstall behavior is unchanged; it removes the xvm registration for `xlings`
- no system config or shell profile changes are introduced by this index update

## Test plan
- `sha256sum` against the published v0.4.41 Linux/macOS release assets
- `git diff --check`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/x/test_xlings.py -m 'static or isolation' --tb=short -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/x/test_xlings.py -m index --tb=short -q`
- GitHub Actions: original Windows CI failure on v0.4.41 package-index entry reproduced the auto-extract issue; follow-up commit holds Windows at 0.4.40