### PR TITLE
fix(mcpp): install extracted archive from runtime dir

### DIFF
--- a/pkgs/m/mcpp.lua
+++ b/pkgs/m/mcpp.lua
@@ -115,9 +115,14 @@ import("xim.libxpkg.pkginfo")
 import("xim.libxpkg.xvm")
 
 function install()
-    local mcpp_dir = pkginfo.install_file()
+    local archive = pkginfo.install_file()
+    local mcpp_dir = archive
         :replace(".tar.gz", "")
         :replace(".zip", "")
+    local runtime_dir = path.join(path.directory(archive), path.filename(mcpp_dir))
+    if os.isdir(runtime_dir) then
+        mcpp_dir = runtime_dir
+    end
     os.tryrm(pkginfo.install_dir())
     os.mv(mcpp_dir, pkginfo.install_dir())
     return true

--- a/tests/m/test_mcpp.py
+++ b/tests/m/test_mcpp.py
@@ -56,6 +56,11 @@ class TestStatic:
             assert re.search(r'\["latest"\]\s*=\s*\{\s*ref\s*=\s*"0\.0\.34"\s*\}', block)
             assert re.search(r'\["0\.0\.34"\]\s*=\s*"XLINGS_RES"', block)
 
+    @pytest.mark.static
+    def test_install_uses_runtime_dir(self, meta):
+        assert "path.directory(archive)" in meta.raw_content
+        assert "path.filename(mcpp_dir)" in meta.raw_content
+
 
 class TestIndex:
     @pytest.mark.index


### PR DESCRIPTION
## Summary
- make mcpp install() resolve extracted archive directories relative to pkginfo.install_file()
- keep compatibility with cwd-based extraction if the directory is already visible there
- add a static test to preserve this runtime-dir handling

## Why
After PR #257, `xim:mcpp@0.0.34` downloaded and extracted successfully, but the install dir only contained `.xpkg.lua`. The archive was extracted under xlings runtimedir while the hook tried to move a cwd-relative directory name.

## Verification
- `xlings remove xim:mcpp@0.0.34 -y || true`
- `xlings remove local:mcpp@0.0.34 -y || true`
- `xlings config --add-xpkg "$PWD/pkgs/m/mcpp.lua"`
- `xlings install local:mcpp@0.0.34 -y`
- `/home/speak/.xlings/data/xpkgs/local-x-mcpp/0.0.34/bin/mcpp --version` -> `mcpp 0.0.34 -`
- `xlings use mcpp@0.0.34 && mcpp --version` -> `mcpp 0.0.34 -`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/m/test_mcpp.py -q` -> 14 passed