### PR TITLE
feat(llvm): add 22.1.8 + align macOS/Windows to slim self-contained toolchain

### DIFF
--- a/.agents/skills/llvm-subpackaging/SKILL.md
+++ b/.agents/skills/llvm-subpackaging/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: llvm-subpackaging
+description: LLVM 全平台分包（sub-packaging）规范 / 设计方案 / SOP。把上游单体 LLVM 工具链 carve 成两个自包含包——`llvm`（slim 自包含工具链 = 编译器 + lld + binutils + libc++ + compiler-rt）与 `llvm-tools`（clang-format/tidy/clangd）——并发布到 xlings-res 双镜像（GitHub gh + GitCode gtc）。用于新增/对齐某平台的 llvm 包、升级版本、保证 linux/macosx/windows 三平台一致。
+---
+
+# LLVM 分包规范 / SOP（2 包模型）
+
+把上游 **1.4–2GB 单体** LLVM 整包 carve 成两个职责单一、**自包含**的包,让用户按需安装,
+不必每次拖整包(还含 1.2GB 用不到的静态库 + lldb + 全部 extra 工具)。
+
+> 详细清单与命令见:
+> - `references/split-manifest.md` —— 两个包的二进制/库清单、平台矩阵、自包含事实
+> - `references/publish-resources.md` —— gh / gtc 双镜像发布 SOP、资产命名、sha256 校验
+
+## 0) 背景事实(决定整套设计)
+
+1. **2 包,不是 3 包。** 历史上曾拆成 `llvm-core` + `llvm-libcxx` + `llvm-tools`(commit
+   `9db2ba94`),但随后 `99b004dc` **主动把 libc++ 并回 `llvm`、删掉独立 `llvm-libcxx`**,
+   让 `llvm` 成为一个自包含 toolchain。所以当前正确模型是:
+   **`llvm`(core+libc++ 合并)** + **`llvm-tools`**。release 上残留的 `llvm-core-*`/
+   `llvm-libcxx-*` 资产是被放弃的旧拆分,**不再使用、不要复活**。
+2. **上游没有现成分包。** `github.com/llvm/llvm-project` 全是单体整包
+   (mac `LLVM-<ver>-macOS-<arch>.tar.xz`≈1.45GB;win `clang+llvm-<ver>-x86_64-pc-windows-msvc.tar.xz`)。
+   两个包都是 xlings-res 下游 carve 的。
+3. **目标二进制静态自包含。** clang 驱动(`clang-<major>`)、`lld`、`clang-format`/`tidy`/
+   `clangd` 都静态链接 LLVM,只依赖系统库;无共享 `libLLVM`。mac 的 `libclang-cpp.dylib`/
+   `liblldb.dylib`、win 的 `libclang.dll`/`liblldb.dll` 只服务 extra/lldb 工具 → **全部丢弃**。
+4. **不做 strip。** LLVM release 二进制无 DWARF `debug_info`,strip 只省 ~8–10%,不值得。
+
+## 1) 包定义(三平台统一)
+
+| 包 | 职责 | 关键内容 |
+|----|------|---------|
+| **`llvm`** | slim 自包含工具链(编译+链接+binutils+C++ 标准库) | `bin/`: clang-<major>(+clang/clang++/clang-cl/clang-cpp 软链)、lld(+ld.lld/ld64.lld/lld-link/wasm-ld)、llvm-ar/nm/ranlib/strip/objcopy/objdump/readobj/readelf/symbolizer/profdata/cov/link/as/dis/size/rc/config/lib/dlltool/addr2line/...(权威 33 项见 manifest);`lib/clang/<major>/include`(builtin 头)+`lib/clang/<major>/lib`(compiler-rt);**libc++**(linux/mac):`include/c++/v1`、`lib/` 的 libc++/libc++abi/libunwind、`share/libc++/v1/std.cppm`。windows 无 libc++(用 MSVC STL)。 |
+| **`llvm-tools`** | 编辑器/开发工具 | `bin/`: clang-format、clang-tidy、clangd;`lib/clang/<major>/include`(clangd resource-dir 需要) |
+
+> **被丢弃(不进任何包)**:全部 `.a` 静态库(mac≈1.24GB)、`libclang-cpp`/`liblldb*` + lldb 工具、
+> clang extra 工具(clang-move/refactor/query/check/scan-deps/...)、MLIR、docs。
+
+**一致性铁律**:三平台同名包职责一致,只允许平台差异化:
+- 扩展名 `.so`(linux)/`.dylib`(mac)/`.dll|.exe`(win);库目录 linux/mac 用 `lib/<triple>/`(mac libc++ 直接在 `lib/`),win DLL 在 `bin/`
+- 驱动名:win 多 `clang-cl`/`lld-link`/`llvm-lib`
+- **libc++ 仅 linux/mac**;windows `llvm` 是 core-only
+
+## 2) 自包含校验(carve 验收红线)
+
+放进包的每个二进制运行期只允许依赖①系统库②同包随附库。
+- **macOS**:Mach-O `LC_LOAD_DYLIB` 读取器(纯 Python,见 `build-llvm-subpkg.sh`),非
+  `/usr/lib`、`/System` 即不合格 → 中止。
+- **Linux**:`ldd` 只能是系统库(不应出现 `libLLVM.so`)。
+- **Windows**:核心 exe 静态链接;`objdump -p` 确认不 import `LLVM-C.dll`/`libclang.dll`/
+  `liblldb.dll`(实测 clang.exe/lld.exe 都不 import)→ 不打包那些 DLL。
+
+## 3) Carve 工具
+
+`.agents/tools/build-llvm-subpkg.sh`(manifest 驱动,从 `build-llvm-tools.sh` 泛化):
+
+```bash
+# 合并 slim llvm(mac/win,从上游全量 carve)
+build-llvm-subpkg.sh --in <full.tar.xz|解压dir> --pkg llvm   --version 22.1.8 --platform macosx  --arch arm64
+build-llvm-subpkg.sh --in <dir>                  --pkg tools  --version 22.1.8 --platform windows --arch x86_64
+```
+- `--pkg llvm` = core + libcxx(libc++ 缺失时自动跳过,如 windows)+ share/libc++。
+- 同源整包先解压一次成 dir,再对 dir 多次 carve(避免重复解压);见 stage 里的 `carve.sh`。
+- macOS 自动跑自包含校验;**不 strip**;按平台默认格式打包(mac=tar.xz;win=tar.xz+zip)。
+
+## 4) 发布到 xlings-res(双镜像,必须一致)
+
+`GLOBAL=github.com/xlings-res/llvm`、`CN=gitcode.com/xlings-res/llvm`,tag=版本号。
+- 命名:`<pkg>-<ver>-<platform>-<arch>.<ext>`(`pkg`∈{`llvm`,`llvm-tools`};平台 `linux-x86_64`/
+  `macosx-arm64`/`windows-x86_64`;ext:mac=`tar.xz`、win=`tar.xz`+`zip`、linux=`tar.gz`+`tar.xz`)。
+- **GLOBAL**:`gh release upload <tag> <file>... --clobber --repo xlings-res/llvm`(支持覆盖)。
+- **CN**:GitCode 不能覆盖;**新资产名直接 `gtc release upload`**;若是替换旧同名资产,
+  **由维护者手动在网页删旧资产**后我再上传(gtc 不能删)。
+- 发布后从 GLOBAL、CN、carve 产物三方 sha256 比对一致;补旧版本时 `latest` 不倒退。
+- 完整命令见 `references/publish-resources.md`。
+
+## 5) 接线包索引(.lua 配方)
+
+- `pkgs/l/llvm.lua`:三平台 `xpm`。linux/win 用 `"XLINGS_RES"`(资源已就绪);mac 用显式
+  `url={GLOBAL=...,CN=...}`(沿用 `llvm-tools.lua` 的 macosx 写法)。**不 pin sha256**。
+  `install()` 把解压目录 `os.mv` 到 `install_dir()`,并按平台生成 `clang.cfg`/`clang++.cfg`
+  (sysroot 注入 + 指向**本包内**的 libc++ 头/库 —— libc++ 与 clang 同包,故路径自洽,
+  这正是 `99b004dc` 合并的理由)。windows 无 libc++ 不生成 libc++ cfg。
+- `pkgs/l/llvm-tools.lua`:三平台,自包含,`config()` 注册 clang-format/tidy/clangd。
+- 版本骨架:`["latest"]={ref=...}` + 每版本一条;某平台缺该版本资源(如 linux 22.1.8 待
+  自建)就**不要给该平台加该版本条目 / 不要把 latest 指过去**,否则 CI install 测试必挂。
+- 隔离合规(`xpkg-creater`):禁 `os.exec("xvm ...")`、禁改 PATH/profile;import 仅 `xim.libxpkg.*`。
+
+## 6) 平台落地能力(谁能产哪个)
+
+- **macosx-arm64 / windows-x86_64**:可从上游全量 carve(本机即可),由本流程产出。
+- **linux-x86_64**:`llvm` 是 xlings **自建 slim 构建**(非上游 carve),由维护者的构建管线产出;
+  `llvm-tools` 可从上游 Linux 全量 carve 但通常随自建管线一起。→ **linux 新版本资源不在本 SOP 自动覆盖范围**,需维护者构建后再接线。
+
+## 7) 验收清单
+
+- [ ] 模型为 2 包(`llvm` + `llvm-tools`),未复活 core/libcxx。
+- [ ] 每个二进制过自包含校验;未 strip。
+- [ ] 资产 GLOBAL+CN 齐全、命名合规、sha256 三方一致。
+- [ ] 配方三平台结构对齐、不 pin sha256、隔离合规;无资源的平台/版本不接线。
+- [ ] 新增/改包带 tests、走 `pr-workflow` 过全部 CI(含 macos-install-test)。

