### PR TITLE
feat(mcpp): bump to 0.0.30

### DIFF
--- a/pkgs/m/mcpp.lua
+++ b/pkgs/m/mcpp.lua
@@ -39,7 +39,8 @@ package = {
     xpm = {
         linux = {
             url_template = "https://github.com/mcpp-community/mcpp/releases/download/v{version}/mcpp-{version}-linux-x86_64.tar.gz",
-            ["latest"] = { ref = "0.0.29" },
+            ["latest"] = { ref = "0.0.30" },
+            ["0.0.30"] = "XLINGS_RES",
             ["0.0.29"] = "XLINGS_RES",
             ["0.0.28"] = "XLINGS_RES",
             ["0.0.27"] = "XLINGS_RES",
@@ -68,7 +69,8 @@ package = {
             ["0.0.1"] = "XLINGS_RES",
         },
         macosx = {
-            ["latest"] = { ref = "0.0.29" },
+            ["latest"] = { ref = "0.0.30" },
+            ["0.0.30"] = "XLINGS_RES",
             ["0.0.29"] = "XLINGS_RES",
             ["0.0.28"] = "XLINGS_RES",
             ["0.0.27"] = "XLINGS_RES",
@@ -83,7 +85,8 @@ package = {
             ["0.0.16"] = "XLINGS_RES",
         },
         windows = {
-            ["latest"] = { ref = "0.0.29" },
+            ["latest"] = { ref = "0.0.30" },
+            ["0.0.30"] = "XLINGS_RES",
             ["0.0.29"] = "XLINGS_RES",
             ["0.0.28"] = "XLINGS_RES",
             ["0.0.27"] = "XLINGS_RES",

--- a/tests/m/test_mcpp.py
+++ b/tests/m/test_mcpp.py
@@ -1,4 +1,5 @@
 """测试 mcpp 包"""
+import re
 import pytest
 from tests.lib.xpkg_parser import parse_xpkg
 from tests.lib.assertions import (
@@ -35,6 +36,23 @@ class TestStatic:
     @pytest.mark.static
     def test_no_typos(self):
         assert_no_typos(PKG_FILE)
+
+    @pytest.mark.static
+    def test_latest_0030_uses_xlings_res(self, meta):
+        def platform_block(platform, next_marker):
+            start = meta.raw_content.index(f"        {platform} = {{")
+            end = meta.raw_content.index(next_marker, start)
+            return meta.raw_content[start:end]
+
+        platforms = (
+            ("linux", "        macosx = {"),
+            ("macosx", "        windows = {"),
+            ("windows", "\n        },\n    },"),
+        )
+        for platform, next_marker in platforms:
+            block = platform_block(platform, next_marker)
+            assert re.search(r'\["latest"\]\s*=\s*\{\s*ref\s*=\s*"0\.0\.30"\s*\}', block)
+            assert re.search(r'\["0\.0\.30"\]\s*=\s*"XLINGS_RES"', block)
 
 
 class TestIndex:

--- a/tests/m/test_mcpp.py
+++ b/tests/m/test_mcpp.py
@@ -39,6 +39,7 @@ class TestStatic:
 
     @pytest.mark.static
     def test_latest_0030_uses_xlings_res(self, meta):
+        # 0.0.x mcpp assets are distributed through the XLINGS_RES mirrors.
         def platform_block(platform, next_marker):
             start = meta.raw_content.index(f"        {platform} = {{")
             end = meta.raw_content.index(next_marker, start)


### PR DESCRIPTION
## Summary
- publish `xlings-res/mcpp` release `0.0.30` with Linux, macOS, and Windows assets for XLINGS_RES
- update `mcpp` latest refs from `0.0.29` to `0.0.30` on linux/macosx/windows
- add a static regression test requiring all mcpp platforms to expose `0.0.30` via `XLINGS_RES`

## Resource handling
- `mcpp` continues to use `XLINGS_RES`; no sha256 is declared in the xpkg entry, matching existing package convention
- assets were copied from upstream `mcpp-community/mcpp` release `v0.0.30`
- RES release: https://github.com/xlings-res/mcpp/releases/tag/0.0.30

## Test plan
- RED: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/m/test_mcpp.py::TestStatic::test_latest_0030_uses_xlings_res -q` failed before the xpkg update because latest still pointed to 0.0.29
- GREEN: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/m/test_mcpp.py::TestStatic::test_latest_0030_uses_xlings_res -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/m/test_mcpp.py -m "static or isolation or index" -v`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/ -m static --tb=short -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/ -m isolation --tb=short -q`
- `git diff --check`
- isolated HOME install smoke: `xlings install local:mcpp@0.0.30 -y` installed `mcpp 0.0.30`, then `xlings remove local:mcpp@0.0.30 -y` removed it

Note: #248 was closed because GitHub Actions did not create any check suites on that head branch after multiple pushes.
