### PR TITLE
feat(mcpp-vscode-clangd): add windows support

### DIFF
--- a/pkgs/m/mcpp-vscode-clangd.lua
+++ b/pkgs/m/mcpp-vscode-clangd.lua
@@ -19,6 +19,11 @@ package = {
             ["latest"] = { ref = "20.1.7" },
             ["20.1.7"] = {},
         },
+        windows = {
+            deps = { "xim:mcpp", "xim:code", "xim:llvm-tools@20.1.7" },
+            ["latest"] = { ref = "20.1.7" },
+            ["20.1.7"] = {},
+        },
     },
 }
 
@@ -43,7 +48,8 @@ function config()
         os.mkdir(vscode_dir)
     end
     local settings = os.isfile(settings_file) and json.loadfile(settings_file) or {}
-    settings["clangd.path"] = path.join(pkginfo.dep_install_dir("llvm-tools", pkginfo.version()), "bin", "clangd")
+    local clangd_exe = os.host() == "windows" and "clangd.exe" or "clangd"
+    settings["clangd.path"] = path.join(pkginfo.dep_install_dir("llvm-tools", pkginfo.version()), "bin", clangd_exe)
     -- Enable clangd's C++20 modules support so mcpp's `import std;` /
     -- `import <module>;` projects resolve correctly under the editor.
     settings["clangd.arguments"] = { "--experimental-modules-support" }

--- a/tests/m/test_mcpp_vscode_clangd.py
+++ b/tests/m/test_mcpp_vscode_clangd.py
@@ -76,6 +76,24 @@ class TestStatic:
         assert 'mcpp toolchain install llvm@" .. pkginfo.version() .. " default' in meta.raw_content
 
     @pytest.mark.static
+    def test_supports_windows(self, meta):
+        # windows must mirror the linux deps and version pins, since mcpp,
+        # code and llvm-tools all ship windows artifacts.
+        windows = re.search(r"windows\s*=\s*\{(.*?)\n        \}", meta.raw_content, re.DOTALL)
+        assert windows, "missing windows xpm block"
+        windows_body = windows.group(1)
+        for dep in ("xim:mcpp", "xim:code", "xim:llvm-tools@20.1.7"):
+            assert re.search(rf'["\']{re.escape(dep)}["\']', windows_body), \
+                f"windows missing dependency: {dep}"
+        assert '["20.1.7"]' in windows_body
+
+    @pytest.mark.static
+    def test_clangd_path_is_host_aware(self, meta):
+        # clangd binary is `clangd.exe` on windows, `clangd` elsewhere.
+        assert 'os.host() == "windows"' in meta.raw_content
+        assert '"clangd.exe"' in meta.raw_content
+
+    @pytest.mark.static
     def test_configures_clangd_path_only(self, meta):
         assert '"clangd.path"' in meta.raw_content
         assert "compile-commands-dir" not in meta.raw_content


### PR DESCRIPTION
## What

Add Windows support to the `mcpp-vscode-clangd@20.1.7` config package.

## Why it's easy

All three dependencies already ship Windows artifacts and handle the `.exe` suffix themselves:

- **`xim:mcpp`** — has an `xpm.windows` table and resolves `mcpp.exe`
- **`xim:code`** — full Windows install/config (zip extract, shortcut, `code.cmd` alias)
- **`xim:llvm-tools@20.1.7`** — has an `xpm.windows` zip and registers `clangd.exe`

So the only platform-specific logic in this config package is the clangd binary name. (No macOS variant — `llvm-tools` has no macOS build.)

## Changes

- Mirror the linux `deps`/version pins under a new `xpm.windows` block.
- Resolve the clangd binary as `clangd.exe` on Windows (`clangd` elsewhere) for `settings["clangd.path"]`.

The rest of `config()` is already cross-platform: the `mcpp toolchain install` / `mcpp build` commands, the `code --install-extension` call (registered for all platforms via xvm), and `pkginfo.dep_install_dir` all work on Windows unchanged.

## Tests

Added two static tests (windows xpm block mirrors linux deps; host-aware clangd path). Full suite passes:

\`\`\`
26 passed
\`\`\`