### PR TITLE
feat(mcpp): bump to 0.0.35

### DIFF
--- a/.agents/docs/2026-05-30-xlings-mcpp-release-rollout-plan.md
+++ b/.agents/docs/2026-05-30-xlings-mcpp-release-rollout-plan.md
@@ -1,0 +1,40 @@
+# xim-pkgindex: xlings mcpp Build Rollout Plan
+
+> 状态: pending on xlings release
+> 分支: `codex/xlings-mcpp-release-rollout`
+> 目标: 在 xlings 合入并发布使用官方 mcpp-index 的新版本后，更新 xim-pkgindex 和 xlings-res，使用户可以通过现有包索引安装到打通后的版本。
+
+## 前置条件
+
+- [ ] mcpp core PR 合入。
+- [ ] mcpp `0.0.35` 发布完成。
+- [ ] mcpp-index 官方依赖包 PR 合入。
+- [ ] xlings 迁移 PR 合入。
+- [ ] xlings 新版本 GitHub Release / GitCode Release 资产发布完成。
+
+## xim-pkgindex 待办
+
+- [ ] 更新 `pkgs/x/xlings.lua` 到新版本。
+- [ ] 刷新 `XLINGS_RES` 镜像资产。
+- [ ] 确认 Linux/macOS/Windows 三平台 URL、sha256、文件大小。
+- [ ] 更新 CI bootstrap 版本变量。
+- [ ] 本地 smoke test: `local:xlings@<version>`。
+- [ ] 创建 PR 并等待 CI。
+
+## 验证命令
+
+```bash
+xim search xlings
+xim install local:xlings@<version> -y
+xlings --version
+```
+
+## Checkpoints
+
+- [ ] 文档 checkpoint commit。
+- [ ] 等 xlings release 资产确认。
+- [ ] 更新 package descriptor。
+- [ ] 更新 xlings-res 镜像。
+- [ ] PR draft 创建。
+- [ ] CI 每 120s 检查一次直到完成。
+

--- a/.agents/docs/2026-05-30-xlings-mcpp-release-rollout-plan.md
+++ b/.agents/docs/2026-05-30-xlings-mcpp-release-rollout-plan.md
@@ -1,19 +1,23 @@
 # xim-pkgindex: xlings mcpp Build Rollout Plan
 
-> 状态: pending on xlings release
+> 状态: in progress
 > 分支: `codex/xlings-mcpp-release-rollout`
 > 目标: 在 xlings 合入并发布使用官方 mcpp-index 的新版本后，更新 xim-pkgindex 和 xlings-res，使用户可以通过现有包索引安装到打通后的版本。
 
 ## 前置条件
 
-- [ ] mcpp core PR 合入。
-- [ ] mcpp `0.0.35` 发布完成。
-- [ ] mcpp-index 官方依赖包 PR 合入。
+- [x] mcpp core PR 合入。
+- [x] mcpp `0.0.35` 发布完成。
+- [x] mcpp-index 官方依赖包 PR 合入。
 - [ ] xlings 迁移 PR 合入。
 - [ ] xlings 新版本 GitHub Release / GitCode Release 资产发布完成。
 
 ## xim-pkgindex 待办
 
+- [x] 更新 `pkgs/m/mcpp.lua` 到 `0.0.35`,供 xlings CI bootstrap 使用。
+- [x] 镜像 `mcpp 0.0.35` 三平台资产到 `xlings-res/mcpp`。
+- [x] 本地 smoke test: `local:mcpp@0.0.35` 安装后 `xlings use mcpp@0.0.35`,
+  `mcpp --version` = `0.0.35`。
 - [ ] 更新 `pkgs/x/xlings.lua` 到新版本。
 - [ ] 刷新 `XLINGS_RES` 镜像资产。
 - [ ] 确认 Linux/macOS/Windows 三平台 URL、sha256、文件大小。
@@ -32,9 +36,9 @@ xlings --version
 ## Checkpoints
 
 - [ ] 文档 checkpoint commit。
+- [x] `mcpp 0.0.35` release 资产确认并镜像。
 - [ ] 等 xlings release 资产确认。
 - [ ] 更新 package descriptor。
 - [ ] 更新 xlings-res 镜像。
 - [ ] PR draft 创建。
 - [ ] CI 每 120s 检查一次直到完成。
-

