### PR TITLE
feat(v2): XPackage Spec V2 (multi-arch) + node per-arch fix

### DIFF
--- a/docs/V2/CHANGELOG.md
+++ b/docs/V2/CHANGELOG.md
@@ -1,0 +1,30 @@
+# XPackage V2 — Change Log
+
+Records the schema change and the per-recipe version/arch-coverage changes
+introduced with **XPackage Spec V2 (multi-arch)**. Requires **xlings ≥ 0.4.61**
+(libxpkg ≥ 0.0.42).
+
+## Schema
+
+- `spec = "2"`: architecture is now a first-class, install-time-resolved
+  dimension. New version-entry shapes: per-arch map (B), URL template +
+  per-arch sha256 (C), and `res = true` + per-arch sha256. Arch names are
+  normalized (`arm64↔aarch64`, `amd64↔x86_64`). `package.archs` is now
+  validated fail-closed. See [`xpackage-spec.md`](./xpackage-spec.md).
+
+## Recipes migrated
+
+| Recipe | spec | Change |
+|--------|------|--------|
+| `node` | 1 → 2 | **Bug fix + arch coverage.** Declared `archs={x86_64}` while shipping a `darwin-arm64`-only macOS URL and x64-only linux/windows. Now `archs={x86_64,aarch64}`; the per-version builder functions return per-arch maps (arm64 linux/windows, x64 macOS); install dir templates are arch-aware. No `url_template` dependency, so this migrates cleanly. |
+
+## Follow-up (needs maintainer reconciliation)
+
+- `github-gh`: has the same amd64-for-every-arch bug, but upstream maintains it
+  via a `url_template` field consumed by the version-check bot. Migrating to
+  per-arch maps must be reconciled with that templating/auto-versioning
+  mechanism (e.g. an arch-aware `url_template`) rather than removed — left to
+  a follow-up so the bot keeps working.
+- `cmake`: already arch-correct via `XLINGS_RES` (which embeds the host arch).
+  Migrating to the `res` shape would add per-arch checksums — deferred until
+  real per-arch sha256 values are available from the resource server.

