### PR TITLE
mcpp: 0.0.68 (dimensional ABI compat)

### DIFF
--- a/pkgs/m/mcpp.lua
+++ b/pkgs/m/mcpp.lua
@@ -39,7 +39,8 @@ package = {
     xpm = {
         linux = {
             url_template = "https://github.com/mcpp-community/mcpp/releases/download/v{version}/mcpp-{version}-linux-x86_64.tar.gz",
-            ["latest"] = { ref = "0.0.67" },
+            ["latest"] = { ref = "0.0.68" },
+            ["0.0.68"] = "XLINGS_RES",
             ["0.0.67"] = "XLINGS_RES",
             ["0.0.66"] = "XLINGS_RES",
             ["0.0.65"] = "XLINGS_RES",
@@ -102,7 +103,8 @@ package = {
             ["0.0.1"] = "XLINGS_RES",
         },
         macosx = {
-            ["latest"] = { ref = "0.0.67" },
+            ["latest"] = { ref = "0.0.68" },
+            ["0.0.68"] = "XLINGS_RES",
             ["0.0.67"] = "XLINGS_RES",
             ["0.0.66"] = "XLINGS_RES",
             ["0.0.65"] = "XLINGS_RES",
@@ -151,7 +153,8 @@ package = {
             ["0.0.16"] = "XLINGS_RES",
         },
         windows = {
-            ["latest"] = { ref = "0.0.67" },
+            ["latest"] = { ref = "0.0.68" },
+            ["0.0.68"] = "XLINGS_RES",
             ["0.0.67"] = "XLINGS_RES",
             ["0.0.66"] = "XLINGS_RES",
             ["0.0.65"] = "XLINGS_RES",


### PR DESCRIPTION
Bumps mcpp to 0.0.68 (all 3 platform blocks: latest ref + XLINGS_RES sentinel). 0.0.68 fixes the dimensional ABI compat bug (glibc C library buildable under clang/libc++). Mirrored to xlings-res/mcpp (github + gitcode, 4 platforms, sha256 verified).