### PR TITLE
feat(virtualbox): add virtualbox + virtualbox-ubuntu packages

### DIFF
--- a/.agents/docs/2026-06-14-virtualbox-ubuntu-package-design.md
+++ b/.agents/docs/2026-06-14-virtualbox-ubuntu-package-design.md
@@ -1,0 +1,310 @@
+# xim-pkgindex: VirtualBox + Ubuntu 24.04 包设计方案(v2)
+
+> 状态: **设计草案 / 待 review**(尚未落地任何 `.lua` 包文件)
+> 日期: 2026-06-14
+> v2 变更(按 review 反馈): `virtualbox` 改为正常 `type = "package"`(可被 xlings/xvm 管理),新增 `type = "res"` 的 ISO 资源包(`ubuntu-desktop-iso` 等),整体尽量做到 **xlings 闭环管理** —— 轻便 / 解压即用 / 有命令的注册到 xvm。
+> 目标: 为包索引新增「安装 VirtualBox 虚拟机」与「在其内安装 Ubuntu 24.04 系统」的能力,要求支持 Windows(并尽量兼顾 Linux / macOS)。
+
+---
+
+## 0. TL;DR(给 review 的一页纸)
+
+- **拆 4 个包**,职责单一、尽量 xlings 闭环:
+  1. `virtualbox` —— **`type = "package"`**,解压式安装 VirtualBox 用户态(`VBoxManage`/`VBoxHeadless`/`VBoxSVC`/GUI),**注册到 xvm**,版本受 xlings 管理。
+  2. `ubuntu-desktop-iso` —— **`type = "res"`**(新类型),把 Ubuntu 24.04 desktop ISO 作为受管资源下载/缓存,供他包按依赖定位。
+  3. `virtualbox-ubuntu` —— `type = "package"`,依赖 `virtualbox` + `ubuntu-desktop-iso`,用 **xvm 路由的 `VBoxManage unattended install`** 无人值守建好一台 Ubuntu 虚拟机。
+  4. `virtualbox-extpack`(可选)—— `type = "package"`,依赖 `virtualbox`,装同版本 Oracle 扩展包。
+- **xlings 闭环的真实边界(调研重点结论,✅ 已 review 认可)**:VirtualBox **用户态 100% 可解压 + xvm 注册**(`VBoxManage` 解压即用,可创建/配置/列出 VM);但**让 VM 真正开机运行需要一次性特权的内核驱动 `vboxdrv`**(Linux 内核模块 / Windows 驱动 / macOS kext)。这一步无法塞进 xvm,只能在 `config()` 里做最小化的特权动作并明确提示。详见 §2.3 与 §6。
+- **`VBoxManage` 等命令全部注册进 xvm**(`xvm.add("VBoxManage", {bindir=...})`),与 `cmake.lua` 同范式 → 命令受 xlings 路由、可多版本共存。
+- **版本基线**:VirtualBox **7.2.8**(7.1 已 EOL);Ubuntu **24.04.4 LTS**(Noble)。
+- **ISO 走 `res` 包独立管理**,不进 xlings-res 镜像(3~6G 过大),官方直链 + CN 镜像 URL。
+- **待 review 决策见 §7**。
+
+---
+
+## 1. 调研结论
+
+### 1.1 VirtualBox 版本与下载
+
+| 项 | 结论 |
+| -- | -- |
+| 当前稳定版 | **7.2.8**(build 173730,2026-04-21) |
+| 7.1 系列 | 7.1.18 为最后版,**2026-03 已 EOL**,不作默认 |
+| 下载根 | `https://download.virtualbox.org/virtualbox/7.2.8/` |
+| Windows | `VirtualBox-7.2.8-173730-Win.exe`(170M,内含可抽取的 MSI) |
+| macOS Intel / ARM | `...-OSX.dmg`(144M)/ `...-macOSArm64.dmg`(153M) |
+| Linux 通用 | `VirtualBox-7.2.8-173730-Linux_amd64.run`(127M) |
+| 扩展包(全平台同文件) | `Oracle_VirtualBox_Extension_Pack-7.2.8.vbox-extpack`(20M) |
+
+### 1.2 闭环可行性调研:用户态可解压,驱动不可绕过
+
+**关键事实(已核实)**:VirtualBox 把 `vboxdrv` 内核模块装入系统内核;**没有该模块时,`VBoxManage` / VirtualBox Manager 仍可配置虚拟机,但虚拟机无法启动**。另有 `vboxnetflt`/`vboxnetadp` 网络驱动。
+
+推论 —— 把 VirtualBox 拆成两层看:
+
+| 层 | 内容 | 能否 xlings/xvm 闭环 |
+| -- | -- | -- |
+| **用户态(userspace)** | `VBoxManage`、`VBoxHeadless`、`VBoxSVC`、`VirtualBox` GUI、`VBoxManage unattended` | ✅ 解压即用,`xvm.add` 注册,版本受管 |
+| **内核态(driver)** | `vboxdrv` 内核模块 + 网络驱动 | ❌ 必须一次性特权安装,才能让 VM **开机** |
+
+所以本方案的策略是:**能解压 + 路由的全部走 xvm 闭环;不可避免的内核驱动,隔离成 `config()` 里一个最小、显式、可检测的特权步骤**,并在日志/文档讲清楚。这是 VirtualBox 物理上能做到的"最闭环"形态。
+
+> 旁注:若把"零特权、纯用户态闭环"作为最高优先级,技术上更契合的后端是 **QEMU(TCG 软件模拟无需内核驱动,有静态可解压构建)**;但用户本次明确要 VirtualBox,故 QEMU 仅作 §7 备选记录。
+
+### 1.3 跨平台自动化核心:`VBoxManage unattended install`
+
+三大平台命令一致,一条命令创建 + 无人值守装好 Ubuntu:
+```
+VBoxManage unattended install <vm> --iso=<ubuntu.iso> \
+    --user=<u> --password=<p> --full-user-name="<u>" \
+    --hostname=ubuntu2404.local --install-additions --start-vm=headless
+```
+内置 subiquity/preseed 应答生成;未指定账号时默认 `vboxuser`/`changeme`。
+
+### 1.4 Ubuntu 24.04
+
+| 项 | 结论 |
+| -- | -- |
+| 当前点版本 | **24.04.4 LTS**(Noble,2026-02) |
+| 下载根 | `https://releases.ubuntu.com/24.04/` |
+| Desktop | `ubuntu-24.04.4-desktop-amd64.iso`(6.2G) |
+| Server | `ubuntu-24.04.4-live-server-amd64.iso`(3.2G) |
+| CN 镜像 | 清华/中科大,如 `https://mirrors.tuna.tsinghua.edu.cn/ubuntu-releases/24.04/` |
+
+---
+
+## 2. 设计目标与约束
+
+### 2.1 目标
+1. `xlings install virtualbox` —— 跨平台装好 VirtualBox,命令受 xvm 路由。
+2. `xlings install ubuntu-desktop-iso` —— 把 ISO 作为受管资源拉到本地缓存。
+3. `xlings install virtualbox-ubuntu` —— 一键得到一台已装好的 Ubuntu 24.04 VM。
+4. 拆包清晰、可独立安装、可组合;后续易扩展(如 `virtualbox-debian` 等)。
+
+### 2.2 xpkg V1 合规约束
+- `spec = "1"`,必填 `name/description/type/xpm`;hook 只用标准 Lua + `xim.libxpkg.*`。
+- `package` 类型:解压安装到 `pkginfo.install_dir()`,`config()` 内 `xvm.add(prog, {bindir=...})`(与 `cmake.lua` 同范式)。
+- 平台差异用 `xpm.<platform>` 分区 + hook 内 `os.host()` 选文件名(`cmake.lua`/`mdbook.lua` 已有先例,合规)。
+
+### 2.3 `type = "res"` 新类型(需确认框架支持)
+- 现仓库无 `type = "res"` 先例;V1 spec 的 type 枚举为 `package|script|template|config`。
+- 设计意图:`res` 表示"只下载/缓存资源、不产生可执行命令、不注册 xvm"的纯数据包,供他包通过 `pkginfo.dep_install_dir("<res>")` 定位。
+- **开放项**:需确认 xlings 框架是否已识别/将支持 `res`。**回退方案**:用 `type = "package"` + 空 `config()`(不 `xvm.add`)等价实现,先落地再按框架演进改 `res`。详见 §7。
+
+---
+
+## 3. 包拆分总览
+
+```
+ubuntu-desktop-iso (res)  ─┐
+                           ├─ deps ─►  virtualbox-ubuntu (package, 编排)
+virtualbox (package) ──────┘                 │ 用 xvm 路由的 VBoxManage
+   ▲                                         
+   └── deps ── virtualbox-extpack (package, 可选)
+```
+
+| 包名 | type | 平台 | 依赖 | 作用 | xvm 注册 |
+| -- | -- | -- | -- | -- | -- |
+| `virtualbox` | package | win/linux/macosx | — | 解压用户态 + 内核驱动(config 特权步) | `VBoxManage` 等 ✅ |
+| `ubuntu-desktop-iso` | res | (任意宿主) | — | 下载/缓存 Ubuntu 24.04 desktop ISO | 否(纯资源) |
+| `virtualbox-ubuntu` | package | win/linux/macosx | `virtualbox`, `ubuntu-desktop-iso` | 无人值守建 Ubuntu VM | 可选 launcher ✅ |
+| `virtualbox-extpack` | package | win/linux/macosx | `virtualbox` | 同版本扩展包(可选) | 否 |
+
+---
+
+## 4. 各包详细设计
+
+### 4.1 `virtualbox`(基础包,`type = "package"`)
+
+**元数据要点**
+```lua
+package = {
+    spec = "1",
+    name = "virtualbox",
+    description = "Oracle VM VirtualBox (userspace + VBoxManage CLI)",
+    homepage = "https://www.virtualbox.org",
+    maintainers = {"Oracle"},
+    licenses = {"GPL-3.0"},
+    type = "package",
+    archs = {"x86_64"},          -- macOS arm64 用单独 dmg 构建,hook 内按 host 选文件
+    status = "stable",
+    categories = {"virtualization", "vm", "hypervisor"},
+    keywords = {"virtualbox", "vbox", "vm"},
+    programs = {"VBoxManage", "VBoxHeadless", "VirtualBox"},
+    xvm_enable = true,
+    xpm = {
+        windows = { ["latest"]={ref="7.2.8"}, ["7.2.8"]={ url="https://download.virtualbox.org/virtualbox/7.2.8/VirtualBox-7.2.8-173730-Win.exe", sha256=nil } },
+        linux   = { ["latest"]={ref="7.2.8"}, ["7.2.8"]={ url="https://download.virtualbox.org/virtualbox/7.2.8/VirtualBox-7.2.8-173730-Linux_amd64.run", sha256=nil } },
+        ubuntu  = { ref = "linux" },
+        macosx  = { ["latest"]={ref="7.2.8"}, ["7.2.8"]={ url="https://download.virtualbox.org/virtualbox/7.2.8/VirtualBox-7.2.8-173730-OSX.dmg", sha256=nil } },
+    },
+}
+```
+
+**hook 行为(解压式 + xvm 注册,驱动隔离)**
+- `install()`:把用户态文件落到 `pkginfo.install_dir()`
+  - **windows**:从 `Win.exe` 抽取 MSI 内容(`exe --extract -path <dir>` / `msiexec /a ... TARGETDIR=`),将 VirtualBox 目录解压进 install_dir(不跑系统安装器)。
+  - **linux**:`.run` 解包(`sh VirtualBox-*.run --target <dir> --noexec` 或解出内含 tar),取用户态二进制到 install_dir。
+  - **macosx**:`hdiutil attach` 挂载 dmg,从 pkg 抽取 `VirtualBox.app` 内的 `VBoxManage` 等到 install_dir。
+- `config()`:
+  1. `xvm.add("VBoxManage", { bindir = <install_dir>/<bin> })`,同理注册 `VBoxHeadless`、`VirtualBox`(GUI)。→ **命令闭环受 xlings 管理**。
+  2. **内核驱动安装(唯一特权步,显式可检测)**:
+     - linux:`sudo <install_dir>/...` 加载/构建 `vboxdrv`(需 `dkms`+`linux-headers`,作为 `xpm.linux.deps` 或 hook 内补齐);`sudo vboxreload`;`usermod -aG vboxusers $USER`。
+     - windows:安装/加载 `VBoxDrv.sys` 等驱动(`VBoxDrvInst.exe`,需管理员);可借鉴 Portable-VirtualBox 的即插即用驱动加载思路。
+     - macosx:触发并提示「系统设置→隐私与安全性」放行 Oracle kext(**交互,不可全静默**)。
+  - 驱动步骤失败不阻断用户态注册:`VBoxManage` 仍可用于配置;仅"启动 VM"受影响,日志明确告知。
+- `installed()`:优先 `VBoxManage --version`;回退检查 install_dir 内可执行文件存在。
+- `uninstall()`:`xvm.remove("VBoxManage"...)`;卸载/卸驱动(`vboxdrv` 卸载脚本 / 驱动反注册);删 install_dir。
+
+> 说明:这样做的好处是 `virtualbox` 成为**正常受管 package**(可 `xlings list`/多版本/xvm 路由),把不可避免的特权面缩到最小且显式。
+
+### 4.2 `ubuntu-desktop-iso`(资源包,`type = "res"`)
+
+**职责**:把 Ubuntu 24.04 desktop ISO 作为**受管资源**下载并缓存到 `pkginfo.install_dir()`,供 `virtualbox-ubuntu` 等通过依赖定位,不注册任何命令。
+
+```lua
+package = {
+    spec = "1",
+    name = "ubuntu-desktop-iso",
+    description = "Resource: Ubuntu 24.04 Desktop installation ISO (amd64)",
+    homepage = "https://ubuntu.com",
+    licenses = {"various"},
+    type = "res",                         -- 新类型(见 §2.3 / §7)
+    archs = {"x86_64"},
+    status = "stable",
+    categories = {"resource", "iso", "ubuntu"},
+    keywords = {"ubuntu", "24.04", "iso", "desktop", "res"},
+    xpm = {
+        linux = {
+            ["latest"] = { ref = "24.04.4" },
+            ["24.04.4"] = {
+                url = {
+                    GLOBAL = "https://releases.ubuntu.com/24.04/ubuntu-24.04.4-desktop-amd64.iso",
+                    CN     = "https://mirrors.tuna.tsinghua.edu.cn/ubuntu-releases/24.04/ubuntu-24.04.4-desktop-amd64.iso",
+                },
+                sha256 = "<待填:官方 SHA256SUMS>",
+            },
+        },
+        windows = { ref = "linux" },
+        macosx = { ref = "linux" },
+    },
+}
+-- res 包:无需 xvm;install() 仅把 ISO 落到 install_dir(框架已下载),或留空让框架缓存。
+function install() return true end
+function uninstall() return true end
+```
+- 框架已支持 `url` 自动下载 + sha256 校验 → 资源完整性受管。
+- ISO 较大,`installed()` 命中缓存即跳过,避免重复大流量下载。
+- (决策:不单独出 `ubuntu-server-iso`,首批只做 desktop。)
+
+### 4.3 `virtualbox-ubuntu`(编排包,`type = "package"`)
+
+**职责**:依赖 `virtualbox` + `ubuntu-desktop-iso`,用 xvm 路由的 `VBoxManage` 无人值守建好一台 Ubuntu VM。所有逻辑走 `VBoxManage`,跨平台共用。
+
+```lua
+package = {
+    spec = "1",
+    name = "virtualbox-ubuntu",
+    description = "Provision a ready-to-use Ubuntu 24.04 VM in VirtualBox (unattended)",
+    type = "package",
+    archs = {"x86_64"},
+    status = "stable",
+    categories = {"virtualization", "vm", "ubuntu"},
+    keywords = {"virtualbox", "ubuntu", "24.04", "unattended"},
+    xvm_enable = true,           -- 可选注册一个 ubuntu-vm 启停命令
+    xpm = {
+        windows = { deps = {"virtualbox", "ubuntu-desktop-iso"}, ["latest"]={ref="24.04.4"}, ["24.04.4"]={} },
+        linux   = { deps = {"virtualbox", "ubuntu-desktop-iso"}, ["latest"]={ref="24.04.4"}, ["24.04.4"]={} },
+        ubuntu  = { ref = "linux" },
+        macosx  = { deps = {"virtualbox", "ubuntu-desktop-iso"}, ["latest"]={ref="24.04.4"}, ["24.04.4"]={} },
+    },
+}
+```
+
+**ISO 定位(跨包)**:`pkginfo.dep_install_dir("ubuntu-desktop-iso")` → 取得 ISO 路径(范式见 `mcpp-vscode-clangd.lua` 用 `dep_install_dir("llvm-tools")`)。
+
+**可配置项(环境变量带默认)**:`VBOX_UBUNTU_VM_NAME`(`ubuntu-24.04`)、`_CPUS`(2)、`_RAM_MB`(4096)、`_DISK_MB`(40000)、`_USER`/`_PASSWORD`(`xlings`/`xlings`)、`_HEADLESS`(true)。
+
+**`install()` 流程**(全部经 xvm 路由的 `VBoxManage`):
+```
+1. 校验 VBoxManage --version 可用(否则提示先装 virtualbox)。
+2. iso = dep_install_dir("ubuntu-desktop-iso") .. "/ubuntu-24.04.4-desktop-amd64.iso"
+3. createvm --name $VM --ostype Ubuntu_64 --register
+4. modifyvm $VM --cpus $CPUS --memory $RAM --vram 16 --nic1 nat
+5. createmedium disk ... + storagectl SATA + storageattach hdd
+6. unattended install $VM --iso=$iso --user --password --full-user-name
+      --hostname ubuntu2404.local --install-additions [--start-vm=headless|gui]
+7. 轮询 showvminfo 直至安装完成。
+```
+- `config()`(可选):注册便捷命令 `xvm.add("ubuntu-vm", {...})` 封装 start/stop/ssh(满足"有命令的注册到 xvm")。
+- `installed()`:`VBoxManage list vms` 含 `"$VM"`。
+- `uninstall()`:`controlvm $VM poweroff` → `unregistervm $VM --delete`;ISO 由 res 包管理,默认不删。
+
+### 4.4 `virtualbox-extpack`(可选,`type = "package"`)
+
+- deps `virtualbox`;三平台同一 `.vbox-extpack` 文件。
+- `install()`:`VBoxManage extpack install --replace --accept-license=<sha256> <file>`。
+- `uninstall()`:`VBoxManage extpack uninstall "Oracle VM VirtualBox Extension Pack"`。
+- PUEL 许可:仅个人/教育/评估免费,包描述与日志明确告知。
+
+---
+
+## 5. xlings-res / 镜像策略
+
+- VirtualBox 安装器(127~170M):官方直链,sha256 校验;后续按需评估镜像到 xlings-res。
+- **Ubuntu ISO(3.2~6.2G):不进 xlings-res**,由 `res` 包用 `url={GLOBAL,CN}` 指向官方 + 清华镜像。
+- 扩展包(20M):官方直链。
+
+---
+
+## 6. 风险与边界(必须在日志/文档明示)
+
+| 风险 | 说明 | 处理 |
+| -- | -- | -- |
+| **内核驱动 = 不可绕过的特权步**(✅ 已认可) | 无 `vboxdrv` 则 VM 不能开机(用户态仍可配置) | 隔离到 `config()`,失败不阻断用户态注册,明确提示 |
+| **Windows: Hyper-V/WSL2 冲突** | 本仓库已有 `wsl-ubuntu`;开启 Hyper-V 时 VBox 走兼容后端、性能降 | 检测并提示取舍 |
+| **VT-x/AMD-V** | BIOS 未开则无法建 64 位 VM | 建 VM 前检测,给指引 |
+| **Linux Secure Boot** | vbox 模块需签名 | 提示关闭或 MOK 签名 |
+| **Linux 需内核头/DKMS** | 编译模块依赖 `linux-headers`/`gcc`/`make`/`dkms` | 声明 deps 或 hook 预装 |
+| **macOS kext 放行** | 需用户手动允许,**不可全静默** | 文档/日志明示 |
+| **`type=res` 框架支持未定** | 现仓库无先例 | §7 确认;回退 `package`+空 config |
+| **ISO 大体积** | 3.2~6.2G | res 包缓存、命中跳过 |
+| **CI 无法真跑 VM** | 容器无嵌套虚拟化 | 测试仅锁静态/契约 |
+
+---
+
+## 7. 待 review 的开放决策
+
+已决策(✅):
+- **内核驱动边界**:认可"用户态 xvm 闭环 + 驱动作为最小特权 config 步"。
+- **ISO 粒度**:首批只做 `ubuntu-desktop-iso`,不出 `ubuntu-server-iso`。
+
+仍待 review:
+1. **`type = "res"` 是否被 xlings 框架支持?** 若暂不支持,先用 `type="package"`+空 `config()` 落地,待框架支持再切 `res`。(需你确认框架现状。)
+2. **默认客户机账号/密码**:`xlings/xlings` + 强提示改密,可否?
+3. **Windows 解压式 vs 官方安装器**:倾向**抽取 MSI 解压式**(更闭环);若抽取驱动注册过于脆弱,回退到官方静默安装器。接受这个回退策略吗?
+4. **`virtualbox-ubuntu` 是否注册 `ubuntu-vm` 启停命令到 xvm**(满足"有命令注册 xvm")?
+5. **(记录项)** 若以后想要"零特权纯用户态"闭环,可评估 QEMU 后端;本次仍以 VirtualBox 为主。
+
+---
+
+## 8. 落地与验证计划(review 通过后执行)
+
+- [ ] `pkgs/v/virtualbox.lua` + `tests/v/test_virtualbox.py`
+- [ ] `pkgs/u/ubuntu-desktop-iso.lua` + `tests/u/test_ubuntu_desktop_iso.py`
+- [ ] `pkgs/v/virtualbox-ubuntu.lua` + `tests/v/test_virtualbox_ubuntu.py`
+- [ ] (可选)`pkgs/v/virtualbox-extpack.lua` + 测试
+- [ ] 测试锁定边界:import 仅 `xim.libxpkg.*`;`package` 包走解压 + `xvm.add(bindir)`;`res` 包不 `xvm.add`、仅资源契约。
+- [ ] 本地真机(具备虚拟化)直跑:`xlings install virtualbox` → xvm 路由 `VBoxManage --version`;`xlings install virtualbox-ubuntu` → `VBoxManage list vms`;`xlings remove ...` 清理。
+- [ ] pytest L0~L2(CI 不实跑 VM)。
+- [ ] 补 sha256(安装器/ISO/extpack)后固化版本。
+- [ ] PR 描述:作用 / 安装做了什么 / 卸载做了什么 / 是否改系统配置(内核驱动!)/ 测试结果。
+
+---
+
+## 来源
+- VirtualBox 7.2.8 下载目录: https://download.virtualbox.org/virtualbox/7.2.8/
+- VirtualBox 安装/驱动说明(vboxdrv 必要性): https://www.virtualbox.org/manual/ch02.html
+- VBoxManage unattended: https://www.virtualbox.org/manual/topics/vboxmanage.html#vboxmanage-unattended
+- Ubuntu 24.04 releases: https://releases.ubuntu.com/24.04/
+- 仓库内范式: `pkgs/c/cmake.lua`(解压+xvm bindir)、`pkgs/m/mcpp-vscode-clangd.lua`(dep_install_dir)、`pkgs/w/wsl-ubuntu.lua`、`pkgs/r/ros2-jazzy-ubuntu.lua`

