### PR TITLE
mcpp: 0.0.61 (latest ref + XLINGS_RES)

### DIFF
--- a/pkgs/m/mcpp.lua
+++ b/pkgs/m/mcpp.lua
@@ -39,7 +39,8 @@ package = {
     xpm = {
         linux = {
             url_template = "https://github.com/mcpp-community/mcpp/releases/download/v{version}/mcpp-{version}-linux-x86_64.tar.gz",
-            ["latest"] = { ref = "0.0.60" },
+            ["latest"] = { ref = "0.0.61" },
+            ["0.0.61"] = "XLINGS_RES",
             ["0.0.60"] = "XLINGS_RES",
             ["0.0.59"] = "XLINGS_RES",
             ["0.0.58"] = "XLINGS_RES",
@@ -95,7 +96,8 @@ package = {
             ["0.0.1"] = "XLINGS_RES",
         },
         macosx = {
-            ["latest"] = { ref = "0.0.60" },
+            ["latest"] = { ref = "0.0.61" },
+            ["0.0.61"] = "XLINGS_RES",
             ["0.0.60"] = "XLINGS_RES",
             ["0.0.59"] = "XLINGS_RES",
             ["0.0.58"] = "XLINGS_RES",
@@ -137,7 +139,8 @@ package = {
             ["0.0.16"] = "XLINGS_RES",
         },
         windows = {
-            ["latest"] = { ref = "0.0.60" },
+            ["latest"] = { ref = "0.0.61" },
+            ["0.0.61"] = "XLINGS_RES",
             ["0.0.60"] = "XLINGS_RES",
             ["0.0.59"] = "XLINGS_RES",
             ["0.0.58"] = "XLINGS_RES",


### PR DESCRIPTION
Bump `pkgs/m/mcpp.lua` to **0.0.61** — `latest.ref → 0.0.61` + `["0.0.61"] = "XLINGS_RES"` in all three platform blocks (linux / macosx / windows).

`mcpp-community/mcpp` **v0.0.61 is published** and **mirrored to `xlings-res/mcpp`** on GitHub + GitCode (4 platforms incl. aarch64), so the `XLINGS_RES` sentinel resolves on both GLOBAL and CN.

On merge, the publish-artifact CI re-packs the index artifact + moves the pointer (GitHub + GitCode), so `xlings install mcpp` picks up 0.0.61 without an xlings release.

Ships: offline-first miss-triggered index refresh + `mcpp index status`, first-init `--verbose` timing logs, install.sh linux-aarch64 + CN mirror.