### PR TITLE
mcpp: 0.0.70 (latest) — XLINGS_RES mirrors

### DIFF
--- a/pkgs/m/mcpp.lua
+++ b/pkgs/m/mcpp.lua
@@ -39,7 +39,8 @@ package = {
     xpm = {
         linux = {
             url_template = "https://github.com/mcpp-community/mcpp/releases/download/v{version}/mcpp-{version}-linux-x86_64.tar.gz",
-            ["latest"] = { ref = "0.0.68" },
+            ["latest"] = { ref = "0.0.70" },
+            ["0.0.70"] = "XLINGS_RES",
             ["0.0.68"] = "XLINGS_RES",
             ["0.0.67"] = "XLINGS_RES",
             ["0.0.66"] = "XLINGS_RES",
@@ -103,7 +104,8 @@ package = {
             ["0.0.1"] = "XLINGS_RES",
         },
         macosx = {
-            ["latest"] = { ref = "0.0.68" },
+            ["latest"] = { ref = "0.0.70" },
+            ["0.0.70"] = "XLINGS_RES",
             ["0.0.68"] = "XLINGS_RES",
             ["0.0.67"] = "XLINGS_RES",
             ["0.0.66"] = "XLINGS_RES",
@@ -153,7 +155,8 @@ package = {
             ["0.0.16"] = "XLINGS_RES",
         },
         windows = {
-            ["latest"] = { ref = "0.0.68" },
+            ["latest"] = { ref = "0.0.70" },
+            ["0.0.70"] = "XLINGS_RES",
             ["0.0.68"] = "XLINGS_RES",
             ["0.0.67"] = "XLINGS_RES",
             ["0.0.66"] = "XLINGS_RES",


### PR DESCRIPTION
Point mcpp `latest` to 0.0.70 across linux/macosx/windows and add the 0.0.70 → XLINGS_RES entry. Artifacts mirrored to xlings-res/mcpp on GitHub + GitCode (4 platforms verified). 

0.0.70 = cold-init mirror auto-detection (hands region selection back to xlings; fixes overseas/GitHub-CI cold bootstrap) + Feature System v2 (feature `defines` + `provides`/`requires` capabilities).