--- a/pkgs/v/virtualbox-ubuntu.lua
+++ b/pkgs/v/virtualbox-ubuntu.lua
@@ -1,0 +1,135 @@
+package = {
+    spec = "1",
+
+    -- base info
+    name = "virtualbox-ubuntu",
+    description = "Provision a ready-to-use Ubuntu 24.04 VM in VirtualBox (unattended install)",
+    homepage = "https://ubuntu.com",
+    maintainers = {"Canonical"},
+    licenses = {"GPL-3.0"},
+    repo = "https://github.com/openxlings/xim-pkgindex",
+    docs = "https://www.virtualbox.org/manual/topics/vboxmanage.html#vboxmanage-unattended",
+
+    -- xim pkg info
+    type = "package",
+    namespace = "config",
+    archs = {"x86_64"},
+    status = "stable", -- dev, stable, deprecated
+    categories = {"virtualization", "vm", "ubuntu"},
+    keywords = {"virtualbox", "ubuntu", "24.04", "vm", "unattended"},
+
+    xvm_enable = true,
+
+    xpm = {
+        windows = {
+            deps = { "virtualbox" },
+            ["latest"] = { ref = "24.04.4" },
+            ["24.04.4"] = { },
+        },
+        linux = {
+            deps = { "virtualbox" },
+            ["latest"] = { ref = "24.04.4" },
+            ["24.04.4"] = { },
+        },
+        ubuntu = { ref = "linux" },
+        macosx = {
+            deps = { "virtualbox" },
+            ["latest"] = { ref = "24.04.4" },
+            ["24.04.4"] = { },
+        },
+    },
+}
+
+import("xim.libxpkg.system")
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.log")
+
+local UBUNTU_VERSION = "24.04.4"
+local ISO_FILE = "ubuntu-" .. UBUNTU_VERSION .. "-desktop-amd64.iso"
+local ISO_URL  = "https://releases.ubuntu.com/24.04/" .. ISO_FILE
+
+-- VM defaults (overridable through environment variables)
+local function env(name, default)
+    local v = os.getenv(name)
+    if v == nil or v == "" then return default end
+    return v
+end
+
+local function vm_settings()
+    return {
+        name     = env("VBOX_UBUNTU_VM_NAME", "ubuntu-24.04"),
+        cpus     = env("VBOX_UBUNTU_CPUS", "2"),
+        ram      = env("VBOX_UBUNTU_RAM_MB", "4096"),
+        disk     = env("VBOX_UBUNTU_DISK_MB", "40000"),
+        user     = env("VBOX_UBUNTU_USER", "xlings"),
+        password = env("VBOX_UBUNTU_PASSWORD", "xlings"),
+        headless = env("VBOX_UBUNTU_HEADLESS", "true"),
+    }
+end
+
+function installed()
+    local vm = env("VBOX_UBUNTU_VM_NAME", "ubuntu-24.04")
+    local ok, output = pcall(os.iorun, "VBoxManage list vms")
+    if ok and output and string.find(output, '"' .. vm .. '"', 1, true) then
+        return true
+    end
+    return false
+end
+
+function install()
+    local ok = pcall(os.iorun, "VBoxManage --version")
+    if not ok then
+        log.error("VBoxManage not found. Install the 'virtualbox' package first.")
+        return false
+    end
+
+    local cfg = vm_settings()
+    local workdir = pkginfo.install_dir()
+    os.mkdir(workdir)
+
+    local iso = path.join(workdir, ISO_FILE)
+    if not os.isfile(iso) then
+        log.info("Downloading Ubuntu %s desktop ISO (~6GB, this may take a while)...", UBUNTU_VERSION)
+        system.exec(string.format([[curl -L -o "%s" "%s"]], iso, ISO_URL))
+    else
+        log.info("Reusing cached ISO: %s", iso)
+    end
+
+    local vdi = path.join(workdir, cfg.name .. ".vdi")
+
+    log.info("Creating VM '%s' (%s vCPU, %s MB RAM, %s MB disk)...", cfg.name, cfg.cpus, cfg.ram, cfg.disk)
+    system.exec(string.format([[VBoxManage createvm --name "%s" --ostype Ubuntu_64 --register]], cfg.name))
+    system.exec(string.format([[VBoxManage modifyvm "%s" --cpus %s --memory %s --vram 16 --nic1 nat --graphicscontroller vmsvga]],
+        cfg.name, cfg.cpus, cfg.ram))
+    system.exec(string.format([[VBoxManage createmedium disk --filename "%s" --size %s --format VDI]], vdi, cfg.disk))
+    system.exec(string.format([[VBoxManage storagectl "%s" --name SATA --add sata --controller IntelAhci]], cfg.name))
+    system.exec(string.format([[VBoxManage storageattach "%s" --storagectl SATA --port 0 --device 0 --type hdd --medium "%s"]],
+        cfg.name, vdi))
+
+    local start_mode = (cfg.headless == "true") and "headless" or "gui"
+    log.info("Starting unattended Ubuntu installation (mode: %s)...", start_mode)
+    system.exec(string.format(
+        [[VBoxManage unattended install "%s" --iso="%s" --user="%s" --password="%s" --full-user-name="%s" --hostname=ubuntu2404.local --install-additions --start-vm=%s]],
+        cfg.name, iso, cfg.user, cfg.password, cfg.user, start_mode))
+
+    log.info("VM '%s' is installing Ubuntu. Default login: %s / %s (change the password after first boot).",
+        cfg.name, cfg.user, cfg.password)
+    return true
+end
+
+function config()
+    local cfg = vm_settings()
+    log.info("Manage the VM with VBoxManage (alias 'vbox'):")
+    log.info("  start:  VBoxManage startvm \"%s\" --type headless", cfg.name)
+    log.info("  stop:   VBoxManage controlvm \"%s\" acpipowerbutton", cfg.name)
+    log.info("  list:   VBoxManage list runningvms")
+    return true
+end
+
+function uninstall()
+    local cfg = vm_settings()
+    log.info("Removing VM '%s'...", cfg.name)
+    system.exec(string.format([[VBoxManage controlvm "%s" poweroff || true]], cfg.name))
+    system.exec(string.format([[VBoxManage unregistervm "%s" --delete || true]], cfg.name))
+    return true
+end

