### PR TITLE
mcpp: add 0.0.53, latest -> 0.0.53

### DIFF
--- a/pkgs/m/mcpp.lua
+++ b/pkgs/m/mcpp.lua
@@ -39,7 +39,8 @@ package = {
     xpm = {
         linux = {
             url_template = "https://github.com/mcpp-community/mcpp/releases/download/v{version}/mcpp-{version}-linux-x86_64.tar.gz",
-            ["latest"] = { ref = "0.0.52" },
+            ["latest"] = { ref = "0.0.53" },
+            ["0.0.53"] = "XLINGS_RES",
             ["0.0.52"] = "XLINGS_RES",
             ["0.0.51"] = "XLINGS_RES",
             ["0.0.50"] = "XLINGS_RES",
@@ -87,7 +88,8 @@ package = {
             ["0.0.1"] = "XLINGS_RES",
         },
         macosx = {
-            ["latest"] = { ref = "0.0.52" },
+            ["latest"] = { ref = "0.0.53" },
+            ["0.0.53"] = "XLINGS_RES",
             ["0.0.52"] = "XLINGS_RES",
             ["0.0.51"] = "XLINGS_RES",
             ["0.0.50"] = "XLINGS_RES",
@@ -121,7 +123,8 @@ package = {
             ["0.0.16"] = "XLINGS_RES",
         },
         windows = {
-            ["latest"] = { ref = "0.0.52" },
+            ["latest"] = { ref = "0.0.53" },
+            ["0.0.53"] = "XLINGS_RES",
             ["0.0.52"] = "XLINGS_RES",
             ["0.0.51"] = "XLINGS_RES",
             ["0.0.50"] = "XLINGS_RES",

--- a/tests/m/test_mcpp.py
+++ b/tests/m/test_mcpp.py
@@ -12,7 +12,7 @@ from tests.lib.assertions import (
 from tests.lib.platform_utils import skip_if_not
 
 PKG = "mcpp"
-INSTALL_PKG = "local:mcpp@0.0.52"
+INSTALL_PKG = "local:mcpp@0.0.53"
 PKG_FILE = "pkgs/m/mcpp.lua"
 
 
@@ -39,7 +39,7 @@ class TestStatic:
         assert_no_typos(PKG_FILE)
 
     @pytest.mark.static
-    def test_latest_0052_uses_xlings_res(self, meta):
+    def test_latest_0053_uses_xlings_res(self, meta):
         # 0.0.x mcpp assets are distributed through the XLINGS_RES mirrors.
         def platform_block(platform, next_marker):
             start = meta.raw_content.index(f"        {platform} = {{")
@@ -53,8 +53,8 @@ class TestStatic:
         )
         for platform, next_marker in platforms:
             block = platform_block(platform, next_marker)
-            assert re.search(r'\["latest"\]\s*=\s*\{\s*ref\s*=\s*"0\.0\.52"\s*\}', block)
-            assert re.search(r'\["0\.0\.52"\]\s*=\s*"XLINGS_RES"', block)
+            assert re.search(r'\["latest"\]\s*=\s*\{\s*ref\s*=\s*"0\.0\.53"\s*\}', block)
+            assert re.search(r'\["0\.0\.53"\]\s*=\s*"XLINGS_RES"', block)
 
     @pytest.mark.static
     def test_install_uses_runtime_dir(self, meta):
@@ -97,7 +97,7 @@ class TestVerify:
     @pytest.mark.verify
     @skip_if_not('linux')
     def test_mcpp(self):
-        assert_command_output("xlings use mcpp local:0.0.52 >/dev/null && mcpp --version", contains="mcpp 0.0.52")
+        assert_command_output("xlings use mcpp local:0.0.53 >/dev/null && mcpp --version", contains="mcpp 0.0.53")
 
     @pytest.mark.verify
     @skip_if_not('linux')


### PR DESCRIPTION
Adds mcpp **0.0.53** to the index and bumps `latest` across linux / macosx / windows.

Release artifacts are mirrored to `xlings-res/mcpp@0.0.53` (GLOBAL = GitHub, CN = GitCode); the `XLINGS_RES` sentinel resolves to those. All three platform assets verified reachable (HTTP 200).

Upstream: mcpp-community/mcpp v0.0.53 — live download progress + speed for library/component installs (previously only toolchain downloads showed progress).