--- a/docs/V2/xpackage-spec.md
+++ b/docs/V2/xpackage-spec.md
@@ -1,0 +1,105 @@
+# XPackage Spec V2
+
+> `spec = "2"` — adds **multi-architecture** package description.
+> V2 is a strict superset of [V1](../V1/xpackage-spec.md): every V1 recipe is a
+> valid V2 recipe. Only the additions are documented here; for everything else
+> (base fields, hooks, libxpkg stdlib, `XLINGS_RES`, mirror tables) see V1.
+
+## Why V2
+
+In V1, `xpm` resolved a download by **platform + version** only. Architecture
+was a flat `archs = {...}` metadata list that was **never used** during URL
+resolution and **never validated**. Recipes that shipped one URL per platform
+silently served the same binary to every CPU arch — e.g. a recipe declaring
+`archs = {"x86_64", "aarch64"}` but hard-coding an `amd64` URL would install a
+broken binary on ARM. V2 makes architecture a **first-class, declarative,
+install-time-resolved** dimension, with a mandatory per-arch checksum.
+
+Requires **xlings ≥ 0.4.61** (libxpkg ≥ 0.0.42). Older clients ignore the new
+shapes; keep a V1 fallback entry if you must support them.
+
+## Arch names (canonical + aliases)
+
+Use the **canonical** spelling in `archs` and in arch keys. Aliases are
+accepted on input and normalized:
+
+| Canonical | Accepted aliases |
+|-----------|------------------|
+| `x86_64`  | `amd64`, `x64`, `x86-64` |
+| `aarch64` | `arm64`, `armv8` |
+| `x86`     | `i386`, `i686` |
+
+Resolution and `archs` validation are **fail-closed**: if the host arch is not
+provided by the entry (and `archs` is non-empty and excludes it), the install
+aborts with a clear error instead of fetching a wrong binary.
+
+## The three new version-entry shapes
+
+A version entry value may now be, in addition to the V1 forms
+(`"XLINGS_RES"`, `"url-string"`, `{ url=, sha256=, ref= }`):
+
+### Shape B — per-arch resource map
+
+Each arch carries its own `url` (string or `{GLOBAL=,CN=}` mirror table) and
+`sha256`. Best when upstream URLs are irregular.
+
+```lua
+["2.86.0"] = {
+    x86_64  = { url = "https://.../gh_2.86.0_linux_amd64.tar.gz", sha256 = "..." },
+    aarch64 = { url = "https://.../gh_2.86.0_linux_arm64.tar.gz", sha256 = "..." },
+}
+```
+
+### Shape C — URL template + per-arch sha256
+
+One `url` template covers all arches; `sha256` becomes a per-arch table.
+Placeholders: `${name}` `${version}` `${os}` (`linux`/`macosx`/`windows`)
+`${arch}` (canonical) `${arch_alias}` (mapped via the optional `arch_alias`
+table) `${ext}` (`zip` on windows, else `tar.gz`). Best when URLs are regular.
+
+```lua
+["1.0.0"] = {
+    url = "https://ex/${name}-${version}-${os}-${arch_alias}.${ext}",
+    sha256 = { x86_64 = "aaaa...", aarch64 = "bbbb..." },
+    arch_alias = { x86_64 = "amd64", aarch64 = "arm64" },  -- optional
+}
+```
+
+### Shape res — `XLINGS_RES` with per-arch checksums
+
+The V1 `"XLINGS_RES"` magic string auto-generates a URL but carries **no
+checksum**. The `res` shape closes that gap: same auto-URL, now with a
+mandatory per-arch `sha256`.
+
+```lua
+["4.0.2"] = {
+    res = true,
+    sha256 = { x86_64 = "aaaa...", aarch64 = "bbbb..." },
+}
+```
+Auto-URL pattern (unchanged from V1 `XLINGS_RES`):
+`{res-server}/{name}/releases/download/{version}/{name}-{version}-{os}-{arch}.{ext}`
+
+## Resolution order (install time, on the host)
+
+1. follow version `ref` (e.g. `latest → 4.0.2`) — unchanged;
+2. **Shape B**: pick `archs[host_arch]` → `{url, sha256}` (fail-closed);
+3. **res**: build the `XLINGS_RES` URL + `sha256[host_arch]` (fail-closed);
+4. **Shape C**: expand the template with the host arch + `sha256[host_arch]` (fail-closed);
+5. otherwise the V1 single-arch path (`url`/`sha256`/`XLINGS_RES`) — unchanged;
+6. mirror (`GLOBAL`/`CN`) selection applies **after** the arch pick.
+
+The index keeps the **raw, arch-agnostic** data; arch is resolved per-host at
+install time (so a single shared index artifact serves every arch).
+
+## Install hooks must be arch-aware too
+
+If a recipe unpacks an arch-named directory, derive it from `os.arch()` in the
+hook (don't hard-code one arch). `os.arch()` returns the canonical host arch.
+
+```lua
+function install()
+    local dir = string.format("gh_%s_%s_%s", pkginfo.version(), os.host(), os.arch())
+    -- ... move dir into pkginfo.install_dir()
+end
+```

--- a/docs/V2/xpackage-template.lua
+++ b/docs/V2/xpackage-template.lua
@@ -1,0 +1,64 @@
+package = {
+    spec = "2",
+
+    -- base info
+    name = "package-name",
+    description = "Package description",
+    type = "package",
+    licenses = {"MIT"},
+    repo = "https://example.com/repo",
+
+    -- xim pkg info. archs is validated fail-closed against the host arch.
+    archs = {"x86_64", "aarch64"},
+    status = "stable",
+    programs = {"program1"},
+    xvm_enable = true,
+
+    xpm = {
+        -- Shape B: per-arch resource map (irregular upstream URLs)
+        linux = {
+            ["latest"] = { ref = "1.0.0" },
+            ["1.0.0"] = {
+                x86_64  = { url = "https://ex/pkg-1.0.0-linux-x86_64.tar.gz", sha256 = "..." },
+                aarch64 = { url = "https://ex/pkg-1.0.0-linux-arm64.tar.gz",  sha256 = "..." },
+            },
+        },
+        -- Shape C: URL template + per-arch sha256 (regular URLs).
+        -- Placeholders: ${name} ${version} ${os} ${arch} ${arch_alias} ${ext}
+        macosx = {
+            ["latest"] = { ref = "1.0.0" },
+            ["1.0.0"] = {
+                url = "https://ex/${name}-${version}-${os}-${arch_alias}.${ext}",
+                sha256 = { x86_64 = "...", aarch64 = "..." },
+                arch_alias = { x86_64 = "amd64", aarch64 = "arm64" },
+            },
+        },
+        -- Shape res: XLINGS_RES auto-URL + per-arch checksums
+        windows = {
+            ["latest"] = { ref = "1.0.0" },
+            ["1.0.0"] = {
+                res = true,
+                sha256 = { x86_64 = "...", aarch64 = "..." },
+            },
+        },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+
+function install()
+    -- os.arch() returns the canonical host arch (x86_64 / aarch64)
+    os.mv("program1", pkginfo.install_dir())
+    return true
+end
+
+function config()
+    xvm.add("package-name")
+    return true
+end
+
+function uninstall()
+    xvm.remove("package-name")
+    return true
+end

--- a/pkgs/n/node.lua
+++ b/pkgs/n/node.lua
@@ -1,17 +1,33 @@
+-- V2 Scheme B per-arch builders: each returns a { x86_64 = {...}, aarch64 = {...} }
+-- map so x86_64 AND aarch64 both resolve to the correct nodejs.org asset.
+-- (V1 previously shipped only x64 on linux/windows and only darwin-arm64 on
+-- macOS, contradicting its own archs declaration.)
 local function _win_url(ver)
-    return { url = string.format("https://nodejs.org/dist/v%s/node-v%s-win-x64.zip", ver, ver), sha256 = nil }
+    return {
+        x86_64  = { url = string.format("https://nodejs.org/dist/v%s/node-v%s-win-x64.zip",   ver, ver) },
+        aarch64 = { url = string.format("https://nodejs.org/dist/v%s/node-v%s-win-arm64.zip", ver, ver) },
+    }
 end
 local function _linux_url(ver)
-    return { url = string.format("https://nodejs.org/dist/v%s/node-v%s-linux-x64.tar.xz", ver, ver), sha256 = nil }
+    return {
+        x86_64  = { url = string.format("https://nodejs.org/dist/v%s/node-v%s-linux-x64.tar.xz",   ver, ver) },
+        aarch64 = { url = string.format("https://nodejs.org/dist/v%s/node-v%s-linux-arm64.tar.xz", ver, ver) },
+    }
 end
 local function _mac_url(ver)
-    return { url = string.format("https://nodejs.org/dist/v%s/node-v%s-darwin-arm64.tar.gz", ver, ver), sha256 = nil }
+    return {
+        x86_64  = { url = string.format("https://nodejs.org/dist/v%s/node-v%s-darwin-x64.tar.gz",   ver, ver) },
+        aarch64 = { url = string.format("https://nodejs.org/dist/v%s/node-v%s-darwin-arm64.tar.gz", ver, ver) },
+    }
 end
+
+-- node's release dir/file token per platform+arch (used by install()).
+local function _node_arch() return ({ x86_64 = "x64", aarch64 = "arm64" })[os.arch()] or "x64" end
 
 -- xpkg info
 
 package = {
-    spec = "1",
+    spec = "2",
     homepage = "https://nodejs.org",
     name = "node",
     description = "Node.js is a JavaScript runtime built on Chrome's V8 JavaScript engine",
@@ -22,7 +38,7 @@ package = {
     docs = "https://nodejs.org/docs",
 
     -- xim pkg info
-    archs = {"x86_64"},
+    archs = {"x86_64", "aarch64"},
     status = "stable", -- dev, stable, deprecated
     categories = {"node", "javascript"},
 
@@ -89,17 +105,18 @@ import("xim.libxpkg.pkginfo")
 import("xim.libxpkg.xvm")
 import("xim.libxpkg.log")
 
+-- Arch-aware extracted-dir templates (node uses x64/arm64 tokens).
 local node_dir_template = {
-    linux = "node-v%s-linux-x64",
-    windows = "node-v%s-win-x64",
-    macosx = "node-v%s-darwin-arm64",
+    linux = "node-v%s-linux-%s",
+    windows = "node-v%s-win-%s",
+    macosx = "node-v%s-darwin-%s",
 }
 
 function install()
     os.tryrm(pkginfo.install_dir())
     log.debug("Installing Node.js to %s ...", pkginfo.install_dir())
     os.mv(
-        string.format(node_dir_template[os.host()], pkginfo.version()),
+        string.format(node_dir_template[os.host()], pkginfo.version(), _node_arch()),
         pkginfo.install_dir()
     )
     return true


### PR DESCRIPTION
## What
Introduces **XPackage Spec V2 (multi-arch)** docs and migrates `node`.

- `docs/V2/`: spec (per-arch map / URL-template+per-arch-sha256 / `res` shapes), template, CHANGELOG. Arch normalization (arm64↔aarch64) + fail-closed `archs` validation. Requires xlings ≥ 0.4.61 (libxpkg ≥ 0.0.42).
- `node`: spec 1→2; `archs {x86_64}` → `{x86_64,aarch64}`; the per-version builder functions now return per-arch maps (adds arm64 linux/windows, x64 macOS — fixes the declared-x86_64-but-shipped-darwin-arm64 inconsistency); install dir is arch-aware. No `url_template` dependency → clean migration.

## Deferred (see CHANGELOG)
- `github-gh`: same amd64-for-every-arch bug, but upstream drives it via a `url_template` consumed by the version-check bot. Per-arch migration must be reconciled with that mechanism (arch-aware template) rather than dropping it — left as follow-up so the bot keeps working.
- `cmake`: already arch-correct via `XLINGS_RES`; `res`-shape checksums deferred until real per-arch sha256 are available.

Depends on the engine: openxlings/xlings#346 (0.4.61) + openxlings/libxpkg 0.0.42 (merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)