### PR TITLE
mcpp: add 0.0.44

### DIFF
--- a/pkgs/m/mcpp.lua
+++ b/pkgs/m/mcpp.lua
@@ -39,7 +39,8 @@ package = {
     xpm = {
         linux = {
             url_template = "https://github.com/mcpp-community/mcpp/releases/download/v{version}/mcpp-{version}-linux-x86_64.tar.gz",
-            ["latest"] = { ref = "0.0.43" },
+            ["latest"] = { ref = "0.0.44" },
+            ["0.0.44"] = "XLINGS_RES",
             ["0.0.43"] = "XLINGS_RES",
             ["0.0.42"] = "XLINGS_RES",
             ["0.0.41"] = "XLINGS_RES",
@@ -79,7 +80,8 @@ package = {
             ["0.0.1"] = "XLINGS_RES",
         },
         macosx = {
-            ["latest"] = { ref = "0.0.43" },
+            ["latest"] = { ref = "0.0.44" },
+            ["0.0.44"] = "XLINGS_RES",
             ["0.0.43"] = "XLINGS_RES",
             ["0.0.42"] = "XLINGS_RES",
             ["0.0.41"] = "XLINGS_RES",
@@ -105,7 +107,8 @@ package = {
             ["0.0.16"] = "XLINGS_RES",
         },
         windows = {
-            ["latest"] = { ref = "0.0.43" },
+            ["latest"] = { ref = "0.0.44" },
+            ["0.0.44"] = "XLINGS_RES",
             ["0.0.43"] = "XLINGS_RES",
             ["0.0.42"] = "XLINGS_RES",
             ["0.0.41"] = "XLINGS_RES",

--- a/tests/m/test_mcpp.py
+++ b/tests/m/test_mcpp.py
@@ -12,7 +12,7 @@ from tests.lib.assertions import (
 from tests.lib.platform_utils import skip_if_not
 
 PKG = "mcpp"
-INSTALL_PKG = "local:mcpp@0.0.43"
+INSTALL_PKG = "local:mcpp@0.0.44"
 PKG_FILE = "pkgs/m/mcpp.lua"
 
 
@@ -39,7 +39,7 @@ class TestStatic:
         assert_no_typos(PKG_FILE)
 
     @pytest.mark.static
-    def test_latest_0043_uses_xlings_res(self, meta):
+    def test_latest_0044_uses_xlings_res(self, meta):
         # 0.0.x mcpp assets are distributed through the XLINGS_RES mirrors.
         def platform_block(platform, next_marker):
             start = meta.raw_content.index(f"        {platform} = {{")
@@ -53,8 +53,8 @@ class TestStatic:
         )
         for platform, next_marker in platforms:
             block = platform_block(platform, next_marker)
-            assert re.search(r'\["latest"\]\s*=\s*\{\s*ref\s*=\s*"0\.0\.43"\s*\}', block)
-            assert re.search(r'\["0\.0\.43"\]\s*=\s*"XLINGS_RES"', block)
+            assert re.search(r'\["latest"\]\s*=\s*\{\s*ref\s*=\s*"0\.0\.44"\s*\}', block)
+            assert re.search(r'\["0\.0\.44"\]\s*=\s*"XLINGS_RES"', block)
 
     @pytest.mark.static
     def test_install_uses_runtime_dir(self, meta):
@@ -97,7 +97,7 @@ class TestVerify:
     @pytest.mark.verify
     @skip_if_not('linux')
     def test_mcpp(self):
-        assert_command_output("xlings use mcpp local:0.0.43 >/dev/null && mcpp --version", contains="mcpp 0.0.43")
+        assert_command_output("xlings use mcpp local:0.0.44 >/dev/null && mcpp --version", contains="mcpp 0.0.44")
 
     @pytest.mark.verify
     @skip_if_not('linux')


### PR DESCRIPTION
## Summary
- add mcpp 0.0.44 as the latest version for Linux, macOS, and Windows
- keep the 0.0.x assets routed through XLINGS_RES mirrors
- update the mcpp package tests and local install smoke to 0.0.44

## Verification
- mcpp-community/mcpp v0.0.44 release published: https://github.com/mcpp-community/mcpp/releases/tag/v0.0.44
- xlings-res/mcpp 0.0.44 GitHub mirror published: https://github.com/xlings-res/mcpp/releases/tag/0.0.44
- GitCode xlings-res/mcpp 0.0.44 mirror published
- official, GitHub mirror, and GitCode mirror asset sha256 values match for all three platform archives
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/m/test_mcpp.py` -> 14 passed
