### PR TITLE
feat(mcpp): add 0.0.37 package

### DIFF
--- a/pkgs/m/mcpp.lua
+++ b/pkgs/m/mcpp.lua
@@ -39,7 +39,8 @@ package = {
     xpm = {
         linux = {
             url_template = "https://github.com/mcpp-community/mcpp/releases/download/v{version}/mcpp-{version}-linux-x86_64.tar.gz",
-            ["latest"] = { ref = "0.0.36" },
+            ["latest"] = { ref = "0.0.37" },
+            ["0.0.37"] = "XLINGS_RES",
             ["0.0.36"] = "XLINGS_RES",
             ["0.0.35"] = "XLINGS_RES",
             ["0.0.34"] = "XLINGS_RES",
@@ -74,7 +75,8 @@ package = {
             ["0.0.1"] = "XLINGS_RES",
         },
         macosx = {
-            ["latest"] = { ref = "0.0.36" },
+            ["latest"] = { ref = "0.0.37" },
+            ["0.0.37"] = "XLINGS_RES",
             ["0.0.36"] = "XLINGS_RES",
             ["0.0.35"] = "XLINGS_RES",
             ["0.0.34"] = "XLINGS_RES",
@@ -95,7 +97,8 @@ package = {
             ["0.0.16"] = "XLINGS_RES",
         },
         windows = {
-            ["latest"] = { ref = "0.0.36" },
+            ["latest"] = { ref = "0.0.37" },
+            ["0.0.37"] = "XLINGS_RES",
             ["0.0.36"] = "XLINGS_RES",
             ["0.0.35"] = "XLINGS_RES",
             ["0.0.34"] = "XLINGS_RES",

--- a/tests/m/test_mcpp.py
+++ b/tests/m/test_mcpp.py
@@ -12,7 +12,7 @@ from tests.lib.assertions import (
 from tests.lib.platform_utils import skip_if_not
 
 PKG = "mcpp"
-INSTALL_PKG = "local:mcpp@0.0.36"
+INSTALL_PKG = "local:mcpp@0.0.37"
 PKG_FILE = "pkgs/m/mcpp.lua"
 
 
@@ -39,7 +39,7 @@ class TestStatic:
         assert_no_typos(PKG_FILE)
 
     @pytest.mark.static
-    def test_latest_0036_uses_xlings_res(self, meta):
+    def test_latest_0037_uses_xlings_res(self, meta):
         # 0.0.x mcpp assets are distributed through the XLINGS_RES mirrors.
         def platform_block(platform, next_marker):
             start = meta.raw_content.index(f"        {platform} = {{")
@@ -53,8 +53,8 @@ class TestStatic:
         )
         for platform, next_marker in platforms:
             block = platform_block(platform, next_marker)
-            assert re.search(r'\["latest"\]\s*=\s*\{\s*ref\s*=\s*"0\.0\.36"\s*\}', block)
-            assert re.search(r'\["0\.0\.36"\]\s*=\s*"XLINGS_RES"', block)
+            assert re.search(r'\["latest"\]\s*=\s*\{\s*ref\s*=\s*"0\.0\.37"\s*\}', block)
+            assert re.search(r'\["0\.0\.37"\]\s*=\s*"XLINGS_RES"', block)
 
     @pytest.mark.static
     def test_install_uses_runtime_dir(self, meta):
@@ -97,7 +97,7 @@ class TestVerify:
     @pytest.mark.verify
     @skip_if_not('linux')
     def test_mcpp(self):
-        assert_command_output("mcpp --version", contains="mcpp 0.0.36")
+        assert_command_output("mcpp --version", contains="mcpp 0.0.37")
 
     @pytest.mark.verify
     @skip_if_not('linux')


### PR DESCRIPTION
## Summary

- Add `mcpp` 0.0.37 for Linux, macOS ARM64, and Windows.
- Move `mcpp` `latest` from 0.0.36 to 0.0.37.
- Update the package tests to install and verify 0.0.37.

## Release and mirror

Upstream release:
- `mcpp-community/mcpp` `v0.0.37`
- Release workflow: `26702651922` passed for Linux, macOS ARM64, and Windows.
- Tag `v0.0.37` points to `4c9e7fa44d278147862ad1d695c5216ff3082c33`.

XLINGS_RES mirror:
- GitHub RES: `xlings-res/mcpp@0.0.37`
- GitCode RES: `xlings-res/mcpp@0.0.37`

SHA256, verified identical across upstream, GitHub RES, and GitCode RES:

```text
a78830fa4eabdc7811954f2f58882b17073ea77add2a43b5aab532189000764a  mcpp-0.0.37-macosx-arm64.tar.gz
c2f95a42727e829a8b947b44093bad75cb8287804c43d80744dc6b39728aef04  mcpp-0.0.37-windows-x86_64.zip
cf4509f0841a1ff04f2924570c40037bccbebcd97f0df630f2d1a6827dab57e4  mcpp-0.0.37-linux-x86_64.tar.gz
```

## Verification

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q tests/m/test_mcpp.py` in an isolated `HOME` / `XLINGS_HOME`: `14 passed`.
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q tests/m/test_mcpp.py -m 'static or isolation'`: `10 passed, 4 deselected`.
- Installed local package entry in isolated `XLINGS_HOME` and confirmed `mcpp --version` reports `mcpp 0.0.37`.
- Built `/home/speak/test/tmp/xlings` twice with the installed mcpp 0.0.37 package:
  - First cold build completed after toolchain/package download.
  - Second warm build reported `Cached mcpplibs.tinyhttps v0.2.3` and `Cached mcpplibs.xpkg v0.0.41`.
  - Both build logs had `0` xlings `[N/M]` internal index progress lines.
  - Both build logs had `0` `warning: bmi cache populate failed` lines.
