### PR TITLE
Update mcpp package to 0.0.45

### DIFF
--- a/pkgs/m/mcpp.lua
+++ b/pkgs/m/mcpp.lua
@@ -39,7 +39,8 @@ package = {
     xpm = {
         linux = {
             url_template = "https://github.com/mcpp-community/mcpp/releases/download/v{version}/mcpp-{version}-linux-x86_64.tar.gz",
-            ["latest"] = { ref = "0.0.44" },
+            ["latest"] = { ref = "0.0.45" },
+            ["0.0.45"] = "XLINGS_RES",
             ["0.0.44"] = "XLINGS_RES",
             ["0.0.43"] = "XLINGS_RES",
             ["0.0.42"] = "XLINGS_RES",
@@ -80,7 +81,8 @@ package = {
             ["0.0.1"] = "XLINGS_RES",
         },
         macosx = {
-            ["latest"] = { ref = "0.0.44" },
+            ["latest"] = { ref = "0.0.45" },
+            ["0.0.45"] = "XLINGS_RES",
             ["0.0.44"] = "XLINGS_RES",
             ["0.0.43"] = "XLINGS_RES",
             ["0.0.42"] = "XLINGS_RES",
@@ -107,7 +109,8 @@ package = {
             ["0.0.16"] = "XLINGS_RES",
         },
         windows = {
-            ["latest"] = { ref = "0.0.44" },
+            ["latest"] = { ref = "0.0.45" },
+            ["0.0.45"] = "XLINGS_RES",
             ["0.0.44"] = "XLINGS_RES",
             ["0.0.43"] = "XLINGS_RES",
             ["0.0.42"] = "XLINGS_RES",

--- a/tests/m/test_mcpp.py
+++ b/tests/m/test_mcpp.py
@@ -12,7 +12,7 @@ from tests.lib.assertions import (
 from tests.lib.platform_utils import skip_if_not
 
 PKG = "mcpp"
-INSTALL_PKG = "local:mcpp@0.0.44"
+INSTALL_PKG = "local:mcpp@0.0.45"
 PKG_FILE = "pkgs/m/mcpp.lua"
 
 
@@ -39,7 +39,7 @@ class TestStatic:
         assert_no_typos(PKG_FILE)
 
     @pytest.mark.static
-    def test_latest_0044_uses_xlings_res(self, meta):
+    def test_latest_0045_uses_xlings_res(self, meta):
         # 0.0.x mcpp assets are distributed through the XLINGS_RES mirrors.
         def platform_block(platform, next_marker):
             start = meta.raw_content.index(f"        {platform} = {{")
@@ -53,8 +53,8 @@ class TestStatic:
         )
         for platform, next_marker in platforms:
             block = platform_block(platform, next_marker)
-            assert re.search(r'\["latest"\]\s*=\s*\{\s*ref\s*=\s*"0\.0\.44"\s*\}', block)
-            assert re.search(r'\["0\.0\.44"\]\s*=\s*"XLINGS_RES"', block)
+            assert re.search(r'\["latest"\]\s*=\s*\{\s*ref\s*=\s*"0\.0\.45"\s*\}', block)
+            assert re.search(r'\["0\.0\.45"\]\s*=\s*"XLINGS_RES"', block)
 
     @pytest.mark.static
     def test_install_uses_runtime_dir(self, meta):
@@ -90,14 +90,14 @@ class TestLifecycle:
     @pytest.mark.lifecycle
     @skip_if_not('linux')
     def test_install(self):
-        assert_install_succeeds(INSTALL_PKG)
+        assert_install_succeeds(INSTALL_PKG, timeout=420)
 
 
 class TestVerify:
     @pytest.mark.verify
     @skip_if_not('linux')
     def test_mcpp(self):
-        assert_command_output("xlings use mcpp local:0.0.44 >/dev/null && mcpp --version", contains="mcpp 0.0.44")
+        assert_command_output("xlings use mcpp local:0.0.45 >/dev/null && mcpp --version", contains="mcpp 0.0.45")
 
     @pytest.mark.verify
     @skip_if_not('linux')


### PR DESCRIPTION
## Summary
- update mcpp latest to 0.0.45 for Linux, macOS, and Windows
- add 0.0.45 XLINGS_RES entries for all supported platforms
- update mcpp package tests to install and verify local:mcpp@0.0.45

## Release / mirror checks
- mcpp-community/mcpp v0.0.45 release published with Linux, macOS, and Windows assets
- xlings-res/mcpp 0.0.45 GitHub release contains the three mirrored platform assets
- GitCode xlings-res/mcpp 0.0.45 assets were uploaded and byte-compared against the upstream downloads

## Validation
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/m/test_mcpp.py -q