--- a/.agents/skills/llvm-subpackaging/SKILL.md
+++ b/.agents/skills/llvm-subpackaging/SKILL.md
@@ -89,9 +89,14 @@ build-llvm-subpkg.sh --in <dir>                  --pkg tools  --version 22.1.8 -
 
 ## 6) 平台落地能力(谁能产哪个)
 
-- **macosx-arm64 / windows-x86_64**:可从上游全量 carve(本机即可),由本流程产出。
-- **linux-x86_64**:`llvm` 是 xlings **自建 slim 构建**(非上游 carve),由维护者的构建管线产出;
-  `llvm-tools` 可从上游 Linux 全量 carve 但通常随自建管线一起。→ **linux 新版本资源不在本 SOP 自动覆盖范围**,需维护者构建后再接线。
+**三平台都从上游全量 release carve,本机即可产出**(同一 `build-llvm-subpkg.sh` 流程):
+- macosx-arm64 ← `LLVM-<ver>-macOS-ARM64.tar.xz`
+- windows-x86_64 ← `clang+llvm-<ver>-x86_64-pc-windows-msvc.tar.xz`
+- linux-x86_64 ← `LLVM-<ver>-Linux-X64.tar.xz`(含 libc++ / share/libc++ / compiler-rt,与 mac 同构;
+  clang 二进制运行期只依赖系统库,编译期目标由 `llvm.lua` 的 sysroot 注入 cfg 决定)
+
+> 上游 Linux 全量约 1.9GB(carve 后 `llvm`≈150M xz)。早期误以为 linux 需"自建构建",
+> 实测可直接 carve 上游,与 mac/win 完全一致。
 
 ## 7) 验收清单
 

--- a/.agents/skills/llvm-subpackaging/references/publish-resources.md
+++ b/.agents/skills/llvm-subpackaging/references/publish-resources.md
@@ -1,0 +1,75 @@
+# xlings-res 资源发布 SOP（llvm 子包，双镜像）
+
+资产仓库：`xlings-res/llvm`（同一仓库，按 tag=版本号 归档）。
+- `GLOBAL` = https://github.com/xlings-res/llvm
+- `CN`     = https://gitcode.com/xlings-res/llvm
+
+两镜像**必须含完全相同的资产**，否则不能把配方切到该版本。
+
+## 1. 资产命名约定
+
+```
+<pkg>-<version>-<platform>-<arch>.<ext>
+```
+- `<pkg>`：`llvm` | `llvm-tools`（2 包模型；不再有 core/libcxx）
+- `<platform>-<arch>`：`linux-x86_64` | `macosx-arm64` | `windows-x86_64`
+- `<ext>`：linux=`tar.gz`+`tar.xz`、macosx=`tar.xz`、windows=`tar.xz`+`zip`（与现网资产对齐；
+  同平台同版本两个包扩展名一致）
+
+例：`llvm-22.1.8-macosx-arm64.tar.xz`、`llvm-tools-22.1.8-windows-x86_64.zip`
+
+## 2. 发布命令
+
+### GLOBAL（GitHub，支持覆盖）
+
+```bash
+# release 已存在时：
+gh release upload <tag> <file>... --clobber --repo xlings-res/llvm
+# release 不存在时先建：
+gh release create <tag> --repo xlings-res/llvm --title <tag> --notes "llvm <tag> sub-packages"
+```
+
+### CN（GitCode）
+
+```bash
+# 新 tag 先建 release：
+gtc release create xlings-res/llvm --tag <tag> --name "LLVM <tag> (split packages)"
+# 上传（新资产名直接传）：
+gtc release upload xlings-res/llvm --tag <tag> <file>...
+```
+> **gtc 不能删资产**，也不能覆盖同名资产。若要替换旧同名资产,**由维护者在 GitCode 网页
+> 手动删除**后再 `gtc release upload`。新资产名(如新增平台/新版本)无需删除,直接上传。
+
+`gtc` 位置与配置见 reference 备忘（`/home/speak/.local/bin/gtc`，
+token 在 `~/.config/gitcode-tool/config.json`）。
+`gtc release create` 可能 HTTP 400，回退用 GitCode API 直接建 release（见备忘）。
+
+## 3. sha256 三方核对（发布后必做）
+
+```bash
+sha256sum <file>                                  # carve 产物
+curl -sL <GLOBAL_url> | sha256sum                 # GitHub RES
+curl -sL <CN_url>     | sha256sum                 # GitCode RES
+# 三者必须完全一致
+```
+
+URL 形如：
+```
+https://github.com/xlings-res/llvm/releases/download/<tag>/<asset>
+https://gitcode.com/xlings-res/llvm/releases/download/<tag>/<asset>
+```
+
+## 4. 发布前/后检查单
+
+- [ ] 三平台每个子包资产都已上传到 **GLOBAL 与 CN**，命名合规。
+- [ ] 每个资产 sha256 三方一致（carve / GLOBAL / CN）。
+- [ ] 补发旧版本时，两边 `latest` 仍指向应为最新的版本（不倒退）。
+- [ ] 配方 `sha256 = nil`，同名替换无需改配方；若某配方 pin 了 sha256，同步更新。
+- [ ] PR/汇报中写清 GLOBAL/CN 的 tag 与 sha256 结果（`xpkg-creater` §1.2.1 要求）。
+
+## 5. 与既有机制的关系
+
+- 资产路径与「索引仓库分发（Y-asset）」同一套资源服务，但属不同资产，互不混淆
+  （见 `xpkg-creater` §1.2.1 与 `docs/design/index-distribution.md`）。
+- 同名替换上线方式与工具链 strip 重打包一致（见
+  `.agents/docs/2026-06-22-toolchain-strip-plan.md` 的"上线方式"一节）。

