### PR TITLE
fix(llvm-tools): bundle clang builtin headers (resource-dir)

### DIFF
--- a/.agents/tools/build-llvm-tools.sh
+++ b/.agents/tools/build-llvm-tools.sh
@@ -90,6 +90,22 @@ for t in "${TOOLS[@]}"; do
 done
 [ "$found" -eq 3 ] || die "expected 3 tools, got $found"
 
+# --- clang builtin headers (resource-dir) ----------------------------------
+# clangd derives its resource-dir from its OWN location (<bin>/../lib/clang/<major>)
+# and auto-adds <resource-dir>/include to the search path. Without the builtin
+# headers there (stddef.h, stdint.h, the intrinsic headers, ...), any TU that
+# pulls in libc++ <cstddef> — e.g. via `#include <gtest/gtest.h>` — fails with
+# "'stddef.h' file not found", because libc++'s <stddef.h> does
+# `#include_next <stddef.h>` expecting the compiler builtin header. These are
+# host-independent text headers, so they ship in every platform's bundle.
+RESVER="${VERSION%%.*}"
+HDRSRC="$(find "$SRCROOT" -type d -path "*/lib/clang/${RESVER}/include" -print -quit 2>/dev/null || true)"
+[ -n "$HDRSRC" ] || die "could not find lib/clang/${RESVER}/include under $SRCROOT"
+mkdir -p "$WORK/$BUNDLE/lib/clang/${RESVER}"
+cp -R "$HDRSRC" "$WORK/$BUNDLE/lib/clang/${RESVER}/include"
+[ -f "$WORK/$BUNDLE/lib/clang/${RESVER}/include/stddef.h" ] || die "builtin headers copy missing stddef.h"
+log "  + lib/clang/${RESVER}/include  ($(du -sh "$WORK/$BUNDLE/lib/clang/${RESVER}/include" | cut -f1) builtin headers)"
+
 # --- macOS self-containment check (Mach-O LC_LOAD_DYLIB) -------------------
 if [ "$PLATFORM" = "macosx" ]; then
     log "verifying macOS binaries are self-contained (system-only dylibs) ..."

--- a/pkgs/l/llvm-tools.lua
+++ b/pkgs/l/llvm-tools.lua
@@ -41,6 +41,9 @@ package = {
         -- macOS-ARM64). The slim bundle is carved from the upstream full
         -- LLVM release via .agents/tools/build-llvm-tools.sh; clang-format,
         -- clang-tidy and clangd are self-contained (system-only dylibs).
+        -- The bundle also ships lib/clang/<major>/include (clang builtin
+        -- headers) so clangd's derived resource-dir resolves stddef.h etc.
+        -- for files that include libc++ headers (e.g. #include <gtest/gtest.h>).
         macosx = {
             ["latest"] = { ref = "20.1.7" },
             ["20.1.7"] = {


### PR DESCRIPTION
## 问题
clangd 从自身位置推导 resource-dir = `<bin>/../lib/clang/<major>` 并自动加 `<resource-dir>/include`。但 `llvm-tools` 精简包**只有 bin/**,该目录缺失 → 任何经 libc++ `<cstddef>` 的 TU(如 `#include <gtest/gtest.h>`)报 `'stddef.h' file not found`(libc++ `<stddef.h>` 用 `#include_next <stddef.h>` 找编译器内置头)。在 mcpp 测试文件里表现为 clangd 报红 / 早期版本 SIGSEGV。

## 修复
`build-llvm-tools.sh` 现在把 `lib/clang/<major>/include`(clang 内置头,host 无关)拷入 bundle,防止后续重打包回归。

## 已同步更新 xlings-res 制品(本 PR 外的运维动作)
`xlings-res/llvm@20.1.7` 的 5 个 llvm-tools 资产(linux .tar.gz/.tar.xz、macos .tar.xz、windows .tar.xz/.zip)已重打包补头并上传 **GitHub + GitCode**,字节核验一致、含 `lib/clang/20/include/stddef.h`。index `sha256=nil`,无需改 url/hash。

## 验证
全新 `mcpp new` 项目 + `mcpp test` 后,用重打包的 clangd `--check` 测试文件 → `All checks completed, 0 errors`(`stddef.h not found` 消失)。配合 mcpp 0.0.63(保留 tests/ 的 cdb 条目)即完整闭环。