### PR TITLE
chore(mcpp): bump package to 0.0.36

### DIFF
--- a/.agents/docs/2026-05-30-xlings-mcpp-release-rollout-plan.md
+++ b/.agents/docs/2026-05-30-xlings-mcpp-release-rollout-plan.md
@@ -1,6 +1,6 @@
 # xim-pkgindex: xlings mcpp Build Rollout Plan
 
-> 状态: in progress
+> 状态: complete
 > 分支: `codex/xlings-mcpp-release-rollout`
 > 目标: 在 xlings 合入并发布使用官方 mcpp-index 的新版本后，更新 xim-pkgindex 和 xlings-res，使用户可以通过现有包索引安装到打通后的版本。
 
@@ -9,8 +9,8 @@
 - [x] mcpp core PR 合入。
 - [x] mcpp `0.0.35` 发布完成。
 - [x] mcpp-index 官方依赖包 PR 合入。
-- [ ] xlings 迁移 PR 合入。
-- [ ] xlings 新版本 GitHub Release / GitCode Release 资产发布完成。
+- [x] xlings 迁移 PR 合入。
+- [x] xlings 新版本 GitHub Release / xlings-res 资产发布完成。
 
 ## xim-pkgindex 待办
 
@@ -18,12 +18,12 @@
 - [x] 镜像 `mcpp 0.0.35` 三平台资产到 `xlings-res/mcpp`。
 - [x] 本地 smoke test: `local:mcpp@0.0.35` 安装后 `xlings use mcpp@0.0.35`,
   `mcpp --version` = `0.0.35`。
-- [ ] 更新 `pkgs/x/xlings.lua` 到新版本。
-- [ ] 刷新 `XLINGS_RES` 镜像资产。
-- [ ] 确认 Linux/macOS/Windows 三平台 URL、sha256、文件大小。
-- [ ] 更新 CI bootstrap 版本变量。
-- [ ] 本地 smoke test: `local:xlings@<version>`。
-- [ ] 创建 PR 并等待 CI。
+- [x] 更新 `pkgs/x/xlings.lua` 到新版本。
+- [x] 刷新 `XLINGS_RES` 镜像资产。
+- [x] 确认 Linux/macOS/Windows 三平台 URL、sha256、文件大小。
+- [x] 更新 CI bootstrap 版本变量。
+- [x] 本地 smoke test: `local:xlings@<version>`。
+- [x] 创建 PR 并等待 CI。
 
 ## 验证命令
 
@@ -35,10 +35,33 @@ xlings --version
 
 ## Checkpoints
 
-- [ ] 文档 checkpoint commit。
+- [x] 文档 checkpoint commit。
 - [x] `mcpp 0.0.35` release 资产确认并镜像。
-- [ ] 等 xlings release 资产确认。
-- [ ] 更新 package descriptor。
-- [ ] 更新 xlings-res 镜像。
-- [ ] PR draft 创建。
-- [ ] CI 每 120s 检查一次直到完成。
+- [x] 等 xlings release 资产确认。
+- [x] 更新 package descriptor。
+- [x] 更新 xlings-res 镜像。
+- [x] PR 创建。
+- [x] CI 每 120s 检查一次直到完成。
+
+## Final Outcome
+
+- mcpp package update PR: https://github.com/openxlings/xim-pkgindex/pull/259
+- xlings package update PR: https://github.com/openxlings/xim-pkgindex/pull/260
+- mcpp mirror: https://github.com/xlings-res/mcpp/releases/tag/0.0.35
+- xlings mirror: https://github.com/xlings-res/xlings/releases/tag/0.4.46
+- xlings release source: https://github.com/openxlings/xlings/releases/tag/v0.4.46
+- Final package index commit: `66f8674817a859bc66392ed871485775113762fa`
+- CI evidence:
+  - PR #260 `pkgindex test`: Linux, macOS install, Windows, Linux install all success.
+  - PR #260 `xpkg test`: static/isolation and index-registration success.
+
+## Follow-up: mcpp 0.0.36
+
+Final xlings verification found that older mixed `~/.mcpp/registry/data` caches
+could contain xlings index clones but miss the default `mcpplibs` clone. mcpp
+`0.0.35` treated that state as fresh and skipped the default-index refresh.
+
+- mcpp PR #89 fixed default `mcpplibs` freshness and was released as `0.0.36`.
+- `xlings-res/mcpp` mirrors were published for `0.0.36` on GitHub and GitCode.
+- `pkgs/m/mcpp.lua` now points `latest` to `0.0.36` so xlings CI can use the
+  corrected bootstrap tool.

