### PR TITLE
Update mcpp package to 0.0.46

### DIFF
--- a/pkgs/m/mcpp.lua
+++ b/pkgs/m/mcpp.lua
@@ -39,7 +39,8 @@ package = {
     xpm = {
         linux = {
             url_template = "https://github.com/mcpp-community/mcpp/releases/download/v{version}/mcpp-{version}-linux-x86_64.tar.gz",
-            ["latest"] = { ref = "0.0.45" },
+            ["latest"] = { ref = "0.0.46" },
+            ["0.0.46"] = "XLINGS_RES",
             ["0.0.45"] = "XLINGS_RES",
             ["0.0.44"] = "XLINGS_RES",
             ["0.0.43"] = "XLINGS_RES",
@@ -81,7 +82,8 @@ package = {
             ["0.0.1"] = "XLINGS_RES",
         },
         macosx = {
-            ["latest"] = { ref = "0.0.45" },
+            ["latest"] = { ref = "0.0.46" },
+            ["0.0.46"] = "XLINGS_RES",
             ["0.0.45"] = "XLINGS_RES",
             ["0.0.44"] = "XLINGS_RES",
             ["0.0.43"] = "XLINGS_RES",
@@ -109,7 +111,8 @@ package = {
             ["0.0.16"] = "XLINGS_RES",
         },
         windows = {
-            ["latest"] = { ref = "0.0.45" },
+            ["latest"] = { ref = "0.0.46" },
+            ["0.0.46"] = "XLINGS_RES",
             ["0.0.45"] = "XLINGS_RES",
             ["0.0.44"] = "XLINGS_RES",
             ["0.0.43"] = "XLINGS_RES",

--- a/tests/m/test_mcpp.py
+++ b/tests/m/test_mcpp.py
@@ -12,7 +12,7 @@ from tests.lib.assertions import (
 from tests.lib.platform_utils import skip_if_not
 
 PKG = "mcpp"
-INSTALL_PKG = "local:mcpp@0.0.45"
+INSTALL_PKG = "local:mcpp@0.0.46"
 PKG_FILE = "pkgs/m/mcpp.lua"
 
 
@@ -39,7 +39,7 @@ class TestStatic:
         assert_no_typos(PKG_FILE)
 
     @pytest.mark.static
-    def test_latest_0045_uses_xlings_res(self, meta):
+    def test_latest_0046_uses_xlings_res(self, meta):
         # 0.0.x mcpp assets are distributed through the XLINGS_RES mirrors.
         def platform_block(platform, next_marker):
             start = meta.raw_content.index(f"        {platform} = {{")
@@ -53,8 +53,8 @@ class TestStatic:
         )
         for platform, next_marker in platforms:
             block = platform_block(platform, next_marker)
-            assert re.search(r'\["latest"\]\s*=\s*\{\s*ref\s*=\s*"0\.0\.45"\s*\}', block)
-            assert re.search(r'\["0\.0\.45"\]\s*=\s*"XLINGS_RES"', block)
+            assert re.search(r'\["latest"\]\s*=\s*\{\s*ref\s*=\s*"0\.0\.46"\s*\}', block)
+            assert re.search(r'\["0\.0\.46"\]\s*=\s*"XLINGS_RES"', block)
 
     @pytest.mark.static
     def test_install_uses_runtime_dir(self, meta):
@@ -97,7 +97,7 @@ class TestVerify:
     @pytest.mark.verify
     @skip_if_not('linux')
     def test_mcpp(self):
-        assert_command_output("xlings use mcpp local:0.0.45 >/dev/null && mcpp --version", contains="mcpp 0.0.45")
+        assert_command_output("xlings use mcpp local:0.0.46 >/dev/null && mcpp --version", contains="mcpp 0.0.46")
 
     @pytest.mark.verify
     @skip_if_not('linux')


### PR DESCRIPTION
## Summary
- update mcpp latest refs to 0.0.46 for Linux, macOS, and Windows
- add 0.0.46 XLINGS_RES entries
- update mcpp package tests to install and verify 0.0.46

## Mirror verification
- GitHub: https://github.com/xlings-res/mcpp/releases/tag/0.0.46
- GitCode: xlings-res/mcpp@0.0.46 published with Linux, macOS, and Windows runtime archives
- Asset sha256 values match upstream mcpp-community/mcpp v0.0.46 release archives

## Local checks
- lua5.4 descriptor load for pkgs/m/mcpp.lua
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/m/test_mcpp.py -m "static or isolation or index" -> 11 passed, 3 deselected