### PR TITLE
mcpp: add 0.0.48 (latest)

### DIFF
--- a/pkgs/m/mcpp.lua
+++ b/pkgs/m/mcpp.lua
@@ -39,7 +39,8 @@ package = {
     xpm = {
         linux = {
             url_template = "https://github.com/mcpp-community/mcpp/releases/download/v{version}/mcpp-{version}-linux-x86_64.tar.gz",
-            ["latest"] = { ref = "0.0.46" },
+            ["latest"] = { ref = "0.0.48" },
+            ["0.0.48"] = "XLINGS_RES",
             ["0.0.46"] = "XLINGS_RES",
             ["0.0.45"] = "XLINGS_RES",
             ["0.0.44"] = "XLINGS_RES",
@@ -82,7 +83,8 @@ package = {
             ["0.0.1"] = "XLINGS_RES",
         },
         macosx = {
-            ["latest"] = { ref = "0.0.46" },
+            ["latest"] = { ref = "0.0.48" },
+            ["0.0.48"] = "XLINGS_RES",
             ["0.0.46"] = "XLINGS_RES",
             ["0.0.45"] = "XLINGS_RES",
             ["0.0.44"] = "XLINGS_RES",
@@ -111,7 +113,8 @@ package = {
             ["0.0.16"] = "XLINGS_RES",
         },
         windows = {
-            ["latest"] = { ref = "0.0.46" },
+            ["latest"] = { ref = "0.0.48" },
+            ["0.0.48"] = "XLINGS_RES",
             ["0.0.46"] = "XLINGS_RES",
             ["0.0.45"] = "XLINGS_RES",
             ["0.0.44"] = "XLINGS_RES",

--- a/tests/m/test_mcpp.py
+++ b/tests/m/test_mcpp.py
@@ -53,8 +53,8 @@ class TestStatic:
         )
         for platform, next_marker in platforms:
             block = platform_block(platform, next_marker)
-            assert re.search(r'\["latest"\]\s*=\s*\{\s*ref\s*=\s*"0\.0\.46"\s*\}', block)
-            assert re.search(r'\["0\.0\.46"\]\s*=\s*"XLINGS_RES"', block)
+            assert re.search(r'\["latest"\]\s*=\s*\{\s*ref\s*=\s*"0\.0\.48"\s*\}', block)
+            assert re.search(r'\["0\.0\.48"\]\s*=\s*"XLINGS_RES"', block)
 
     @pytest.mark.static
     def test_install_uses_runtime_dir(self, meta):

--- a/tests/m/test_mcpp.py
+++ b/tests/m/test_mcpp.py
@@ -12,7 +12,7 @@ from tests.lib.assertions import (
 from tests.lib.platform_utils import skip_if_not
 
 PKG = "mcpp"
-INSTALL_PKG = "local:mcpp@0.0.46"
+INSTALL_PKG = "local:mcpp@0.0.48"
 PKG_FILE = "pkgs/m/mcpp.lua"
 
 
@@ -39,7 +39,7 @@ class TestStatic:
         assert_no_typos(PKG_FILE)
 
     @pytest.mark.static
-    def test_latest_0046_uses_xlings_res(self, meta):
+    def test_latest_0048_uses_xlings_res(self, meta):
         # 0.0.x mcpp assets are distributed through the XLINGS_RES mirrors.
         def platform_block(platform, next_marker):
             start = meta.raw_content.index(f"        {platform} = {{")
@@ -97,7 +97,7 @@ class TestVerify:
     @pytest.mark.verify
     @skip_if_not('linux')
     def test_mcpp(self):
-        assert_command_output("xlings use mcpp local:0.0.46 >/dev/null && mcpp --version", contains="mcpp 0.0.46")
+        assert_command_output("xlings use mcpp local:0.0.48 >/dev/null && mcpp --version", contains="mcpp 0.0.48")
 
     @pytest.mark.verify
     @skip_if_not('linux')


### PR DESCRIPTION
Adds mcpp 0.0.48 (all platforms) and bumps latest. Mirror: https://github.com/xlings-res/mcpp/releases/tag/0.0.48 (byte-identical to mcpp-community/mcpp v0.0.48). Highlights: capability architecture (why/doctor/abi enforcement/resolution.json), features/profiles/provides= schema knobs, glibc first-run default + GL runtime closure (windowed apps work out of the box), new --template gui.