### PR TITLE
xlings: add 0.4.50, latest -> 0.4.50 (macOS 14+ support, static libc++)

### DIFF
--- a/pkgs/x/xlings.lua
+++ b/pkgs/x/xlings.lua
@@ -34,7 +34,8 @@ package = {
     -- Historical 0.4.x entries keep their direct GitHub release URLs.
     xpm = {
         linux = {
-            ["latest"] = { ref = "0.4.49" },
+            ["latest"] = { ref = "0.4.50" },
+            ["0.4.50"] = "XLINGS_RES",
             ["0.4.49"] = "XLINGS_RES",
             ["0.4.48"] = "XLINGS_RES",
             ["0.4.47"] = "XLINGS_RES",
@@ -176,7 +177,8 @@ package = {
             ["0.3.0"] = "XLINGS_RES",
         },
         macosx = {
-            ["latest"] = { ref = "0.4.49" },
+            ["latest"] = { ref = "0.4.50" },
+            ["0.4.50"] = "XLINGS_RES",
             ["0.4.49"] = "XLINGS_RES",
             ["0.4.48"] = "XLINGS_RES",
             ["0.4.47"] = "XLINGS_RES",
@@ -318,7 +320,8 @@ package = {
             ["0.3.0"] = "XLINGS_RES",
         },
         windows = {
-            ["latest"] = { ref = "0.4.49" },
+            ["latest"] = { ref = "0.4.50" },
+            ["0.4.50"] = "XLINGS_RES",
             ["0.4.49"] = "XLINGS_RES",
             ["0.4.48"] = "XLINGS_RES",
             ["0.4.47"] = "XLINGS_RES",

--- a/tests/x/test_xlings.py
+++ b/tests/x/test_xlings.py
@@ -12,7 +12,7 @@ from tests.lib.assertions import (
 from tests.lib.platform_utils import skip_if_not
 
 PKG = "xlings"
-INSTALL_PKG = "local:xlings@0.4.49"
+INSTALL_PKG = "local:xlings@0.4.50"
 PKG_FILE = "pkgs/x/xlings.lua"
 
 
@@ -45,16 +45,16 @@ class TestStatic:
             end = meta.raw_content.index(f"        {next_platform} = {{", start)
             return meta.raw_content[start:end]
 
-        mirrored_versions = ("0.4.49", "0.4.48", "0.4.47", "0.4.46", "0.4.44", "0.4.43", "0.4.42", "0.4.41", "0.4.40")
+        mirrored_versions = ("0.4.50", "0.4.49", "0.4.48", "0.4.47", "0.4.46", "0.4.44", "0.4.43", "0.4.42", "0.4.41", "0.4.40")
         for platform, next_platform in (("linux", "macosx"), ("macosx", "windows")):
             block = platform_block(platform, next_platform)
-            assert re.search(r'\["latest"\]\s*=\s*\{\s*ref\s*=\s*"0\.4\.49"\s*\}', block)
+            assert re.search(r'\["latest"\]\s*=\s*\{\s*ref\s*=\s*"0\.4\.50"\s*\}', block)
             for version in mirrored_versions:
                 escaped = re.escape(version)
                 assert re.search(rf'\["{escaped}"\]\s*=\s*"XLINGS_RES"', block)
 
         windows = meta.raw_content[meta.raw_content.index("        windows = {"):]
-        assert re.search(r'\["latest"\]\s*=\s*\{\s*ref\s*=\s*"0\.4\.49"\s*\}', windows)
+        assert re.search(r'\["latest"\]\s*=\s*\{\s*ref\s*=\s*"0\.4\.50"\s*\}', windows)
         for version in mirrored_versions:
             escaped = re.escape(version)
             assert re.search(rf'\["{escaped}"\]\s*=\s*"XLINGS_RES"', windows)
@@ -96,6 +96,6 @@ class TestVerify:
     @skip_if_not('linux')
     def test_xlings(self):
         assert_command_output(
-            "xlings use xlings@0.4.49 >/dev/null && xlings --version 2>&1 | head -1",
-            contains="xlings 0.4.49",
+            "xlings use xlings@0.4.50 >/dev/null && xlings --version 2>&1 | head -1",
+            contains="xlings 0.4.50",
         )


### PR DESCRIPTION
## Summary
- Add `0.4.50` to all three platform blocks in `pkgs/x/xlings.lua`, pointing `latest` at it (mirrored via XLINGS_RES on GitHub + GitCode, sha256-verified against upstream).
- Sync `tests/x/test_xlings.py` (INSTALL_PKG / mirrored_versions / latest regex / use+contains) following the 0.4.49 pattern (#278).

## Release highlights (openxlings/xlings v0.4.50)
- macOS binaries now declare `minos=14.0` and link libc++ statically (only `libSystem.B.dylib`), so they run on macOS 14+ instead of requiring macOS 15.
- Built with mcpp 0.0.50 `macos_deployment_target` support; CI asserts the Mach-O floor and static runtime on every release.

## Verification
- `xlings-0.4.50-macosx-arm64.tar.gz`: `LC_BUILD_VERSION minos=14.0.0`, dylibs = `/usr/lib/libSystem.B.dylib` only.
- Mirror sha256 of macosx asset matches upstream: `7012129d…c62f7e6`.