### PR TITLE
[codex] feat(mcpp): add 0.0.38 package

### DIFF
--- a/pkgs/m/mcpp.lua
+++ b/pkgs/m/mcpp.lua
@@ -39,7 +39,8 @@ package = {
     xpm = {
         linux = {
             url_template = "https://github.com/mcpp-community/mcpp/releases/download/v{version}/mcpp-{version}-linux-x86_64.tar.gz",
-            ["latest"] = { ref = "0.0.37" },
+            ["latest"] = { ref = "0.0.38" },
+            ["0.0.38"] = "XLINGS_RES",
             ["0.0.37"] = "XLINGS_RES",
             ["0.0.36"] = "XLINGS_RES",
             ["0.0.35"] = "XLINGS_RES",
@@ -75,7 +76,8 @@ package = {
             ["0.0.1"] = "XLINGS_RES",
         },
         macosx = {
-            ["latest"] = { ref = "0.0.37" },
+            ["latest"] = { ref = "0.0.38" },
+            ["0.0.38"] = "XLINGS_RES",
             ["0.0.37"] = "XLINGS_RES",
             ["0.0.36"] = "XLINGS_RES",
             ["0.0.35"] = "XLINGS_RES",
@@ -97,7 +99,8 @@ package = {
             ["0.0.16"] = "XLINGS_RES",
         },
         windows = {
-            ["latest"] = { ref = "0.0.37" },
+            ["latest"] = { ref = "0.0.38" },
+            ["0.0.38"] = "XLINGS_RES",
             ["0.0.37"] = "XLINGS_RES",
             ["0.0.36"] = "XLINGS_RES",
             ["0.0.35"] = "XLINGS_RES",

--- a/tests/m/test_mcpp.py
+++ b/tests/m/test_mcpp.py
@@ -12,7 +12,7 @@ from tests.lib.assertions import (
 from tests.lib.platform_utils import skip_if_not
 
 PKG = "mcpp"
-INSTALL_PKG = "local:mcpp@0.0.37"
+INSTALL_PKG = "local:mcpp@0.0.38"
 PKG_FILE = "pkgs/m/mcpp.lua"
 
 
@@ -39,7 +39,7 @@ class TestStatic:
         assert_no_typos(PKG_FILE)
 
     @pytest.mark.static
-    def test_latest_0037_uses_xlings_res(self, meta):
+    def test_latest_0038_uses_xlings_res(self, meta):
         # 0.0.x mcpp assets are distributed through the XLINGS_RES mirrors.
         def platform_block(platform, next_marker):
             start = meta.raw_content.index(f"        {platform} = {{")
@@ -53,8 +53,8 @@ class TestStatic:
         )
         for platform, next_marker in platforms:
             block = platform_block(platform, next_marker)
-            assert re.search(r'\["latest"\]\s*=\s*\{\s*ref\s*=\s*"0\.0\.37"\s*\}', block)
-            assert re.search(r'\["0\.0\.37"\]\s*=\s*"XLINGS_RES"', block)
+            assert re.search(r'\["latest"\]\s*=\s*\{\s*ref\s*=\s*"0\.0\.38"\s*\}', block)
+            assert re.search(r'\["0\.0\.38"\]\s*=\s*"XLINGS_RES"', block)
 
     @pytest.mark.static
     def test_install_uses_runtime_dir(self, meta):
@@ -97,7 +97,7 @@ class TestVerify:
     @pytest.mark.verify
     @skip_if_not('linux')
     def test_mcpp(self):
-        assert_command_output("mcpp --version", contains="mcpp 0.0.37")
+        assert_command_output("xlings use mcpp local:0.0.38 >/dev/null && mcpp --version", contains="mcpp 0.0.38")
 
     @pytest.mark.verify
     @skip_if_not('linux')


### PR DESCRIPTION
## Summary

- Add `mcpp` 0.0.38 to `pkgs/m/mcpp.lua` for Linux, macOS ARM64, and Windows.
- Move `latest` to 0.0.38 across all supported platforms.
- Update the mcpp package test to install and select `local:mcpp@0.0.38` before verifying the command version.

## Mirror

- GitHub: https://github.com/xlings-res/mcpp/releases/tag/0.0.38
- GitCode: `xlings-res/mcpp@0.0.38`

## Validation

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/m/test_mcpp.py -q --tb=short`
- `xlings install local:mcpp@0.0.38 -y && xlings use mcpp local:0.0.38 >/dev/null && mcpp --version`
- `curl -L --range 0-0` for GitHub and GitCode Linux mirror URLs returned HTTP 206.
