### PR TITLE
chore: bump mcpp to 0.0.43

### DIFF
--- a/pkgs/m/mcpp.lua
+++ b/pkgs/m/mcpp.lua
@@ -39,7 +39,8 @@ package = {
     xpm = {
         linux = {
             url_template = "https://github.com/mcpp-community/mcpp/releases/download/v{version}/mcpp-{version}-linux-x86_64.tar.gz",
-            ["latest"] = { ref = "0.0.42" },
+            ["latest"] = { ref = "0.0.43" },
+            ["0.0.43"] = "XLINGS_RES",
             ["0.0.42"] = "XLINGS_RES",
             ["0.0.41"] = "XLINGS_RES",
             ["0.0.38"] = "XLINGS_RES",
@@ -78,7 +79,8 @@ package = {
             ["0.0.1"] = "XLINGS_RES",
         },
         macosx = {
-            ["latest"] = { ref = "0.0.42" },
+            ["latest"] = { ref = "0.0.43" },
+            ["0.0.43"] = "XLINGS_RES",
             ["0.0.42"] = "XLINGS_RES",
             ["0.0.41"] = "XLINGS_RES",
             ["0.0.38"] = "XLINGS_RES",
@@ -103,7 +105,8 @@ package = {
             ["0.0.16"] = "XLINGS_RES",
         },
         windows = {
-            ["latest"] = { ref = "0.0.42" },
+            ["latest"] = { ref = "0.0.43" },
+            ["0.0.43"] = "XLINGS_RES",
             ["0.0.42"] = "XLINGS_RES",
             ["0.0.41"] = "XLINGS_RES",
             ["0.0.38"] = "XLINGS_RES",

--- a/tests/m/test_mcpp.py
+++ b/tests/m/test_mcpp.py
@@ -12,7 +12,7 @@ from tests.lib.assertions import (
 from tests.lib.platform_utils import skip_if_not
 
 PKG = "mcpp"
-INSTALL_PKG = "local:mcpp@0.0.42"
+INSTALL_PKG = "local:mcpp@0.0.43"
 PKG_FILE = "pkgs/m/mcpp.lua"
 
 
@@ -39,7 +39,7 @@ class TestStatic:
         assert_no_typos(PKG_FILE)
 
     @pytest.mark.static
-    def test_latest_0042_uses_xlings_res(self, meta):
+    def test_latest_0043_uses_xlings_res(self, meta):
         # 0.0.x mcpp assets are distributed through the XLINGS_RES mirrors.
         def platform_block(platform, next_marker):
             start = meta.raw_content.index(f"        {platform} = {{")
@@ -53,8 +53,8 @@ class TestStatic:
         )
         for platform, next_marker in platforms:
             block = platform_block(platform, next_marker)
-            assert re.search(r'\["latest"\]\s*=\s*\{\s*ref\s*=\s*"0\.0\.42"\s*\}', block)
-            assert re.search(r'\["0\.0\.42"\]\s*=\s*"XLINGS_RES"', block)
+            assert re.search(r'\["latest"\]\s*=\s*\{\s*ref\s*=\s*"0\.0\.43"\s*\}', block)
+            assert re.search(r'\["0\.0\.43"\]\s*=\s*"XLINGS_RES"', block)
 
     @pytest.mark.static
     def test_install_uses_runtime_dir(self, meta):
@@ -97,7 +97,7 @@ class TestVerify:
     @pytest.mark.verify
     @skip_if_not('linux')
     def test_mcpp(self):
-        assert_command_output("xlings use mcpp local:0.0.42 >/dev/null && mcpp --version", contains="mcpp 0.0.42")
+        assert_command_output("xlings use mcpp local:0.0.43 >/dev/null && mcpp --version", contains="mcpp 0.0.43")
 
     @pytest.mark.verify
     @skip_if_not('linux')


### PR DESCRIPTION
## Summary

- bump `mcpp` latest refs to `0.0.43` on linux, macOS, and Windows
- add `0.0.43 = "XLINGS_RES"` entries for all supported platforms
- update package tests from `0.0.42` to `0.0.43`

## Mirror Status

- GitHub mirror: `xlings-res/mcpp@0.0.43` created with linux, macOS, and Windows assets
- GitCode mirror: `gtc release publish xlings-res/mcpp --tag 0.0.43` completed and uploaded the same three assets

## Verification

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/m/test_mcpp.py`
- `python3 .github/scripts/version-check.py --only mcpp`