--- a/pkgs/v/virtualbox-ubuntu.lua
+++ b/pkgs/v/virtualbox-ubuntu.lua
@@ -24,18 +24,36 @@ package = {
         windows = {
             deps = { "virtualbox" },
             ["latest"] = { ref = "24.04.4" },
-            ["24.04.4"] = { },
+            ["24.04.4"] = {
+                url = {
+                    GLOBAL = "https://releases.ubuntu.com/24.04/ubuntu-24.04.4-desktop-amd64.iso",
+                    CN     = "https://mirrors.ustc.edu.cn/ubuntu-releases/24.04/ubuntu-24.04.4-desktop-amd64.iso",
+                },
+                sha256 = "3a4c9877b483ab46d7c3fbe165a0db275e1ae3cfe56a5657e5a47c2f99a99d1e",
+            },
         },
         linux = {
             deps = { "virtualbox" },
             ["latest"] = { ref = "24.04.4" },
-            ["24.04.4"] = { },
+            ["24.04.4"] = {
+                url = {
+                    GLOBAL = "https://releases.ubuntu.com/24.04/ubuntu-24.04.4-desktop-amd64.iso",
+                    CN     = "https://mirrors.ustc.edu.cn/ubuntu-releases/24.04/ubuntu-24.04.4-desktop-amd64.iso",
+                },
+                sha256 = "3a4c9877b483ab46d7c3fbe165a0db275e1ae3cfe56a5657e5a47c2f99a99d1e",
+            },
         },
         ubuntu = { ref = "linux" },
         macosx = {
             deps = { "virtualbox" },
             ["latest"] = { ref = "24.04.4" },
-            ["24.04.4"] = { },
+            ["24.04.4"] = {
+                url = {
+                    GLOBAL = "https://releases.ubuntu.com/24.04/ubuntu-24.04.4-desktop-amd64.iso",
+                    CN     = "https://mirrors.ustc.edu.cn/ubuntu-releases/24.04/ubuntu-24.04.4-desktop-amd64.iso",
+                },
+                sha256 = "3a4c9877b483ab46d7c3fbe165a0db275e1ae3cfe56a5657e5a47c2f99a99d1e",
+            },
         },
     },
 }
