### PR TITLE
feat(mcpp): bump to 0.0.33 for all platforms

### DIFF
--- a/pkgs/m/mcpp.lua
+++ b/pkgs/m/mcpp.lua
@@ -39,7 +39,8 @@ package = {
     xpm = {
         linux = {
             url_template = "https://github.com/mcpp-community/mcpp/releases/download/v{version}/mcpp-{version}-linux-x86_64.tar.gz",
-            ["latest"] = { ref = "0.0.31" },
+            ["latest"] = { ref = "0.0.33" },
+            ["0.0.33"] = "XLINGS_RES",
             ["0.0.31"] = "XLINGS_RES",
             ["0.0.30"] = "XLINGS_RES",
             ["0.0.29"] = "XLINGS_RES",
@@ -70,7 +71,8 @@ package = {
             ["0.0.1"] = "XLINGS_RES",
         },
         macosx = {
-            ["latest"] = { ref = "0.0.31" },
+            ["latest"] = { ref = "0.0.33" },
+            ["0.0.33"] = "XLINGS_RES",
             ["0.0.31"] = "XLINGS_RES",
             ["0.0.30"] = "XLINGS_RES",
             ["0.0.29"] = "XLINGS_RES",
@@ -87,7 +89,8 @@ package = {
             ["0.0.16"] = "XLINGS_RES",
         },
         windows = {
-            ["latest"] = { ref = "0.0.31" },
+            ["latest"] = { ref = "0.0.33" },
+            ["0.0.33"] = "XLINGS_RES",
             ["0.0.31"] = "XLINGS_RES",
             ["0.0.30"] = "XLINGS_RES",
             ["0.0.29"] = "XLINGS_RES",

--- a/tests/m/test_mcpp.py
+++ b/tests/m/test_mcpp.py
@@ -7,11 +7,12 @@ from tests.lib.assertions import (
     assert_no_typos, assert_no_exec_xvm, assert_no_bashrc_modification,
     assert_no_direct_path_modification, assert_uses_new_api,
     assert_xim_add_succeeds, assert_install_succeeds,
-    assert_command_output, assert_xvm_registered,
+    assert_command_output, assert_xvm_shim_exists,
 )
 from tests.lib.platform_utils import skip_if_not
 
 PKG = "mcpp"
+INSTALL_PKG = "local:mcpp@0.0.33"
 PKG_FILE = "pkgs/m/mcpp.lua"
 
 
@@ -38,7 +39,7 @@ class TestStatic:
         assert_no_typos(PKG_FILE)
 
     @pytest.mark.static
-    def test_latest_0031_uses_xlings_res(self, meta):
+    def test_latest_0033_uses_xlings_res(self, meta):
         # 0.0.x mcpp assets are distributed through the XLINGS_RES mirrors.
         def platform_block(platform, next_marker):
             start = meta.raw_content.index(f"        {platform} = {{")
@@ -52,8 +53,8 @@ class TestStatic:
         )
         for platform, next_marker in platforms:
             block = platform_block(platform, next_marker)
-            assert re.search(r'\["latest"\]\s*=\s*\{\s*ref\s*=\s*"0\.0\.31"\s*\}', block)
-            assert re.search(r'\["0\.0\.31"\]\s*=\s*"XLINGS_RES"', block)
+            assert re.search(r'\["latest"\]\s*=\s*\{\s*ref\s*=\s*"0\.0\.33"\s*\}', block)
+            assert re.search(r'\["0\.0\.33"\]\s*=\s*"XLINGS_RES"', block)
 
 
 class TestIndex:
@@ -84,16 +85,16 @@ class TestLifecycle:
     @pytest.mark.lifecycle
     @skip_if_not('linux')
     def test_install(self):
-        assert_install_succeeds(PKG)
+        assert_install_succeeds(INSTALL_PKG)
 
 
 class TestVerify:
     @pytest.mark.verify
     @skip_if_not('linux')
     def test_mcpp(self):
-        assert_command_output("mcpp --version", contains="mcpp")
+        assert_command_output("mcpp --version", contains="mcpp 0.0.33")
 
     @pytest.mark.verify
     @skip_if_not('linux')
-    def test_xvm_mcpp(self):
-        assert_xvm_registered("mcpp")
+    def test_mcpp_shim(self):
+        assert_xvm_shim_exists("mcpp")


### PR DESCRIPTION
## Summary
- bump `mcpp` latest to `0.0.33` for Linux, macOS, and Windows
- add `0.0.33` XLINGS_RES entries for all supported platforms
- tighten the mcpp package test to install `local:mcpp@0.0.33` explicitly and verify the shim/version

## Mirror verification
- GitHub mirror: `xlings-res/mcpp@0.0.33`
- GitCode mirror: `xlings-res/mcpp@0.0.33`
- verified upstream, GitHub mirror, and GitCode mirror assets are byte-identical by sha256:
  - `mcpp-0.0.33-linux-x86_64.tar.gz`: `c13cee9e0961ebe27779b8f4de7f43a1cbd5b3218ee3ca3778abdffc28b792da`
  - `mcpp-0.0.33-macosx-arm64.tar.gz`: `fa1693b7f56c9932df00db37c44bd70a16ed4729d3feb1b0397b04bbd818710e`
  - `mcpp-0.0.33-windows-x86_64.zip`: `ab18bf940988acb3d26da88265bf4948bb947bccbd84c52add8eafc33be5bab2`

## Test Plan
- `git diff --check`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/m/test_mcpp.py`
- `xlings install local:mcpp@0.0.33 -y`
- `xlings use mcpp@0.0.33 && mcpp --version`
