### PR TITLE
feat(d2x): bump to 0.1.5 for all platforms

### DIFF
--- a/pkgs/d/d2x.lua
+++ b/pkgs/d/d2x.lua
@@ -24,7 +24,8 @@ package = {
 
     xpm = {
         windows = {
-            ["latest"] = { ref = "0.1.4" },
+            ["latest"] = { ref = "0.1.5" },
+            ["0.1.5"] = "XLINGS_RES",
             ["0.1.4"] = "XLINGS_RES",
             ["0.1.3"] = "XLINGS_RES",
             ["0.1.2"] = "XLINGS_RES",
@@ -32,7 +33,8 @@ package = {
         },
         linux = {
             deps = { "xim:glibc@2.39", "xim:openssl@3.1.5" },
-            ["latest"] = { ref = "0.1.4" },
+            ["latest"] = { ref = "0.1.5" },
+            ["0.1.5"] = "XLINGS_RES",
             ["0.1.4"] = "XLINGS_RES",
             ["0.1.3"] = "XLINGS_RES",
             ["0.1.2"] = "XLINGS_RES",
@@ -40,7 +42,8 @@ package = {
             ["0.1.0"] = "XLINGS_RES",
         },
         macosx = {
-            ["latest"] = { ref = "0.1.4" },
+            ["latest"] = { ref = "0.1.5" },
+            ["0.1.5"] = "XLINGS_RES",
             ["0.1.4"] = "XLINGS_RES",
             ["0.1.3"] = "XLINGS_RES",
         }


### PR DESCRIPTION
## Summary
将 `d2x` 包索引升级到 **0.1.5**（windows/linux/macosx 三平台 `0.1.5 = XLINGS_RES`，`latest -> 0.1.5`）。

## 包的作用
`d2x` 是 xlings 生态的交互式教程项目工具（`Book + Video + Code + X`）。

## 安装时做了什么
- 下载 `XLINGS_RES` 镜像中的 `d2x-0.1.5-<platform>` 资产并解压;
- `install()`：将解压目录移动到 `pkginfo.install_dir()`;
- `config()`：`xvm.add("d2x")` 注册到 xvm（subos 隔离路由）。
- linux 依赖：`xim:glibc@2.39`、`xim:openssl@3.1.5`（沿用既有声明）。

## 卸载时做了什么
- `uninstall()`：`xvm.remove("d2x")`，移除 xvm 注册。

## 是否修改系统配置/环境变量
否。仅通过 xvm shim 路由命令，不改 `.bashrc`/PATH，不直接 `apt/brew`。

## XLINGS_RES 镜像发布（双源一致）
上游权威 release：https://github.com/d2learn/d2x/releases/tag/v0.1.5
- GitHub RES：https://github.com/xlings-res/d2x/releases/tag/0.1.5
- GitCode RES：https://gitcode.com/xlings-res/d2x/releases/tag/0.1.5

三处资产 sha256 逐一比对一致（上游 = GitHub RES = GitCode RES）：

| 资产 | sha256 |
| --- | --- |
| d2x-0.1.5-linux-x86_64.tar.gz | `d98d77a179e0cf7671a8e61321d03055d896855d9fef7ba77d1d82317cc2b37a` |
| d2x-0.1.5-macosx-arm64.tar.gz | `47d0ebbcbaba18642cdd72838b40f8d7ace1a3cd131bc5906b638851b82cb6ee` |
| d2x-0.1.5-windows-x86_64.zip | `2642e0c8c79b6a77e573b92ec4de88733710bc857d43698fc9f7c910c87beca0` |

两侧 `latest` 仍指向 0.1.5（无 latest 倒退）。

## Test plan
- 本地 pytest：`-m static`、`-m isolation`、`-m index` 全过(d2x 测试文件)。
- 本地功能验证：`xlings install local:d2x@0.1.5 -y` 成功(从 xlings-res 镜像下载)，`d2x --version` = `0.1.5`。
- CI 需验证：static/isolation、index-registration、多平台 install/uninstall。
