### PR TITLE
feat(xlings): use XLINGS_RES for 0.4.41

### DIFF
--- a/pkgs/x/xlings.lua
+++ b/pkgs/x/xlings.lua
@@ -29,18 +29,13 @@ package = {
 
     xvm_enable = true,
 
-    -- 0.4.4+ is pinned to a direct GitHub release URL so it can be
-    -- installed without going through the xlings mirror (XLINGS_RES).
-    -- Older versions stay on XLINGS_RES — the mirror still resolves
-    -- them, and the new GitHub-direct shape is being introduced
-    -- one version at a time.
+    -- The current Linux/macOS release uses XLINGS_RES so downloads can
+    -- resolve through the configured multi-mirror resource service.
+    -- Historical 0.4.x entries keep their direct GitHub release URLs.
     xpm = {
         linux = {
             ["latest"] = { ref = "0.4.41" },
-            ["0.4.41"] = {
-                url = "https://github.com/openxlings/xlings/releases/download/v0.4.41/xlings-0.4.41-linux-x86_64.tar.gz",
-                sha256 = "196ffcdc19611808198ea6f43a6ce03061c56e712418ec267499b4727d56e876",
-            },
+            ["0.4.41"] = "XLINGS_RES",
             ["0.4.40"] = {
                 url = "https://github.com/openxlings/xlings/releases/download/v0.4.40/xlings-0.4.40-linux-x86_64.tar.gz",
                 sha256 = "02e47440aae74f8a8f6d32e001001aedc9742c36af048a3af604b1ae450257c4",
@@ -178,10 +173,7 @@ package = {
         },
         macosx = {
             ["latest"] = { ref = "0.4.41" },
-            ["0.4.41"] = {
-                url = "https://github.com/openxlings/xlings/releases/download/v0.4.41/xlings-0.4.41-macosx-arm64.tar.gz",
-                sha256 = "105f0fbb43d523c875e6221f26446e535f704532604849d43725a24af8745bcd",
-            },
+            ["0.4.41"] = "XLINGS_RES",
             ["0.4.40"] = {
                 url = "https://github.com/openxlings/xlings/releases/download/v0.4.40/xlings-0.4.40-macosx-arm64.tar.gz",
                 sha256 = "25589957250cb0be51a22ee2cea4615a3665c5fed257c1e1568f4d7be5b81e75",

--- a/tests/x/test_xlings.py
+++ b/tests/x/test_xlings.py
@@ -1,4 +1,5 @@
 """测试 xlings 包"""
+import re
 import pytest
 from tests.lib.xpkg_parser import parse_xpkg
 from tests.lib.assertions import (
@@ -35,6 +36,21 @@ class TestStatic:
     @pytest.mark.static
     def test_no_typos(self):
         assert_no_typos(PKG_FILE)
+
+    @pytest.mark.static
+    def test_latest_linux_macos_use_xlings_res(self, meta):
+        def platform_block(platform, next_platform):
+            start = meta.raw_content.index(f"        {platform} = {{")
+            end = meta.raw_content.index(f"        {next_platform} = {{", start)
+            return meta.raw_content[start:end]
+
+        for platform, next_platform in (("linux", "macosx"), ("macosx", "windows")):
+            block = platform_block(platform, next_platform)
+            assert re.search(r'\["latest"\]\s*=\s*\{\s*ref\s*=\s*"0\.4\.41"\s*\}', block)
+            assert re.search(r'\["0\.4\.41"\]\s*=\s*"XLINGS_RES"', block)
+
+        windows = meta.raw_content[meta.raw_content.index("        windows = {"):]
+        assert re.search(r'\["latest"\]\s*=\s*\{\s*ref\s*=\s*"0\.4\.40"\s*\}', windows)
 
 
 class TestIndex:
@@ -73,4 +89,3 @@ class TestVerify:
     @skip_if_not('linux')
     def test_xlings(self):
         assert_command_output("xlings --version 2>&1 | head -1", contains="xlings")
-


### PR DESCRIPTION
## Summary
- publish `xlings-res/xlings` release `0.4.41` with Linux/macOS assets for the XLINGS_RES multi-mirror resource service
- switch `xlings` Linux/macOS `0.4.41` package entries from direct upstream GitHub URLs to `XLINGS_RES`
- keep Windows latest at `0.4.40`; the previous 0.4.41 Windows package-index path still has the archive extraction issue recorded in #246
- add a static regression test that enforces Linux/macOS latest use `XLINGS_RES` while Windows remains pinned to 0.4.40

## Resource handling
- `XLINGS_RES` resolves to `https://github.com/xlings-res/xlings/releases/download/0.4.41/...` and configured fallback resource servers
- no sha256 is declared for `XLINGS_RES`, following the current package-index convention
- source assets were copied from `openxlings/xlings` release `v0.4.41`

## Test plan
- RED: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/x/test_xlings.py::TestStatic::test_latest_linux_macos_use_xlings_res -q` failed before the xpkg change because 0.4.41 still used direct URLs
- GREEN: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/x/test_xlings.py::TestStatic::test_latest_linux_macos_use_xlings_res -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/x/test_xlings.py -m "static or isolation or index" -v`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/ -m static --tb=short -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/ -m isolation --tb=short -q`
- `git diff --check`
- isolated HOME install smoke: `xlings install local:xlings@0.4.41 -y` downloaded from RES, installed `xlings 0.4.41`, and `xlings remove local:xlings@0.4.41 -y` removed it
