### PR TITLE
feat(claude-llm): add DeepSeek config package

### DIFF
--- a/.agents/skills/xpkg-creater/SKILL.md
+++ b/.agents/skills/xpkg-creater/SKILL.md
@@ -89,6 +89,31 @@ xpm = {
 - `import("common")`
 - `import("platform")`
 
+### 2.1.1 通用 Lua/API 边界
+
+一般情况下，新增或维护 xpkg 只能使用三类能力：
+- XPackage Spec V1 规定的 `package` 元数据、`xpm` 描述和 lifecycle hooks。
+- 标准 Lua 语法与标准库（例如 `string/table/io/os.getenv/pcall/error` 等）。
+- 必要的 `xim.libxpkg.*` API（例如 `pkginfo/xvm/system/log/json`）。
+
+不要默认引入 xmake 私有 runtime/API。除非某个既有包的兼容性约束已经证明必须使用，否则避免：
+- `core.*`、`detect.*`、`runtime.*`、`xim.base.runtime`
+- `common`、`platform`
+- `path.*`、`os.host()`、`is_host()`、`try { ... }`、`raise(...)`
+
+测试也应默认锁定这条边界：import 只能来自 `xim.libxpkg.*`，路径、错误处理、文件 IO 优先用标准 Lua 或 `libxpkg` 可移植封装。
+
+### 2.1.2 配置型包的 Lua 边界
+
+对 `type = "config"` 且会写入用户工具配置的包（例如 Claude/LLM 配置）：
+- 只使用标准 Lua 语法、`package` 元数据、hooks，以及必要的 `xim.libxpkg.*` import。
+- 不使用 xmake 私有 import/API：`core.*`、`detect.*`、`xim.base.runtime`、`runtime.*`、`is_host()`、`os.host()`、`path.*`、`try { ... }`。
+- Lua 错误使用标准 `error(...)`，不要使用 `raise(...)`。
+- `install()` 保持轻量，默认 `return true`；实际配置写入放在 `config()`。
+- 修改已有 JSON 配置时先读取并保留原对象，只更新本包负责的 key；写入前备份，并用 `log.info/log.warn/log.error` 说明结果，敏感 token 不要明文打印。
+- 如果用户未输入新 key 但已有有效配置，使用 `log.warn` 提示继续复用旧 key 且不改 token；如果没有可复用 key，使用 `log.error` 后失败。
+- 针对独立行为（例如修复 Claude token 缓存的 env 项）单独抽成函数，便于测试锁定边界。
+
 ### 2.2 install() 约束
 
 `install()` 只负责安装动作本身：
@@ -118,6 +143,8 @@ xpm = {
 1. 在 `pkgs/<首字母>/<name>.lua` 新增或修改包。
 2. 若新增包，创建镜像测试文件：
    - `tests/<首字母>/test_<name_with_underscore>.py`
+   - 测试默认锁定：只 import `xim.libxpkg.*`，只使用标准 Lua + xpkg 规范，不使用 `path.*`/`os.host()`/`try {}`/`raise()` 等 xmake 私有 API。
+   - 对写用户配置的 `type = "config"` 包，额外锁定：`install()` 轻量，实际写入在 `config()`。
 3. 先跑本地直接命令验证（索引/安装/搜索/卸载）。
 4. 再跑测试集验证（L0~L4，至少 L0/L1/L2）。
 5. 准备 PR：写清楚包用途、安装/卸载行为、系统影响、测试结果。

--- a/docs/V1/xpackage-spec.md
+++ b/docs/V1/xpackage-spec.md
@@ -80,6 +80,8 @@ function uninstall() ... end
 
 ### 禁用 API 与替代方案
 
+> xmake兼容api逐步优化使用libxpkg原生的运行时
+
 | 禁用（xmake 特有） | 替代（xpkg 规范） |
 |-------------------|-----------------|
 | `is_host("linux")` | `os.host() == "linux"` |

--- a/pkgs/c/claude-llm.lua
+++ b/pkgs/c/claude-llm.lua
@@ -1,0 +1,223 @@
+package = {
+    spec = "1",
+    name = "claude-llm",
+    description = "Configure Claude Code to use DeepSeek Anthropic-compatible API",
+    homepage = "https://platform.deepseek.com/api_keys",
+    licenses = {"Apache-2.0"},
+
+    type = "config",
+    namespace = "config",
+    status = "dev",
+    categories = {"ai", "claude", "config"},
+    keywords = {"claude", "claude-code", "deepseek", "llm"},
+
+    xpm = {
+        windows = {
+            deps = { "xim:claude" },
+            ["latest"] = { ref = "deepseek" },
+            ["deepseek"] = {},
+        },
+        linux = {
+            deps = { "xim:claude" },
+            ["latest"] = { ref = "deepseek" },
+            ["deepseek"] = {},
+        },
+        macosx = {
+            deps = { "xim:claude" },
+            ["latest"] = { ref = "deepseek" },
+            ["deepseek"] = {},
+        },
+    },
+}
+
+import("xim.libxpkg.json")
+import("xim.libxpkg.log")
+import("xim.libxpkg.system")
+
+local function __trim(value)
+    return (value or ""):match("^%s*(.-)%s*$")
+end
+
+local function __home_dir()
+    if os.host() == "windows" then
+        local userprofile = os.getenv("USERPROFILE")
+        if userprofile and userprofile ~= "" then
+            return userprofile
+        end
+
+        local homedrive = os.getenv("HOMEDRIVE")
+        local homepath = os.getenv("HOMEPATH")
+        if homedrive and homepath and homedrive ~= "" and homepath ~= "" then
+            return homedrive .. homepath
+        end
+    end
+
+    local home = os.getenv("HOME")
+    if home and home ~= "" then
+        return home
+    end
+
+    local fallback = os.getenv("USERPROFILE")
+    if fallback and fallback ~= "" then
+        return fallback
+    end
+
+    error("无法定位用户主目录，未写入 Claude 配置", 0)
+end
+
+local function __backup_if_exists(file)
+    if os.isfile(file) then
+        local backup = file .. ".bak." .. os.date("%Y%m%d-%H%M%S")
+        os.cp(file, backup)
+        log.info("已备份已有配置: " .. backup)
+    end
+end
+
+local function __load_json_object(file)
+    if not os.isfile(file) then
+        return {}
+    end
+
+    local value = try {
+        function()
+            return json.loadfile(file)
+        end,
+        catch = function(err)
+            log.warn("已有 JSON 配置读取失败，将使用新配置覆盖: " .. file)
+            return {}
+        end
+    }
+
+    if type(value) ~= "table" then
+        return {}
+    end
+    return value
+end
+
+local function __existing_deepseek_api_key(env)
+    if type(env) ~= "table" then
+        return nil
+    end
+    if env["ANTHROPIC_BASE_URL"] ~= "https://api.deepseek.com/anthropic" then
+        return nil
+    end
+
+    local existing_api_key = __trim(env["ANTHROPIC_AUTH_TOKEN"])
+    if existing_api_key == "" then
+        return nil
+    end
+    return existing_api_key
+end
+
+local function __read_deepseek_api_key(existing_api_key)
+    print("请先在 DeepSeek 平台创建或复制 API Key:")
+    print("")
+    print("  -> https://platform.deepseek.com/api_keys")
+    print("")
+    print("复制 DeepSeek API Key 后粘贴到下面, 按回车继续")
+    io.write("DeepSeek API Key: ")
+    io.flush()
+
+    local api_key = __trim(io.read("*l"))
+    if api_key == "" then
+        if existing_api_key then
+            log.warn("未输入新的 DeepSeek API Key，将复用已有 key，不修改 ANTHROPIC_AUTH_TOKEN")
+            return existing_api_key, true
+        end
+        log.error("未输入 DeepSeek API Key，且没有可复用的旧 DeepSeek key")
+        error("未输入 DeepSeek API Key，且没有可复用的旧 DeepSeek key", 0)
+    end
+    return api_key, false
+end
+
+local function __ensure_onboarding_completed()
+    local config_file = path.join(__home_dir(), ".claude.json")
+    __backup_if_exists(config_file)
+
+    local config = __load_json_object(config_file)
+    config["hasCompletedOnboarding"] = true
+
+    json.savefile(config_file, config, { indent = true })
+    log.info("已确保 Claude onboarding 状态: hasCompletedOnboarding=true")
+end
+
+local function __log_env_update(key, value, hidden)
+    if hidden then
+        log.info("已配置 Claude env.%s = <已隐藏>", key)
+    else
+        --log.info("已配置 Claude env.%s = %s", key, value)
+    end
+end
+
+local function __set_env(env, key, value, hidden)
+    env[key] = value
+    __log_env_update(key, value, hidden)
+end
+
+local function __apply_deepseek_env(env, api_key, keep_existing_key)
+    if not keep_existing_key then
+        __set_env(env, "ANTHROPIC_AUTH_TOKEN", api_key, true)
+    end
+    __set_env(env, "ANTHROPIC_BASE_URL", "https://api.deepseek.com/anthropic")
+    __set_env(env, "ANTHROPIC_MODEL", "deepseek-v4-pro[1m]")
+    __set_env(env, "ANTHROPIC_DEFAULT_OPUS_MODEL", "deepseek-v4-pro[1m]")
+    __set_env(env, "ANTHROPIC_DEFAULT_SONNET_MODEL", "deepseek-v4-pro[1m]")
+    __set_env(env, "ANTHROPIC_DEFAULT_HAIKU_MODEL", "deepseek-v4-pro[1m]")
+    __set_env(env, "CLAUDE_CODE_SUBAGENT_MODEL", "deepseek-v4-pro[1m]")
+    __set_env(env, "CLAUDE_CODE_EFFORT_LEVEL", "max")
+    __set_env(env, "API_TIMEOUT_MS", "3000000")
+    __set_env(env, "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC", "1")
+end
+
+local function __apply_claude_token_cache_fix(env)
+    log.info("修复 Claude token 缓存机制: 禁用 attribution header, 避免随机值导致的缓存失效")
+    __set_env(env, "CLAUDE_CODE_ATTRIBUTION_HEADER", "0")
+end
+
+local function __write_claude_settings(settings_file, settings, api_key, keep_existing_key)
+    local claude_dir = path.directory(settings_file)
+    if not os.isdir(claude_dir) then
+        os.mkdir(claude_dir)
+    end
+
+    __backup_if_exists(settings_file)
+
+    if type(settings.env) ~= "table" then
+        settings.env = {}
+    end
+    __apply_deepseek_env(settings.env, api_key, keep_existing_key)
+    __apply_claude_token_cache_fix(settings.env)
+    json.savefile(settings_file, settings, { indent = true })
+
+    log.info("已写入 Claude DeepSeek 配置: " .. settings_file)
+end
+
+local function __verify_claude_deepseek()
+    log.info("正在调用 Claude Code 发起一次纯文本 DeepSeek 配置验证请求...")
+    print("")
+    system.exec([[claude -p --setting-sources user --tools "" --no-session-persistence "你是什么模型? 以及 1 + 2 = ? . 最后恭喜/并简单赞扬用户配置好了claude + deepseek的环境！"]])
+    print("")
+end
+
+function install()
+    return true
+end
+
+function config()
+    local settings_file = path.join(__home_dir(), ".claude", "settings.json")
+    local settings = __load_json_object(settings_file)
+    if type(settings.env) ~= "table" then
+        settings.env = {}
+    end
+    local existing_api_key = __existing_deepseek_api_key(settings.env)
+    local api_key, keep_existing_key = __read_deepseek_api_key(existing_api_key)
+    __ensure_onboarding_completed()
+    __write_claude_settings(settings_file, settings, api_key, keep_existing_key)
+    log.info("Claude DeepSeek 配置已完成。验证通过后即可直接使用 claude 命令行工具...")
+    __verify_claude_deepseek()
+    return true
+end
+
+function uninstall()
+    return true
+end

--- a/tests/c/test_claude_llm.py
+++ b/tests/c/test_claude_llm.py
@@ -1,0 +1,238 @@
+"""Tests for pkgs/c/claude-llm.lua."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from tests.lib.assertions import (
+    assert_no_bashrc_modification,
+    assert_no_direct_path_modification,
+    assert_no_exec_xvm,
+    assert_no_typos,
+    assert_required_fields,
+    assert_uses_new_api,
+    assert_valid_spec,
+    assert_valid_type,
+    assert_xim_add_succeeds,
+)
+from tests.lib.xpkg_parser import parse_xpkg
+
+
+PKG_FILE = "pkgs/c/claude-llm.lua"
+
+
+@pytest.fixture(scope="module")
+def meta():
+    return parse_xpkg(PKG_FILE)
+
+
+@pytest.fixture(scope="module")
+def raw_content():
+    return Path(PKG_FILE).read_text(encoding="utf-8")
+
+
+@pytest.mark.static
+class TestClaudeLlmStatic:
+    """Static package contract tests."""
+
+    def test_required_fields_and_spec(self, meta):
+        assert_required_fields(meta)
+        assert_valid_spec(meta)
+        assert_valid_type(meta)
+        assert_no_typos(PKG_FILE)
+
+    def test_metadata(self, meta):
+        assert meta.name == "claude-llm"
+        assert meta.pkg_type == "config"
+        assert meta.namespace == "config"
+
+    def test_platforms_depend_on_claude(self, raw_content, meta):
+        assert set(meta.platforms.keys()) == {"windows", "linux", "macosx"}
+
+        for platform in ("windows", "linux", "macosx"):
+            assert platform in raw_content
+
+        assert raw_content.count("[\"latest\"] = { ref = \"deepseek\" }") == 3
+        assert raw_content.count("[\"deepseek\"] = {}") == 3
+        assert raw_content.count("\"xim:claude\"") == 3
+
+    def test_imports_are_limited_to_libxpkg(self, raw_content, meta):
+        assert "xim.libxpkg.json" in meta.imports
+        assert "xim.libxpkg.log" in meta.imports
+        assert "xim.libxpkg.system" in meta.imports
+
+        for imported in meta.imports:
+            assert imported.startswith("xim.libxpkg."), imported
+
+        forbidden = [
+            "import(\"core.",
+            "import(\"detect.",
+            "import(\"lib.detect.",
+            "import(\"xim.base.runtime",
+            "import(\"common\")",
+            "import(\"platform\")",
+            "runtime.",
+            "is_host(",
+            "os.scriptdir(",
+            "raise(",
+        ]
+        for token in forbidden:
+            assert token not in raw_content
+
+    def test_top_level_is_declarative(self, raw_content):
+        first_function = raw_content.index("local function")
+        top_level = raw_content[:first_function]
+
+        forbidden_runtime_calls = [
+            "os.getenv(",
+            "os.isfile(",
+            "os.isdir(",
+            "os.cp(",
+            "os.mkdir(",
+            "io.read(",
+            "system.exec(",
+            "json.loadfile(",
+            "json.savefile(",
+        ]
+        for token in forbidden_runtime_calls:
+            assert token not in top_level
+
+    def test_install_is_trivial_and_config_does_work(self, meta, raw_content):
+        install_hook = re.search(r"function install\(\)(.*?)\nend", raw_content, re.S)
+        config_hook = re.search(r"function config\(\)(.*?)\nend", raw_content, re.S)
+
+        assert install_hook is not None
+        assert config_hook is not None
+        assert "return true" in install_hook.group(1)
+        assert "__write_claude_settings(settings_file, settings, api_key, keep_existing_key)" in config_hook.group(1)
+        assert "__ensure_onboarding_completed()" in config_hook.group(1)
+
+        assert "settings = __load_json_object(settings_file)" in raw_content
+        assert "settings.env = {}" in raw_content
+
+    def test_uses_standard_lua_error_not_xmake_raise(self, raw_content):
+        assert "error(" in raw_content
+        assert "raise(" not in raw_content
+        assert "无法定位用户主目录，未写入 Claude 配置" in raw_content
+
+    def test_configures_expected_claude_files(self, raw_content):
+        assert ".claude" in raw_content
+        assert "settings.json" in raw_content
+        assert ".claude.json" in raw_content
+        assert "hasCompletedOnboarding" in raw_content
+        assert "os.getenv(\"HOME\")" in raw_content
+        assert "os.getenv(\"USERPROFILE\")" in raw_content
+
+    def test_preserves_and_merges_existing_claude_settings(self, raw_content):
+        assert "local settings = __load_json_object(settings_file)" in raw_content
+        assert "if type(settings.env) ~= \"table\" then" in raw_content
+        assert "settings.env = {}" in raw_content
+        assert "__apply_deepseek_env(settings.env, api_key, keep_existing_key)" in raw_content
+        assert "json.savefile(settings_file, settings" in raw_content
+        assert "json.savefile(settings_file, {" not in raw_content
+
+    def test_existing_config_is_backed_up_before_write(self, raw_content):
+        assert "__backup_if_exists(settings_file)" in raw_content
+        assert "__backup_if_exists(config_file)" in raw_content
+        assert ".bak." in raw_content
+        assert "os.date(\"%Y%m%d-%H%M%S\")" in raw_content
+        assert "os.cp(file, backup)" in raw_content
+
+    def test_prompts_and_trims_deepseek_api_key(self, raw_content):
+        assert "https://platform.deepseek.com/api_keys" in raw_content
+        assert "DeepSeek API Key" in raw_content
+        assert "io.read(\"*l\")" in raw_content
+        assert ":match(\"^%s*(.-)%s*$\")" in raw_content
+
+    def test_prompts_with_standard_lua_and_logs_status_with_libxpkg(self, raw_content):
+        assert 'print("请先在 DeepSeek 平台创建或复制 API Key:")' in raw_content
+        assert 'io.write("DeepSeek API Key: ")' in raw_content
+        assert "io.flush()" in raw_content
+        assert "cprint(" not in raw_content
+        assert "log.info(\"已配置 Claude env.%s = %s\", key, value)" in raw_content
+        assert "log.info(\"已配置 Claude env.%s = <已隐藏>\", key)" in raw_content
+
+    def test_applies_expected_deepseek_environment(self, raw_content):
+        expected_values = {
+            "ANTHROPIC_BASE_URL": "https://api.deepseek.com/anthropic",
+            "ANTHROPIC_MODEL": "deepseek-v4-pro[1m]",
+            "ANTHROPIC_DEFAULT_OPUS_MODEL": "deepseek-v4-pro[1m]",
+            "ANTHROPIC_DEFAULT_SONNET_MODEL": "deepseek-v4-pro[1m]",
+            "ANTHROPIC_DEFAULT_HAIKU_MODEL": "deepseek-v4-pro[1m]",
+            "CLAUDE_CODE_SUBAGENT_MODEL": "deepseek-v4-pro[1m]",
+            "CLAUDE_CODE_EFFORT_LEVEL": "max",
+            "API_TIMEOUT_MS": "3000000",
+            "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
+        }
+
+        for key, value in expected_values.items():
+            assert f'__set_env(env, "{key}", "{value}")' in raw_content
+
+        assert '__set_env(env, "ANTHROPIC_AUTH_TOKEN", api_key, true)' in raw_content
+        assert "sk-xxx" not in raw_content
+
+    def test_attribution_header_is_separate_token_cache_fix(self, raw_content):
+        deepseek_env_function = re.search(
+            r"local function __apply_deepseek_env\(env, api_key, keep_existing_key\)(.*?)\nend",
+            raw_content,
+            re.S,
+        )
+        assert deepseek_env_function is not None
+        assert "CLAUDE_CODE_ATTRIBUTION_HEADER" not in deepseek_env_function.group(1)
+
+        assert "local function __apply_claude_token_cache_fix(env)" in raw_content
+        assert (
+            '__set_env(env, "CLAUDE_CODE_ATTRIBUTION_HEADER", "0")'
+            in raw_content
+        )
+        assert "__apply_claude_token_cache_fix(settings.env)" in raw_content
+        assert "修复 Claude token 缓存机制" in raw_content
+
+    def test_empty_input_reuses_existing_deepseek_key_only_when_present(self, raw_content):
+        assert "local existing_api_key = __existing_deepseek_api_key(settings.env)" in raw_content
+        assert "local api_key, keep_existing_key = __read_deepseek_api_key(existing_api_key)" in raw_content
+        assert "return existing_api_key, true" in raw_content
+        assert "不修改 ANTHROPIC_AUTH_TOKEN" in raw_content
+        assert "log.warn(" in raw_content
+        assert "if not keep_existing_key then" in raw_content
+        assert "没有可复用的旧 DeepSeek key" in raw_content
+
+    def test_existing_key_reuse_requires_deepseek_endpoint(self, raw_content):
+        assert (
+            'env["ANTHROPIC_BASE_URL"] ~= "https://api.deepseek.com/anthropic"'
+            in raw_content
+        )
+        assert 'local existing_api_key = __trim(env["ANTHROPIC_AUTH_TOKEN"])' in raw_content
+        assert "return existing_api_key" in raw_content
+
+    def test_verification_command_avoids_new_directory_prompt(self, raw_content):
+        assert "system.exec(" in raw_content
+        assert "claude -p" in raw_content
+        assert "--setting-sources user" in raw_content
+        assert '--tools ""' in raw_content
+        assert "--no-session-persistence" in raw_content
+        assert "DeepSeek 配置验证成功" not in raw_content
+
+
+@pytest.mark.index
+class TestClaudeLlmIndex:
+    def test_xim_add_succeeds(self):
+        assert_xim_add_succeeds(PKG_FILE)
+
+
+@pytest.mark.isolation
+class TestClaudeLlmIsolation:
+    def test_no_exec_xvm(self):
+        assert_no_exec_xvm(PKG_FILE)
+
+    def test_no_bashrc_modification(self):
+        assert_no_bashrc_modification(PKG_FILE)
+
+    def test_no_direct_path_modification(self):
+        assert_no_direct_path_modification(PKG_FILE)
+
+    def test_uses_new_api(self):
+        assert_uses_new_api(PKG_FILE)


### PR DESCRIPTION
## Summary
- Add `config:claude-llm` package for configuring Claude Code to use DeepSeek Anthropic-compatible API.
- Add static/index/isolation tests covering metadata, deps, config lifecycle, env values, backup behavior, and xpkg registration.
- Update xpkg authoring guidance in `.agents/skills/xpkg-creater` and V1 spec note for libxpkg-native runtime direction.

## Behavior
- `install()` stays trivial and returns true.
- `config()` prompts for DeepSeek API key, backs up/writes Claude settings, sets expected DeepSeek env values, marks onboarding complete, and runs a Claude validation command.
- `uninstall()` is a no-op and returns true.
- The package modifies user Claude configuration files (`~/.claude/settings.json` and `~/.claude.json`) and does not modify shell profiles or PATH directly.

## Test plan
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/c/test_claude_llm.py -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/c/test_claude_llm.py -m "static or isolation" -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/c/test_claude_llm.py -m index -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_xpkg_spec.py -q`
- `git diff --check && git diff --cached --check`
