### PR TITLE
fix(code): make Windows shortcut creation non-fatal in config()

### DIFF
--- a/pkgs/c/code.lua
+++ b/pkgs/c/code.lua
@@ -147,24 +147,27 @@ function install()
 end
 
 function config()
-    local xvm_cmd_template1 = [[xvm add code %s --path "%s/bin" --alias %s]]
-    local xvm_cmd_template2 = [[xvm add vscode %s --path "%s/bin" --alias %s]]
     local code_alias = "code"
     local appdir = pkginfo.install_dir()
 
     -- config desktop entry
     if os.host() == "windows" then
         code_alias = "code.cmd"
-        -- create desktop shortcut
-        local lnk_filename = "Visual Studio Code - [" .. pkginfo.version() .. "]"
-        create_windows_shortcut(
-            lnk_filename,
-            path.join(pkginfo.install_dir(), "code.exe"),
-            path.join(pkginfo.install_dir(), "code.exe"),
-            pkginfo.install_dir()
-        )
-        os.cp(lnk_filename .. ".lnk", path.join("C:/Users", os.getenv("USERNAME"), "Desktop"))
-        os.mv(lnk_filename .. ".lnk", get_shortcut_dir()[os.host()])
+        -- Desktop / Start Menu shortcut is best-effort: a OneDrive-redirected
+        -- Desktop (or missing dir) makes os.cp throw, which must NOT abort config
+        -- before the xvm.add "installed" marker below — else code is never marked
+        -- installed and every dependent install re-runs this forever.
+        pcall(function()
+            local lnk_filename = "Visual Studio Code - [" .. pkginfo.version() .. "]"
+            create_windows_shortcut(
+                lnk_filename,
+                path.join(pkginfo.install_dir(), "code.exe"),
+                path.join(pkginfo.install_dir(), "code.exe"),
+                pkginfo.install_dir()
+            )
+            os.trycp(lnk_filename .. ".lnk", path.join("C:/Users", os.getenv("USERNAME"), "Desktop"))
+            os.trymv(lnk_filename .. ".lnk", get_shortcut_dir()[os.host()])
+        end)
     elseif os.host() == "macosx" then
         -- de-quarantine + lsregister are one-time install-time concerns now (see install()).
         -- config() stays idempotent: only resolve the bin path used for the xvm alias below.


### PR DESCRIPTION
## Problem

Follow-up to #306. The same gating trap we fixed for macOS still existed on **Windows**.

In `config()`, the desktop/Start-Menu shortcut steps run *before* `xvm.add(...)`:

```lua
create_windows_shortcut(...)   -- os.exec("wscript ...") throws on failure
os.cp(... "C:/Users/$USERNAME/Desktop")   -- throws on failure
os.mv(...)
```

`os.cp`/`os.mv`/`os.exec` are the **throwing** xmake-lua variants. A **OneDrive-redirected or missing Desktop** (very common on Windows) makes `os.cp` raise, aborting `config()` before reaching `xvm.add` — the "installed" marker (`XPkgManager:installed` → `xvm.has`). Result: `code` never marked installed → every dependent install (e.g. `mcpp-vscode-clangd`) re-runs config forever. Identical failure mode to the macOS `xattr` bug.

## Fix

- Wrap the Windows shortcut block in `pcall` (best-effort UI integration must not gate the installed marker) and use the non-throwing `os.trycp` / `os.trymv`.
- Remove unused `xvm_cmd_template1` / `xvm_cmd_template2` dead locals.

No change to the install/config split: desktop shortcuts correctly stay in `config()` (user-env integration, paired with `uninstall()`); only their failure is now non-fatal.

## Verify

- `luac -p pkgs/c/code.lua` passes.