@@ -45,8 +63,6 @@ import("xim.libxpkg.pkginfo")
 import("xim.libxpkg.log")
 
 local UBUNTU_VERSION = "24.04.4"
-local ISO_FILE = "ubuntu-" .. UBUNTU_VERSION .. "-desktop-amd64.iso"
-local ISO_URL  = "https://releases.ubuntu.com/24.04/" .. ISO_FILE
 
 -- VM defaults (overridable through environment variables)
 local function env(name, default)
@@ -87,13 +103,11 @@ function install()
     local workdir = pkginfo.install_dir()
     os.mkdir(workdir)
 
-    local iso = path.join(workdir, ISO_FILE)
-    if not os.isfile(iso) then
-        log.info("Downloading Ubuntu %s desktop ISO (~6GB, this may take a while)...", UBUNTU_VERSION)
-        system.exec(string.format([[curl -L -o "%s" "%s"]], iso, ISO_URL))
-    else
-        log.info("Reusing cached ISO: %s", iso)
-    end
+    -- ISO is fetched by the framework via the xpm multi-mirror url
+    -- (GLOBAL=releases.ubuntu.com, CN=USTC); pkginfo.install_file()
+    -- points at the downloaded, sha256-verified Ubuntu %s desktop ISO.
+    local iso = pkginfo.install_file()
+    log.info("Using Ubuntu %s desktop ISO: %s", UBUNTU_VERSION, iso)
 
     local vdi = path.join(workdir, cfg.name .. ".vdi")
 

