### PR TITLE
mcpp: 0.0.67 (identity-first candidate selection)

### DIFF
--- a/pkgs/m/mcpp.lua
+++ b/pkgs/m/mcpp.lua
@@ -39,7 +39,8 @@ package = {
     xpm = {
         linux = {
             url_template = "https://github.com/mcpp-community/mcpp/releases/download/v{version}/mcpp-{version}-linux-x86_64.tar.gz",
-            ["latest"] = { ref = "0.0.66" },
+            ["latest"] = { ref = "0.0.67" },
+            ["0.0.67"] = "XLINGS_RES",
             ["0.0.66"] = "XLINGS_RES",
             ["0.0.65"] = "XLINGS_RES",
             ["0.0.64"] = "XLINGS_RES",
@@ -101,7 +102,8 @@ package = {
             ["0.0.1"] = "XLINGS_RES",
         },
         macosx = {
-            ["latest"] = { ref = "0.0.66" },
+            ["latest"] = { ref = "0.0.67" },
+            ["0.0.67"] = "XLINGS_RES",
             ["0.0.66"] = "XLINGS_RES",
             ["0.0.65"] = "XLINGS_RES",
             ["0.0.64"] = "XLINGS_RES",
@@ -149,7 +151,8 @@ package = {
             ["0.0.16"] = "XLINGS_RES",
         },
         windows = {
-            ["latest"] = { ref = "0.0.66" },
+            ["latest"] = { ref = "0.0.67" },
+            ["0.0.67"] = "XLINGS_RES",
             ["0.0.66"] = "XLINGS_RES",
             ["0.0.65"] = "XLINGS_RES",
             ["0.0.64"] = "XLINGS_RES",


### PR DESCRIPTION
Bump mcpp to 0.0.67 across linux/macosx/windows blocks (latest ref + XLINGS_RES entry). Mirrored to xlings-res/mcpp on GitHub + GitCode (4 platform tarballs, byte-identical verified). Upstream: mcpp-community/mcpp#176.