### PR TITLE
chore(mcpp): bump to 0.0.62 (macOS -lSystem link fix)

### DIFF
--- a/pkgs/m/mcpp.lua
+++ b/pkgs/m/mcpp.lua
@@ -39,7 +39,8 @@ package = {
     xpm = {
         linux = {
             url_template = "https://github.com/mcpp-community/mcpp/releases/download/v{version}/mcpp-{version}-linux-x86_64.tar.gz",
-            ["latest"] = { ref = "0.0.61" },
+            ["latest"] = { ref = "0.0.62" },
+            ["0.0.62"] = "XLINGS_RES",
             ["0.0.61"] = "XLINGS_RES",
             ["0.0.60"] = "XLINGS_RES",
             ["0.0.59"] = "XLINGS_RES",
@@ -96,7 +97,8 @@ package = {
             ["0.0.1"] = "XLINGS_RES",
         },
         macosx = {
-            ["latest"] = { ref = "0.0.61" },
+            ["latest"] = { ref = "0.0.62" },
+            ["0.0.62"] = "XLINGS_RES",
             ["0.0.61"] = "XLINGS_RES",
             ["0.0.60"] = "XLINGS_RES",
             ["0.0.59"] = "XLINGS_RES",
@@ -139,7 +141,8 @@ package = {
             ["0.0.16"] = "XLINGS_RES",
         },
         windows = {
-            ["latest"] = { ref = "0.0.61" },
+            ["latest"] = { ref = "0.0.62" },
+            ["0.0.62"] = "XLINGS_RES",
             ["0.0.61"] = "XLINGS_RES",
             ["0.0.60"] = "XLINGS_RES",
             ["0.0.59"] = "XLINGS_RES",


### PR DESCRIPTION
Bumps `pkgs/m/mcpp.lua` to **0.0.62** across all 3 platform blocks (linux/macosx/windows): `latest.ref = 0.0.62` + `["0.0.62"] = XLINGS_RES`.

Upstream `mcpp-community/mcpp` v0.0.62 is released and mirrored to `xlings-res/mcpp` on both GitHub and GitCode (4 platform tarballs, byte-identical, verified). Ships the macOS `library not found for -lSystem` link fix (#162) + first-run stdin fix (#163).

`publish-artifact.yml` will auto-republish the index artifact + pointers on merge.