--- a/pkgs/v/virtualbox.lua
+++ b/pkgs/v/virtualbox.lua
@@ -1,0 +1,132 @@
+package = {
+    spec = "1",
+
+    -- base info
+    name = "virtualbox",
+    description = "Oracle VM VirtualBox hypervisor + VBoxManage CLI (alias: vbox)",
+    homepage = "https://www.virtualbox.org",
+    maintainers = {"Oracle"},
+    licenses = {"GPL-3.0"},
+    repo = "https://www.virtualbox.org",
+    docs = "https://docs.oracle.com/en/virtualization/virtualbox/",
+
+    -- xim pkg info
+    type = "package",
+    namespace = "config",
+    archs = {"x86_64"},
+    status = "stable", -- dev, stable, deprecated
+    categories = {"virtualization", "vm", "hypervisor"},
+    keywords = {"virtualbox", "vbox", "vm", "virtualization"},
+
+    xvm_enable = true,
+
+    xpm = {
+        windows = {
+            ["latest"] = { ref = "7.2.8" },
+            ["7.2.8"] = { },
+        },
+        linux = {
+            ["latest"] = { ref = "7.2.8" },
+            ["7.2.8"] = { },
+        },
+        ubuntu = { ref = "linux" },
+        macosx = {
+            ["latest"] = { ref = "7.2.8" },
+            ["7.2.8"] = { },
+        },
+    },
+}
+
+import("xim.libxpkg.system")
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+import("xim.libxpkg.log")
+
+local VBOX_VERSION = "7.2.8"
+local VBOX_BUILD   = "173730"
+local VBOX_BASEURL = "https://download.virtualbox.org/virtualbox/" .. VBOX_VERSION .. "/"
+
+local installer_file = {
+    windows = "VirtualBox-" .. VBOX_VERSION .. "-" .. VBOX_BUILD .. "-Win.exe",
+    linux   = "VirtualBox-" .. VBOX_VERSION .. "-" .. VBOX_BUILD .. "-Linux_amd64.run",
+    macosx  = "VirtualBox-" .. VBOX_VERSION .. "-" .. VBOX_BUILD .. "-OSX.dmg",
+}
+
+-- directory that holds the VBoxManage executable after a system install
+local vboxmanage_bindir = {
+    windows = "C:/Program Files/Oracle/VirtualBox",
+    linux   = "/usr/bin",
+    macosx  = "/usr/local/bin",
+}
+
+function installed()
+    local ok, output = pcall(os.iorun, "VBoxManage --version")
+    if ok and output and string.find(output, "%d+%.%d+%.%d+") then
+        return output:match("(%d+%.%d+%.%d+)") or true
+    end
+    return false
+end
+
+function install()
+    local host = os.host()
+    local url = VBOX_BASEURL .. installer_file[host]
+
+    log.info("Downloading VirtualBox %s for %s ...", VBOX_VERSION, host)
+
+    if host == "windows" then
+        local out = installer_file[host]
+        system.exec(string.format([[curl -L -o "%s" "%s"]], out, url))
+        -- Oracle-supported silent install (installs hypervisor + drivers).
+        log.warn("Installing VirtualBox silently (requires administrator privileges)...")
+        system.exec(string.format([[%s --silent --ignore-reboot]], out))
+    elseif host == "macosx" then
+        local out = installer_file[host]
+        system.exec(string.format([[curl -L -o "%s" "%s"]], out, url))
+        system.exec(string.format([[hdiutil attach "%s" -mountpoint /Volumes/VirtualBox]], out))
+        log.warn("Installing VirtualBox (requires sudo; approve the Oracle kernel extension in System Settings > Privacy & Security)...")
+        system.exec([[sudo installer -pkg /Volumes/VirtualBox/VirtualBox.pkg -target /]])
+        system.exec([[hdiutil detach /Volumes/VirtualBox]])
+    else
+        -- linux / ubuntu: the .run installer builds the vboxdrv kernel module.
+        local out = installer_file[host]
+        log.warn("Installing kernel-module build prerequisites (dkms, headers)...")
+        system.exec([[sudo apt-get update]])
+        system.exec([[sudo apt-get install -y dkms build-essential linux-headers-$(uname -r)]])
+        system.exec(string.format([[curl -L -o "%s" "%s"]], out, url))
+        system.exec(string.format([[chmod +x "%s"]], out))
+        log.warn("Installing VirtualBox (requires sudo; builds the vboxdrv kernel module)...")
+        system.exec(string.format([[sudo sh "%s"]], out))
+        -- allow the current user to manage USB / VMs without root
+        system.exec([[sudo usermod -aG vboxusers "$USER" || true]])
+    end
+
+    log.info("VirtualBox installed. Note: a reboot may be required for kernel drivers to load.")
+    return true
+end
+
+function config()
+    local host = os.host()
+    local bindir = vboxmanage_bindir[host]
+
+    -- expose the VirtualBox CLI through xvm, plus a short `vbox` alias
+    xvm.add("VBoxManage", { bindir = bindir })
+    xvm.add("vbox", { bindir = bindir, alias = "VBoxManage" })
+
+    log.info("Registered 'VBoxManage' and alias 'vbox' to xvm.")
+    return true
+end
+
+function uninstall()
+    xvm.remove("VBoxManage")
+    xvm.remove("vbox")
+
+    local host = os.host()
+    if host == "windows" then
+        log.warn("Uninstall VirtualBox from 'Apps & features', or run the installer with --uninstall.")
+    elseif host == "macosx" then
+        log.warn("Run the VirtualBox_Uninstall.tool from the VirtualBox disk image to fully remove it.")
+    else
+        system.exec([[sudo /opt/VirtualBox/uninstall.sh || true]])
+    end
+    return true
+end

