### PR TITLE
version-check: support XLINGS_RES-style auto-bump (fix xlings going stale)

### DIFF
--- a/.github/scripts/test_version_check.py
+++ b/.github/scripts/test_version_check.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Offline tests for version-check.py — focused on the XLINGS_RES auto-bump
+path (and a guard that url_template behaviour is unchanged).
+
+Self-contained (no pytest): run `python3 .github/scripts/test_version_check.py`.
+Exit 0 = all pass, non-zero = failure. The res_versioned path needs no
+network (no artifact download / sha256), so these tests are deterministic.
+"""
+
+import importlib.util
+import tempfile
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+spec = importlib.util.spec_from_file_location("vcheck", HERE / "version-check.py")
+vc = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(vc)
+
+_failures = []
+
+
+def check(cond, msg):
+    if cond:
+        print(f"  ok: {msg}")
+    else:
+        print(f"  FAIL: {msg}")
+        _failures.append(msg)
+
+
+RES_FIXTURE = '''package = {
+    name = "xlings",
+    repo = "https://github.com/openxlings/xlings",
+    xpm = {
+        linux = {
+            res_versioned = true,
+            ["latest"] = { ref = "0.4.60" },
+            ["0.4.60"] = "XLINGS_RES",
+            ["0.4.55"] = "XLINGS_RES",
+        },
+        macosx = {
+            res_versioned = true,
+            ["latest"] = { ref = "0.4.60" },
+            ["0.4.60"] = "XLINGS_RES",
+        },
+        windows = {
+            res_versioned = true,
+            ["latest"] = { ref = "0.4.60" },
+            ["0.4.60"] = "XLINGS_RES",
+        },
+    },
+}
+'''
+
+URL_FIXTURE = '''package = {
+    name = "uv",
+    repo = "https://github.com/astral-sh/uv",
+    xpm = {
+        linux = {
+            url_template = "https://example.com/uv-{version}-linux.tar.gz",
+            ["latest"] = { ref = "1.0.0" },
+            ["1.0.0"] = { url = "https://example.com/uv-1.0.0-linux.tar.gz", sha256 = "aa" },
+        },
+    },
+}
+'''
+
+
+def test_extract_res_versioned():
+    print("test_extract_res_versioned")
+    check(vc.extract_res_versioned("res_versioned = true,") is True, "detects true")
+    check(vc.extract_res_versioned('url_template = "x"') is False, "absent -> false")
+
+
+def test_res_apply_bump():
+    print("test_res_apply_bump (offline, no network)")
+    with tempfile.TemporaryDirectory() as d:
+        p = Path(d) / "xlings.lua"
+        p.write_text(RES_FIXTURE, encoding="utf-8")
+        result = vc.apply_bump(
+            p, current="0.4.60", upstream="0.4.61",
+            proposed_urls={}, token=None,
+            res_platforms=["linux", "macosx", "windows"],
+        )
+        out = p.read_text(encoding="utf-8")
+        check(result["status"] == "applied", f"status applied (got {result['status']})")
+        check(out.count('["latest"] = { ref = "0.4.61" }') == 3, "latest bumped on all 3 platforms")
+        check(out.count('["0.4.61"] = "XLINGS_RES"') == 3, "new XLINGS_RES entry on all 3 platforms")
+        check('["0.4.60"] = "XLINGS_RES"' in out, "old version entry preserved")
+        check("sha256" not in out, "no sha256 written for res entries")
+        check(all(v == "XLINGS_RES" for v in result["platforms"].values()),
+              "per-platform reports XLINGS_RES")
+
+
+def test_url_apply_bump_unaffected(monkeypatch_sha="deadbeef"):
+    print("test_url_apply_bump still works (sha256 stubbed)")
+    orig = vc.compute_sha256
+    vc.compute_sha256 = lambda url, token: monkeypatch_sha
+    try:
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "uv.lua"
+            p.write_text(URL_FIXTURE, encoding="utf-8")
+            result = vc.apply_bump(
+                p, current="1.0.0", upstream="1.1.0",
+                proposed_urls={"linux": "https://example.com/uv-1.1.0-linux.tar.gz"},
+                token=None, res_platforms=[],
+            )
+            out = p.read_text(encoding="utf-8")
+            check(result["status"] == "applied", "url-mode status applied")
+            check('["latest"] = { ref = "1.1.0" }' in out, "url-mode latest bumped")
+            check(f'sha256 = "{monkeypatch_sha}"' in out, "url-mode writes sha256")
+            check('["1.1.0"] = {' in out, "url-mode appends url block")
+    finally:
+        vc.compute_sha256 = orig
+
+
+if __name__ == "__main__":
+    test_extract_res_versioned()
+    test_res_apply_bump()
+    test_url_apply_bump_unaffected()
+    if _failures:
+        print(f"\n{len(_failures)} FAILURE(S)")
+        raise SystemExit(1)
+    print("\nAll tests passed.")

--- a/.github/scripts/version-check.py
+++ b/.github/scripts/version-check.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
 """Upstream version checker (and optional bumper) for xim-pkgindex.
 