--- a/.agents/skills/llvm-subpackaging/references/split-manifest.md
+++ b/.agents/skills/llvm-subpackaging/references/split-manifest.md
@@ -57,14 +57,14 @@ mac/win 三个工具均静态自包含(self-containment 校验已证实)。
 
 | 维度 | linux-x86_64 | macosx-arm64 | windows-x86_64 |
 |------|-------------|--------------|----------------|
-| `llvm` 来源 | xlings 自建 slim 构建（维护者管线） | 上游 `LLVM-<ver>-macOS-ARM64` carve | 上游 `clang+llvm-<ver>-x86_64-pc-windows-msvc` carve |
+| `llvm` 来源 | 上游 `LLVM-<ver>-Linux-X64` carve | 上游 `LLVM-<ver>-macOS-ARM64` carve | 上游 `clang+llvm-<ver>-x86_64-pc-windows-msvc` carve |
 | libc++ | 有 | 有 | **无**（MSVC STL） |
 | 共享库扩展名 | `.so` | `.dylib` | `.dll` |
 | libc++ 库目录 | `lib/<triple>/` | `lib/`（直接） | — |
 | 可执行后缀 | 无 | 无 | `.exe` |
 | 资产扩展名 | `tar.gz`+`tar.xz` | `tar.xz` | `tar.xz`+`zip` |
 | 自包含校验 | `ldd` | Mach-O LC_LOAD_DYLIB | `objdump -p` 导入表 |
-| 本流程能否产出 | 否（维护者构建） | 是 | 是 |
+| 本流程能否产出 | 是（上游 carve） | 是 | 是 |
 
 ## 4. 自包含事实（20.1.7/22.1.8 实测）
 

--- a/.agents/skills/llvm-subpackaging/references/split-manifest.md
+++ b/.agents/skills/llvm-subpackaging/references/split-manifest.md
@@ -1,0 +1,86 @@
+# LLVM 包清单 / 平台矩阵 / 自包含事实(2 包模型)
+
+> 权威依据:现网 `llvm-20.1.7-linux-x86_64`(Unix 基准)与 `llvm-20.1.7-windows-x86_64`
+> (Windows 基准)资产的实际 `bin/` 集;macOS 取自上游 `LLVM-<ver>-macOS-ARM64` 实测。
+> carve 工具 `.agents/tools/build-llvm-subpkg.sh` 的 `CORE_BINS` 即按本清单硬编码。
+
+## 1. `llvm` —— slim 自包含工具链(编译 + 链接 + binutils + C++ 标准库)
+
+### bin/ —— Unix(linux + macosx),权威 34 项(linux `llvm` 资产)
+
+```
+clang clang++ clang-<major> clang-cl clang-cpp clang-scan-deps
+ld64.lld ld.lld lld lld-link wasm-ld
+llvm-addr2line llvm-ar llvm-as llvm-bitcode-strip llvm-config llvm-cov
+llvm-dis llvm-dlltool llvm-lib llvm-link llvm-nm llvm-objcopy llvm-objdump
+llvm-otool llvm-profdata llvm-ranlib llvm-rc llvm-readelf llvm-readobj
+llvm-size llvm-strip llvm-symbolizer hwasan_symbolize
+```
+> `clang`/`clang++`/`clang-cl`/`clang-cpp` 是指向 `clang-<major>` 的软链;
+> `hwasan_symbolize` 仅 linux(mac 缺,carve 自动跳过)。
+
+### bin/ —— Windows,权威 27 exe + 2 DLL(windows `llvm` 资产)
+
+```
+clang.exe clang++.exe clang-cl.exe clang-scan-deps.exe lld-link.exe
+llvm-addr2line llvm-ar llvm-config llvm-cov llvm-cvtres llvm-cxxfilt
+llvm-dlltool llvm-lib llvm-mt llvm-nm llvm-objcopy llvm-objdump
+llvm-profdata llvm-ranlib llvm-rc llvm-readelf llvm-readobj llvm-size
+llvm-strings llvm-strip llvm-symbolizer llvm-windres        (.exe)
+libiomp5md.dll libomp.dll                                   (openmp 运行时)
+```
+> Windows 无独立 `lld`/`wasm-ld`/`clang-cpp`/`llvm-as|dis|link|bitcode-strip|otool`;
+> 多 `cvtres/mt/windres/cxxfilt/strings`(Windows 工具链)。核心 exe 静态链接,
+> 不 import `LLVM-C.dll`/`libclang.dll`/`liblldb.dll`(实测),故那些 DLL 不打包。
+
+### lib/ + include/ + share/(所有平台)
+
+```
+lib/clang/<major>/include/      # clang builtin 头(stddef.h…)
+lib/clang/<major>/lib/...       # compiler-rt(各平台子目录)
+# 以下仅 linux/macosx(windows 用 MSVC STL,无 libc++):
+include/c++/v1/                 # libc++ 头
+include/<triple>/c++/v1/        # 平台特化头(若上游提供)
+lib/<triple>/ 或 lib/           # libc++ / libc++abi / libunwind (.so|.dylib + .a) + libc++.modules.json
+share/libc++/v1/                # std.cppm / std.compat.cppm + std/*.inc(`import std;` 需要)
+```
+
+## 2. `llvm-tools` —— 编辑器/开发工具(三平台已发布)
+
+```
+bin/  clang-format  clang-tidy  clangd      (windows 带 .exe)
+lib/clang/<major>/include/                  # clangd 推导 resource-dir 需要
+```
+mac/win 三个工具均静态自包含(self-containment 校验已证实)。
+
+## 3. 平台矩阵
+
+| 维度 | linux-x86_64 | macosx-arm64 | windows-x86_64 |
+|------|-------------|--------------|----------------|
+| `llvm` 来源 | xlings 自建 slim 构建（维护者管线） | 上游 `LLVM-<ver>-macOS-ARM64` carve | 上游 `clang+llvm-<ver>-x86_64-pc-windows-msvc` carve |
+| libc++ | 有 | 有 | **无**（MSVC STL） |
+| 共享库扩展名 | `.so` | `.dylib` | `.dll` |
+| libc++ 库目录 | `lib/<triple>/` | `lib/`（直接） | — |
+| 可执行后缀 | 无 | 无 | `.exe` |
+| 资产扩展名 | `tar.gz`+`tar.xz` | `tar.xz` | `tar.xz`+`zip` |
+| 自包含校验 | `ldd` | Mach-O LC_LOAD_DYLIB | `objdump -p` 导入表 |
+| 本流程能否产出 | 否（维护者构建） | 是 | 是 |
+
+## 4. 自包含事实（20.1.7/22.1.8 实测）
+
+- macOS `lib/`：少量 dylib + 大量静态 `.a`（1.24GB），**无 `libLLVM.dylib`**；
+  `libclang-cpp.dylib`(185M)/`liblldb.dylib`(166M) 只服务 extra/lldb 工具 → 丢弃。
+- `clang-<major>`/`lld`/`clangd`/`clang-tidy`/`clang-format` 体积大正因**静态链接** LLVM，自包含。
+- 全部二进制 `debug_info` 段数=0（无 DWARF）→ 不 strip。
+
+## 5. 体积参考（压缩后）
+
+| 资产 | 20.1.7 | 22.1.8 |
+|------|--------|--------|
+| 上游 mac 全量（carve 输入） | 1449M | 1480M |
+| 上游 win 全量（carve 输入） | 939M | 862M |
+| `llvm-<ver>-macosx-arm64.tar.xz`（产出） | ~97M | ~见产出 |
+| `llvm-<ver>-windows-x86_64`（产出） | （现网既有） | ~见产出 |
+| `llvm-tools-<ver>-macosx-arm64.tar.xz` | 49M | ~37M |
+
+分包后用户装 `llvm`(~100M)或 `llvm-tools`(~40–70M),相对 1.4G 整包是数量级收益。

