### PR TITLE
ci: standalone publish-artifact workflow (decouple index publish from xlings release)

### DIFF
--- a/.github/workflows/publish-artifact.yml
+++ b/.github/workflows/publish-artifact.yml
@@ -1,0 +1,70 @@
+name: Publish Index Artifact
+
+# Decouples xim-pkgindex artifact publishing from xlings releases: editing the
+# index here (pkgs/**) re-publishes the versioned index artifact + rolling
+# pointer to xlings-res/xim-index (GitHub + GitCode), so default (artifact-source)
+# clients pick up the change on their next refresh — no xlings release needed.
+# Design: .agents/docs/2026-06-24-artifact-publish-mechanism.md
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'pkgs/**'
+      - 'xim-indexrepos.lua'
+      - '.xpkgindex.json'
+  workflow_dispatch:
+  schedule:
+    - cron: '0 18 * * *'   # nightly catch-all / mirror re-sync
+
+# Serialize: a later push supersedes an in-flight publish.
+concurrency:
+  group: publish-index-artifact
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    env:
+      # PAT with write to xlings-res/xim-index (release assets + pointer file).
+      XLINGS_RES_TOKEN: ${{ secrets.XLINGS_RES_TOKEN }}
+      GITCODE_TOKEN: ${{ secrets.GITCODE_TOKEN }}
+      # gh CLI (used by publish_xim_index.sh) targets xlings-res, so it must use
+      # the cross-repo PAT, not the default repo-scoped GITHUB_TOKEN.
+      GH_TOKEN: ${{ secrets.XLINGS_RES_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # need HEAD short-sha for content-hash artifact name
+
+      - name: Install gtc (gitcode-cli)
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/sunrisepeak/gitcode-cli/main/bin/gtc \
+            -o "$HOME/.local/bin/gtc" --create-dirs || \
+          { mkdir -p "$HOME/.local/bin"; curl -fsSL https://raw.githubusercontent.com/sunrisepeak/gitcode-cli/main/bin/gtc -o "$HOME/.local/bin/gtc"; }
+          chmod +x "$HOME/.local/bin/gtc"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Build + publish index artifact (content-hash version)
+        if: ${{ env.XLINGS_RES_TOKEN != '' }}
+        run: |
+          set -euo pipefail
+          # Content-hash naming: decouple the artifact from any xlings/mcpp version.
+          VER="$(git rev-parse --short HEAD)"
+          echo "publishing xim-index @ $VER"
+          bash tools/build_xim_index_artifact.sh --src . --version "$VER" --out build/index
+          # gh -> github xlings-res; gtc -> gitcode (skipped automatically if token absent)
+          if [ -n "${GITCODE_TOKEN:-}" ]; then
+            bash tools/publish_xim_index.sh --version "$VER" --dir build/index
+          else
+            bash tools/publish_xim_index.sh --version "$VER" --dir build/index --skip-gitcode
+          fi
+          # Combined rolling pointer (repo file, overwriteable) on both ends.
+          bash tools/push_index_pointers.sh build/index
+
+      - name: Skipped (no XLINGS_RES_TOKEN)
+        if: ${{ env.XLINGS_RES_TOKEN == '' }}
+        run: echo "XLINGS_RES_TOKEN not set — skipping publish (fork/no-secret run)."

--- a/tools/build_xim_index_artifact.sh
+++ b/tools/build_xim_index_artifact.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# Build a versioned xim package-index *artifact* + manifest for publishing
+# to xlings-res (Y-asset model; see .agents/docs/2026-06-22-index-as-resource-impl-plan.md).
+#
+# An index artifact is a plain tarball of the index tree (pkgs/, .xpkgindex.json,
+# xim-indexrepos.lua, ...) with the .git history stripped, plus a manifest.json
+# describing it (sha256/size + format_version + a reserved signature slot for a
+# future minisign/X-full upgrade).
+#
+# Output (in OUT_DIR):
+#   xim-index[-<name>]-<ver>.tar.gz
+#   xim-index[-<name>]-<ver>.manifest.json
+#
+# Usage:
+#   tools/build_xim_index_artifact.sh --version <ver> --out <dir> [--name <sub>] [--src <dir>]
+#
+# Env:
+#   XLINGS_RELEASE_MIRROR=GLOBAL|CN     pick clone origin when --src omitted (default GLOBAL)
+#   XLINGS_RELEASE_PKGINDEX_URL         override clone URL
+#   XLINGS_RELEASE_PKGINDEX_REF=main    git ref to snapshot (default main)
+set -euo pipefail
+
+VERSION="" OUT_DIR="" NAME="" SRC_DIR=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --version) VERSION="$2"; shift 2 ;;
+    --out)     OUT_DIR="$2"; shift 2 ;;
+    --name)    NAME="$2";    shift 2 ;;
+    --src)     SRC_DIR="$2"; shift 2 ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+[[ -z "$VERSION" || -z "$OUT_DIR" ]] && { echo "usage: $0 --version <ver> --out <dir> [--name <sub>] [--src <dir>]" >&2; exit 2; }
+
+info() { echo "[index-artifact] $*"; }
+fail() { echo "[index-artifact] FAIL: $*" >&2; exit 1; }
+
+# sha256 helper (Linux: sha256sum, macOS: shasum -a 256)
+sha256_of() {
+  if command -v sha256sum >/dev/null 2>&1; then sha256sum "$1" | awk '{print $1}';
+  elif command -v shasum >/dev/null 2>&1; then shasum -a 256 "$1" | awk '{print $1}';
+  else fail "no sha256 tool (sha256sum/shasum)"; fi
+}
+
+MIRROR="${XLINGS_RELEASE_MIRROR:-GLOBAL}"
+REF="${XLINGS_RELEASE_PKGINDEX_REF:-main}"
+# Sub-index name → repo. Main index has no name.
+if [[ -z "$NAME" ]]; then
+  case "$MIRROR" in
+    CN) DEFAULT_URL="https://gitee.com/sunrisepeak/xim-pkgindex.git" ;;
+    *)  DEFAULT_URL="https://github.com/openxlings/xim-pkgindex.git" ;;
+  esac
+  ARTIFACT_BASE="xim-index-${VERSION}"
+else
+  DEFAULT_URL="https://github.com/d2learn/xim-pkgindex-${NAME}.git"
+  ARTIFACT_BASE="xim-index-${NAME}-${VERSION}"
+fi
+URL="${XLINGS_RELEASE_PKGINDEX_URL:-$DEFAULT_URL}"
+
+mkdir -p "$OUT_DIR"
+OUT_DIR="$(cd "$OUT_DIR" && pwd)"
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/xim-index-build.XXXXXX")"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+TREE="$TMP_ROOT/tree"
+if [[ -n "$SRC_DIR" ]]; then
+  info "Using local source: $SRC_DIR"
+  [[ -d "$SRC_DIR/pkgs" ]] || fail "source dir missing pkgs/: $SRC_DIR"
+  cp -a "$SRC_DIR" "$TREE"
+else
+  info "Cloning $URL ($REF)"
+  if ! git clone --depth 1 --branch "$REF" "$URL" "$TREE" 2>/dev/null; then
+    rm -rf "$TREE"
+    git clone "$URL" "$TREE"
+    git -C "$TREE" checkout --quiet "$REF"
+  fi
+fi
+
+# Record source commit (before stripping .git) for traceability.
+SOURCE_COMMIT="unknown"
+if [[ -d "$TREE/.git" ]]; then
+  SOURCE_COMMIT="$(git -C "$TREE" rev-parse HEAD 2>/dev/null || echo unknown)"
+fi
+rm -rf "$TREE/.git"
+[[ -d "$TREE/pkgs" ]] || fail "index tree missing pkgs/ after fetch"
+
+# Deterministic-ish tarball (sorted names, stable owners).
+ARTIFACT="$OUT_DIR/${ARTIFACT_BASE}.tar.gz"
+info "Packing $ARTIFACT"
+tar --sort=name --owner=0 --group=0 --numeric-owner \
+    -czf "$ARTIFACT" -C "$TREE" . 2>/dev/null \
+  || tar -czf "$ARTIFACT" -C "$TREE" .   # BSD tar fallback (no --sort)
+
+SHA="$(sha256_of "$ARTIFACT")"
+SIZE="$(wc -c < "$ARTIFACT" | tr -d ' ')"
+GENERATED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+MANIFEST="$OUT_DIR/${ARTIFACT_BASE}.manifest.json"
+cat > "$MANIFEST" <<JSON
+{
+  "format_version": 1,
+  "index_version": "${VERSION}",
+  "index_name": "${NAME:-xim}",
+  "generated_at": "${GENERATED_AT}",
+  "source_commit": "${SOURCE_COMMIT}",
+  "artifact": {
+    "name": "${ARTIFACT_BASE}.tar.gz",
+    "sha256": "${SHA}",
+    "size": ${SIZE}
+  },
+  "signature": null
+}
+JSON
+
+info "Done:"
+info "  artifact: $ARTIFACT"
+info "  sha256:   $SHA  ($SIZE bytes)"
+info "  manifest: $MANIFEST"

