### PR TITLE
feat(xlings): add 0.4.44 support

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Installation Xlings on Ubuntu
         run: |
           export XLINGS_NON_INTERACTIVE=1
-          export XLINGS_VERSION=v0.4.43
+          export XLINGS_VERSION=v0.4.44
           curl -fsSL https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.sh | bash
           echo "XLINGS_HOME=$HOME/.xlings" >> "$GITHUB_ENV"
           echo "PATH=$HOME/.xlings/subos/current/bin:$HOME/.xlings/bin:$PATH" >> "$GITHUB_ENV"
@@ -76,7 +76,7 @@ jobs:
         shell: pwsh
         run: |
           $env:XLINGS_NON_INTERACTIVE = "1"
-          $env:XLINGS_VERSION = "v0.4.43"
+          $env:XLINGS_VERSION = "v0.4.44"
           iex (Invoke-WebRequest `
             -Uri "https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.ps1" `
             -UseBasicParsing).Content
@@ -127,7 +127,7 @@ jobs:
       - name: Install xlings on Ubuntu
         run: |
           export XLINGS_NON_INTERACTIVE=1
-          export XLINGS_VERSION=v0.4.43
+          export XLINGS_VERSION=v0.4.44
           curl -fsSL https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.sh | bash
           echo "XLINGS_HOME=$HOME/.xlings" >> "$GITHUB_ENV"
           echo "$HOME/.xlings/bin"               >> "$GITHUB_PATH"
@@ -170,7 +170,7 @@ jobs:
       - name: Install xlings on macOS
         run: |
           export XLINGS_NON_INTERACTIVE=1
-          export XLINGS_VERSION=v0.4.43
+          export XLINGS_VERSION=v0.4.44
           curl -fsSL https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.sh | bash
           echo "XLINGS_HOME=$HOME/.xlings" >> "$GITHUB_ENV"
           echo "$HOME/.xlings/bin"               >> "$GITHUB_PATH"

--- a/.github/workflows/ci-xpkg-test.yml
+++ b/.github/workflows/ci-xpkg-test.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Install xlings
         run: |
           export XLINGS_NON_INTERACTIVE=1
-          export XLINGS_VERSION=v0.4.43
+          export XLINGS_VERSION=v0.4.44
           curl -fsSL https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.sh | bash
           echo "XLINGS_HOME=$HOME/.xlings" >> "$GITHUB_ENV"
           echo "PATH=$HOME/.xlings/subos/current/bin:$HOME/.xlings/bin:$PATH" >> "$GITHUB_ENV"

--- a/pkgs/x/xlings.lua
+++ b/pkgs/x/xlings.lua
@@ -34,7 +34,8 @@ package = {
     -- Historical 0.4.x entries keep their direct GitHub release URLs.
     xpm = {
         linux = {
-            ["latest"] = { ref = "0.4.43" },
+            ["latest"] = { ref = "0.4.44" },
+            ["0.4.44"] = "XLINGS_RES",
             ["0.4.43"] = "XLINGS_RES",
             ["0.4.42"] = "XLINGS_RES",
             ["0.4.41"] = "XLINGS_RES",
@@ -171,7 +172,8 @@ package = {
             ["0.3.0"] = "XLINGS_RES",
         },
         macosx = {
-            ["latest"] = { ref = "0.4.43" },
+            ["latest"] = { ref = "0.4.44" },
+            ["0.4.44"] = "XLINGS_RES",
             ["0.4.43"] = "XLINGS_RES",
             ["0.4.42"] = "XLINGS_RES",
             ["0.4.41"] = "XLINGS_RES",
@@ -308,7 +310,8 @@ package = {
             ["0.3.0"] = "XLINGS_RES",
         },
         windows = {
-            ["latest"] = { ref = "0.4.43" },
+            ["latest"] = { ref = "0.4.44" },
+            ["0.4.44"] = "XLINGS_RES",
             ["0.4.43"] = "XLINGS_RES",
             ["0.4.42"] = "XLINGS_RES",
             ["0.4.41"] = "XLINGS_RES",

--- a/tests/x/test_xlings.py
+++ b/tests/x/test_xlings.py
@@ -44,16 +44,16 @@ class TestStatic:
             end = meta.raw_content.index(f"        {next_platform} = {{", start)
             return meta.raw_content[start:end]
 
-        mirrored_versions = ("0.4.43", "0.4.42", "0.4.41", "0.4.40")
+        mirrored_versions = ("0.4.44", "0.4.43", "0.4.42", "0.4.41", "0.4.40")
         for platform, next_platform in (("linux", "macosx"), ("macosx", "windows")):
             block = platform_block(platform, next_platform)
-            assert re.search(r'\["latest"\]\s*=\s*\{\s*ref\s*=\s*"0\.4\.43"\s*\}', block)
+            assert re.search(r'\["latest"\]\s*=\s*\{\s*ref\s*=\s*"0\.4\.44"\s*\}', block)
             for version in mirrored_versions:
                 escaped = re.escape(version)
                 assert re.search(rf'\["{escaped}"\]\s*=\s*"XLINGS_RES"', block)
 
         windows = meta.raw_content[meta.raw_content.index("        windows = {"):]
-        assert re.search(r'\["latest"\]\s*=\s*\{\s*ref\s*=\s*"0\.4\.43"\s*\}', windows)
+        assert re.search(r'\["latest"\]\s*=\s*\{\s*ref\s*=\s*"0\.4\.44"\s*\}', windows)
         for version in mirrored_versions:
             escaped = re.escape(version)
             assert re.search(rf'\["{escaped}"\]\s*=\s*"XLINGS_RES"', windows)


### PR DESCRIPTION
## Summary
- add `xlings` `0.4.44` as the latest Linux/macOS/Windows version
- route `0.4.44` through `XLINGS_RES` and keep mirrored historical entries covered by tests
- bump package-index CI bootstrap xlings to `v0.4.44`

## RES mirror evidence
- Official release: https://github.com/openxlings/xlings/releases/tag/v0.4.44
- GitHub RES: https://github.com/xlings-res/xlings/releases/tag/0.4.44
- GitCode RES: `xlings-res/xlings@0.4.44`
- Downloaded official, GitHub RES, and GitCode RES assets and verified byte-identical sha256:
  - linux: `202c23c70f429e98d99924fa9917d312d5c36bf035625842f424e09ad930fa77`
  - macosx: `473bca42f705880e3fbd096c1a1138a90e2ce0cdc8a016485a42d65b751e3616`
  - windows: `afcbafbbb1a266b92ef8d81468e2e47c4cc229250d4729ce0cd4cb65ce6a55f5`
- Official latest is `v0.4.44`; GitHub RES latest and GitCode RES latest are both `0.4.44`.

## Test plan
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/x/test_xlings.py -m 'static or isolation or index' --tb=short -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/ -m static --tb=short -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/ -m isolation --tb=short -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/ -m index --tb=short -q`
- temp `XLINGS_HOME` smoke: official `xlings 0.4.44` + current `pkgs/x/xlings.lua` installed `local:xlings@0.4.44` successfully
- CI: wait for pkgindex Linux/Windows/macOS install tests and xpkg static/index checks