--- a/.agents/tools/build-llvm-subpkg.sh
+++ b/.agents/tools/build-llvm-subpkg.sh
@@ -1,0 +1,274 @@
+#!/usr/bin/env bash
+#
+# build-llvm-subpkg.sh — carve an xlings-res LLVM sub-package (core | libcxx |
+# tools) out of a full upstream LLVM distribution.
+#
+# This generalizes build-llvm-tools.sh: same carve + repack + sha256 flow, but
+# manifest-driven so it can produce all three sub-packages defined by the
+# llvm-subpackaging skill (.agents/skills/llvm-subpackaging):
+#
+#   llvm-core    compiler driver + lld + binutils-equivalents + compiler-rt
+#                + clang builtin headers
+#   llvm-libcxx  libc++ / libc++abi / libunwind (headers + libs)
+#   llvm-tools   clang-format, clang-tidy, clangd + clang builtin headers
+#
+# Output layout (matches existing assets):
+#   <pkg>-<ver>-<platform>-<arch>/{bin,lib,include}/...
+# Asset naming: <pkg>-<ver>-<platform>-<arch>.<ext>
+#   macosx -> tar.xz ; windows -> tar.xz + zip ; linux -> tar.gz + tar.xz
+#
+# macOS binaries are verified self-contained (system-only dylibs) via an
+# embedded Mach-O LC_LOAD_DYLIB reader (no otool; runs on Linux). NO strip
+# (LLVM release binaries carry no DWARF debug_info; see the skill).
+#
+# Usage:
+#   build-llvm-subpkg.sh --in <full-llvm.tar.xz|dir> --pkg core|libcxx|tools \
+#       --version 22.1.8 --platform macosx --arch arm64 \
+#       [--out <dir>] [--formats "tar.xz zip"]
+#
+set -euo pipefail
+
+die() { echo "error: $*" >&2; exit 1; }
+log() { echo ">> $*" >&2; }
+
+IN="" PKG="" VERSION="" PLATFORM="" ARCH="" OUT="$PWD" FORMATS=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --in)       IN="$2"; shift 2;;
+        --pkg)      PKG="$2"; shift 2;;
+        --version)  VERSION="$2"; shift 2;;
+        --platform) PLATFORM="$2"; shift 2;;
+        --arch)     ARCH="$2"; shift 2;;
+        --out)      OUT="$2"; shift 2;;
+        --formats)  FORMATS="$2"; shift 2;;
+        -h|--help)  grep '^#' "$0" | sed 's/^# \?//'; exit 0;;
+        *) die "unknown arg: $1";;
+    esac
+done
+
+[ -n "$IN" ]       || die "--in is required (full LLVM tarball or extracted dir)"
+[ -n "$PKG" ]      || die "--pkg is required (core|libcxx|tools)"
+[ -n "$VERSION" ]  || die "--version is required (e.g. 22.1.8)"
+[ -n "$PLATFORM" ] || die "--platform is required (linux|macosx|windows)"
+[ -n "$ARCH" ]     || die "--arch is required (x86_64|arm64)"
+[ -e "$IN" ]       || die "input not found: $IN"
+case "$PKG" in llvm|core|libcxx|tools) ;; *) die "--pkg must be llvm|core|libcxx|tools";; esac
+
+# default formats per platform (match existing released assets)
+if [ -z "$FORMATS" ]; then
+    case "$PLATFORM" in
+        macosx)  FORMATS="tar.xz";;
+        windows) FORMATS="tar.xz zip";;
+        linux)   FORMATS="tar.gz tar.xz";;
+    esac
+fi
+
+EXE=""
+[ "$PLATFORM" = "windows" ] && EXE=".exe"
+MAJOR="${VERSION%%.*}"
+# merged toolchain ships as `llvm-<ver>-...`; component pkgs as `llvm-<pkg>-<ver>-...`
+if [ "$PKG" = "llvm" ]; then
+    BUNDLE="llvm-${VERSION}-${PLATFORM}-${ARCH}"
+else
+    BUNDLE="llvm-${PKG}-${VERSION}-${PLATFORM}-${ARCH}"
+fi
+
+# `llvm` core bin manifest — authoritative per-platform set, matching the
+# existing xlings-res `llvm-<ver>-<platform>` assets so all platforms stay
+# consistent. Unix (linux/mac) = the linux `llvm` set (34); windows = the
+# existing windows `llvm` set (27 exes + 2 openmp DLLs).
+if [ "$PLATFORM" = "windows" ]; then
+    CORE_BINS=(
+        clang clang++ clang-cl clang-scan-deps lld-link
+        llvm-addr2line llvm-ar llvm-config llvm-cov llvm-cvtres llvm-cxxfilt
+        llvm-dlltool llvm-lib llvm-mt llvm-nm llvm-objcopy llvm-objdump
+        llvm-profdata llvm-ranlib llvm-rc llvm-readelf llvm-readobj llvm-size
+        llvm-strings llvm-strip llvm-symbolizer llvm-windres
+    )
+    CORE_DLLS=(libiomp5md.dll libomp.dll)   # openmp runtime, bundled on windows
+else
+    CORE_BINS=(
+        clang clang++ clang-${MAJOR} clang-cl clang-cpp clang-scan-deps
+        ld64.lld ld.lld lld lld-link wasm-ld
+        llvm-addr2line llvm-ar llvm-as llvm-bitcode-strip llvm-config llvm-cov
+        llvm-dis llvm-dlltool llvm-lib llvm-link llvm-nm llvm-objcopy llvm-objdump
+        llvm-otool llvm-profdata llvm-ranlib llvm-rc llvm-readelf llvm-readobj
+        llvm-size llvm-strip llvm-symbolizer hwasan_symbolize
+    )
+    CORE_DLLS=()
+fi
+TOOLS_BINS=(clang-format clang-tidy clangd)
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+DEST="$WORK/$BUNDLE"
+mkdir -p "$DEST"
+
+# --- locate / extract source root -----------------------------------------
+if [ -d "$IN" ]; then
+    SRCROOT="$IN"
+else
+    log "extracting $IN (full decompress; reuse a dir input to avoid repeating) ..."
+    mkdir -p "$WORK/src"
+    case "$IN" in
+        *.tar.xz) tar -xJf "$IN" -C "$WORK/src";;
+        *.tar.gz|*.tgz) tar -xzf "$IN" -C "$WORK/src";;
+        *.zip) ( cd "$WORK/src" && unzip -q "$IN" );;
+        *) die "unsupported input archive: $IN";;
+    esac
+    SRCROOT="$WORK/src"
+fi
+
+# top dir inside the source (e.g. LLVM-22.1.8-macOS-ARM64 or clang+llvm-...)
+TOP="$(find "$SRCROOT" -maxdepth 2 -type d -name 'bin' -print -quit 2>/dev/null | xargs -r dirname)"
+[ -n "$TOP" ] && [ -d "$TOP" ] || die "could not locate <root>/bin under $SRCROOT"
+log "source root: $TOP"
+
+copy_bin() { # $1 = basename (no exe suffix)
+    local name="$1$EXE" src="$TOP/bin/$1$EXE"
+    if [ -e "$src" ] || [ -L "$src" ]; then
+        cp -a "$src" "$DEST/bin/$name"
+        return 0
+    fi
+    return 1
+}
+
+copy_builtin_headers() {
+    local hs="$TOP/lib/clang/$MAJOR/include"
+    [ -d "$hs" ] || die "missing builtin headers: lib/clang/$MAJOR/include"
+    mkdir -p "$DEST/lib/clang/$MAJOR"
+    cp -R "$hs" "$DEST/lib/clang/$MAJOR/include"
+    [ -f "$DEST/lib/clang/$MAJOR/include/stddef.h" ] || die "builtin headers missing stddef.h"
+    log "  + lib/clang/$MAJOR/include ($(du -sh "$DEST/lib/clang/$MAJOR/include" | cut -f1))"
+}
+
+do_tools() {
+    mkdir -p "$DEST/bin"
+    for t in "${TOOLS_BINS[@]}"; do copy_bin "$t" || die "missing $t$EXE"; log "  + bin/$t$EXE"; done
+    copy_builtin_headers
+}
+
+do_core() {
+    mkdir -p "$DEST/bin"
+    local n=0 t
+    for t in "${CORE_BINS[@]}"; do
+        if copy_bin "$t"; then n=$((n+1)); else log "  - (absent on $PLATFORM) $t"; fi
+    done
+    [ "$n" -ge 5 ] || die "core: only $n binaries found, expected the clang/lld/llvm-* set"
+    log "  + $n core binaries"
+    # bundled runtime DLLs (windows openmp)
+    for d in "${CORE_DLLS[@]:-}"; do
+        [ -n "$d" ] || continue
+        if [ -e "$TOP/bin/$d" ]; then cp -a "$TOP/bin/$d" "$DEST/bin/$d"; log "  + bin/$d"; fi
+    done
+    copy_builtin_headers
+    # compiler-rt
+    if [ -d "$TOP/lib/clang/$MAJOR/lib" ]; then
+        cp -R "$TOP/lib/clang/$MAJOR/lib" "$DEST/lib/clang/$MAJOR/lib"
+        log "  + lib/clang/$MAJOR/lib (compiler-rt, $(du -sh "$DEST/lib/clang/$MAJOR/lib" | cut -f1))"
+    fi
+}
+
+do_libcxx() {
+    # headers
+    if [ -d "$TOP/include/c++" ]; then
+        mkdir -p "$DEST/include"; cp -R "$TOP/include/c++" "$DEST/include/c++"
+        log "  + include/c++ ($(du -sh "$DEST/include/c++" | cut -f1))"
+    else die "libcxx: missing include/c++/v1"; fi
+    # per-triple headers (e.g. include/<triple>/c++/v1)
+    local d rel f found=0
+    while IFS= read -r d; do
+        rel="${d#$TOP/}"; mkdir -p "$DEST/$(dirname "$rel")"; cp -R "$d" "$DEST/$rel"
+        log "  + $rel"
+    done < <(find "$TOP/include" -mindepth 2 -maxdepth 2 -type d -name 'c++' 2>/dev/null)
+    # libs: libc++ / libc++abi / libunwind (+ modules json), preserve path under lib/
+    while IFS= read -r f; do
+        rel="${f#$TOP/}"; mkdir -p "$DEST/$(dirname "$rel")"; cp -a "$f" "$DEST/$rel"; found=$((found+1))
+    done < <(find "$TOP/lib" -maxdepth 2 \( \
+        -name 'libc++*' -o -name 'libc++abi*' -o -name 'libunwind*' -o -name 'libc++.modules.json' \
+        \) 2>/dev/null)
+    log "  + $found libcxx lib artifacts"
+    [ "$found" -ge 1 ] || die "libcxx: no libc++/libc++abi/libunwind libs found (not shipped on $PLATFORM?)"
+    # libc++ std modules (share/libc++/v1/std.cppm) — needed by `import std;`
+    if [ -d "$TOP/share/libc++" ]; then
+        mkdir -p "$DEST/share"; cp -R "$TOP/share/libc++" "$DEST/share/libc++"
+        log "  + share/libc++ ($(du -sh "$DEST/share/libc++" | cut -f1))"
+    fi
+}
+
+case "$PKG" in
+  tools)  do_tools;;
+  core)   do_core;;
+  libcxx) do_libcxx;;
+  llvm)   do_core
+          # libc++ only ships on linux/macOS; windows clang uses the MSVC STL
+          if [ -d "$TOP/include/c++" ]; then do_libcxx; else log "  (no libc++ on $PLATFORM — MSVC STL)"; fi;;
+esac
+
+# --- macOS self-containment check (Mach-O LC_LOAD_DYLIB) -------------------
+if [ "$PLATFORM" = "macosx" ] && [ -d "$DEST/bin" ]; then
+    log "verifying macOS binaries are self-contained (system-only dylibs) ..."
+    # only real Mach-O files (skip symlinks)
+    mapfile -t MACHO < <(find "$DEST/bin" -type f)
+    if [ "${#MACHO[@]}" -gt 0 ]; then
+        python3 - "${MACHO[@]}" <<'PY' || die "self-containment check failed"
+import struct, sys
+MH=(0xFEEDFACE,0xFEEDFACF); LOAD={0x0C,0x80000018,0x8000001F}; RPATH=0x1C
+def macho(data,off):
+    le=struct.unpack_from("<I",data,off)[0]; be=struct.unpack_from(">I",data,off)[0]
+    en="<" if le in MH else ">"; magic=le if le in MH else be
+    is64=magic==0xFEEDFACF
+    nc=struct.unpack_from(en+("IiiIIII" if not is64 else "IiiIIIII"),data,off)[4]
+    o=off+(32 if is64 else 28); deps=[]
+    for _ in range(nc):
+        cmd,sz=struct.unpack_from(en+"II",data,o)
+        if cmd in LOAD:
+            no=struct.unpack_from(en+"I",data,o+8)[0]
+            deps.append(data[o+no:o+sz].split(b"\0")[0].decode(errors="replace"))
+        o+=sz
+    return deps
+bad=False
+for path in sys.argv[1:]:
+    data=open(path,"rb").read()
+    if len(data)<4: continue
+    be=struct.unpack_from(">I",data,0)[0]
+    le=struct.unpack_from("<I",data,0)[0]
+    offs=[]
+    if be in (0xCAFEBABE,0xCAFEBABF):
+        n=struct.unpack_from(">I",data,4)[0]; is64=be==0xCAFEBABF; a=8
+        for _ in range(n):
+            if is64: off=struct.unpack_from(">Q",data,a+8)[0]; a+=32
+            else:    off=struct.unpack_from(">I",data,a+8)[0]; a+=20
+            offs.append(off)
+    elif le in MH or be in MH: offs=[0]
+    else: continue  # not Mach-O (e.g. a script) — skip
+    deps=set()
+    for off in offs: deps|=set(macho(data,off))
+    ext=[d for d in deps if not (d.startswith("/usr/lib/") or d.startswith("/System/"))]
+    if ext:
+        bad=True
+        print(f"   !! {path.split('/')[-1]} non-system deps:", file=sys.stderr)
+        for d in ext: print(f"        {d}", file=sys.stderr)
+sys.exit(1 if bad else 0)
+PY
+        log "  OK: all macOS binaries depend only on system libraries"
+    fi
+fi
+
+# --- repack ----------------------------------------------------------------
+mkdir -p "$OUT"
+OUT="$(cd "$OUT" && pwd)"   # absolutize: the zip step cd's into $WORK
+echo
+echo "=== $BUNDLE ==="
+for FMT in $FORMATS; do
+    OUTFILE="$OUT/${BUNDLE}.${FMT}"
+    case "$FMT" in
+        tar.xz) tar -C "$WORK" -cJf "$OUTFILE" "$BUNDLE";;
+        tar.gz) tar -C "$WORK" -czf "$OUTFILE" "$BUNDLE";;
+        zip)    ( cd "$WORK" && zip -q -r -X "$OUTFILE" "$BUNDLE" );;
+        *) die "unknown format: $FMT";;
+    esac
+    SHA="$(sha256sum "$OUTFILE" | cut -d' ' -f1)"
+    printf "  %-10s %8s  %s\n" "$FMT" "$(du -h "$OUTFILE" | cut -f1)" "$SHA"
+    echo "$SHA  $(basename "$OUTFILE")" >> "$OUT/SHA256SUMS.txt"
+done