--- a/tools/publish_xim_index.sh
+++ b/tools/publish_xim_index.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Publish a built xim-index artifact + manifest to xlings-res/xim-index on both
+# GitHub (gh) and GitCode (gtc). Idempotent: creates the release if missing,
+# then uploads with clobber. Also refreshes a stable "latest" pointer asset
+# (<base>.manifest.json copied to xim-index[-<name>]-latest.json).
+#
+# Usage:
+#   tools/publish_xim_index.sh --version <ver> --dir <artifact-dir> [--name <sub>] \
+#       [--github-repo xlings-res/xim-index] [--gitcode-repo xlings-res/xim-index] \
+#       [--dry-run] [--skip-github] [--skip-gitcode]
+#
+# Auth: gh uses its own login; gtc uses GITCODE_TOKEN env or `gtc --token`.
+set -euo pipefail
+
+VERSION="" DIR="" NAME="" DRY=0 SKIP_GH=0 SKIP_GTC=0
+GH_REPO="xlings-res/xim-index" GTC_REPO="xlings-res/xim-index"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --version)     VERSION="$2"; shift 2 ;;
+    --dir)         DIR="$2"; shift 2 ;;
+    --name)        NAME="$2"; shift 2 ;;
+    --github-repo) GH_REPO="$2"; shift 2 ;;
+    --gitcode-repo)GTC_REPO="$2"; shift 2 ;;
+    --dry-run)     DRY=1; shift ;;
+    --skip-github) SKIP_GH=1; shift ;;
+    --skip-gitcode)SKIP_GTC=1; shift ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+[[ -z "$VERSION" || -z "$DIR" ]] && { echo "usage: $0 --version <ver> --dir <artifact-dir> [--name <sub>] [--dry-run]" >&2; exit 2; }
+
+info() { echo "[publish] $*"; }
+run()  { if [[ "$DRY" == 1 ]]; then echo "[dry-run] $*"; else "$@"; fi; }
+
+if [[ -z "$NAME" ]]; then BASE="xim-index-${VERSION}"; LATEST="xim-index-latest.json";
+else BASE="xim-index-${NAME}-${VERSION}"; LATEST="xim-index-${NAME}-latest.json"; fi
+
+# The client reads the rolling "latest" tag by default (see indexfetch.cppm
+# index_tag_()). We also archive each version under v<ver> for reproducibility
+# (room for the future X-full/lockfile pinning).
+ROLLING_TAG="latest"
+ARCHIVE_TAG="v${VERSION}"
+ART="$DIR/${BASE}.tar.gz"
+MAN="$DIR/${BASE}.manifest.json"
+[[ -f "$ART" ]] || { echo "missing artifact: $ART" >&2; exit 1; }
+[[ -f "$MAN" ]] || { echo "missing manifest: $MAN" >&2; exit 1; }
+
+# The "latest" pointer is NOT a release asset (gitcode can't overwrite/delete
+# those). It is a repo FILE pushed via git (overwriteable) and served raw — see
+# tools/push_index_pointers.sh. Here we just emit the pointer JSON into DIR for
+# that step to collect. The artifact tarball IS a release asset: its name is
+# version-unique (xim-index-<ver>.tar.gz), so it's always a fresh upload.
+LATEST_JSON="$DIR/$LATEST"   # xim-index[-name]-latest.json (collected by pointer push)
+cp "$MAN" "$LATEST_JSON"
+
+publish_gh() {  # <tag> <file...>
+  local tag="$1"; shift
+  if [[ "$DRY" == 1 ]]; then
+    echo "[dry-run] gh release create/view $tag -R $GH_REPO; gh release upload $tag $* -R $GH_REPO --clobber"
+    return
+  fi
+  gh release view "$tag" -R "$GH_REPO" >/dev/null 2>&1 \
+    || gh release create "$tag" -R "$GH_REPO" --title "$tag" --notes "xim package index ($VERSION)"
+  gh release upload "$tag" "$@" -R "$GH_REPO" --clobber
+}
+publish_gtc() {  # <tag> <file...>
+  local tag="$1"; shift
+  if [[ "$DRY" == 1 ]]; then
+    echo "[dry-run] gtc release create $GTC_REPO --tag $tag; gtc release upload $GTC_REPO $* --tag $tag"
+    return
+  fi
+  gtc release create "$GTC_REPO" --tag "$tag" --name "$tag" 2>/dev/null || true
+  # Upload ONE file at a time with retry: a multi-file gtc upload can 502
+  # mid-way and silently drop the remaining files (obs_callback flakiness),
+  # leaving e.g. only the linux asset. Per-file + retry makes it reliable.
+  local f try
+  for f in "$@"; do
+    for try in 1 2 3; do
+      if gtc release upload "$GTC_REPO" "$f" --tag "$tag" 2>&1 | tail -1 | grep -q uploaded; then break; fi
+      echo "[publish] gtc upload $(basename "$f") try $try failed, retrying..."; sleep 3
+    done
+  done
+}
+
+if [[ "$SKIP_GH" == 0 ]]; then
+  info "GitHub $GH_REPO: artifact -> rolling '$ROLLING_TAG' + archive '$ARCHIVE_TAG'"
+  # Artifact (version-unique -> fresh) + the legacy release-asset .json pointer
+  # for backward compat: pre-0.4.54 clients read xim-index[-sub]-latest.json from
+  # the release (gh --clobber can overwrite it). 0.4.54+ clients read the combined
+  # repo-file pointer (tools/push_index_pointers.sh). GitCode can't overwrite a
+  # release asset, so the legacy pointer is github-only; old CN clients fall to it.
+  publish_gh "$ROLLING_TAG" "$ART" "$LATEST_JSON"
+  publish_gh "$ARCHIVE_TAG" "$ART" "$MAN"
+fi
+if [[ "$SKIP_GTC" == 0 ]]; then
+  info "GitCode $GTC_REPO: artifact -> rolling '$ROLLING_TAG' + archive '$ARCHIVE_TAG'"
+  publish_gtc "$ROLLING_TAG" "$ART"
+  publish_gtc "$ARCHIVE_TAG" "$ART"
+fi
+echo "[publish] pointer JSON emitted: $LATEST_JSON (push via tools/push_index_pointers.sh)"
+
+DESTS=""
+[[ "$SKIP_GH"  == 0 ]] && DESTS="$GH_REPO(gh)"
+[[ "$SKIP_GTC" == 0 ]] && DESTS="${DESTS:+$DESTS, }$GTC_REPO(gtc)"
+info "Published $BASE (+ $LATEST pointer; tags: $ROLLING_TAG, $ARCHIVE_TAG) to: ${DESTS:-<none>}"

