### PR TITLE
fix(freetype): point CN mirror to gitcode (now published)

### DIFF
--- a/pkgs/f/freetype.lua
+++ b/pkgs/f/freetype.lua
@@ -21,9 +21,8 @@ package = {
             ["latest"] = { ref = "2.13.2" },
             ["2.13.2"] = {
                 url = {
-                    -- CN: switch to gitcode.com/xlings-res/freetype once the mirror is published
                     GLOBAL = "https://github.com/xlings-res/freetype/releases/download/2.13.2/freetype-2.13.2-linux-x86_64.tar.gz",
-                    CN     = "https://github.com/xlings-res/freetype/releases/download/2.13.2/freetype-2.13.2-linux-x86_64.tar.gz",
+                    CN     = "https://gitcode.com/xlings-res/freetype/releases/download/2.13.2/freetype-2.13.2-linux-x86_64.tar.gz",
                 },
                 sha256 = "461bd3493988542edabdda6ac54436e796d2f56055478acfb8efec7aa1cc55ac",
             },


### PR DESCRIPTION
gitcode.com/xlings-res/freetype release 2.13.2 is live with identical sha256 `461bd349…` (verified download parity). Switches CN from the temporary github URL to the gitcode mirror. Completes dual-source (github GLOBAL + gitcode CN) for freetype.