### PR TITLE
chore(mcpp): bump to 0.0.65

### DIFF
--- a/pkgs/m/mcpp.lua
+++ b/pkgs/m/mcpp.lua
@@ -39,7 +39,8 @@ package = {
     xpm = {
         linux = {
             url_template = "https://github.com/mcpp-community/mcpp/releases/download/v{version}/mcpp-{version}-linux-x86_64.tar.gz",
-            ["latest"] = { ref = "0.0.64" },
+            ["latest"] = { ref = "0.0.65" },
+            ["0.0.65"] = "XLINGS_RES",
             ["0.0.64"] = "XLINGS_RES",
             ["0.0.63"] = "XLINGS_RES",
             ["0.0.62"] = "XLINGS_RES",
@@ -99,7 +100,8 @@ package = {
             ["0.0.1"] = "XLINGS_RES",
         },
         macosx = {
-            ["latest"] = { ref = "0.0.64" },
+            ["latest"] = { ref = "0.0.65" },
+            ["0.0.65"] = "XLINGS_RES",
             ["0.0.64"] = "XLINGS_RES",
             ["0.0.63"] = "XLINGS_RES",
             ["0.0.62"] = "XLINGS_RES",
@@ -145,7 +147,8 @@ package = {
             ["0.0.16"] = "XLINGS_RES",
         },
         windows = {
-            ["latest"] = { ref = "0.0.64" },
+            ["latest"] = { ref = "0.0.65" },
+            ["0.0.65"] = "XLINGS_RES",
             ["0.0.64"] = "XLINGS_RES",
             ["0.0.63"] = "XLINGS_RES",
             ["0.0.62"] = "XLINGS_RES",


### PR DESCRIPTION
Bump mcpp index to 0.0.65 (linux/macosx/windows).

Upstream mcpp-community/mcpp v0.0.65 — fix #168 (`mcpp add gtest` + `mcpp build` LNK2005/duplicate main): feature-gated dependency sources (gtest_main behind `main` feature, default off) + `mcpp add --dev`. Pairs with mcpplibs/mcpp-index gtest descriptor (already published).

Mirrored to xlings-res/mcpp@0.0.65 (GitHub + GitCode, 4 platforms, byte-verified).