### PR TITLE
mcpp: 0.0.54 (latest)

### DIFF
--- a/pkgs/m/mcpp.lua
+++ b/pkgs/m/mcpp.lua
@@ -39,7 +39,8 @@ package = {
     xpm = {
         linux = {
             url_template = "https://github.com/mcpp-community/mcpp/releases/download/v{version}/mcpp-{version}-linux-x86_64.tar.gz",
-            ["latest"] = { ref = "0.0.53" },
+            ["latest"] = { ref = "0.0.54" },
+            ["0.0.54"] = "XLINGS_RES",
             ["0.0.53"] = "XLINGS_RES",
             ["0.0.52"] = "XLINGS_RES",
             ["0.0.51"] = "XLINGS_RES",
@@ -88,7 +89,8 @@ package = {
             ["0.0.1"] = "XLINGS_RES",
         },
         macosx = {
-            ["latest"] = { ref = "0.0.53" },
+            ["latest"] = { ref = "0.0.54" },
+            ["0.0.54"] = "XLINGS_RES",
             ["0.0.53"] = "XLINGS_RES",
             ["0.0.52"] = "XLINGS_RES",
             ["0.0.51"] = "XLINGS_RES",
@@ -123,7 +125,8 @@ package = {
             ["0.0.16"] = "XLINGS_RES",
         },
         windows = {
-            ["latest"] = { ref = "0.0.53" },
+            ["latest"] = { ref = "0.0.54" },
+            ["0.0.54"] = "XLINGS_RES",
             ["0.0.53"] = "XLINGS_RES",
             ["0.0.52"] = "XLINGS_RES",
             ["0.0.51"] = "XLINGS_RES",

--- a/tests/m/test_mcpp.py
+++ b/tests/m/test_mcpp.py
@@ -12,7 +12,7 @@ from tests.lib.assertions import (
 from tests.lib.platform_utils import skip_if_not
 
 PKG = "mcpp"
-INSTALL_PKG = "local:mcpp@0.0.53"
+INSTALL_PKG = "local:mcpp@0.0.54"
 PKG_FILE = "pkgs/m/mcpp.lua"
 
 
@@ -39,7 +39,7 @@ class TestStatic:
         assert_no_typos(PKG_FILE)
 
     @pytest.mark.static
-    def test_latest_0053_uses_xlings_res(self, meta):
+    def test_latest_0054_uses_xlings_res(self, meta):
         # 0.0.x mcpp assets are distributed through the XLINGS_RES mirrors.
         def platform_block(platform, next_marker):
             start = meta.raw_content.index(f"        {platform} = {{")
@@ -53,8 +53,8 @@ class TestStatic:
         )
         for platform, next_marker in platforms:
             block = platform_block(platform, next_marker)
-            assert re.search(r'\["latest"\]\s*=\s*\{\s*ref\s*=\s*"0\.0\.53"\s*\}', block)
-            assert re.search(r'\["0\.0\.53"\]\s*=\s*"XLINGS_RES"', block)
+            assert re.search(r'\["latest"\]\s*=\s*\{\s*ref\s*=\s*"0\.0\.54"\s*\}', block)
+            assert re.search(r'\["0\.0\.54"\]\s*=\s*"XLINGS_RES"', block)
 
     @pytest.mark.static
     def test_install_uses_runtime_dir(self, meta):
@@ -97,7 +97,7 @@ class TestVerify:
     @pytest.mark.verify
     @skip_if_not('linux')
     def test_mcpp(self):
-        assert_command_output("xlings use mcpp local:0.0.53 >/dev/null && mcpp --version", contains="mcpp 0.0.53")
+        assert_command_output("xlings use mcpp local:0.0.54 >/dev/null && mcpp --version", contains="mcpp 0.0.54")
 
     @pytest.mark.verify
     @skip_if_not('linux')


### PR DESCRIPTION
Bump mcpp to 0.0.54 (latest ref + XLINGS_RES entries in all three platform blocks) and update tests/m/test_mcpp.py accordingly.

- Upstream release: https://github.com/mcpp-community/mcpp/releases/tag/v0.0.54
- Mirrors: xlings-res/mcpp 0.0.54 on GitHub + GitCode, all three assets sha256-verified byte-identical to upstream
- Changes: namespaced `--template` fetch fix (mcpp#130); internal cli architecture modularization (mcpp#129), no CLI behavior change