### PR TITLE
fix(xlings): sync RES mirrors and bump CI bootstrap

### DIFF
--- a/.agents/skills/xpkg-creater/SKILL.md
+++ b/.agents/skills/xpkg-creater/SKILL.md
@@ -75,6 +75,18 @@ xpm = {
 
 参考实现：`pkgs/g/github-gh.lua`
 
+### 1.2.1 XLINGS_RES 镜像发布要求
+
+当某个版本在包索引中写成 `"XLINGS_RES"` 时，该版本已经进入 xlings 多镜像资源服务链路。发布前必须同时满足：
+
+- `https://github.com/xlings-res/<pkg>` 与 `https://gitcode.com/xlings-res/<pkg>` 都存在同名 tag/release。
+- 两边 release 都包含该版本声明会使用的全部平台资产；文件名必须符合 xlings-res 约定。
+- 两边资产必须来自同一个权威上游 release 或同一次构建产物；发布后从 GitHub RES、GitCode RES、权威上游各下载一次并比对 sha256，确认字节一致。
+- 如果补发历史版本，发布后确认两边 `latest` 仍指向应当作为最新的版本，不要因为补旧版本导致 latest 倒退。
+- PR 描述或汇报中写清楚 GitHub RES、GitCode RES 的 release/tag，以及 sha256 校验结果。
+
+如果 GitHub RES 和 GitCode RES 任一侧缺资源、版本不一致、资产不一致，不能把该版本切到 `"XLINGS_RES"`；先补齐镜像资源，再改包索引。
+
 ## 2) hooks 实现规范（核心）
 
 ### 2.1 import 规范

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Installation Xlings on Ubuntu
         run: |
           export XLINGS_NON_INTERACTIVE=1
-          export XLINGS_VERSION=v0.4.42
+          export XLINGS_VERSION=v0.4.43
           curl -fsSL https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.sh | bash
           echo "XLINGS_HOME=$HOME/.xlings" >> "$GITHUB_ENV"
           echo "PATH=$HOME/.xlings/subos/current/bin:$HOME/.xlings/bin:$PATH" >> "$GITHUB_ENV"
@@ -76,7 +76,7 @@ jobs:
         shell: pwsh
         run: |
           $env:XLINGS_NON_INTERACTIVE = "1"
-          $env:XLINGS_VERSION = "v0.4.42"
+          $env:XLINGS_VERSION = "v0.4.43"
           iex (Invoke-WebRequest `
             -Uri "https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.ps1" `
             -UseBasicParsing).Content
@@ -127,7 +127,7 @@ jobs:
       - name: Install xlings on Ubuntu
         run: |
           export XLINGS_NON_INTERACTIVE=1
-          export XLINGS_VERSION=v0.4.42
+          export XLINGS_VERSION=v0.4.43
           curl -fsSL https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.sh | bash
           echo "XLINGS_HOME=$HOME/.xlings" >> "$GITHUB_ENV"
           echo "$HOME/.xlings/bin"               >> "$GITHUB_PATH"
@@ -170,7 +170,7 @@ jobs:
       - name: Install xlings on macOS
         run: |
           export XLINGS_NON_INTERACTIVE=1
-          export XLINGS_VERSION=v0.4.42
+          export XLINGS_VERSION=v0.4.43
           curl -fsSL https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.sh | bash
           echo "XLINGS_HOME=$HOME/.xlings" >> "$GITHUB_ENV"
           echo "$HOME/.xlings/bin"               >> "$GITHUB_PATH"

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Installation Xlings on Ubuntu
         run: |
           export XLINGS_NON_INTERACTIVE=1
-          export XLINGS_VERSION=v0.4.13
+          export XLINGS_VERSION=v0.4.42
           curl -fsSL https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.sh | bash
           echo "XLINGS_HOME=$HOME/.xlings" >> "$GITHUB_ENV"
           echo "PATH=$HOME/.xlings/subos/current/bin:$HOME/.xlings/bin:$PATH" >> "$GITHUB_ENV"
@@ -76,7 +76,7 @@ jobs:
         shell: pwsh
         run: |
           $env:XLINGS_NON_INTERACTIVE = "1"
-          $env:XLINGS_VERSION = "v0.4.13"
+          $env:XLINGS_VERSION = "v0.4.42"
           iex (Invoke-WebRequest `
             -Uri "https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.ps1" `
             -UseBasicParsing).Content
@@ -127,7 +127,7 @@ jobs:
       - name: Install xlings on Ubuntu
         run: |
           export XLINGS_NON_INTERACTIVE=1
-          export XLINGS_VERSION=v0.4.13
+          export XLINGS_VERSION=v0.4.42
           curl -fsSL https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.sh | bash
           echo "XLINGS_HOME=$HOME/.xlings" >> "$GITHUB_ENV"
           echo "$HOME/.xlings/bin"               >> "$GITHUB_PATH"
@@ -170,7 +170,7 @@ jobs:
       - name: Install xlings on macOS
         run: |
           export XLINGS_NON_INTERACTIVE=1
-          export XLINGS_VERSION=v0.4.13
+          export XLINGS_VERSION=v0.4.42
           curl -fsSL https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.sh | bash
           echo "XLINGS_HOME=$HOME/.xlings" >> "$GITHUB_ENV"
           echo "$HOME/.xlings/bin"               >> "$GITHUB_PATH"

--- a/.github/workflows/ci-xpkg-test.yml
+++ b/.github/workflows/ci-xpkg-test.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Install xlings
         run: |
           export XLINGS_NON_INTERACTIVE=1
-          export XLINGS_VERSION=v0.4.42
+          export XLINGS_VERSION=v0.4.43
           curl -fsSL https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.sh | bash
           echo "XLINGS_HOME=$HOME/.xlings" >> "$GITHUB_ENV"
           echo "PATH=$HOME/.xlings/subos/current/bin:$HOME/.xlings/bin:$PATH" >> "$GITHUB_ENV"

--- a/.github/workflows/ci-xpkg-test.yml
+++ b/.github/workflows/ci-xpkg-test.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Install xlings
         run: |
           export XLINGS_NON_INTERACTIVE=1
-          export XLINGS_VERSION=v0.4.13
+          export XLINGS_VERSION=v0.4.42
           curl -fsSL https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.sh | bash
           echo "XLINGS_HOME=$HOME/.xlings" >> "$GITHUB_ENV"
           echo "PATH=$HOME/.xlings/subos/current/bin:$HOME/.xlings/bin:$PATH" >> "$GITHUB_ENV"

--- a/pkgs/x/xlings.lua
+++ b/pkgs/x/xlings.lua
@@ -34,7 +34,8 @@ package = {
     -- Historical 0.4.x entries keep their direct GitHub release URLs.
     xpm = {
         linux = {
-            ["latest"] = { ref = "0.4.42" },
+            ["latest"] = { ref = "0.4.43" },
+            ["0.4.43"] = "XLINGS_RES",
             ["0.4.42"] = "XLINGS_RES",
             ["0.4.41"] = "XLINGS_RES",
             ["0.4.40"] = "XLINGS_RES",
@@ -170,7 +171,8 @@ package = {
             ["0.3.0"] = "XLINGS_RES",
         },
         macosx = {
-            ["latest"] = { ref = "0.4.42" },
+            ["latest"] = { ref = "0.4.43" },
+            ["0.4.43"] = "XLINGS_RES",
             ["0.4.42"] = "XLINGS_RES",
             ["0.4.41"] = "XLINGS_RES",
             ["0.4.40"] = "XLINGS_RES",
@@ -306,7 +308,8 @@ package = {
             ["0.3.0"] = "XLINGS_RES",
         },
         windows = {
-            ["latest"] = { ref = "0.4.42" },
+            ["latest"] = { ref = "0.4.43" },
+            ["0.4.43"] = "XLINGS_RES",
             ["0.4.42"] = "XLINGS_RES",
             ["0.4.41"] = "XLINGS_RES",
             ["0.4.40"] = "XLINGS_RES",

--- a/pkgs/x/xlings.lua
+++ b/pkgs/x/xlings.lua
@@ -29,7 +29,7 @@ package = {
 
     xvm_enable = true,
 
-    -- The current release uses XLINGS_RES so downloads can
+    -- Recent mirrored releases use XLINGS_RES so downloads can
     -- resolve through the configured multi-mirror resource service.
     -- Historical 0.4.x entries keep their direct GitHub release URLs.
     xpm = {
@@ -37,10 +37,7 @@ package = {
             ["latest"] = { ref = "0.4.42" },
             ["0.4.42"] = "XLINGS_RES",
             ["0.4.41"] = "XLINGS_RES",
-            ["0.4.40"] = {
-                url = "https://github.com/openxlings/xlings/releases/download/v0.4.40/xlings-0.4.40-linux-x86_64.tar.gz",
-                sha256 = "02e47440aae74f8a8f6d32e001001aedc9742c36af048a3af604b1ae450257c4",
-            },
+            ["0.4.40"] = "XLINGS_RES",
             ["0.4.39"] = {
                 url = "https://github.com/openxlings/xlings/releases/download/v0.4.39/xlings-0.4.39-linux-x86_64.tar.gz",
                 sha256 = "beac3c49dc561527e56f62564f9229510389e11379640819c352af17e3567f71",
@@ -176,10 +173,7 @@ package = {
             ["latest"] = { ref = "0.4.42" },
             ["0.4.42"] = "XLINGS_RES",
             ["0.4.41"] = "XLINGS_RES",
-            ["0.4.40"] = {
-                url = "https://github.com/openxlings/xlings/releases/download/v0.4.40/xlings-0.4.40-macosx-arm64.tar.gz",
-                sha256 = "25589957250cb0be51a22ee2cea4615a3665c5fed257c1e1568f4d7be5b81e75",
-            },
+            ["0.4.40"] = "XLINGS_RES",
             ["0.4.39"] = {
                 url = "https://github.com/openxlings/xlings/releases/download/v0.4.39/xlings-0.4.39-macosx-arm64.tar.gz",
                 sha256 = "cdae486f87c3b980186ed20d6ebf01fd1b4d725d2ae6984e3d6729a3b0b3cb5f",
@@ -314,10 +308,8 @@ package = {
         windows = {
             ["latest"] = { ref = "0.4.42" },
             ["0.4.42"] = "XLINGS_RES",
-            ["0.4.40"] = {
-                url = "https://github.com/openxlings/xlings/releases/download/v0.4.40/xlings-0.4.40-windows-x86_64.zip",
-                sha256 = "92afb39331eb406b15ea96b727f5ade53d05205e1afe6b72d442e4607c3f3aee",
-            },
+            ["0.4.41"] = "XLINGS_RES",
+            ["0.4.40"] = "XLINGS_RES",
             ["0.4.39"] = {
                 url = "https://github.com/openxlings/xlings/releases/download/v0.4.39/xlings-0.4.39-windows-x86_64.zip",
                 sha256 = "b6b83a6b627682023a07e7ceca7f6b757cb3a82eaba7bc4157081d1435e9d376",

--- a/tests/x/test_xlings.py
+++ b/tests/x/test_xlings.py
@@ -38,20 +38,25 @@ class TestStatic:
         assert_no_typos(PKG_FILE)
 
     @pytest.mark.static
-    def test_latest_platforms_use_xlings_res(self, meta):
+    def test_recent_versions_use_xlings_res(self, meta):
         def platform_block(platform, next_platform):
             start = meta.raw_content.index(f"        {platform} = {{")
             end = meta.raw_content.index(f"        {next_platform} = {{", start)
             return meta.raw_content[start:end]
 
+        recent_versions = ("0.4.42", "0.4.41", "0.4.40")
         for platform, next_platform in (("linux", "macosx"), ("macosx", "windows")):
             block = platform_block(platform, next_platform)
             assert re.search(r'\["latest"\]\s*=\s*\{\s*ref\s*=\s*"0\.4\.42"\s*\}', block)
-            assert re.search(r'\["0\.4\.42"\]\s*=\s*"XLINGS_RES"', block)
+            for version in recent_versions:
+                escaped = re.escape(version)
+                assert re.search(rf'\["{escaped}"\]\s*=\s*"XLINGS_RES"', block)
 
         windows = meta.raw_content[meta.raw_content.index("        windows = {"):]
         assert re.search(r'\["latest"\]\s*=\s*\{\s*ref\s*=\s*"0\.4\.42"\s*\}', windows)
-        assert re.search(r'\["0\.4\.42"\]\s*=\s*"XLINGS_RES"', windows)
+        for version in recent_versions:
+            escaped = re.escape(version)
+            assert re.search(rf'\["{escaped}"\]\s*=\s*"XLINGS_RES"', windows)
 
 
 class TestIndex:

--- a/tests/x/test_xlings.py
+++ b/tests/x/test_xlings.py
@@ -44,17 +44,17 @@ class TestStatic:
             end = meta.raw_content.index(f"        {next_platform} = {{", start)
             return meta.raw_content[start:end]
 
-        recent_versions = ("0.4.42", "0.4.41", "0.4.40")
+        mirrored_versions = ("0.4.43", "0.4.42", "0.4.41", "0.4.40")
         for platform, next_platform in (("linux", "macosx"), ("macosx", "windows")):
             block = platform_block(platform, next_platform)
-            assert re.search(r'\["latest"\]\s*=\s*\{\s*ref\s*=\s*"0\.4\.42"\s*\}', block)
-            for version in recent_versions:
+            assert re.search(r'\["latest"\]\s*=\s*\{\s*ref\s*=\s*"0\.4\.43"\s*\}', block)
+            for version in mirrored_versions:
                 escaped = re.escape(version)
                 assert re.search(rf'\["{escaped}"\]\s*=\s*"XLINGS_RES"', block)
 
         windows = meta.raw_content[meta.raw_content.index("        windows = {"):]
-        assert re.search(r'\["latest"\]\s*=\s*\{\s*ref\s*=\s*"0\.4\.42"\s*\}', windows)
-        for version in recent_versions:
+        assert re.search(r'\["latest"\]\s*=\s*\{\s*ref\s*=\s*"0\.4\.43"\s*\}', windows)
+        for version in mirrored_versions:
             escaped = re.escape(version)
             assert re.search(rf'\["{escaped}"\]\s*=\s*"XLINGS_RES"', windows)
 


### PR DESCRIPTION
## Summary
- update `xlings` latest to `0.4.43` on Linux/macOS/Windows
- use `XLINGS_RES` for `0.4.43`, keeping mirrored `0.4.42/0.4.41/0.4.40` entries
- bump package-index CI bootstrap xlings to `v0.4.43` so Windows package install uses the upstream extraction fix
- document the xpkg skill requirement that `XLINGS_RES` resources must be synchronized to both GitHub RES and GitCode RES with byte-level verification

## Upstream fix / release
- Upstream fix PR: https://github.com/openxlings/xlings/pull/308
- Version bump PR: https://github.com/openxlings/xlings/pull/309
- Official release: https://github.com/openxlings/xlings/releases/tag/v0.4.43

## RES mirror evidence
- GitHub RES: https://github.com/xlings-res/xlings/releases/tag/0.4.43
- GitCode RES: `xlings-res/xlings@0.4.43`
- Downloaded official, GitHub RES, and GitCode RES assets and verified byte-identical sha256:
  - linux: `c16d46dbe8a805d7de536d6071e7e08f63c8064c08da617b135b01842b4dcbcd`
  - macosx: `b43267642af54cd10c964b3a2168ecc8848d4c412ef77069a280e499415adbfe`
  - windows: `d170b90f9a6e76142a4de8f0cbf9902f327a95a58c079831790959140d23672d`
- GitHub RES latest and GitCode RES latest both return `0.4.43`.

## Test plan
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/x/test_xlings.py -m 'static or isolation or index' --tb=short -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/ -m static --tb=short -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/ -m isolation --tb=short -q`
- temp `XLINGS_HOME` smoke: official `xlings 0.4.43` + current `pkgs/x/xlings.lua` installed `local:xlings@0.4.43` successfully
- CI: wait for pkgindex Linux/Windows/macOS install tests and xpkg static/index checks
