### PR TITLE
xlings: bump to 0.4.60 (latest)

### DIFF
--- a/pkgs/x/xlings.lua
+++ b/pkgs/x/xlings.lua
@@ -34,7 +34,8 @@ package = {
     -- Historical 0.4.x entries keep their direct GitHub release URLs.
     xpm = {
         linux = {
-            ["latest"] = { ref = "0.4.55" },
+            ["latest"] = { ref = "0.4.60" },
+            ["0.4.60"] = "XLINGS_RES",
             ["0.4.55"] = "XLINGS_RES",
             ["0.4.54"] = "XLINGS_RES",
             ["0.4.53"] = "XLINGS_RES",
@@ -182,7 +183,8 @@ package = {
             ["0.3.0"] = "XLINGS_RES",
         },
         macosx = {
-            ["latest"] = { ref = "0.4.55" },
+            ["latest"] = { ref = "0.4.60" },
+            ["0.4.60"] = "XLINGS_RES",
             ["0.4.55"] = "XLINGS_RES",
             ["0.4.54"] = "XLINGS_RES",
             ["0.4.53"] = "XLINGS_RES",
@@ -330,7 +332,8 @@ package = {
             ["0.3.0"] = "XLINGS_RES",
         },
         windows = {
-            ["latest"] = { ref = "0.4.55" },
+            ["latest"] = { ref = "0.4.60" },
+            ["0.4.60"] = "XLINGS_RES",
             ["0.4.55"] = "XLINGS_RES",
             ["0.4.54"] = "XLINGS_RES",
             ["0.4.53"] = "XLINGS_RES",


### PR DESCRIPTION
Repoints the `xlings` recipe `latest` 0.4.55 → **0.4.60** (+ adds `0.4.60 = XLINGS_RES`) for linux/macosx/windows.

**Why:** `latest` was stuck at 0.4.55, so `xlings install xlings@latest` (behind `xlings self update`) couldn't reach released 0.4.56–0.4.60. Binaries verified mirrored to `xlings-res/xlings@0.4.60` (GitHub + GitCode, all 4 platforms).

0.4.60 ships openxlings/xlings#342 (default sub-indexes migrate git→artifact). This closes the user-facing ecosystem loop: `self update` → 0.4.60 → `xlings update` migrates sub-indexes. Lua syntax validated locally.