### PR TITLE
feat(mcpp): bump to 0.0.31 for all platforms

### DIFF
--- a/pkgs/m/mcpp.lua
+++ b/pkgs/m/mcpp.lua
@@ -39,7 +39,8 @@ package = {
     xpm = {
         linux = {
             url_template = "https://github.com/mcpp-community/mcpp/releases/download/v{version}/mcpp-{version}-linux-x86_64.tar.gz",
-            ["latest"] = { ref = "0.0.30" },
+            ["latest"] = { ref = "0.0.31" },
+            ["0.0.31"] = "XLINGS_RES",
             ["0.0.30"] = "XLINGS_RES",
             ["0.0.29"] = "XLINGS_RES",
             ["0.0.28"] = "XLINGS_RES",
@@ -69,7 +70,8 @@ package = {
             ["0.0.1"] = "XLINGS_RES",
         },
         macosx = {
-            ["latest"] = { ref = "0.0.30" },
+            ["latest"] = { ref = "0.0.31" },
+            ["0.0.31"] = "XLINGS_RES",
             ["0.0.30"] = "XLINGS_RES",
             ["0.0.29"] = "XLINGS_RES",
             ["0.0.28"] = "XLINGS_RES",
@@ -85,7 +87,8 @@ package = {
             ["0.0.16"] = "XLINGS_RES",
         },
         windows = {
-            ["latest"] = { ref = "0.0.30" },
+            ["latest"] = { ref = "0.0.31" },
+            ["0.0.31"] = "XLINGS_RES",
             ["0.0.30"] = "XLINGS_RES",
             ["0.0.29"] = "XLINGS_RES",
             ["0.0.28"] = "XLINGS_RES",

--- a/tests/m/test_mcpp.py
+++ b/tests/m/test_mcpp.py
@@ -38,7 +38,7 @@ class TestStatic:
         assert_no_typos(PKG_FILE)
 
     @pytest.mark.static
-    def test_latest_0030_uses_xlings_res(self, meta):
+    def test_latest_0031_uses_xlings_res(self, meta):
         # 0.0.x mcpp assets are distributed through the XLINGS_RES mirrors.
         def platform_block(platform, next_marker):
             start = meta.raw_content.index(f"        {platform} = {{")
@@ -52,8 +52,8 @@ class TestStatic:
         )
         for platform, next_marker in platforms:
             block = platform_block(platform, next_marker)
-            assert re.search(r'\["latest"\]\s*=\s*\{\s*ref\s*=\s*"0\.0\.30"\s*\}', block)
-            assert re.search(r'\["0\.0\.30"\]\s*=\s*"XLINGS_RES"', block)
+            assert re.search(r'\["latest"\]\s*=\s*\{\s*ref\s*=\s*"0\.0\.31"\s*\}', block)
+            assert re.search(r'\["0\.0\.31"\]\s*=\s*"XLINGS_RES"', block)
 
 
 class TestIndex:


### PR DESCRIPTION
## Summary
- update `mcpp` latest from `0.0.30` to `0.0.31` for Linux, macOS, and Windows
- add `0.0.31` as an `XLINGS_RES` mirrored version on all supported platforms
- update the mcpp package test expectations for the new latest version

## Resource verification
- Upstream release: https://github.com/mcpp-community/mcpp/releases/tag/v0.0.31
- GitHub RES release: https://github.com/xlings-res/mcpp/releases/tag/0.0.31
- GitCode RES release: https://gitcode.com/xlings-res/mcpp/releases/tag/0.0.31
- Re-downloaded upstream, GitHub RES, and GitCode RES assets and compared sha256 byte-for-byte.

```text
680ed2fcc8633e9baa9ffa81e73563ba96a081972d0688e034d49011affa4893  mcpp-0.0.31-macosx-arm64.tar.gz
820287219fbb449f55fdeb95a91ad4410ba6a0bed524fc8e818f975ee9e65489  mcpp-0.0.31-windows-x86_64.zip
c074dbaebf885b202c0c921434c4ce664a13a2c93d541573176d8645286867ec  mcpp-0.0.31-linux-x86_64.tar.gz
```

## Test plan
- `git diff --check`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/m/test_mcpp.py -m "static or isolation" -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/m/test_mcpp.py -m index -q`
- isolated install smoke:
  - `xlings subos new default`
  - `xlings update`
  - `xlings config --add-xpkg pkgs/m/mcpp.lua`
  - `xlings install local:mcpp -y`
  - installed binary `/tmp/.../xlings-home/data/xpkgs/local-x-mcpp/0.0.31/bin/mcpp --version` -> `mcpp 0.0.31 -`
