### PR TITLE
feat(xlings): bump to 0.4.47

### DIFF
--- a/.agents/docs/2026-05-30-xlings-mcpp-release-rollout-plan.md
+++ b/.agents/docs/2026-05-30-xlings-mcpp-release-rollout-plan.md
@@ -65,3 +65,15 @@ could contain xlings index clones but miss the default `mcpplibs` clone. mcpp
 - `xlings-res/mcpp` mirrors were published for `0.0.36` on GitHub and GitCode.
 - `pkgs/m/mcpp.lua` now points `latest` to `0.0.36` so xlings CI can use the
   corrected bootstrap tool.
+
+## Follow-up: xlings 0.4.47
+
+After xlings PR #315 switched CI/release bootstrap to `mcpp 0.0.36`, xlings
+`v0.4.47` was released from merge commit
+`66e601bcc84d787f4f772494f807cf85af85b745`.
+
+- Release run: https://github.com/openxlings/xlings/actions/runs/26692719560
+- Source release: https://github.com/openxlings/xlings/releases/tag/v0.4.47
+- Mirror release: https://github.com/xlings-res/xlings/releases/tag/0.4.47
+- GitCode mirror: `xlings-res/xlings@0.4.47`
+- `pkgs/x/xlings.lua` now points `latest` to `0.4.47`.

--- a/pkgs/x/xlings.lua
+++ b/pkgs/x/xlings.lua
@@ -34,7 +34,8 @@ package = {
     -- Historical 0.4.x entries keep their direct GitHub release URLs.
     xpm = {
         linux = {
-            ["latest"] = { ref = "0.4.46" },
+            ["latest"] = { ref = "0.4.47" },
+            ["0.4.47"] = "XLINGS_RES",
             ["0.4.46"] = "XLINGS_RES",
             ["0.4.44"] = "XLINGS_RES",
             ["0.4.43"] = "XLINGS_RES",
@@ -173,7 +174,8 @@ package = {
             ["0.3.0"] = "XLINGS_RES",
         },
         macosx = {
-            ["latest"] = { ref = "0.4.46" },
+            ["latest"] = { ref = "0.4.47" },
+            ["0.4.47"] = "XLINGS_RES",
             ["0.4.46"] = "XLINGS_RES",
             ["0.4.44"] = "XLINGS_RES",
             ["0.4.43"] = "XLINGS_RES",
@@ -312,7 +314,8 @@ package = {
             ["0.3.0"] = "XLINGS_RES",
         },
         windows = {
-            ["latest"] = { ref = "0.4.46" },
+            ["latest"] = { ref = "0.4.47" },
+            ["0.4.47"] = "XLINGS_RES",
             ["0.4.46"] = "XLINGS_RES",
             ["0.4.44"] = "XLINGS_RES",
             ["0.4.43"] = "XLINGS_RES",

--- a/tests/x/test_xlings.py
+++ b/tests/x/test_xlings.py
@@ -12,6 +12,7 @@ from tests.lib.assertions import (
 from tests.lib.platform_utils import skip_if_not
 
 PKG = "xlings"
+INSTALL_PKG = "local:xlings@0.4.47"
 PKG_FILE = "pkgs/x/xlings.lua"
 
 
@@ -44,16 +45,16 @@ class TestStatic:
             end = meta.raw_content.index(f"        {next_platform} = {{", start)
             return meta.raw_content[start:end]
 
-        mirrored_versions = ("0.4.46", "0.4.44", "0.4.43", "0.4.42", "0.4.41", "0.4.40")
+        mirrored_versions = ("0.4.47", "0.4.46", "0.4.44", "0.4.43", "0.4.42", "0.4.41", "0.4.40")
         for platform, next_platform in (("linux", "macosx"), ("macosx", "windows")):
             block = platform_block(platform, next_platform)
-            assert re.search(r'\["latest"\]\s*=\s*\{\s*ref\s*=\s*"0\.4\.46"\s*\}', block)
+            assert re.search(r'\["latest"\]\s*=\s*\{\s*ref\s*=\s*"0\.4\.47"\s*\}', block)
             for version in mirrored_versions:
                 escaped = re.escape(version)
                 assert re.search(rf'\["{escaped}"\]\s*=\s*"XLINGS_RES"', block)
 
         windows = meta.raw_content[meta.raw_content.index("        windows = {"):]
-        assert re.search(r'\["latest"\]\s*=\s*\{\s*ref\s*=\s*"0\.4\.46"\s*\}', windows)
+        assert re.search(r'\["latest"\]\s*=\s*\{\s*ref\s*=\s*"0\.4\.47"\s*\}', windows)
         for version in mirrored_versions:
             escaped = re.escape(version)
             assert re.search(rf'\["{escaped}"\]\s*=\s*"XLINGS_RES"', windows)
@@ -87,11 +88,14 @@ class TestLifecycle:
     @pytest.mark.lifecycle
     @skip_if_not('linux')
     def test_install(self):
-        assert_install_succeeds(PKG)
+        assert_install_succeeds(INSTALL_PKG)
 
 
 class TestVerify:
     @pytest.mark.verify
     @skip_if_not('linux')
     def test_xlings(self):
-        assert_command_output("xlings --version 2>&1 | head -1", contains="xlings")
+        assert_command_output(
+            "xlings use xlings@0.4.47 >/dev/null && xlings --version 2>&1 | head -1",
+            contains="xlings 0.4.47",
+        )


### PR DESCRIPTION
## Summary

- update `xim:xlings` latest to `0.4.47`
- add `0.4.47` XLINGS_RES entries for Linux, macOS, and Windows
- tighten the xlings package test to install `local:xlings@0.4.47` and verify `xlings use xlings@0.4.47`
- record the xlings 0.4.47 release/mirror rollout in `.agents/docs`

## Release evidence

- Source release: https://github.com/openxlings/xlings/releases/tag/v0.4.47
- Source release run: https://github.com/openxlings/xlings/actions/runs/26692719560
- GitHub mirror: https://github.com/xlings-res/xlings/releases/tag/0.4.47
- GitCode mirror: `xlings-res/xlings@0.4.47`

## Verification

- `git diff --check`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest tests/x/test_xlings.py` -> 12 passed