### PR TITLE
chore(mcpp): bump to 0.0.64

### DIFF
--- a/pkgs/m/mcpp.lua
+++ b/pkgs/m/mcpp.lua
@@ -39,7 +39,8 @@ package = {
     xpm = {
         linux = {
             url_template = "https://github.com/mcpp-community/mcpp/releases/download/v{version}/mcpp-{version}-linux-x86_64.tar.gz",
-            ["latest"] = { ref = "0.0.63" },
+            ["latest"] = { ref = "0.0.64" },
+            ["0.0.64"] = "XLINGS_RES",
             ["0.0.63"] = "XLINGS_RES",
             ["0.0.62"] = "XLINGS_RES",
             ["0.0.61"] = "XLINGS_RES",
@@ -98,7 +99,8 @@ package = {
             ["0.0.1"] = "XLINGS_RES",
         },
         macosx = {
-            ["latest"] = { ref = "0.0.63" },
+            ["latest"] = { ref = "0.0.64" },
+            ["0.0.64"] = "XLINGS_RES",
             ["0.0.63"] = "XLINGS_RES",
             ["0.0.62"] = "XLINGS_RES",
             ["0.0.61"] = "XLINGS_RES",
@@ -143,7 +145,8 @@ package = {
             ["0.0.16"] = "XLINGS_RES",
         },
         windows = {
-            ["latest"] = { ref = "0.0.63" },
+            ["latest"] = { ref = "0.0.64" },
+            ["0.0.64"] = "XLINGS_RES",
             ["0.0.63"] = "XLINGS_RES",
             ["0.0.62"] = "XLINGS_RES",
             ["0.0.61"] = "XLINGS_RES",


### PR DESCRIPTION
Bump mcpp index to 0.0.64 (linux/macosx/windows: latest ref + new XLINGS_RES entry).

Upstream mcpp-community/mcpp v0.0.64 — fix `mcpp test` `duplicate symbol: main` (gtest_main collision with a test's own main); links a dev-dependency's own main-providing object conditionally, all {own/framework main} × {uses/doesn't use gtest} combos, all platforms.

Mirrored to xlings-res/mcpp@0.0.64 (GitHub + GitCode, 4 platforms, byte-verified).