--- a/.github/scripts/posix-test.sh
+++ b/.github/scripts/posix-test.sh
@@ -112,6 +112,13 @@ failures=()
 tested=0
 skipped=0
 
+# Register official sub-indexes so packages that delegate to them resolve.
+# e.g. xim:linux-headers is a thin delegator whose payload lives in
+# scode:linux-headers (xim-pkgindex-scode); without the scode index any
+# package depending on linux-headers (llvm, gcc, glibc, ...) fails to install
+# with "package 'scode:linux-headers@<ver>' not found". Best-effort.
+"$XLINGS_CMD" config --index-repo "scode:https://github.com/openxlings/xim-pkgindex-scode.git" 2>/dev/null || true
+
 for rel_file in "${files[@]}"; do
     [[ -n "$rel_file" ]] || continue
     lua_file="$WORKSPACE_ROOT/$rel_file"

--- a/.github/scripts/windows-test.ps1
+++ b/.github/scripts/windows-test.ps1
@@ -81,6 +81,11 @@ $failures = @()
 $tested   = 0
 $skipped  = 0
 
+# Register official sub-indexes so packages that delegate to them resolve
+# (see posix-test.sh for rationale: xim:linux-headers -> scode:linux-headers).
+# Best-effort.
+& $xlingsCmd config --index-repo "scode:https://github.com/openxlings/xim-pkgindex-scode.git" 2>&1 | Out-Null
+
 foreach ($relFile in $files) {
     $luaFile = Join-Path $WorkspaceRoot $relFile
     if (-not (Test-Path $luaFile)) {

--- a/pkgs/l/llvm-tools.lua
+++ b/pkgs/l/llvm-tools.lua
@@ -36,6 +36,13 @@ package = {
                 },
                 sha256 = nil,
             },
+            ["22.1.8"] = {
+                url = {
+                    GLOBAL = "https://github.com/xlings-res/llvm/releases/download/22.1.8/llvm-tools-22.1.8-windows-x86_64.zip",
+                    CN = "https://gitcode.com/xlings-res/llvm/releases/download/22.1.8/llvm-tools-22.1.8-windows-x86_64.zip",
+                },
+                sha256 = nil,
+            },
         },
         -- Apple Silicon only, mirroring llvm.lua's macosx (which ships
         -- macOS-ARM64). The slim bundle is carved from the upstream full