-Scans every `pkgs/**/*.lua` for an opt-in `url_template` field on any
-platform inside the `xpm` table. For each opted-in package, queries the
-GitHub Releases API for the latest tag, compares against the version
-recorded in `xpm.<plat>.["latest"].ref`, and prints a JSON report of
-every package whose upstream has moved ahead.
+Scans every `pkgs/**/*.lua` for an opt-in marker on any platform inside
+the `xpm` table — either `url_template` (hardcoded url+sha256 packages) or
+`res_versioned = true` (XLINGS_RES packages, e.g. xlings itself). For each
+opted-in package, queries the GitHub Releases API for the latest tag,
+compares against the version recorded in `xpm.<plat>.["latest"].ref`, and
+prints a JSON report of every package whose upstream has moved ahead.
 
 In `--apply` mode the script additionally downloads each new artifact,
 computes its sha256, and rewrites the lua file in-place: a new
@@ -101,6 +102,20 @@ def extract_url_template(platform_body: str) -> str | None:
     return m.group(1) if m else None
 
 
+def extract_res_versioned(platform_body: str) -> bool:
+    """True if the platform opts into XLINGS_RES-style auto-bump.
+
+    Marked with `res_versioned = true`. Such a platform tracks its `repo`'s
+    latest GitHub release just like `url_template`, but on bump it appends
+    `["<ver>"] = "XLINGS_RES"` (resolved through the multi-mirror resource
+    service) instead of a hardcoded url+sha256 — so it keeps the mirror
+    fallback that XLINGS_RES gives and needs no artifact download. This is
+    what lets the bot keep `xlings` (and other XLINGS_RES packages) current
+    instead of silently going stale.
+    """
+    return re.search(r'\bres_versioned\s*=\s*true\b', platform_body) is not None
+
+
 def extract_latest_ref(platform_body: str) -> str | None:
     m = re.search(
         r'\["latest"\]\s*=\s*\{\s*ref\s*=\s*"([^"]+)"',
@@ -148,18 +163,22 @@ def check_package(lua_path: Path, token: str | None) -> dict[str, Any] | None:
     if not xpm:
         return None
 
-    platforms: dict[str, dict[str, str]] = {}
+    platforms: dict[str, dict[str, Any]] = {}
     for plat in _PLATFORM_KEYS:
         body = find_platform_block(xpm, plat)
         if not body:
             continue
         tmpl = extract_url_template(body)
+        res = extract_res_versioned(body)
         ref = extract_latest_ref(body)
-        if tmpl or ref:
-            platforms[plat] = {"url_template": tmpl, "ref": ref}
+        if tmpl or res or ref:
+            platforms[plat] = {"url_template": tmpl, "res_versioned": res, "ref": ref}
 
-    if not any(p.get("url_template") for p in platforms.values()):
-        # No opt-in marker on any platform → manual maintenance.
+    # Opt-in is either url_template (hardcoded url+sha256 mode) or
+    # res_versioned (XLINGS_RES mode). A platform that sets neither is
+    # manually maintained and skipped.
+    if not any(p.get("url_template") or p.get("res_versioned")
+               for p in platforms.values()):
         return None
 
     # Validate each opted-in template has the placeholder.
@@ -176,7 +195,7 @@ def check_package(lua_path: Path, token: str | None) -> dict[str, Any] | None:
     current_versions = {
         plat: info["ref"]
         for plat, info in platforms.items()
-        if info.get("url_template") and info.get("ref")
+        if (info.get("url_template") or info.get("res_versioned")) and info.get("ref")
     }
     if len(set(current_versions.values())) != 1:
         return {
@@ -247,10 +266,14 @@ def check_package(lua_path: Path, token: str | None) -> dict[str, Any] | None:
 
     record["status"] = "update-available"
     proposed: dict[str, str] = {}
+    res_platforms: list[str] = []
     for plat, info in platforms.items():
         if info.get("url_template"):
             proposed[plat] = info["url_template"].replace("{version}", upstream)
+        elif info.get("res_versioned"):
+            res_platforms.append(plat)
     record["proposed_urls"] = proposed
+    record["proposed_res"] = res_platforms
     return record
 
 
@@ -304,13 +327,23 @@ def apply_bump(
     upstream: str,
     proposed_urls: dict[str, str],
     token: str | None,
+    res_platforms: list[str] | None = None,
 ) -> dict[str, Any]:
-    """Edit lua_path in place: append `["<upstream>"] = {...}` per platform
-    and bump `["latest"].ref` from <current> to <upstream>. Existing
-    version entries are untouched.
+    """Edit lua_path in place: append a new `["<upstream>"]` entry per
+    platform and bump `["latest"].ref` from <current> to <upstream>.
+    Existing version entries are untouched.
+
+    Two entry shapes, per platform:
+      - url_template platforms (in `proposed_urls`): the artifact is
+        downloaded, its sha256 computed, and a
+        `["<upstream>"] = { url = ..., sha256 = ... }` block appended.
+      - res_versioned platforms (in `res_platforms`): a bare
+        `["<upstream>"] = "XLINGS_RES"` entry is appended — no download,
+        no sha256 (the resource service resolves + verifies it).
 
     Returns a record describing what happened (status + per-platform).
     """
+    res_platforms = res_platforms or []
     text = lua_path.read_text(encoding="utf-8")
 
     # Locate xpm block once so per-platform searches stay scoped to it.
@@ -366,6 +399,30 @@ def apply_bump(
             )
         )
         per_platform[plat] = sha
+
+    # XLINGS_RES platforms: append a bare entry, no download/sha256.
+    for plat in res_platforms:
+        plat_range = find_block_range(text, plat, xpm[0])
+        if not plat_range or plat_range[1] > xpm[1]:
+            continue
+        plat_body = text[plat_range[0] : plat_range[1]]
+        latest_pat = re.compile(
+            r'(?m)^(?P<indent>[ \t]*)\["latest"\]\s*=\s*\{\s*ref\s*=\s*"'
+            + re.escape(current)
+            + r'"\s*\}\s*,?[ \t]*\n'
+        )
+        m = latest_pat.search(plat_body)
+        if not m:
+            continue
+        indent = m.group("indent")
+        replacement = (
+            f'{indent}["latest"] = {{ ref = "{upstream}" }},\n'
+            f'{indent}["{upstream}"] = "XLINGS_RES",\n'
+        )
+        edits.append(
+            (plat_range[0] + m.start(), plat_range[0] + m.end(), replacement)
+        )
+        per_platform[plat] = "XLINGS_RES"
 
     if not edits:
         return {"status": "no-edit", "reason": "no matching latest line on any platform"}
@@ -434,6 +491,7 @@ def main() -> int:
                 rec["upstream"],
                 rec["proposed_urls"],
                 args.token,
+                rec.get("proposed_res", []),
             )
             rec["apply"] = applied
 

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -32,6 +32,9 @@ jobs:
           chmod +x .github/scripts/check-no-direct-ld-libpath.sh
           .github/scripts/check-no-direct-ld-libpath.sh
 
+      - name: version-check unit tests (url_template + XLINGS_RES bump)
+        run: python3 .github/scripts/test_version_check.py
+
 
       - name: Get changed-files (only pull_request）
         uses: tj-actions/changed-files@v46

--- a/docs/spec/url-template.md
+++ b/docs/spec/url-template.md
@@ -54,6 +54,38 @@ is no `source` field; the contract assumes GitHub). Packages whose
 upstream is not a GitHub Release simply leave `url_template`
 unset and continue to be maintained by hand.
 
+## XLINGS_RES mode (`res_versioned`)
+
+Some packages — notably `xlings` itself — record their version entries
+as `["<ver>"] = "XLINGS_RES"` (resolved through the multi-mirror resource
+service) instead of a hardcoded `url + sha256`. They cannot use
+`url_template` (there is no single URL, and the resource service handles
+integrity), so they previously had **no** auto-update path and went stale
+silently (xlings `latest` was stuck 5 releases behind).
+
+Such a platform opts in with `res_versioned = true` next to its version
+table:
+
+```lua
+xpm = {
+    linux = {
+        res_versioned = true,
+        ["latest"] = { ref = "0.4.60" },
+        ["0.4.60"] = "XLINGS_RES",
+    },
+    -- macosx / windows likewise
+}
+```
+
+Resolution is identical to `url_template` (rules 1–5 above: scan, read
+`package.repo`, query `releases/latest`, compare against
+`["latest"].ref`). The only difference is the **bump shape**: on an
+update the updater appends a bare `["<upstream>"] = "XLINGS_RES"` entry
+and bumps `["latest"].ref` — **no artifact download, no sha256** (the
+resource service resolves and verifies the binary, and provides mirror
+fallback). A platform may set `url_template` *or* `res_versioned`, not
+both; `url_template` wins if both are present.
+
 ## What is NOT in scope (v1)
 
 - **The xlings package manager does not consume `url_template`.** It
@@ -73,7 +105,11 @@ unset and continue to be maintained by hand.
 
 ## Behaviour when fields are missing or inconsistent
 
-- No `url_template` on any platform → package is skipped (manual mode).
+- No `url_template` **and** no `res_versioned` on any platform → package
+  is skipped (manual mode).
+- `res_versioned = true` on a platform → that platform auto-bumps as a
+  bare `["<ver>"] = "XLINGS_RES"` entry (no url/sha256). Requires
+  `package.repo` like the `url_template` path.
 - `url_template` on some platforms only → only those platforms are
   refreshed; other platforms are left alone.
 - `package.repo` missing or not a GitHub URL → the package is

--- a/pkgs/x/xlings.lua
+++ b/pkgs/x/xlings.lua
@@ -34,6 +34,9 @@ package = {
     -- Historical 0.4.x entries keep their direct GitHub release URLs.
     xpm = {
         linux = {
+            -- res_versioned: version-bump bot tracks openxlings/xlings releases and
+            -- appends new ["x.y.z"] = "XLINGS_RES" entries (see version-check.py).
+            res_versioned = true,
             ["latest"] = { ref = "0.4.60" },
             ["0.4.60"] = "XLINGS_RES",
             ["0.4.55"] = "XLINGS_RES",
@@ -183,6 +186,9 @@ package = {
             ["0.3.0"] = "XLINGS_RES",
         },
         macosx = {
+            -- res_versioned: version-bump bot tracks openxlings/xlings releases and
+            -- appends new ["x.y.z"] = "XLINGS_RES" entries (see version-check.py).
+            res_versioned = true,
             ["latest"] = { ref = "0.4.60" },
             ["0.4.60"] = "XLINGS_RES",
             ["0.4.55"] = "XLINGS_RES",
@@ -332,6 +338,9 @@ package = {
             ["0.3.0"] = "XLINGS_RES",
         },
         windows = {
+            -- res_versioned: version-bump bot tracks openxlings/xlings releases and
+            -- appends new ["x.y.z"] = "XLINGS_RES" entries (see version-check.py).
+            res_versioned = true,
             ["latest"] = { ref = "0.4.60" },
             ["0.4.60"] = "XLINGS_RES",
             ["0.4.55"] = "XLINGS_RES",


### PR DESCRIPTION
## Problem

The `xlings` recipe's `latest` was stuck at **0.4.55 for 5 releases** — `xlings self update` couldn't reach any newer version, silently. Root cause: the auto-bump bot (`version-check.py`) only recognizes `url_template` packages, but xlings records versions as `["x.y.z"] = "XLINGS_RES"` (no single URL; the resource service handles mirrors + integrity), so xlings had no opt-in and was skipped.

## Fix

Add a second opt-in marker **`res_versioned = true`** (symmetric with `url_template`):
- Tracks `package.repo`'s GitHub `releases/latest` exactly like url_template (scan → query → compare `["latest"].ref`).
- On update: appends a bare `["<ver>"] = "XLINGS_RES"` entry + bumps `["latest"].ref` — **no download, no sha256** (keeps XLINGS_RES multi-mirror fallback).
- `url_template` path untouched; a platform uses one mode or the other.

## Changes
- `version-check.py` — `extract_res_versioned` + opt-in/current/proposed wiring; `apply_bump` handles res platforms.
- `pkgs/x/xlings.lua` — opt in all 3 platforms.
- `test_version_check.py` — offline unit tests (res apply needs no network) + url_template-still-works guard; wired into `ci-test.yml`.
- `docs/spec/url-template.md` — documents the mode.

## Verification
- 12/12 offline assertions pass.
- **Live dry-run**: `xlings` now detected (`status: up-to-date @ 0.4.60`, `repo: openxlings/xlings`) instead of skipped. Next release → auto-PR with `["x.y.z"] = "XLINGS_RES"`.

Follow-up to the index ecosystem unification (openxlings/xlings#342, #343). Prevents the recurrence of the stale-recipe trap.