--- a/pkgs/m/mcpp.lua
+++ b/pkgs/m/mcpp.lua
@@ -39,7 +39,8 @@ package = {
     xpm = {
         linux = {
             url_template = "https://github.com/mcpp-community/mcpp/releases/download/v{version}/mcpp-{version}-linux-x86_64.tar.gz",
-            ["latest"] = { ref = "0.0.34" },
+            ["latest"] = { ref = "0.0.35" },
+            ["0.0.35"] = "XLINGS_RES",
             ["0.0.34"] = "XLINGS_RES",
             ["0.0.33"] = "XLINGS_RES",
             ["0.0.31"] = "XLINGS_RES",
@@ -72,7 +73,8 @@ package = {
             ["0.0.1"] = "XLINGS_RES",
         },
         macosx = {
-            ["latest"] = { ref = "0.0.34" },
+            ["latest"] = { ref = "0.0.35" },
+            ["0.0.35"] = "XLINGS_RES",
             ["0.0.34"] = "XLINGS_RES",
             ["0.0.33"] = "XLINGS_RES",
             ["0.0.31"] = "XLINGS_RES",
@@ -91,7 +93,8 @@ package = {
             ["0.0.16"] = "XLINGS_RES",
         },
         windows = {
-            ["latest"] = { ref = "0.0.34" },
+            ["latest"] = { ref = "0.0.35" },
+            ["0.0.35"] = "XLINGS_RES",
             ["0.0.34"] = "XLINGS_RES",
             ["0.0.33"] = "XLINGS_RES",
             ["0.0.31"] = "XLINGS_RES",

--- a/tests/m/test_mcpp.py
+++ b/tests/m/test_mcpp.py
@@ -12,7 +12,7 @@ from tests.lib.assertions import (
 from tests.lib.platform_utils import skip_if_not
 
 PKG = "mcpp"
-INSTALL_PKG = "local:mcpp@0.0.34"
+INSTALL_PKG = "local:mcpp@0.0.35"
 PKG_FILE = "pkgs/m/mcpp.lua"
 
 
@@ -39,7 +39,7 @@ class TestStatic:
         assert_no_typos(PKG_FILE)
 
     @pytest.mark.static
-    def test_latest_0034_uses_xlings_res(self, meta):
+    def test_latest_0035_uses_xlings_res(self, meta):
         # 0.0.x mcpp assets are distributed through the XLINGS_RES mirrors.
         def platform_block(platform, next_marker):
             start = meta.raw_content.index(f"        {platform} = {{")
@@ -53,8 +53,8 @@ class TestStatic:
         )
         for platform, next_marker in platforms:
             block = platform_block(platform, next_marker)
-            assert re.search(r'\["latest"\]\s*=\s*\{\s*ref\s*=\s*"0\.0\.34"\s*\}', block)
-            assert re.search(r'\["0\.0\.34"\]\s*=\s*"XLINGS_RES"', block)
+            assert re.search(r'\["latest"\]\s*=\s*\{\s*ref\s*=\s*"0\.0\.35"\s*\}', block)
+            assert re.search(r'\["0\.0\.35"\]\s*=\s*"XLINGS_RES"', block)
 
     @pytest.mark.static
     def test_install_uses_runtime_dir(self, meta):
@@ -97,7 +97,7 @@ class TestVerify:
     @pytest.mark.verify
     @skip_if_not('linux')
     def test_mcpp(self):
-        assert_command_output("mcpp --version", contains="mcpp 0.0.34")
+        assert_command_output("mcpp --version", contains="mcpp 0.0.35")
 
     @pytest.mark.verify
     @skip_if_not('linux')


### PR DESCRIPTION
## Summary

- bumps `xim:mcpp` latest and explicit platform entries to `0.0.35`
- updates mcpp package tests to install and verify `0.0.35`
- records that `mcpp 0.0.35` assets were mirrored to `xlings-res/mcpp`

## Validation

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest tests/m/test_mcpp.py` -> 14 passed
- `xlings install local:mcpp@0.0.35 -y` downloaded the mirrored Linux asset
- `xlings use mcpp@0.0.35`; `mcpp --version` and `mcpp self version` both report `0.0.35`

## Downstream

openxlings/xlings#314 should pin `XIM_PKGINDEX_REF` to this branch commit while the PR is in draft, then to main after this PR merges.