### PR TITLE
mcpp: add 0.0.50, latest -> 0.0.50 (macOS floor 14.0, static libc++)

### DIFF
--- a/pkgs/m/mcpp.lua
+++ b/pkgs/m/mcpp.lua
@@ -39,7 +39,8 @@ package = {
     xpm = {
         linux = {
             url_template = "https://github.com/mcpp-community/mcpp/releases/download/v{version}/mcpp-{version}-linux-x86_64.tar.gz",
-            ["latest"] = { ref = "0.0.49" },
+            ["latest"] = { ref = "0.0.50" },
+            ["0.0.50"] = "XLINGS_RES",
             ["0.0.49"] = "XLINGS_RES",
             ["0.0.48"] = "XLINGS_RES",
             ["0.0.46"] = "XLINGS_RES",
@@ -84,7 +85,8 @@ package = {
             ["0.0.1"] = "XLINGS_RES",
         },
         macosx = {
-            ["latest"] = { ref = "0.0.49" },
+            ["latest"] = { ref = "0.0.50" },
+            ["0.0.50"] = "XLINGS_RES",
             ["0.0.49"] = "XLINGS_RES",
             ["0.0.48"] = "XLINGS_RES",
             ["0.0.46"] = "XLINGS_RES",
@@ -115,7 +117,8 @@ package = {
             ["0.0.16"] = "XLINGS_RES",
         },
         windows = {
-            ["latest"] = { ref = "0.0.49" },
+            ["latest"] = { ref = "0.0.50" },
+            ["0.0.50"] = "XLINGS_RES",
             ["0.0.49"] = "XLINGS_RES",
             ["0.0.48"] = "XLINGS_RES",
             ["0.0.46"] = "XLINGS_RES",

--- a/tests/m/test_mcpp.py
+++ b/tests/m/test_mcpp.py
@@ -12,7 +12,7 @@ from tests.lib.assertions import (
 from tests.lib.platform_utils import skip_if_not
 
 PKG = "mcpp"
-INSTALL_PKG = "local:mcpp@0.0.49"
+INSTALL_PKG = "local:mcpp@0.0.50"
 PKG_FILE = "pkgs/m/mcpp.lua"
 
 
@@ -39,7 +39,7 @@ class TestStatic:
         assert_no_typos(PKG_FILE)
 
     @pytest.mark.static
-    def test_latest_0049_uses_xlings_res(self, meta):
+    def test_latest_0050_uses_xlings_res(self, meta):
         # 0.0.x mcpp assets are distributed through the XLINGS_RES mirrors.
         def platform_block(platform, next_marker):
             start = meta.raw_content.index(f"        {platform} = {{")
@@ -53,8 +53,8 @@ class TestStatic:
         )
         for platform, next_marker in platforms:
             block = platform_block(platform, next_marker)
-            assert re.search(r'\["latest"\]\s*=\s*\{\s*ref\s*=\s*"0\.0\.49"\s*\}', block)
-            assert re.search(r'\["0\.0\.49"\]\s*=\s*"XLINGS_RES"', block)
+            assert re.search(r'\["latest"\]\s*=\s*\{\s*ref\s*=\s*"0\.0\.50"\s*\}', block)
+            assert re.search(r'\["0\.0\.50"\]\s*=\s*"XLINGS_RES"', block)
 
     @pytest.mark.static
     def test_install_uses_runtime_dir(self, meta):
@@ -97,7 +97,7 @@ class TestVerify:
     @pytest.mark.verify
     @skip_if_not('linux')
     def test_mcpp(self):
-        assert_command_output("xlings use mcpp local:0.0.49 >/dev/null && mcpp --version", contains="mcpp 0.0.49")
+        assert_command_output("xlings use mcpp local:0.0.50 >/dev/null && mcpp --version", contains="mcpp 0.0.50")
 
     @pytest.mark.verify
     @skip_if_not('linux')


### PR DESCRIPTION
mcpp 0.0.50 (mcpp-community/mcpp#116): macosx-arm64 binary now carries `LC_BUILD_VERSION minos=14.0` and statically links LLVM libc++ via `-Wl,-load_hidden` (runs on macOS 14+ instead of 15-only; deps shrink to libSystem). Also: `[build] macos_deployment_target` manifest field, deployment target in the BMI fingerprint, macOS links via lld, per-unit stdlib (tests use system libc++).

Mirrors live + byte-verified: github/gitcode `xlings-res/mcpp 0.0.50`.