### PR TITLE
mcpp: 0.0.66 (latest)

### DIFF
--- a/pkgs/m/mcpp.lua
+++ b/pkgs/m/mcpp.lua
@@ -39,7 +39,8 @@ package = {
     xpm = {
         linux = {
             url_template = "https://github.com/mcpp-community/mcpp/releases/download/v{version}/mcpp-{version}-linux-x86_64.tar.gz",
-            ["latest"] = { ref = "0.0.65" },
+            ["latest"] = { ref = "0.0.66" },
+            ["0.0.66"] = "XLINGS_RES",
             ["0.0.65"] = "XLINGS_RES",
             ["0.0.64"] = "XLINGS_RES",
             ["0.0.63"] = "XLINGS_RES",
@@ -100,7 +101,8 @@ package = {
             ["0.0.1"] = "XLINGS_RES",
         },
         macosx = {
-            ["latest"] = { ref = "0.0.65" },
+            ["latest"] = { ref = "0.0.66" },
+            ["0.0.66"] = "XLINGS_RES",
             ["0.0.65"] = "XLINGS_RES",
             ["0.0.64"] = "XLINGS_RES",
             ["0.0.63"] = "XLINGS_RES",
@@ -147,7 +149,8 @@ package = {
             ["0.0.16"] = "XLINGS_RES",
         },
         windows = {
-            ["latest"] = { ref = "0.0.65" },
+            ["latest"] = { ref = "0.0.66" },
+            ["0.0.66"] = "XLINGS_RES",
             ["0.0.65"] = "XLINGS_RES",
             ["0.0.64"] = "XLINGS_RES",
             ["0.0.63"] = "XLINGS_RES",


### PR DESCRIPTION
Bump mcpp to 0.0.66 (XLINGS_RES, 3 platforms). Mirrored to xlings-res/mcpp GitHub+GitCode. Fix: link libatomic --as-needed for clang/llvm atomic users (mcpp-community/mcpp#174). Companion llvm 22.1.8 asset now ships libatomic (xim-pkgindex#318 + re-published xlings-res/llvm asset).