### PR TITLE
mcpp: add 0.0.52, latest -> 0.0.52 (macOS portable-by-default)

### DIFF
--- a/pkgs/m/mcpp.lua
+++ b/pkgs/m/mcpp.lua
@@ -39,7 +39,8 @@ package = {
     xpm = {
         linux = {
             url_template = "https://github.com/mcpp-community/mcpp/releases/download/v{version}/mcpp-{version}-linux-x86_64.tar.gz",
-            ["latest"] = { ref = "0.0.51" },
+            ["latest"] = { ref = "0.0.52" },
+            ["0.0.52"] = "XLINGS_RES",
             ["0.0.51"] = "XLINGS_RES",
             ["0.0.50"] = "XLINGS_RES",
             ["0.0.49"] = "XLINGS_RES",
@@ -86,7 +87,8 @@ package = {
             ["0.0.1"] = "XLINGS_RES",
         },
         macosx = {
-            ["latest"] = { ref = "0.0.51" },
+            ["latest"] = { ref = "0.0.52" },
+            ["0.0.52"] = "XLINGS_RES",
             ["0.0.51"] = "XLINGS_RES",
             ["0.0.50"] = "XLINGS_RES",
             ["0.0.49"] = "XLINGS_RES",
@@ -119,7 +121,8 @@ package = {
             ["0.0.16"] = "XLINGS_RES",
         },
         windows = {
-            ["latest"] = { ref = "0.0.51" },
+            ["latest"] = { ref = "0.0.52" },
+            ["0.0.52"] = "XLINGS_RES",
             ["0.0.51"] = "XLINGS_RES",
             ["0.0.50"] = "XLINGS_RES",
             ["0.0.49"] = "XLINGS_RES",

--- a/tests/m/test_mcpp.py
+++ b/tests/m/test_mcpp.py
@@ -12,7 +12,7 @@ from tests.lib.assertions import (
 from tests.lib.platform_utils import skip_if_not
 
 PKG = "mcpp"
-INSTALL_PKG = "local:mcpp@0.0.51"
+INSTALL_PKG = "local:mcpp@0.0.52"
 PKG_FILE = "pkgs/m/mcpp.lua"
 
 
@@ -39,7 +39,7 @@ class TestStatic:
         assert_no_typos(PKG_FILE)
 
     @pytest.mark.static
-    def test_latest_0051_uses_xlings_res(self, meta):
+    def test_latest_0052_uses_xlings_res(self, meta):
         # 0.0.x mcpp assets are distributed through the XLINGS_RES mirrors.
         def platform_block(platform, next_marker):
             start = meta.raw_content.index(f"        {platform} = {{")
@@ -53,8 +53,8 @@ class TestStatic:
         )
         for platform, next_marker in platforms:
             block = platform_block(platform, next_marker)
-            assert re.search(r'\["latest"\]\s*=\s*\{\s*ref\s*=\s*"0\.0\.51"\s*\}', block)
-            assert re.search(r'\["0\.0\.51"\]\s*=\s*"XLINGS_RES"', block)
+            assert re.search(r'\["latest"\]\s*=\s*\{\s*ref\s*=\s*"0\.0\.52"\s*\}', block)
+            assert re.search(r'\["0\.0\.52"\]\s*=\s*"XLINGS_RES"', block)
 
     @pytest.mark.static
     def test_install_uses_runtime_dir(self, meta):
@@ -97,7 +97,7 @@ class TestVerify:
     @pytest.mark.verify
     @skip_if_not('linux')
     def test_mcpp(self):
-        assert_command_output("xlings use mcpp local:0.0.51 >/dev/null && mcpp --version", contains="mcpp 0.0.51")
+        assert_command_output("xlings use mcpp local:0.0.52 >/dev/null && mcpp --version", contains="mcpp 0.0.52")
 
     @pytest.mark.verify
     @skip_if_not('linux')


### PR DESCRIPTION
## Summary
- Add `0.0.52` to all three platform blocks in `pkgs/m/mcpp.lua`, pointing `latest` at it (mirrored via XLINGS_RES on GitHub + GitCode, sha256-verified against upstream).
- Sync `tests/m/test_mcpp.py` following the established pattern (#279/#281).

## Release highlights (mcpp-community/mcpp v0.0.52)
- macOS **portable-by-default** (mcpp#124): built-in `14.0` deployment floor + static LLVM libc++ for every build — a fresh user's `mcpp new hello && mcpp run` now works on macOS 14 out of the box (previously died at dyld against the system libc++; caught by the macos-14 fresh-install CI lane). Opt-out: `[build] static_stdlib = false`.
- macOS artifact verified: `LC_BUILD_VERSION minos=14.0.0`, `libSystem`-only.