### PR TITLE
feat(mcpp): bump to 0.0.34 for all platforms

### DIFF
--- a/pkgs/m/mcpp.lua
+++ b/pkgs/m/mcpp.lua
@@ -39,7 +39,8 @@ package = {
     xpm = {
         linux = {
             url_template = "https://github.com/mcpp-community/mcpp/releases/download/v{version}/mcpp-{version}-linux-x86_64.tar.gz",
-            ["latest"] = { ref = "0.0.33" },
+            ["latest"] = { ref = "0.0.34" },
+            ["0.0.34"] = "XLINGS_RES",
             ["0.0.33"] = "XLINGS_RES",
             ["0.0.31"] = "XLINGS_RES",
             ["0.0.30"] = "XLINGS_RES",
@@ -71,7 +72,8 @@ package = {
             ["0.0.1"] = "XLINGS_RES",
         },
         macosx = {
-            ["latest"] = { ref = "0.0.33" },
+            ["latest"] = { ref = "0.0.34" },
+            ["0.0.34"] = "XLINGS_RES",
             ["0.0.33"] = "XLINGS_RES",
             ["0.0.31"] = "XLINGS_RES",
             ["0.0.30"] = "XLINGS_RES",
@@ -89,7 +91,8 @@ package = {
             ["0.0.16"] = "XLINGS_RES",
         },
         windows = {
-            ["latest"] = { ref = "0.0.33" },
+            ["latest"] = { ref = "0.0.34" },
+            ["0.0.34"] = "XLINGS_RES",
             ["0.0.33"] = "XLINGS_RES",
             ["0.0.31"] = "XLINGS_RES",
             ["0.0.30"] = "XLINGS_RES",

--- a/tests/m/test_mcpp.py
+++ b/tests/m/test_mcpp.py
@@ -12,7 +12,7 @@ from tests.lib.assertions import (
 from tests.lib.platform_utils import skip_if_not
 
 PKG = "mcpp"
-INSTALL_PKG = "local:mcpp@0.0.33"
+INSTALL_PKG = "local:mcpp@0.0.34"
 PKG_FILE = "pkgs/m/mcpp.lua"
 
 
@@ -39,7 +39,7 @@ class TestStatic:
         assert_no_typos(PKG_FILE)
 
     @pytest.mark.static
-    def test_latest_0033_uses_xlings_res(self, meta):
+    def test_latest_0034_uses_xlings_res(self, meta):
         # 0.0.x mcpp assets are distributed through the XLINGS_RES mirrors.
         def platform_block(platform, next_marker):
             start = meta.raw_content.index(f"        {platform} = {{")
@@ -53,8 +53,8 @@ class TestStatic:
         )
         for platform, next_marker in platforms:
             block = platform_block(platform, next_marker)
-            assert re.search(r'\["latest"\]\s*=\s*\{\s*ref\s*=\s*"0\.0\.33"\s*\}', block)
-            assert re.search(r'\["0\.0\.33"\]\s*=\s*"XLINGS_RES"', block)
+            assert re.search(r'\["latest"\]\s*=\s*\{\s*ref\s*=\s*"0\.0\.34"\s*\}', block)
+            assert re.search(r'\["0\.0\.34"\]\s*=\s*"XLINGS_RES"', block)
 
 
 class TestIndex:
@@ -92,7 +92,7 @@ class TestVerify:
     @pytest.mark.verify
     @skip_if_not('linux')
     def test_mcpp(self):
-        assert_command_output("mcpp --version", contains="mcpp 0.0.33")
+        assert_command_output("mcpp --version", contains="mcpp 0.0.34")
 
     @pytest.mark.verify
     @skip_if_not('linux')


### PR DESCRIPTION
## Summary
- add mcpp 0.0.34 to Linux, macOS, and Windows XLINGS_RES entries
- move mcpp latest to 0.0.34
- update mcpp package tests to install and verify 0.0.34

## Release assets
- upstream: https://github.com/mcpp-community/mcpp/releases/tag/v0.0.34
- GitHub mirror: https://github.com/xlings-res/mcpp/releases/tag/0.0.34
- GitCode mirror: xlings-res/mcpp@0.0.34

## Verification
- upstream platform assets downloaded and verified with upstream sha256 sidecars
- GitHub xlings-res mirror assets downloaded back and verified with the same sha256 sidecars
- GitCode publish reported all three platform assets uploaded and GitCode API lists them under tag 0.0.34
- `xlings use mcpp@0.0.34 && mcpp --version` -> `mcpp 0.0.34 -`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/m/test_mcpp.py -q` -> 13 passed