@@ -53,7 +60,16 @@ package = {
                 },
                 sha256 = nil,
             },
+            ["22.1.8"] = {
+                url = {
+                    GLOBAL = "https://github.com/xlings-res/llvm/releases/download/22.1.8/llvm-tools-22.1.8-macosx-arm64.tar.xz",
+                    CN = "https://gitcode.com/xlings-res/llvm/releases/download/22.1.8/llvm-tools-22.1.8-macosx-arm64.tar.xz",
+                },
+                sha256 = nil,
+            },
         },
+        -- NOTE: linux 22.1.8 is built by the maintainer's slim-build pipeline
+        -- (not carved from upstream here); add its xpm entry once published.
     },
 }
 

--- a/pkgs/l/llvm-tools.lua
+++ b/pkgs/l/llvm-tools.lua
@@ -18,7 +18,7 @@ package = {
 
     xpm = {
         linux = {
-            ["latest"] = { ref = "20.1.7" },
+            ["latest"] = { ref = "22.1.8" },
             ["20.1.7"] = {
                 url = {
                     GLOBAL = "https://github.com/xlings-res/llvm/releases/download/20.1.7/llvm-tools-20.1.7-linux-x86_64.tar.gz",
@@ -26,9 +26,16 @@ package = {
                 },
                 sha256 = nil,
             },
+            ["22.1.8"] = {
+                url = {
+                    GLOBAL = "https://github.com/xlings-res/llvm/releases/download/22.1.8/llvm-tools-22.1.8-linux-x86_64.tar.gz",
+                    CN = "https://gitcode.com/xlings-res/llvm/releases/download/22.1.8/llvm-tools-22.1.8-linux-x86_64.tar.gz",
+                },
+                sha256 = nil,
+            },
         },
         windows = {
-            ["latest"] = { ref = "20.1.7" },
+            ["latest"] = { ref = "22.1.8" },
             ["20.1.7"] = {
                 url = {
                     GLOBAL = "https://github.com/xlings-res/llvm/releases/download/20.1.7/llvm-tools-20.1.7-windows-x86_64.zip",
@@ -52,7 +59,7 @@ package = {
         -- headers) so clangd's derived resource-dir resolves stddef.h etc.
         -- for files that include libc++ headers (e.g. #include <gtest/gtest.h>).
         macosx = {
-            ["latest"] = { ref = "20.1.7" },
+            ["latest"] = { ref = "22.1.8" },
             ["20.1.7"] = {
                 url = {
                     GLOBAL = "https://github.com/xlings-res/llvm/releases/download/20.1.7/llvm-tools-20.1.7-macosx-arm64.tar.xz",
@@ -68,8 +75,6 @@ package = {
                 sha256 = nil,
             },
         },
-        -- NOTE: linux 22.1.8 is built by the maintainer's slim-build pipeline
-        -- (not carved from upstream here); add its xpm entry once published.
     },
 }
 

--- a/pkgs/l/llvm.lua
+++ b/pkgs/l/llvm.lua
@@ -19,17 +19,19 @@ package = {
 
     xpm = {
         linux = {
-            -- linux ships the maintainer's slim self-contained build (XLINGS_RES).
-            -- xim:linux-headers is a thin delegator to scode:linux-headers, so the
-            -- install-test harness registers the scode sub-index (see .github/scripts).
+            -- slim self-contained toolchain carved from the upstream full release
+            -- (same as mac/win, via build-llvm-subpkg.sh --pkg llvm). xim:linux-headers
+            -- is a thin delegator to scode:linux-headers, so the install-test harness
+            -- registers the scode sub-index (see .github/scripts).
             deps = {
                 "xim:glibc@2.39",
                 "xim:linux-headers@5.11.1",
                 "xim:zlib@1.3.1",
                 "xim:libxml2@2.13.5",
             },
-            ["latest"] = { ref = "20.1.7" },
+            ["latest"] = { ref = "22.1.8" },
             ["20.1.7"] = "XLINGS_RES",
+            ["22.1.8"] = "XLINGS_RES",
         },
         -- macOS ships a slim, self-contained toolchain carved from the upstream
         -- full release (the 1.4GB upstream monolith is no longer mirrored):
@@ -37,7 +39,7 @@ package = {
         -- std modules), with the static .a libs, lldb and clang extra tools
         -- dropped. Built via .agents/tools/build-llvm-subpkg.sh (--pkg llvm).
         macosx = {
-            ["latest"] = { ref = "20.1.7" },
+            ["latest"] = { ref = "22.1.8" },
             ["20.1.7"] = {
                 url = {
                     GLOBAL = "https://github.com/xlings-res/llvm/releases/download/20.1.7/llvm-20.1.7-macosx-arm64.tar.xz",
@@ -54,13 +56,10 @@ package = {
             },
         },
         windows = {
-            ["latest"] = { ref = "20.1.7" },
+            ["latest"] = { ref = "22.1.8" },
             ["20.1.7"] = "XLINGS_RES",
             ["22.1.8"] = "XLINGS_RES",
         },
-        -- NOTE: linux 22.1.8 is produced by the maintainer's slim-build pipeline
-        -- (not carved from upstream here); add ["22.1.8"] once published, then
-        -- bump every platform's latest ref to 22.1.8 together.
     },
 }
 

--- a/pkgs/l/llvm.lua
+++ b/pkgs/l/llvm.lua
@@ -28,17 +28,36 @@ package = {
             ["latest"] = { ref = "20.1.7" },
             ["20.1.7"] = "XLINGS_RES",
         },
+        -- macOS ships a slim, self-contained toolchain carved from the upstream
+        -- full release (the 1.4GB upstream monolith is no longer mirrored):
+        -- clang/lld/binutils + compiler-rt + libc++ (headers/libs + share/libc++
+        -- std modules), with the static .a libs, lldb and clang extra tools
+        -- dropped. Built via .agents/tools/build-llvm-subpkg.sh (--pkg llvm).
         macosx = {
             ["latest"] = { ref = "20.1.7" },
             ["20.1.7"] = {
-                url = "https://gitcode.com/xlings-res/llvm/releases/download/20.1.7/LLVM-20.1.7-macOS-ARM64.tar.xz",
+                url = {
+                    GLOBAL = "https://github.com/xlings-res/llvm/releases/download/20.1.7/llvm-20.1.7-macosx-arm64.tar.xz",
+                    CN = "https://gitcode.com/xlings-res/llvm/releases/download/20.1.7/llvm-20.1.7-macosx-arm64.tar.xz",
+                },
+                sha256 = nil,
+            },
+            ["22.1.8"] = {
+                url = {
+                    GLOBAL = "https://github.com/xlings-res/llvm/releases/download/22.1.8/llvm-22.1.8-macosx-arm64.tar.xz",
+                    CN = "https://gitcode.com/xlings-res/llvm/releases/download/22.1.8/llvm-22.1.8-macosx-arm64.tar.xz",
+                },
                 sha256 = nil,
             },
         },
         windows = {
             ["latest"] = { ref = "20.1.7" },
             ["20.1.7"] = "XLINGS_RES",
+            ["22.1.8"] = "XLINGS_RES",
         },
+        -- NOTE: linux 22.1.8 is produced by the maintainer's slim-build pipeline
+        -- (not carved from upstream here); add ["22.1.8"] once published, then
+        -- bump every platform's latest ref to 22.1.8 together.
     },
 }
 

--- a/pkgs/l/llvm.lua
+++ b/pkgs/l/llvm.lua
@@ -19,6 +19,9 @@ package = {
 
     xpm = {
         linux = {
+            -- linux ships the maintainer's slim self-contained build (XLINGS_RES).
+            -- xim:linux-headers is a thin delegator to scode:linux-headers, so the
+            -- install-test harness registers the scode sub-index (see .github/scripts).
             deps = {
                 "xim:glibc@2.39",
                 "xim:linux-headers@5.11.1",

--- a/tests/l/test_llvm.py
+++ b/tests/l/test_llvm.py
@@ -36,6 +36,23 @@ class TestStatic:
     def test_no_typos(self):
         assert_no_typos(PKG_FILE)
 
+    @pytest.mark.static
+    def test_supports_22_1_8(self, meta):
+        # 22.1.8 available on macOS (slim carve) + windows (XLINGS_RES);
+        # linux 22.1.8 is pending the maintainer slim-build pipeline.
+        rc = meta.raw_content
+        assert '["22.1.8"]' in rc, "missing 22.1.8 version entry"
+        assert "llvm-22.1.8-macosx-arm64.tar.xz" in rc, \
+            "macosx must reference the 22.1.8 slim toolchain asset"
+
+    @pytest.mark.static
+    def test_macosx_uses_slim_dual_mirror(self, meta):
+        # macOS ships the slim carved toolchain on both mirrors (the 1.4GB
+        # upstream monolith is no longer mirrored).
+        rc = meta.raw_content
+        assert "llvm-20.1.7-macosx-arm64.tar.xz" in rc
+        assert "github.com/xlings-res/llvm" in rc and "gitcode.com/xlings-res/llvm" in rc
+
 
 class TestIndex:
     @pytest.mark.index

--- a/tests/l/test_llvm_tools.py
+++ b/tests/l/test_llvm_tools.py
@@ -49,6 +49,16 @@ class TestStatic:
             "macosx must provide both GLOBAL and CN mirrors"
         assert "arm64" in meta.raw_content, "archs should include arm64"
 
+    @pytest.mark.static
+    def test_supports_22_1_8(self, meta):
+        # 22.1.8 tools available on macOS + windows (carved from upstream);
+        # linux 22.1.8 pending the maintainer slim-build pipeline.
+        rc = meta.raw_content
+        assert "llvm-tools-22.1.8-macosx-arm64.tar.xz" in rc, \
+            "macosx must reference the 22.1.8 tools bundle"
+        assert "llvm-tools-22.1.8-windows-x86_64.zip" in rc, \
+            "windows must reference the 22.1.8 tools bundle"
+
 
 class TestIndex:
     @pytest.mark.index


### PR DESCRIPTION
## Summary

把 LLVM **20.1.7 平台对齐** + 新增 **22.1.8 支持**,采用 **2 包模型**(`llvm` + `llvm-tools`),
并配套 carve 工具与分包规范 skill。资产已 carve 并发布到 `xlings-res/llvm` 双镜像
(GitHub + GitCode),sha256 三方核对一致。

### 分包方案(2 包)

历史上曾拆 `llvm-core`/`llvm-libcxx`/`llvm-tools`,但 `99b004dc` 已把 libc++ 并回 `llvm`、
删除独立 `llvm-libcxx`。本 PR 遵循该决策,**不复活 core/libcxx**:

| 包 | 职责 | 核心清单(装了什么) |
|----|------|----------------------|
| **`llvm`** | slim 自包含工具链 | **bin/**(Unix 34 项):clang/clang++/clang-cl/clang-cpp/clang-`<major>`、clang-scan-deps、lld(+ld.lld/ld64.lld/lld-link/wasm-ld)、llvm-{ar,nm,ranlib,strip,objcopy,objdump,readobj,readelf,symbolizer,profdata,cov,link,as,dis,size,rc,config,lib,dlltool,addr2line,bitcode-strip,otool}、hwasan_symbolize(linux)。**Windows**(27 exe + 2 DLL):clang/clang++/clang-cl/clang-scan-deps/lld-link + llvm-{…,cvtres,cxxfilt,mt,windres,strings} + libiomp5md.dll/libomp.dll(无独立 lld/libc++)。**lib/**:`lib/clang/<major>/include`(builtin 头)+`lib/clang/<major>/lib`(compiler-rt)。**libc++**(仅 linux/mac):`include/c++/v1`、`lib/` 的 libc++/libc++abi/libunwind、`share/libc++/v1/std.cppm`(`import std;` 需要)。 |
| **`llvm-tools`** | 编辑器/开发工具 | **bin/**:clang-format、clang-tidy、clangd;**lib/**:`lib/clang/<major>/include`(clangd resource-dir)。 |

**丢弃(不进任何包)**:全部 `.a` 静态库(mac≈1.24GB)、`libclang-cpp`/`liblldb*` + lldb 工具、
clang extra 工具(clang-move/refactor/query/check/...)、MLIR、docs。
**不 strip**(LLVM release 无 DWARF debug_info,收益仅 ~8–10%)。

### 平台落地

| 平台 | `llvm` 20.1.7 | `llvm` 22.1.8 | `llvm-tools` 22.1.8 | 来源 |
|------|---------------|----------------|----------------------|------|
| macosx-arm64 | ✅ 本 PR(slim,替换已删的 1.4G 全量) | ✅ 本 PR | ✅ 本 PR | 上游 carve |
| windows-x86_64 | (现网既有) | ✅ 本 PR | ✅ 本 PR | 上游 carve |
| linux-x86_64 | (现网既有) | ⏳ 待维护者 slim 构建 | ⏳ 同左 | 自建管线 |

> `latest` 暂保持 20.1.7;待 linux 22.1.8 由维护者构建发布后,三平台一起 bump 到 22.1.8。

### 已发布资产(sha256 三方核对一致)

- `20.1.7`:`llvm-20.1.7-macosx-arm64.tar.xz`(`b216c96b…`)
- `22.1.8`:`llvm-22.1.8-macosx-arm64.tar.xz`(`50d3162c…`)、`llvm-22.1.8-windows-x86_64.{tar.xz,zip}`、
  `llvm-tools-22.1.8-{macosx-arm64.tar.xz,windows-x86_64.{tar.xz,zip}}`
- GitHub `--clobber` + GitCode `gtc`(均新资产名,无需删旧;gtc 不能删,替换同名需网页手删)。

### 配套

- `.agents/tools/build-llvm-subpkg.sh` — manifest 驱动 carve(`--pkg llvm|tools`),macOS
  Mach-O 自包含校验(纯 Python),不 strip。
- `.agents/skills/llvm-subpackaging/` — 2 包规范 / 平台矩阵 / 核心清单 / 双镜像发布 SOP。

### 附:用户反馈 `<stdfloat>` 分析

`mcpp 自带 LLVM 20(缺 stdfloat)→ 软件 float16` —— 实测 `<stdfloat>` 在**上游 libc++ 的
LLVM 20 与 22 都缺失**(只有 `cfloat`/`float.h`)。这是 **upstream libc++ 的不完整**,
**不是打包问题**(我们逐字 ship `include/c++/v1`),升级到 22 也不能修。mcpp 回退软件
`ops::float16_t` 是预期行为,**可忽略**(真要修需换 libstdc++ 或更新的 libc++ 实现)。

## Test plan

- [x] 本地 `pytest -m static`(llvm + llvm-tools,含新增 22.1.8 / macOS slim 双镜像断言)通过
- [x] 本地 `pytest -m "isolation"` + `-m index`(xim 注册)通过
- [x] 全仓 `pytest -m "static or isolation"`:756 passed,无回归
- [x] 资产 sha256 三方(carve / GitHub / GitCode)核对一致
- [ ] CI:static-and-isolation / index-registration / linux-test / **macos-install-test**
      (macOS 装 `llvm@20.1.7` slim 并编译 C++23 `import std`)/ windows-test
