### PR TITLE
mcpp: index 0.0.56

### DIFF
--- a/pkgs/m/mcpp.lua
+++ b/pkgs/m/mcpp.lua
@@ -39,7 +39,8 @@ package = {
     xpm = {
         linux = {
             url_template = "https://github.com/mcpp-community/mcpp/releases/download/v{version}/mcpp-{version}-linux-x86_64.tar.gz",
-            ["latest"] = { ref = "0.0.55" },
+            ["latest"] = { ref = "0.0.56" },
+            ["0.0.56"] = "XLINGS_RES",
             ["0.0.55"] = "XLINGS_RES",
             ["0.0.54"] = "XLINGS_RES",
             ["0.0.53"] = "XLINGS_RES",
@@ -90,7 +91,8 @@ package = {
             ["0.0.1"] = "XLINGS_RES",
         },
         macosx = {
-            ["latest"] = { ref = "0.0.55" },
+            ["latest"] = { ref = "0.0.56" },
+            ["0.0.56"] = "XLINGS_RES",
             ["0.0.55"] = "XLINGS_RES",
             ["0.0.54"] = "XLINGS_RES",
             ["0.0.53"] = "XLINGS_RES",
@@ -127,7 +129,8 @@ package = {
             ["0.0.16"] = "XLINGS_RES",
         },
         windows = {
-            ["latest"] = { ref = "0.0.55" },
+            ["latest"] = { ref = "0.0.56" },
+            ["0.0.56"] = "XLINGS_RES",
             ["0.0.55"] = "XLINGS_RES",
             ["0.0.54"] = "XLINGS_RES",
             ["0.0.53"] = "XLINGS_RES",

--- a/tests/m/test_mcpp.py
+++ b/tests/m/test_mcpp.py
@@ -12,7 +12,7 @@ from tests.lib.assertions import (
 from tests.lib.platform_utils import skip_if_not
 
 PKG = "mcpp"
-INSTALL_PKG = "local:mcpp@0.0.55"
+INSTALL_PKG = "local:mcpp@0.0.56"
 PKG_FILE = "pkgs/m/mcpp.lua"
 
 
@@ -39,7 +39,7 @@ class TestStatic:
         assert_no_typos(PKG_FILE)
 
     @pytest.mark.static
-    def test_latest_0055_uses_xlings_res(self, meta):
+    def test_latest_0056_uses_xlings_res(self, meta):
         # 0.0.x mcpp assets are distributed through the XLINGS_RES mirrors.
         def platform_block(platform, next_marker):
             start = meta.raw_content.index(f"        {platform} = {{")
@@ -53,8 +53,8 @@ class TestStatic:
         )
         for platform, next_marker in platforms:
             block = platform_block(platform, next_marker)
-            assert re.search(r'\["latest"\]\s*=\s*\{\s*ref\s*=\s*"0\.0\.55"\s*\}', block)
-            assert re.search(r'\["0\.0\.55"\]\s*=\s*"XLINGS_RES"', block)
+            assert re.search(r'\["latest"\]\s*=\s*\{\s*ref\s*=\s*"0\.0\.56"\s*\}', block)
+            assert re.search(r'\["0\.0\.56"\]\s*=\s*"XLINGS_RES"', block)
 
     @pytest.mark.static
     def test_install_uses_runtime_dir(self, meta):
@@ -97,7 +97,7 @@ class TestVerify:
     @pytest.mark.verify
     @skip_if_not('linux')
     def test_mcpp(self):
-        assert_command_output("xlings use mcpp local:0.0.55 >/dev/null && mcpp --version", contains="mcpp 0.0.55")
+        assert_command_output("xlings use mcpp local:0.0.56 >/dev/null && mcpp --version", contains="mcpp 0.0.56")
 
     @pytest.mark.verify
     @skip_if_not('linux')


### PR DESCRIPTION
Index `mcpp` 0.0.56 and point `latest` → 0.0.56 across linux / macosx / windows.

- Upstream release: https://github.com/mcpp-community/mcpp/releases/tag/v0.0.56
- Mirror (GitHub): https://github.com/xlings-res/mcpp/releases/tag/0.0.56
- Mirror (GitCode): xlings-res/mcpp@0.0.56

Artifacts (byte-identical to upstream):
- mcpp-0.0.56-linux-x86_64.tar.gz
- mcpp-0.0.56-macosx-arm64.tar.gz
- mcpp-0.0.56-windows-x86_64.zip

0.0.56 highlights: run/test/build no longer leak the bundled-glibc LD_LIBRARY_PATH into the host /bin/sh (fixes a `sh: … GLIBC_2.42 not found` crash on newer-glibc distros); `mcpp pack --mode` renamed to vendored/self-contained/system with old names kept as permanent aliases.