### PR TITLE
feat(xlings): bump to 0.4.42

### DIFF
--- a/pkgs/x/xlings.lua
+++ b/pkgs/x/xlings.lua
@@ -29,12 +29,13 @@ package = {
 
     xvm_enable = true,
 
-    -- The current Linux/macOS release uses XLINGS_RES so downloads can
+    -- The current release uses XLINGS_RES so downloads can
     -- resolve through the configured multi-mirror resource service.
     -- Historical 0.4.x entries keep their direct GitHub release URLs.
     xpm = {
         linux = {
-            ["latest"] = { ref = "0.4.41" },
+            ["latest"] = { ref = "0.4.42" },
+            ["0.4.42"] = "XLINGS_RES",
             ["0.4.41"] = "XLINGS_RES",
             ["0.4.40"] = {
                 url = "https://github.com/openxlings/xlings/releases/download/v0.4.40/xlings-0.4.40-linux-x86_64.tar.gz",
@@ -172,7 +173,8 @@ package = {
             ["0.3.0"] = "XLINGS_RES",
         },
         macosx = {
-            ["latest"] = { ref = "0.4.41" },
+            ["latest"] = { ref = "0.4.42" },
+            ["0.4.42"] = "XLINGS_RES",
             ["0.4.41"] = "XLINGS_RES",
             ["0.4.40"] = {
                 url = "https://github.com/openxlings/xlings/releases/download/v0.4.40/xlings-0.4.40-macosx-arm64.tar.gz",
@@ -310,7 +312,8 @@ package = {
             ["0.3.0"] = "XLINGS_RES",
         },
         windows = {
-            ["latest"] = { ref = "0.4.40" },
+            ["latest"] = { ref = "0.4.42" },
+            ["0.4.42"] = "XLINGS_RES",
             ["0.4.40"] = {
                 url = "https://github.com/openxlings/xlings/releases/download/v0.4.40/xlings-0.4.40-windows-x86_64.zip",
                 sha256 = "92afb39331eb406b15ea96b727f5ade53d05205e1afe6b72d442e4607c3f3aee",

--- a/tests/x/test_xlings.py
+++ b/tests/x/test_xlings.py
@@ -38,7 +38,7 @@ class TestStatic:
         assert_no_typos(PKG_FILE)
 
     @pytest.mark.static
-    def test_latest_linux_macos_use_xlings_res(self, meta):
+    def test_latest_platforms_use_xlings_res(self, meta):
         def platform_block(platform, next_platform):
             start = meta.raw_content.index(f"        {platform} = {{")
             end = meta.raw_content.index(f"        {next_platform} = {{", start)
@@ -46,11 +46,12 @@ class TestStatic:
 
         for platform, next_platform in (("linux", "macosx"), ("macosx", "windows")):
             block = platform_block(platform, next_platform)
-            assert re.search(r'\["latest"\]\s*=\s*\{\s*ref\s*=\s*"0\.4\.41"\s*\}', block)
-            assert re.search(r'\["0\.4\.41"\]\s*=\s*"XLINGS_RES"', block)
+            assert re.search(r'\["latest"\]\s*=\s*\{\s*ref\s*=\s*"0\.4\.42"\s*\}', block)
+            assert re.search(r'\["0\.4\.42"\]\s*=\s*"XLINGS_RES"', block)
 
         windows = meta.raw_content[meta.raw_content.index("        windows = {"):]
-        assert re.search(r'\["latest"\]\s*=\s*\{\s*ref\s*=\s*"0\.4\.40"\s*\}', windows)
+        assert re.search(r'\["latest"\]\s*=\s*\{\s*ref\s*=\s*"0\.4\.42"\s*\}', windows)
+        assert re.search(r'\["0\.4\.42"\]\s*=\s*"XLINGS_RES"', windows)
 
 
 class TestIndex:


### PR DESCRIPTION
## Summary
- Add xlings 0.4.42 as latest for linux, macosx, and windows.
- Use XLINGS_RES for 0.4.42 so downloads resolve through the configured multi-mirror resource service.
- Publish xlings-res/xlings 0.4.42 with linux, macosx, and windows assets: https://github.com/xlings-res/xlings/releases/tag/0.4.42
- Update the xlings static regression test to require latest platforms to use XLINGS_RES.

## Install / uninstall behavior
- install(): unchanged; moves the extracted xlings package directory into pkginfo.install_dir().
- config(): unchanged; registers xlings via xvm.add with bin/ as bindir.
- uninstall(): unchanged; removes the xlings xvm registration.
- System configuration: no new system config, shell profile, or PATH mutation added.

## Test plan
- RED: PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/x/test_xlings.py::TestStatic::test_latest_platforms_use_xlings_res -q failed before the package update.
- GREEN: PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/x/test_xlings.py::TestStatic::test_latest_platforms_use_xlings_res -q
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/x/test_xlings.py -m 'static or isolation or index' -q
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/ -m static --tb=short -q
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/ -m isolation --tb=short -q
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/ -m index --tb=short -q
- git diff --check
- Isolated HOME smoke: xlings update; xlings config --add-xpkg pkgs/x/xlings.lua; xlings install local:xlings@0.4.42 -y; installed binary reported xlings 0.4.42; xlings remove local:xlings@0.4.42 -y
- Compatibility smoke with unpacked xlings 0.4.13 runtime: .github/scripts/posix-test.sh pkgs/x/xlings.lua linux passed