### PR TITLE
xlings: add 0.4.49, latest -> 0.4.49 (adaptive asset mirroring)

### DIFF
--- a/pkgs/x/xlings.lua
+++ b/pkgs/x/xlings.lua
@@ -34,7 +34,8 @@ package = {
     -- Historical 0.4.x entries keep their direct GitHub release URLs.
     xpm = {
         linux = {
-            ["latest"] = { ref = "0.4.48" },
+            ["latest"] = { ref = "0.4.49" },
+            ["0.4.49"] = "XLINGS_RES",
             ["0.4.48"] = "XLINGS_RES",
             ["0.4.47"] = "XLINGS_RES",
             ["0.4.46"] = "XLINGS_RES",
@@ -175,7 +176,8 @@ package = {
             ["0.3.0"] = "XLINGS_RES",
         },
         macosx = {
-            ["latest"] = { ref = "0.4.48" },
+            ["latest"] = { ref = "0.4.49" },
+            ["0.4.49"] = "XLINGS_RES",
             ["0.4.48"] = "XLINGS_RES",
             ["0.4.47"] = "XLINGS_RES",
             ["0.4.46"] = "XLINGS_RES",
@@ -316,7 +318,8 @@ package = {
             ["0.3.0"] = "XLINGS_RES",
         },
         windows = {
-            ["latest"] = { ref = "0.4.48" },
+            ["latest"] = { ref = "0.4.49" },
+            ["0.4.49"] = "XLINGS_RES",
             ["0.4.48"] = "XLINGS_RES",
             ["0.4.47"] = "XLINGS_RES",
             ["0.4.46"] = "XLINGS_RES",

--- a/tests/x/test_xlings.py
+++ b/tests/x/test_xlings.py
@@ -12,7 +12,7 @@ from tests.lib.assertions import (
 from tests.lib.platform_utils import skip_if_not
 
 PKG = "xlings"
-INSTALL_PKG = "local:xlings@0.4.48"
+INSTALL_PKG = "local:xlings@0.4.49"
 PKG_FILE = "pkgs/x/xlings.lua"
 
 
@@ -45,16 +45,16 @@ class TestStatic:
             end = meta.raw_content.index(f"        {next_platform} = {{", start)
             return meta.raw_content[start:end]
 
-        mirrored_versions = ("0.4.48", "0.4.47", "0.4.46", "0.4.44", "0.4.43", "0.4.42", "0.4.41", "0.4.40")
+        mirrored_versions = ("0.4.49", "0.4.48", "0.4.47", "0.4.46", "0.4.44", "0.4.43", "0.4.42", "0.4.41", "0.4.40")
         for platform, next_platform in (("linux", "macosx"), ("macosx", "windows")):
             block = platform_block(platform, next_platform)
-            assert re.search(r'\["latest"\]\s*=\s*\{\s*ref\s*=\s*"0\.4\.48"\s*\}', block)
+            assert re.search(r'\["latest"\]\s*=\s*\{\s*ref\s*=\s*"0\.4\.49"\s*\}', block)
             for version in mirrored_versions:
                 escaped = re.escape(version)
                 assert re.search(rf'\["{escaped}"\]\s*=\s*"XLINGS_RES"', block)
 
         windows = meta.raw_content[meta.raw_content.index("        windows = {"):]
-        assert re.search(r'\["latest"\]\s*=\s*\{\s*ref\s*=\s*"0\.4\.48"\s*\}', windows)
+        assert re.search(r'\["latest"\]\s*=\s*\{\s*ref\s*=\s*"0\.4\.49"\s*\}', windows)
         for version in mirrored_versions:
             escaped = re.escape(version)
             assert re.search(rf'\["{escaped}"\]\s*=\s*"XLINGS_RES"', windows)
@@ -96,6 +96,6 @@ class TestVerify:
     @skip_if_not('linux')
     def test_xlings(self):
         assert_command_output(
-            "xlings use xlings@0.4.48 >/dev/null && xlings --version 2>&1 | head -1",
-            contains="xlings 0.4.48",
+            "xlings use xlings@0.4.49 >/dev/null && xlings --version 2>&1 | head -1",
+            contains="xlings 0.4.49",
         )


### PR DESCRIPTION
xlings 0.4.49 (openxlings/xlings#317) adds adaptive mirroring for plain GitHub asset URLs: a stall watchdog (windowed 10 KB/s / 15 s, curl-style, env `XLINGS_DOWNLOAD_LOW_SPEED`) plus latency-ordered download candidates with a sha256 integrity gate and session-scoped host penalties (env `XLINGS_ADAPTIVE_MIRROR`). Degraded networks no longer hang on the original URL for the full timeout budget before mirrors are tried.

Mirrors are live and byte-verified: github + gitcode `xlings-res/xlings 0.4.49`. Static tests updated alongside (same shape as #277).