--- a/tools/push_index_pointers.sh
+++ b/tools/push_index_pointers.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Assemble the COMBINED index pointer (xim-index-pointers.json) from the per-index
+# manifests in <dir> and push it into xlings-res/xim-index on GitHub and GitCode
+# as a REPO FILE (served raw: raw.githubusercontent.com/.../main/<f> and
+# raw.gitcode.com/.../raw/main/<f>), updated by git push.
+#
+# Why one combined file (not per-index): the client then needs ONE raw fetch for
+# all indexes (main + subs), avoiding gitcode raw rate-limiting. Why a repo file
+# (not a release asset): gitcode release assets can't be overwritten (gtc) or
+# deleted (API 405); a repo file IS overwriteable via git push. Artifacts stay
+# release assets (version-unique names, create-only).
+#
+# Usage: tools/push_index_pointers.sh <dir-with-*-latest.json>
+# Auth:  XLINGS_RES_TOKEN (github), GITCODE_TOKEN (gitcode)
+# Repos: GH_REPO_SLUG / GTC_REPO_SLUG (default xlings-res/xim-index)
+set -euo pipefail
+
+DIR="${1:?usage: push_index_pointers.sh <dir>}"
+GH_REPO_SLUG="${GH_REPO_SLUG:-xlings-res/xim-index}"
+GTC_REPO_SLUG="${GTC_REPO_SLUG:-xlings-res/xim-index}"
+
+compgen -G "$DIR/*-latest.json" >/dev/null 2>&1 || { echo "[pointers] no *-latest.json in $DIR" >&2; exit 1; }
+
+# Assemble combined pointer: filename xim-index-latest.json -> key "xim";
+# xim-index-<name>-latest.json -> key "<name>".
+COMBINED="$DIR/xim-index-pointers.json"
+python3 - "$DIR" "$COMBINED" <<'PY'
+import sys, json, glob, os, re
+d, out = sys.argv[1], sys.argv[2]
+indexes = {}
+for f in sorted(glob.glob(os.path.join(d, "*-latest.json"))):
+    name = os.path.basename(f)
+    if name == "xim-index-pointers.json": continue
+    m = re.match(r'xim-index-(?:(.+)-)?latest\.json$', name)
+    if not m: continue
+    key = m.group(1) or "xim"
+    try: indexes[key] = json.load(open(f, encoding="utf-8"))
+    except Exception as e: print(f"[pointers] skip {name}: {e}", file=sys.stderr)
+json.dump({"format_version": 1, "indexes": indexes}, open(out, "w", encoding="utf-8"), indent=2)
+print(f"[pointers] combined {len(indexes)} index(es): {', '.join(sorted(indexes))}")
+PY
+
+push_one() {  # <clone-url> <label>
+  local url="$1" label="$2" tmp
+  tmp="$(mktemp -d)"
+  if ! git clone -q --depth 1 "$url" "$tmp" 2>/dev/null; then
+    echo "[pointers] $label: clone failed (skip)"; rm -rf "$tmp"; return 0
+  fi
+  # Clean legacy per-index pointers + any probe files; keep only the combined one.
+  rm -f "$tmp"/xim-index-*latest.json "$tmp"/ptest.* "$tmp"/ptestnoext "$tmp"/pov.json 2>/dev/null || true
+  cp "$COMBINED" "$tmp"/xim-index-pointers.json
+  git -C "$tmp" add -A
+  if git -C "$tmp" diff --cached --quiet; then
+    echo "[pointers] $label: no change"; rm -rf "$tmp"; return 0
+  fi
+  git -C "$tmp" -c user.email=ci@xlings.dev -c user.name=xlings-ci \
+      commit -qm "chore: update combined index pointer"
+  if git -C "$tmp" push -q origin HEAD:main 2>/dev/null; then
+    echo "[pointers] $label: pushed"
+  else
+    echo "[pointers] $label: push failed (non-blocking)"
+  fi
+  rm -rf "$tmp"
+}
+
+if [[ -n "${XLINGS_RES_TOKEN:-}" ]]; then
+  push_one "https://x-access-token:${XLINGS_RES_TOKEN}@github.com/${GH_REPO_SLUG}.git" "github"
+else
+  echo "[pointers] XLINGS_RES_TOKEN unset; skipping github"
+fi
+if [[ -n "${GITCODE_TOKEN:-}" ]]; then
+  push_one "https://oauth2:${GITCODE_TOKEN}@gitcode.com/${GTC_REPO_SLUG}.git" "gitcode"
+else
+  echo "[pointers] GITCODE_TOKEN unset; skipping gitcode"
+fi


### PR DESCRIPTION
Adds a push/manual/nightly CI that re-publishes the index artifact + rolling pointer to `xlings-res/xim-index` (GitHub + GitCode) whenever `pkgs/**` changes — so editing the index takes effect for default (artifact-source) clients **without** an xlings release.

- Vendors the standalone publish scripts (build/publish/push-pointers) from xlings/tools.
- Content-hash artifact naming (`xim-index-<short-sha>.tar.gz`) → decoupled from xlings version.
- Uses repo secrets `XLINGS_RES_TOKEN` + `GITCODE_TOKEN`.

Build step verified locally (366KB artifact + manifest). Publish/pointer use the same scripts the xlings release already uses. Will workflow_dispatch to verify end-to-end after merge.

Design: `.agents/docs/2026-06-24-artifact-publish-mechanism.md`