--- a/pkgs/m/mcpp.lua
+++ b/pkgs/m/mcpp.lua
@@ -39,7 +39,8 @@ package = {
     xpm = {
         linux = {
             url_template = "https://github.com/mcpp-community/mcpp/releases/download/v{version}/mcpp-{version}-linux-x86_64.tar.gz",
-            ["latest"] = { ref = "0.0.35" },
+            ["latest"] = { ref = "0.0.36" },
+            ["0.0.36"] = "XLINGS_RES",
             ["0.0.35"] = "XLINGS_RES",
             ["0.0.34"] = "XLINGS_RES",
             ["0.0.33"] = "XLINGS_RES",
@@ -73,7 +74,8 @@ package = {
             ["0.0.1"] = "XLINGS_RES",
         },
         macosx = {
-            ["latest"] = { ref = "0.0.35" },
+            ["latest"] = { ref = "0.0.36" },
+            ["0.0.36"] = "XLINGS_RES",
             ["0.0.35"] = "XLINGS_RES",
             ["0.0.34"] = "XLINGS_RES",
             ["0.0.33"] = "XLINGS_RES",
@@ -93,7 +95,8 @@ package = {
             ["0.0.16"] = "XLINGS_RES",
         },
         windows = {
-            ["latest"] = { ref = "0.0.35" },
+            ["latest"] = { ref = "0.0.36" },
+            ["0.0.36"] = "XLINGS_RES",
             ["0.0.35"] = "XLINGS_RES",
             ["0.0.34"] = "XLINGS_RES",
             ["0.0.33"] = "XLINGS_RES",

--- a/tests/m/test_mcpp.py
+++ b/tests/m/test_mcpp.py
@@ -12,7 +12,7 @@ from tests.lib.assertions import (
 from tests.lib.platform_utils import skip_if_not
 
 PKG = "mcpp"
-INSTALL_PKG = "local:mcpp@0.0.35"
+INSTALL_PKG = "local:mcpp@0.0.36"
 PKG_FILE = "pkgs/m/mcpp.lua"
 
 
@@ -39,7 +39,7 @@ class TestStatic:
         assert_no_typos(PKG_FILE)
 
     @pytest.mark.static
-    def test_latest_0035_uses_xlings_res(self, meta):
+    def test_latest_0036_uses_xlings_res(self, meta):
         # 0.0.x mcpp assets are distributed through the XLINGS_RES mirrors.
         def platform_block(platform, next_marker):
             start = meta.raw_content.index(f"        {platform} = {{")
@@ -53,8 +53,8 @@ class TestStatic:
         )
         for platform, next_marker in platforms:
             block = platform_block(platform, next_marker)
-            assert re.search(r'\["latest"\]\s*=\s*\{\s*ref\s*=\s*"0\.0\.35"\s*\}', block)
-            assert re.search(r'\["0\.0\.35"\]\s*=\s*"XLINGS_RES"', block)
+            assert re.search(r'\["latest"\]\s*=\s*\{\s*ref\s*=\s*"0\.0\.36"\s*\}', block)
+            assert re.search(r'\["0\.0\.36"\]\s*=\s*"XLINGS_RES"', block)
 
     @pytest.mark.static
     def test_install_uses_runtime_dir(self, meta):
@@ -97,7 +97,7 @@ class TestVerify:
     @pytest.mark.verify
     @skip_if_not('linux')
     def test_mcpp(self):
-        assert_command_output("mcpp --version", contains="mcpp 0.0.35")
+        assert_command_output("mcpp --version", contains="mcpp 0.0.36")
 
     @pytest.mark.verify
     @skip_if_not('linux')


### PR DESCRIPTION
## Summary
- publish/use `xim:mcpp@0.0.36` as latest
- record the mcpp 0.0.36 follow-up in rollout docs
- update package tests and local install verification expectations

## Verification
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest tests/m/test_mcpp.py -m 'static or index or isolation'`
- `xlings use mcpp@0.0.36 && mcpp --version`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest tests/m/test_mcpp.py -m 'lifecycle or verify'`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest tests/m/test_mcpp.py`