### PR TITLE
fix(aarch64-linux-musl-gcc): drop xim:glibc dep (self-contained)

### DIFF
--- a/pkgs/a/aarch64-linux-musl-gcc.lua
+++ b/pkgs/a/aarch64-linux-musl-gcc.lua
@@ -41,12 +41,12 @@ package = {
 
     xpm = {
         linux = {
-            -- glibc-hosted cross tools: declare glibc so the sandbox loader is
-            -- present and auto-elfpatch can repoint INTERP/RPATH (same pattern
-            -- as binutils.lua). XLINGS_RES resolves the host-matching asset:
-            --   aarch64-linux-musl-gcc-<ver>-linux-x86_64.tar.gz
-            deps = { "xim:glibc@2.39" },
-
+            -- No deps: this is a self-contained toolchain. The native (aarch64
+            -- host) asset is static (musl-cross-make --static) and the cross
+            -- (x86_64 host) asset runs against the host's own glibc — neither
+            -- needs xim:glibc (which has no aarch64 asset) nor relocation; the
+            -- install hook just unpacks. XLINGS_RES picks the host-matching
+            -- asset: aarch64-linux-musl-gcc-<ver>-linux-{x86_64,aarch64}.tar.gz
             ["latest"] = { ref = "15.1.0" },
             ["15.1.0"] = "XLINGS_RES",
         },


### PR DESCRIPTION
The cross/native aarch64 toolchain is self-contained (native asset static, cross asset uses host glibc). The bogus xim:glibc@2.39 dep — which has no aarch64 asset — made native aarch64 self-host builds 404. Remove it.