### PR TITLE
feat(xlings): bump to 0.4.46

### DIFF
--- a/pkgs/x/xlings.lua
+++ b/pkgs/x/xlings.lua
@@ -34,7 +34,8 @@ package = {
     -- Historical 0.4.x entries keep their direct GitHub release URLs.
     xpm = {
         linux = {
-            ["latest"] = { ref = "0.4.44" },
+            ["latest"] = { ref = "0.4.46" },
+            ["0.4.46"] = "XLINGS_RES",
             ["0.4.44"] = "XLINGS_RES",
             ["0.4.43"] = "XLINGS_RES",
             ["0.4.42"] = "XLINGS_RES",
@@ -172,7 +173,8 @@ package = {
             ["0.3.0"] = "XLINGS_RES",
         },
         macosx = {
-            ["latest"] = { ref = "0.4.44" },
+            ["latest"] = { ref = "0.4.46" },
+            ["0.4.46"] = "XLINGS_RES",
             ["0.4.44"] = "XLINGS_RES",
             ["0.4.43"] = "XLINGS_RES",
             ["0.4.42"] = "XLINGS_RES",
@@ -310,7 +312,8 @@ package = {
             ["0.3.0"] = "XLINGS_RES",
         },
         windows = {
-            ["latest"] = { ref = "0.4.44" },
+            ["latest"] = { ref = "0.4.46" },
+            ["0.4.46"] = "XLINGS_RES",
             ["0.4.44"] = "XLINGS_RES",
             ["0.4.43"] = "XLINGS_RES",
             ["0.4.42"] = "XLINGS_RES",

--- a/tests/x/test_xlings.py
+++ b/tests/x/test_xlings.py
@@ -44,16 +44,16 @@ class TestStatic:
             end = meta.raw_content.index(f"        {next_platform} = {{", start)
             return meta.raw_content[start:end]
 
-        mirrored_versions = ("0.4.44", "0.4.43", "0.4.42", "0.4.41", "0.4.40")
+        mirrored_versions = ("0.4.46", "0.4.44", "0.4.43", "0.4.42", "0.4.41", "0.4.40")
         for platform, next_platform in (("linux", "macosx"), ("macosx", "windows")):
             block = platform_block(platform, next_platform)
-            assert re.search(r'\["latest"\]\s*=\s*\{\s*ref\s*=\s*"0\.4\.44"\s*\}', block)
+            assert re.search(r'\["latest"\]\s*=\s*\{\s*ref\s*=\s*"0\.4\.46"\s*\}', block)
             for version in mirrored_versions:
                 escaped = re.escape(version)
                 assert re.search(rf'\["{escaped}"\]\s*=\s*"XLINGS_RES"', block)
 
         windows = meta.raw_content[meta.raw_content.index("        windows = {"):]
-        assert re.search(r'\["latest"\]\s*=\s*\{\s*ref\s*=\s*"0\.4\.44"\s*\}', windows)
+        assert re.search(r'\["latest"\]\s*=\s*\{\s*ref\s*=\s*"0\.4\.46"\s*\}', windows)
         for version in mirrored_versions:
             escaped = re.escape(version)
             assert re.search(rf'\["{escaped}"\]\s*=\s*"XLINGS_RES"', windows)


### PR DESCRIPTION
## Summary

- updates `xlings` latest to `0.4.46` across Linux/macOS/Windows
- adds `0.4.46` as an `XLINGS_RES` mirrored release
- updates static tests for the mirrored latest version

## Release source

- openxlings/xlings `v0.4.46`: https://github.com/openxlings/xlings/releases/tag/v0.4.46
- xlings-res mirror `0.4.46`: https://github.com/xlings-res/xlings/releases/tag/0.4.46

## Validation

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest tests/x/test_xlings.py -m 'static or index'`