### PR TITLE
chore(mcpp): bump to 0.0.63

### DIFF
--- a/pkgs/m/mcpp.lua
+++ b/pkgs/m/mcpp.lua
@@ -39,7 +39,8 @@ package = {
     xpm = {
         linux = {
             url_template = "https://github.com/mcpp-community/mcpp/releases/download/v{version}/mcpp-{version}-linux-x86_64.tar.gz",
-            ["latest"] = { ref = "0.0.62" },
+            ["latest"] = { ref = "0.0.63" },
+            ["0.0.63"] = "XLINGS_RES",
             ["0.0.62"] = "XLINGS_RES",
             ["0.0.61"] = "XLINGS_RES",
             ["0.0.60"] = "XLINGS_RES",
@@ -97,7 +98,8 @@ package = {
             ["0.0.1"] = "XLINGS_RES",
         },
         macosx = {
-            ["latest"] = { ref = "0.0.62" },
+            ["latest"] = { ref = "0.0.63" },
+            ["0.0.63"] = "XLINGS_RES",
             ["0.0.62"] = "XLINGS_RES",
             ["0.0.61"] = "XLINGS_RES",
             ["0.0.60"] = "XLINGS_RES",
@@ -141,7 +143,8 @@ package = {
             ["0.0.16"] = "XLINGS_RES",
         },
         windows = {
-            ["latest"] = { ref = "0.0.62" },
+            ["latest"] = { ref = "0.0.63" },
+            ["0.0.63"] = "XLINGS_RES",
             ["0.0.62"] = "XLINGS_RES",
             ["0.0.61"] = "XLINGS_RES",
             ["0.0.60"] = "XLINGS_RES",


### PR DESCRIPTION
Bump mcpp index to 0.0.63 across linux/macosx/windows (latest ref + new XLINGS_RES entry).

Upstream: mcpp-community/mcpp v0.0.63 — fix: preserve tests/ entries in compile_commands.json (no completion in tests/ regression).

Mirrored to xlings-res/mcpp@0.0.63 (GitHub + GitCode, 4 platforms, byte-verified).