### PR TITLE
xlings: add 0.4.48, latest -> 0.4.48 (owner-anchored shim dispatch)

### DIFF
--- a/pkgs/x/xlings.lua
+++ b/pkgs/x/xlings.lua
@@ -34,7 +34,8 @@ package = {
     -- Historical 0.4.x entries keep their direct GitHub release URLs.
     xpm = {
         linux = {
-            ["latest"] = { ref = "0.4.47" },
+            ["latest"] = { ref = "0.4.48" },
+            ["0.4.48"] = "XLINGS_RES",
             ["0.4.47"] = "XLINGS_RES",
             ["0.4.46"] = "XLINGS_RES",
             ["0.4.44"] = "XLINGS_RES",
@@ -174,7 +175,8 @@ package = {
             ["0.3.0"] = "XLINGS_RES",
         },
         macosx = {
-            ["latest"] = { ref = "0.4.47" },
+            ["latest"] = { ref = "0.4.48" },
+            ["0.4.48"] = "XLINGS_RES",
             ["0.4.47"] = "XLINGS_RES",
             ["0.4.46"] = "XLINGS_RES",
             ["0.4.44"] = "XLINGS_RES",
@@ -314,7 +316,8 @@ package = {
             ["0.3.0"] = "XLINGS_RES",
         },
         windows = {
-            ["latest"] = { ref = "0.4.47" },
+            ["latest"] = { ref = "0.4.48" },
+            ["0.4.48"] = "XLINGS_RES",
             ["0.4.47"] = "XLINGS_RES",
             ["0.4.46"] = "XLINGS_RES",
             ["0.4.44"] = "XLINGS_RES",


### PR DESCRIPTION
xlings 0.4.48 ships owner-anchored shim dispatch (openxlings/xlings#316): shims resolve against the home that owns the shim file (owner -> env -> default) instead of trusting ambient `XLINGS_HOME`. This fixes shim-resolved tools (git, python, ...) breaking inside embedders that redirect `XLINGS_HOME` (e.g. mcpp's registry sandbox), which deadlocked package-index sync on Windows (repro: mcpp-community/mcpp#114).

Mirrors are live: github xlings-res/xlings 0.4.48 + gitcode xlings-res/xlings 0.4.48.