### PR TITLE
[codex] fix(mcpp): ensure runtime dir before xvm registration

### DIFF
--- a/pkgs/m/mcpp.lua
+++ b/pkgs/m/mcpp.lua
@@ -126,7 +126,15 @@ package = {
 import("xim.libxpkg.pkginfo")
 import("xim.libxpkg.xvm")
 
-function install()
+local function mcpp_bin()
+    return path.join(pkginfo.install_dir(), "bin", "mcpp")
+end
+
+local function ensure_runtime_dir()
+    if os.isfile(mcpp_bin()) then
+        return true
+    end
+
     local archive = pkginfo.install_file()
     local mcpp_dir = archive
         :replace(".tar.gz", "")
@@ -137,10 +145,15 @@ function install()
     end
     os.tryrm(pkginfo.install_dir())
     os.mv(mcpp_dir, pkginfo.install_dir())
-    return true
+    return os.isfile(mcpp_bin())
+end
+
+function install()
+    return ensure_runtime_dir()
 end
 
 function config()
+    ensure_runtime_dir()
     xvm.add("mcpp", { bindir = path.join(pkginfo.install_dir(), "bin") })
     return true
 end

--- a/pkgs/m/mcpp.lua
+++ b/pkgs/m/mcpp.lua
@@ -127,7 +127,11 @@ import("xim.libxpkg.pkginfo")
 import("xim.libxpkg.xvm")
 
 local function mcpp_bin()
-    return path.join(pkginfo.install_dir(), "bin", "mcpp")
+    local exe = "mcpp"
+    if os.host() == "windows" then
+        exe = "mcpp.exe"
+    end
+    return path.join(pkginfo.install_dir(), "bin", exe)
 end
 
 local function ensure_runtime_dir()


### PR DESCRIPTION
## Summary

- Move the mcpp runtime-directory normalization into a shared helper.
- Call the helper from both `install()` and `config()` so official `xim:mcpp@0.0.38` installs recover the extracted runtime directory before xvm registration.

## Root Cause

Local smoke showed `xim:mcpp@0.0.38` downloaded the archive but left only `.xpkg.lua` in the install directory before xvm registration. The xvm entry then pointed at `<install>/bin`, but `bin/mcpp` was missing. Running the same normalization from `config()` fixes the official index path.

## Validation

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/m/test_mcpp.py -q --tb=short`
- Patched local xlings cache with the same logic, then ran `xlings remove xim:mcpp@0.0.38 -y; xlings install xim:mcpp@0.0.38 -y -u; mcpp --version` and got `mcpp 0.0.38 -`.
