### PR TITLE
fix(claude-llm): restore static test baseline

### DIFF
--- a/pkgs/c/claude-llm.lua
+++ b/pkgs/c/claude-llm.lua
@@ -213,7 +213,7 @@ end
 local function __verify_claude()
     log.info("正在调用 Claude Code 发起一次配置验证请求...")
     print("")
-    system.exec([[claude -p --setting-sources user tell_model_name_and_calculate_1_plus_2_use_chinese]])
+    system.exec([[claude -p --setting-sources user --tools "" --no-session-persistence tell_model_name_and_calculate_1_plus_2_use_chinese]])
     print("")
 end
 

--- a/tests/c/test_claude_llm.py
+++ b/tests/c/test_claude_llm.py
@@ -56,8 +56,10 @@ class TestClaudeLlmStatic:
             assert platform in raw_content
 
         assert raw_content.count("[\"latest\"] = { ref = \"deepseek\" }") == 3
-        assert raw_content.count("[\"deepseek\"] = {}") == 3
-        assert raw_content.count("\"xim:claude\"") == 3
+        assert raw_content.count("[\"deepseek\"] = { ref = \"deepseek-v4-pro\" }") == 3
+        assert raw_content.count("[\"deepseek-v4-pro\"] = {}") == 3
+        assert raw_content.count("[\"deepseek-v4-flash\"] = {}") == 3
+        assert raw_content.count("\"xim:claude@2.1.153\"") == 3
 
     def test_imports_are_limited_to_libxpkg(self, raw_content, meta):
         assert "xim.libxpkg.json" in meta.imports
@@ -158,11 +160,6 @@ class TestClaudeLlmStatic:
     def test_applies_expected_deepseek_environment(self, raw_content):
         expected_values = {
             "ANTHROPIC_BASE_URL": "https://api.deepseek.com/anthropic",
-            "ANTHROPIC_MODEL": "deepseek-v4-pro[1m]",
-            "ANTHROPIC_DEFAULT_OPUS_MODEL": "deepseek-v4-pro[1m]",
-            "ANTHROPIC_DEFAULT_SONNET_MODEL": "deepseek-v4-pro[1m]",
-            "ANTHROPIC_DEFAULT_HAIKU_MODEL": "deepseek-v4-pro[1m]",
-            "CLAUDE_CODE_SUBAGENT_MODEL": "deepseek-v4-pro[1m]",
             "CLAUDE_CODE_EFFORT_LEVEL": "max",
             "API_TIMEOUT_MS": "3000000",
             "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
@@ -171,6 +168,14 @@ class TestClaudeLlmStatic:
         for key, value in expected_values.items():
             assert f'__set_env(env, "{key}", "{value}")' in raw_content
 
+        assert '["deepseek-v4-pro"] = "deepseek-v4-pro[1m]"' in raw_content
+        assert '["deepseek-v4-flash"] = "deepseek-v4-flash"' in raw_content
+        assert 'local model_name = version_to_model_name[pkginfo.version()] or "deepseek-v4-pro[1m]"' in raw_content
+        assert '__set_env(env, "ANTHROPIC_MODEL", model_name)' in raw_content
+        assert '__set_env(env, "ANTHROPIC_DEFAULT_OPUS_MODEL", model_name)' in raw_content
+        assert '__set_env(env, "ANTHROPIC_DEFAULT_SONNET_MODEL", model_name)' in raw_content
+        assert '__set_env(env, "ANTHROPIC_DEFAULT_HAIKU_MODEL", "deepseek-v4-flash")' in raw_content
+        assert '__set_env(env, "CLAUDE_CODE_SUBAGENT_MODEL", "deepseek-v4-flash")' in raw_content
         assert '__set_env(env, "ANTHROPIC_AUTH_TOKEN", api_key, true)' in raw_content
         assert "sk-xxx" not in raw_content
 


### PR DESCRIPTION
## Summary
- update claude-llm static tests for the current deepseek-v4-pro/deepseek-v4-flash version map
- keep the claude verification command from opening tool/session prompts by adding `--tools ""` and `--no-session-persistence`

## Why
- `pytest tests/ -m static` is currently failing on main and would block unrelated package update PRs, including xlings 0.4.44.

## Test plan
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/c/test_claude_llm.py -m 'static or isolation or index' --tb=short -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/ -m static --tb=short -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/ -m isolation --tb=short -q`