### PR TITLE
feat(mcpp): bump to 0.0.41

### DIFF
--- a/pkgs/m/mcpp.lua
+++ b/pkgs/m/mcpp.lua
@@ -39,7 +39,8 @@ package = {
     xpm = {
         linux = {
             url_template = "https://github.com/mcpp-community/mcpp/releases/download/v{version}/mcpp-{version}-linux-x86_64.tar.gz",
-            ["latest"] = { ref = "0.0.38" },
+            ["latest"] = { ref = "0.0.41" },
+            ["0.0.41"] = "XLINGS_RES",
             ["0.0.38"] = "XLINGS_RES",
             ["0.0.37"] = "XLINGS_RES",
             ["0.0.36"] = "XLINGS_RES",
@@ -76,7 +77,8 @@ package = {
             ["0.0.1"] = "XLINGS_RES",
         },
         macosx = {
-            ["latest"] = { ref = "0.0.38" },
+            ["latest"] = { ref = "0.0.41" },
+            ["0.0.41"] = "XLINGS_RES",
             ["0.0.38"] = "XLINGS_RES",
             ["0.0.37"] = "XLINGS_RES",
             ["0.0.36"] = "XLINGS_RES",
@@ -99,7 +101,8 @@ package = {
             ["0.0.16"] = "XLINGS_RES",
         },
         windows = {
-            ["latest"] = { ref = "0.0.38" },
+            ["latest"] = { ref = "0.0.41" },
+            ["0.0.41"] = "XLINGS_RES",
             ["0.0.38"] = "XLINGS_RES",
             ["0.0.37"] = "XLINGS_RES",
             ["0.0.36"] = "XLINGS_RES",

--- a/tests/m/test_mcpp.py
+++ b/tests/m/test_mcpp.py
@@ -12,7 +12,7 @@ from tests.lib.assertions import (
 from tests.lib.platform_utils import skip_if_not
 
 PKG = "mcpp"
-INSTALL_PKG = "local:mcpp@0.0.38"
+INSTALL_PKG = "local:mcpp@0.0.41"
 PKG_FILE = "pkgs/m/mcpp.lua"
 
 
@@ -39,7 +39,7 @@ class TestStatic:
         assert_no_typos(PKG_FILE)
 
     @pytest.mark.static
-    def test_latest_0038_uses_xlings_res(self, meta):
+    def test_latest_0041_uses_xlings_res(self, meta):
         # 0.0.x mcpp assets are distributed through the XLINGS_RES mirrors.
         def platform_block(platform, next_marker):
             start = meta.raw_content.index(f"        {platform} = {{")
@@ -53,8 +53,8 @@ class TestStatic:
         )
         for platform, next_marker in platforms:
             block = platform_block(platform, next_marker)
-            assert re.search(r'\["latest"\]\s*=\s*\{\s*ref\s*=\s*"0\.0\.38"\s*\}', block)
-            assert re.search(r'\["0\.0\.38"\]\s*=\s*"XLINGS_RES"', block)
+            assert re.search(r'\["latest"\]\s*=\s*\{\s*ref\s*=\s*"0\.0\.41"\s*\}', block)
+            assert re.search(r'\["0\.0\.41"\]\s*=\s*"XLINGS_RES"', block)
 
     @pytest.mark.static
     def test_install_uses_runtime_dir(self, meta):
@@ -97,7 +97,7 @@ class TestVerify:
     @pytest.mark.verify
     @skip_if_not('linux')
     def test_mcpp(self):
-        assert_command_output("xlings use mcpp local:0.0.38 >/dev/null && mcpp --version", contains="mcpp 0.0.38")
+        assert_command_output("xlings use mcpp local:0.0.41 >/dev/null && mcpp --version", contains="mcpp 0.0.41")
 
     @pytest.mark.verify
     @skip_if_not('linux')


### PR DESCRIPTION
## Summary
- mirror mcpp 0.0.41 assets to xlings-res/mcpp for Linux, macOS, and Windows
- update mcpp latest refs to 0.0.41 across supported platforms
- update mcpp package tests to install/use 0.0.41

## Verification
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/m/test_mcpp.py -q -m "static or index or isolation"
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/m/test_mcpp.py -q -m "lifecycle or verify"
- curl verified GitHub and GitCode xlings-res asset URLs for all three platforms