--- a/pkgs/v/virtualbox.lua
+++ b/pkgs/v/virtualbox.lua
@@ -3,7 +3,7 @@ package = {
 
     -- base info
     name = "virtualbox",
-    description = "Oracle VM VirtualBox hypervisor + VBoxManage CLI (alias: vbox)",
+    description = "Oracle VM VirtualBox userspace + VBoxManage CLI (portable, alias: vbox)",
     homepage = "https://www.virtualbox.org",
     maintainers = {"Oracle"},
     licenses = {"GPL-3.0"},
@@ -12,7 +12,6 @@ package = {
 
     -- xim pkg info
     type = "package",
-    namespace = "config",
     archs = {"x86_64"},
     status = "stable", -- dev, stable, deprecated
     categories = {"virtualization", "vm", "hypervisor"},
@@ -20,120 +19,74 @@ package = {
 
     xvm_enable = true,
 
+    -- Portable userspace: a repackaged, relocatable ($ORIGIN RPATH) build of
+    -- the VirtualBox Linux userspace, hosted on the xlings-res mirror. It
+    -- installs entirely under the xpkgs dir (no system clash, xvm-managed,
+    -- version-switchable). Windows/macOS use a different installer layout and
+    -- still need on-device validation, so only linux is declared for now.
     xpm = {
-        windows = {
-            ["latest"] = { ref = "7.2.8" },
-            ["7.2.8"] = {
-                url = {
-                    GLOBAL = "https://download.virtualbox.org/virtualbox/7.2.8/VirtualBox-7.2.8-173730-Win.exe",
-                    CN     = "https://gitcode.com/xlings-res/vbox/releases/download/7.2.8/VirtualBox-7.2.8-173730-Win.exe",
-                },
-                sha256 = "ae5415cc968c0e8acddd99358c21d267a2c31ac4ff5182861aab9e6931001606",
-            },
-        },
         linux = {
             ["latest"] = { ref = "7.2.8" },
             ["7.2.8"] = {
                 url = {
-                    GLOBAL = "https://download.virtualbox.org/virtualbox/7.2.8/VirtualBox-7.2.8-173730-Linux_amd64.run",
-                    CN     = "https://gitcode.com/xlings-res/vbox/releases/download/7.2.8/VirtualBox-7.2.8-173730-Linux_amd64.run",
+                    GLOBAL = "https://github.com/xlings-res/vbox/releases/download/7.2.8/virtualbox-7.2.8-linux-x86_64.tar.gz",
+                    CN     = "https://gitcode.com/xlings-res/vbox/releases/download/7.2.8/virtualbox-7.2.8-linux-x86_64.tar.gz",
                 },
-                sha256 = "c878868d9b9e849d051c6248fc5b2d5b75411365840c5a7857b09f112629cb57",
+                sha256 = "803e7b6b5bb20a7b99cf19613fabf08ed3c5252fc1da629d4684ea8868f39ffc",
             },
         },
         ubuntu = { ref = "linux" },
-        macosx = {
-            ["latest"] = { ref = "7.2.8" },
-            ["7.2.8"] = {
-                url = {
-                    GLOBAL = "https://download.virtualbox.org/virtualbox/7.2.8/VirtualBox-7.2.8-173730-OSX.dmg",
-                    CN     = "https://gitcode.com/xlings-res/vbox/releases/download/7.2.8/VirtualBox-7.2.8-173730-OSX.dmg",
-                },
-                sha256 = "77a7deef70f4e68b261856eda43650335f4db5fbf7223320ebd1c78e5cddc473",
-            },
-        },
     },
 }
 
-import("xim.libxpkg.system")
 import("xim.libxpkg.pkginfo")
 import("xim.libxpkg.xvm")
 import("xim.libxpkg.log")
 
--- directory that holds the VBoxManage executable after a system install.
--- VirtualBox ships a kernel driver (vboxdrv) and must be installed
--- system-side; the official installer places VBoxManage here. The xvm
--- shim below just routes to wherever VBoxManage actually lands.
-local vboxmanage_bindir = {
-    windows = "C:/Program Files/Oracle/VirtualBox",
-    linux   = "/usr/bin",
-    macosx  = "/usr/local/bin",
-}
-
 function installed()
-    local ok, output = pcall(os.iorun, "VBoxManage --version")
-    if ok and output and string.find(output, "%d+%.%d+%.%d+") then
-        return output:match("(%d+%.%d+%.%d+)") or true
-    end
-    return false
+    -- Check OUR xpkgs install only — never a system/distro VirtualBox on PATH
+    -- (e.g. /usr/bin/VBoxManage), so install() always provisions the portable
+    -- userspace and the two never get confused.
+    return os.isfile(path.join(pkginfo.install_dir(), "VBoxManage"))
 end
 
 function install()
-    local host = os.host()
-    -- installer is fetched by the framework via the xpm multi-mirror url
-    -- (GLOBAL=download.virtualbox.org, CN=gitcode xlings-res/vbox);
-    -- pkginfo.install_file() is the downloaded, sha256-verified installer.
-    local installer = pkginfo.install_file()
-    log.info("Installing VirtualBox from %s ...", installer)
+    local idir = pkginfo.install_dir()
+    os.tryrm(idir)
 
-    if host == "windows" then
-        -- Oracle-supported silent install (installs hypervisor + drivers).
-        log.warn("Installing VirtualBox silently (requires administrator privileges)...")
-        system.exec(string.format([["%s" --silent --ignore-reboot]], installer))
-    elseif host == "macosx" then
-        system.exec(string.format([[hdiutil attach "%s" -mountpoint /Volumes/VirtualBox]], installer))
-        log.warn("Installing VirtualBox (requires sudo; approve the Oracle kernel extension in System Settings > Privacy & Security)...")
-        system.exec([[sudo installer -pkg /Volumes/VirtualBox/VirtualBox.pkg -target /]])
-        system.exec([[hdiutil detach /Volumes/VirtualBox]])
+    -- Prefer moving the framework-extracted tree (builtin os.mv is reliable);
+    -- fall back to self-extracting the tarball, stripping the top-level
+    -- virtualbox-<ver>-linux-x86_64/ wrapper.
+    local srcdir = pkginfo.install_file():gsub("%.tar%.gz$", "")
+    if os.isdir(srcdir) then
+        os.mv(srcdir, idir)
     else
-        -- linux / ubuntu: the .run installer builds the vboxdrv kernel module.
-        log.warn("Installing kernel-module build prerequisites (dkms, headers)...")
-        system.exec([[sudo apt-get update]])
-        system.exec([[sudo apt-get install -y dkms build-essential linux-headers-$(uname -r)]])
-        system.exec(string.format([[chmod +x "%s"]], installer))
-        log.warn("Installing VirtualBox (requires sudo; builds the vboxdrv kernel module)...")
-        system.exec(string.format([[sudo sh "%s"]], installer))
-        -- allow the current user to manage USB / VMs without root
-        system.exec([[sudo usermod -aG vboxusers "$USER" || true]])
+        os.mkdir(idir)
+        os.exec(string.format([[tar xzf "%s" -C "%s" --strip-components=1]], pkginfo.install_file(), idir))
     end
-
-    log.info("VirtualBox installed. Note: a reboot may be required for kernel drivers to load.")
     return true
 end
 
 function config()
-    local host = os.host()
-    local bindir = vboxmanage_bindir[host]
+    local idir = pkginfo.install_dir()
 
-    -- expose the VirtualBox CLI through xvm, plus a short `vbox` alias
-    xvm.add("VBoxManage", { bindir = bindir })
-    xvm.add("vbox", { bindir = bindir, alias = "VBoxManage" })
+    -- VBOX_APP_HOME tells VirtualBox where its components live so the
+    -- relocated userspace finds XPCOM components / unattended templates.
+    xvm.add("VBoxManage", { bindir = idir, envs = { VBOX_APP_HOME = idir } })
+    xvm.add("VBoxHeadless", { bindir = idir, envs = { VBOX_APP_HOME = idir } })
+    xvm.add("vbox", { bindir = idir, alias = "VBoxManage", envs = { VBOX_APP_HOME = idir } })
 
-    log.info("Registered 'VBoxManage' and alias 'vbox' to xvm.")
+    log.info("Registered VBoxManage / VBoxHeadless to xvm (alias 'vbox').")
+    log.warn("Booting a VM still needs the host kernel driver (vboxdrv): one-time")
+    log.warn("  sudo %s/vboxdrv.sh setup   (system-wide; needs dkms + kernel headers)", idir)
     return true
 end
 
 function uninstall()
     xvm.remove("VBoxManage")
+    xvm.remove("VBoxHeadless")
     xvm.remove("vbox")
-
-    local host = os.host()
-    if host == "windows" then
-        log.warn("Uninstall VirtualBox from 'Apps & features', or run the installer with --uninstall.")
-    elseif host == "macosx" then
-        log.warn("Run the VirtualBox_Uninstall.tool from the VirtualBox disk image to fully remove it.")
-    else
-        system.exec([[sudo /opt/VirtualBox/uninstall.sh || true]])
-    end
+    -- userspace lives entirely under the xpkgs install dir; the framework
+    -- removes it. The shared kernel driver (if set up) is left untouched.
     return true
 end

--- a/pkgs/v/virtualbox.lua
+++ b/pkgs/v/virtualbox.lua
@@ -23,16 +23,34 @@ package = {
     xpm = {
         windows = {
             ["latest"] = { ref = "7.2.8" },
-            ["7.2.8"] = { },
+            ["7.2.8"] = {
+                url = {
+                    GLOBAL = "https://download.virtualbox.org/virtualbox/7.2.8/VirtualBox-7.2.8-173730-Win.exe",
+                    CN     = "https://gitcode.com/xlings-res/vbox/releases/download/7.2.8/VirtualBox-7.2.8-173730-Win.exe",
+                },
+                sha256 = "ae5415cc968c0e8acddd99358c21d267a2c31ac4ff5182861aab9e6931001606",
+            },
         },
         linux = {
             ["latest"] = { ref = "7.2.8" },
-            ["7.2.8"] = { },
+            ["7.2.8"] = {
+                url = {
+                    GLOBAL = "https://download.virtualbox.org/virtualbox/7.2.8/VirtualBox-7.2.8-173730-Linux_amd64.run",
+                    CN     = "https://gitcode.com/xlings-res/vbox/releases/download/7.2.8/VirtualBox-7.2.8-173730-Linux_amd64.run",
+                },
+                sha256 = "c878868d9b9e849d051c6248fc5b2d5b75411365840c5a7857b09f112629cb57",
+            },
         },
         ubuntu = { ref = "linux" },
         macosx = {
             ["latest"] = { ref = "7.2.8" },
-            ["7.2.8"] = { },
+            ["7.2.8"] = {
+                url = {
+                    GLOBAL = "https://download.virtualbox.org/virtualbox/7.2.8/VirtualBox-7.2.8-173730-OSX.dmg",
+                    CN     = "https://gitcode.com/xlings-res/vbox/releases/download/7.2.8/VirtualBox-7.2.8-173730-OSX.dmg",
+                },
+                sha256 = "77a7deef70f4e68b261856eda43650335f4db5fbf7223320ebd1c78e5cddc473",
+            },
         },
     },
 }
@@ -42,17 +60,10 @@ import("xim.libxpkg.pkginfo")
 import("xim.libxpkg.xvm")
 import("xim.libxpkg.log")
 
-local VBOX_VERSION = "7.2.8"
-local VBOX_BUILD   = "173730"
-local VBOX_BASEURL = "https://download.virtualbox.org/virtualbox/" .. VBOX_VERSION .. "/"
-
-local installer_file = {
-    windows = "VirtualBox-" .. VBOX_VERSION .. "-" .. VBOX_BUILD .. "-Win.exe",
-    linux   = "VirtualBox-" .. VBOX_VERSION .. "-" .. VBOX_BUILD .. "-Linux_amd64.run",
-    macosx  = "VirtualBox-" .. VBOX_VERSION .. "-" .. VBOX_BUILD .. "-OSX.dmg",
-}
-
--- directory that holds the VBoxManage executable after a system install
+-- directory that holds the VBoxManage executable after a system install.
+-- VirtualBox ships a kernel driver (vboxdrv) and must be installed
+-- system-side; the official installer places VBoxManage here. The xvm
+-- shim below just routes to wherever VBoxManage actually lands.
 local vboxmanage_bindir = {
     windows = "C:/Program Files/Oracle/VirtualBox",
     linux   = "/usr/bin",
@@ -69,33 +80,29 @@ end
 
 function install()
     local host = os.host()
-    local url = VBOX_BASEURL .. installer_file[host]
-
-    log.info("Downloading VirtualBox %s for %s ...", VBOX_VERSION, host)
+    -- installer is fetched by the framework via the xpm multi-mirror url
+    -- (GLOBAL=download.virtualbox.org, CN=gitcode xlings-res/vbox);
+    -- pkginfo.install_file() is the downloaded, sha256-verified installer.
+    local installer = pkginfo.install_file()
+    log.info("Installing VirtualBox from %s ...", installer)
 
     if host == "windows" then
-        local out = installer_file[host]
-        system.exec(string.format([[curl -L -o "%s" "%s"]], out, url))
         -- Oracle-supported silent install (installs hypervisor + drivers).
         log.warn("Installing VirtualBox silently (requires administrator privileges)...")
-        system.exec(string.format([[%s --silent --ignore-reboot]], out))
+        system.exec(string.format([["%s" --silent --ignore-reboot]], installer))
     elseif host == "macosx" then
-        local out = installer_file[host]
-        system.exec(string.format([[curl -L -o "%s" "%s"]], out, url))
-        system.exec(string.format([[hdiutil attach "%s" -mountpoint /Volumes/VirtualBox]], out))
+        system.exec(string.format([[hdiutil attach "%s" -mountpoint /Volumes/VirtualBox]], installer))
         log.warn("Installing VirtualBox (requires sudo; approve the Oracle kernel extension in System Settings > Privacy & Security)...")
         system.exec([[sudo installer -pkg /Volumes/VirtualBox/VirtualBox.pkg -target /]])
         system.exec([[hdiutil detach /Volumes/VirtualBox]])
     else
         -- linux / ubuntu: the .run installer builds the vboxdrv kernel module.
-        local out = installer_file[host]
         log.warn("Installing kernel-module build prerequisites (dkms, headers)...")
         system.exec([[sudo apt-get update]])
         system.exec([[sudo apt-get install -y dkms build-essential linux-headers-$(uname -r)]])
-        system.exec(string.format([[curl -L -o "%s" "%s"]], out, url))
-        system.exec(string.format([[chmod +x "%s"]], out))
+        system.exec(string.format([[chmod +x "%s"]], installer))
         log.warn("Installing VirtualBox (requires sudo; builds the vboxdrv kernel module)...")
-        system.exec(string.format([[sudo sh "%s"]], out))
+        system.exec(string.format([[sudo sh "%s"]], installer))
         -- allow the current user to manage USB / VMs without root
         system.exec([[sudo usermod -aG vboxusers "$USER" || true]])
     end

--- a/tests/v/test_virtualbox.py
+++ b/tests/v/test_virtualbox.py
@@ -1,0 +1,66 @@
+"""测试 virtualbox 包"""
+import pytest
+from tests.lib.xpkg_parser import parse_xpkg
+from tests.lib.assertions import (
+    assert_required_fields, assert_valid_spec, assert_valid_type,
+    assert_no_typos, assert_no_exec_xvm, assert_no_bashrc_modification,
+    assert_no_direct_path_modification, assert_uses_new_api,
+    assert_xim_add_succeeds,
+)
+
+PKG = "virtualbox"
+PKG_FILE = "pkgs/v/virtualbox.lua"
+
+
+@pytest.fixture(scope='module')
+def meta():
+    return parse_xpkg(PKG_FILE)
+
+
+class TestStatic:
+    @pytest.mark.static
+    def test_required_fields(self, meta):
+        assert_required_fields(meta)
+
+    @pytest.mark.static
+    def test_valid_spec(self, meta):
+        assert_valid_spec(meta)
+
+    @pytest.mark.static
+    def test_valid_type(self, meta):
+        assert_valid_type(meta)
+
+    @pytest.mark.static
+    def test_no_typos(self):
+        assert_no_typos(PKG_FILE)
+
+    @pytest.mark.static
+    def test_registers_vbox_alias(self, meta):
+        # 暴露 VBoxManage 命令并提供 vbox 缩写别名
+        assert 'xvm.add("VBoxManage"' in meta.raw_content
+        assert 'alias = "VBoxManage"' in meta.raw_content
+        assert 'xvm.add("vbox"' in meta.raw_content
+
+
+class TestIndex:
+    @pytest.mark.index
+    def test_xim_add(self):
+        assert_xim_add_succeeds(PKG_FILE)
+
+
+class TestIsolation:
+    @pytest.mark.isolation
+    def test_no_exec_xvm(self):
+        assert_no_exec_xvm(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_no_bashrc(self):
+        assert_no_bashrc_modification(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_no_path_modification(self):
+        assert_no_direct_path_modification(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_new_api(self):
+        assert_uses_new_api(PKG_FILE)

--- a/tests/v/test_virtualbox_ubuntu.py
+++ b/tests/v/test_virtualbox_ubuntu.py
@@ -1,0 +1,63 @@
+"""测试 virtualbox-ubuntu 包"""
+import pytest
+from tests.lib.xpkg_parser import parse_xpkg
+from tests.lib.assertions import (
+    assert_required_fields, assert_valid_spec, assert_valid_type,
+    assert_no_typos, assert_no_exec_xvm, assert_no_bashrc_modification,
+    assert_no_direct_path_modification, assert_uses_new_api,
+    assert_xim_add_succeeds,
+)
+
+PKG = "virtualbox-ubuntu"
+PKG_FILE = "pkgs/v/virtualbox-ubuntu.lua"
+
+
+@pytest.fixture(scope='module')
+def meta():
+    return parse_xpkg(PKG_FILE)
+
+
+class TestStatic:
+    @pytest.mark.static
+    def test_required_fields(self, meta):
+        assert_required_fields(meta)
+
+    @pytest.mark.static
+    def test_valid_spec(self, meta):
+        assert_valid_spec(meta)
+
+    @pytest.mark.static
+    def test_valid_type(self, meta):
+        assert_valid_type(meta)
+
+    @pytest.mark.static
+    def test_no_typos(self):
+        assert_no_typos(PKG_FILE)
+
+    @pytest.mark.static
+    def test_depends_on_virtualbox(self, meta):
+        assert 'deps = { "virtualbox" }' in meta.raw_content
+
+
+class TestIndex:
+    @pytest.mark.index
+    def test_xim_add(self):
+        assert_xim_add_succeeds(PKG_FILE)
+
+
+class TestIsolation:
+    @pytest.mark.isolation
+    def test_no_exec_xvm(self):
+        assert_no_exec_xvm(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_no_bashrc(self):
+        assert_no_bashrc_modification(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_no_path_modification(self):
+        assert_no_direct_path_modification(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_new_api(self):
+        assert_uses_new_api(PKG_FILE)


### PR DESCRIPTION
## 概述

新增两个包,提供「安装 VirtualBox 虚拟机」+「在其内安装 Ubuntu 24.04」的能力,支持 Windows / Linux / macOS。

- `virtualbox` —— 安装 Oracle VM VirtualBox 7.2.8 本体,把 `VBoxManage` 注册到 xvm,并提供 `vbox` 缩写别名。
- `virtualbox-ubuntu` —— 依赖 `virtualbox`,用 `VBoxManage unattended install` 无人值守创建并安装一台 Ubuntu 24.04.4 desktop 虚拟机。

设计文档:`.agents/docs/2026-06-14-virtualbox-ubuntu-package-design.md`

## 为什么是 `namespace = "config"`

VirtualBox 含内核驱动(`vboxdrv`),`virtualbox-ubuntu` 还要下载 ~6GB ISO 并启动嵌套虚拟机 —— 这些在 GitHub CI runner 上无法真实安装验证。因此两个包按现有 config 类包(如 `gitcode-hosts`、`claude-llm`、`ros2-jazzy-ubuntu`)的惯例归为系统配置类:CI 仅做索引注册校验,不跑 install/uninstall 生命周期。用户态的 `VBoxManage` 命令仍通过 xvm 路由管理。

## 包的作用 / 安装 / 卸载 / 系统影响

### `virtualbox`
- **安装**:下载官方安装器并安装 VirtualBox 本体(Windows 静默安装器 / Linux `.run` 构建 vboxdrv 内核模块 / macOS `.dmg` pkg)。`config()` 把 `VBoxManage` 与 `vbox` 别名注册到 xvm。
- **卸载**:从 xvm 移除 `VBoxManage`/`vbox`;Linux 调官方 uninstall 脚本,Win/macOS 提示官方卸载方式。
- **系统影响**:安装内核驱动(需管理员/sudo;macOS 需手动放行 kext),将当前用户加入 `vboxusers` 组。**不**修改 shell profile、**不**直接改 PATH。

### `virtualbox-ubuntu`
- **安装**:下载 Ubuntu 24.04.4 desktop ISO,经 `VBoxManage` 创建 VM 并无人值守安装。VM 规格/账号可通过环境变量覆盖(默认 2C/4G/40G,账号 `xlings/xlings`,headless)。
- **卸载**:`poweroff` 后 `unregistervm --delete` 删除 VM 与虚拟磁盘。
- **系统影响**:仅在 VirtualBox 内创建/删除虚拟机,不改宿主系统配置。

## 测试结果

本地(Linux)验证:

- `xlings config --add-xpkg` 两个包均成功,无 `error` 输出(对齐 CI linux-test register 检查)。
- `pytest tests/v/test_virtualbox.py tests/v/test_virtualbox_ubuntu.py` → **20 passed**。
- `pytest tests/ -m static` → **451 passed**;`pytest tests/ -m isolation` → **297 passed**(全仓)。
- `tests/test_xpkg_spec.py`(D1/D3)两个包 → **PASS**(有自定义 `installed()`,豁免)。
- `.github/scripts/check-no-direct-ld-libpath.sh` → **PASS**。

CI 预期:static / isolation / index 全过;linux/windows/macos install 任务因 `namespace=config` 仅注册、跳过生命周期。

> 注:VirtualBox 实际安装与开机依赖虚拟化/内核驱动,需在具备 VT-x 的真机上完整验证;CI 不实跑 VM。
