### PR TITLE
xlings: add 0.4.51, latest -> 0.4.51 (portable sha256 verification)

### DIFF
--- a/pkgs/x/xlings.lua
+++ b/pkgs/x/xlings.lua
@@ -34,7 +34,8 @@ package = {
     -- Historical 0.4.x entries keep their direct GitHub release URLs.
     xpm = {
         linux = {
-            ["latest"] = { ref = "0.4.50" },
+            ["latest"] = { ref = "0.4.51" },
+            ["0.4.51"] = "XLINGS_RES",
             ["0.4.50"] = "XLINGS_RES",
             ["0.4.49"] = "XLINGS_RES",
             ["0.4.48"] = "XLINGS_RES",
@@ -177,7 +178,8 @@ package = {
             ["0.3.0"] = "XLINGS_RES",
         },
         macosx = {
-            ["latest"] = { ref = "0.4.50" },
+            ["latest"] = { ref = "0.4.51" },
+            ["0.4.51"] = "XLINGS_RES",
             ["0.4.50"] = "XLINGS_RES",
             ["0.4.49"] = "XLINGS_RES",
             ["0.4.48"] = "XLINGS_RES",
@@ -320,7 +322,8 @@ package = {
             ["0.3.0"] = "XLINGS_RES",
         },
         windows = {
-            ["latest"] = { ref = "0.4.50" },
+            ["latest"] = { ref = "0.4.51" },
+            ["0.4.51"] = "XLINGS_RES",
             ["0.4.50"] = "XLINGS_RES",
             ["0.4.49"] = "XLINGS_RES",
             ["0.4.48"] = "XLINGS_RES",

--- a/tests/x/test_xlings.py
+++ b/tests/x/test_xlings.py
@@ -12,7 +12,7 @@ from tests.lib.assertions import (
 from tests.lib.platform_utils import skip_if_not
 
 PKG = "xlings"
-INSTALL_PKG = "local:xlings@0.4.50"
+INSTALL_PKG = "local:xlings@0.4.51"
 PKG_FILE = "pkgs/x/xlings.lua"
 
 
@@ -45,16 +45,16 @@ class TestStatic:
             end = meta.raw_content.index(f"        {next_platform} = {{", start)
             return meta.raw_content[start:end]
 
-        mirrored_versions = ("0.4.50", "0.4.49", "0.4.48", "0.4.47", "0.4.46", "0.4.44", "0.4.43", "0.4.42", "0.4.41", "0.4.40")
+        mirrored_versions = ("0.4.51", "0.4.50", "0.4.49", "0.4.48", "0.4.47", "0.4.46", "0.4.44", "0.4.43", "0.4.42", "0.4.41", "0.4.40")
         for platform, next_platform in (("linux", "macosx"), ("macosx", "windows")):
             block = platform_block(platform, next_platform)
-            assert re.search(r'\["latest"\]\s*=\s*\{\s*ref\s*=\s*"0\.4\.50"\s*\}', block)
+            assert re.search(r'\["latest"\]\s*=\s*\{\s*ref\s*=\s*"0\.4\.51"\s*\}', block)
             for version in mirrored_versions:
                 escaped = re.escape(version)
                 assert re.search(rf'\["{escaped}"\]\s*=\s*"XLINGS_RES"', block)
 
         windows = meta.raw_content[meta.raw_content.index("        windows = {"):]
-        assert re.search(r'\["latest"\]\s*=\s*\{\s*ref\s*=\s*"0\.4\.50"\s*\}', windows)
+        assert re.search(r'\["latest"\]\s*=\s*\{\s*ref\s*=\s*"0\.4\.51"\s*\}', windows)
         for version in mirrored_versions:
             escaped = re.escape(version)
             assert re.search(rf'\["{escaped}"\]\s*=\s*"XLINGS_RES"', windows)
@@ -96,6 +96,6 @@ class TestVerify:
     @skip_if_not('linux')
     def test_xlings(self):
         assert_command_output(
-            "xlings use xlings@0.4.50 >/dev/null && xlings --version 2>&1 | head -1",
-            contains="xlings 0.4.50",
+            "xlings use xlings@0.4.51 >/dev/null && xlings --version 2>&1 | head -1",
+            contains="xlings 0.4.51",
         )


### PR DESCRIPTION
## Summary
- Add `0.4.51` to all three platform blocks in `pkgs/x/xlings.lua`, pointing `latest` at it (mirrored via XLINGS_RES on GitHub + GitCode; all three assets sha256-verified byte-identical to upstream on BOTH mirrors).
- Sync `tests/x/test_xlings.py` (same pattern as #278/#280).

## Release highlights (openxlings/xlings v0.4.51)
- **In-process SHA-256** (xlings PR #321): downloader no longer shells out to `sha256sum` — a coreutils tool absent on stock macOS and bare Windows, where every sha256-pinned package fetch failed as "SHA256 mismatch" (user-reported: `mcpp new --template imgui` → `fetch 'imgui@0.0.6' failed` on Windows; CI-reported: mcpplibs fetches on macos-14).
- **Per-candidate integrity fallback**: a mirror serving corrupted bytes is now rejected, penalized, and the next candidate (ultimately the author URL) is tried, instead of failing the whole download.
- macOS artifact: `minos=14.0.0`, `libSystem`-only (floor unchanged).