### PR TITLE
feat(mcpp): bump latest -> 0.0.72

### DIFF
--- a/pkgs/m/mcpp.lua
+++ b/pkgs/m/mcpp.lua
@@ -39,7 +39,8 @@ package = {
     xpm = {
         linux = {
             url_template = "https://github.com/mcpp-community/mcpp/releases/download/v{version}/mcpp-{version}-linux-x86_64.tar.gz",
-            ["latest"] = { ref = "0.0.70" },
+            ["latest"] = { ref = "0.0.72" },
+            ["0.0.72"] = "XLINGS_RES",
             ["0.0.70"] = "XLINGS_RES",
             ["0.0.68"] = "XLINGS_RES",
             ["0.0.67"] = "XLINGS_RES",
@@ -104,7 +105,8 @@ package = {
             ["0.0.1"] = "XLINGS_RES",
         },
         macosx = {
-            ["latest"] = { ref = "0.0.70" },
+            ["latest"] = { ref = "0.0.72" },
+            ["0.0.72"] = "XLINGS_RES",
             ["0.0.70"] = "XLINGS_RES",
             ["0.0.68"] = "XLINGS_RES",
             ["0.0.67"] = "XLINGS_RES",
@@ -155,7 +157,8 @@ package = {
             ["0.0.16"] = "XLINGS_RES",
         },
         windows = {
-            ["latest"] = { ref = "0.0.70" },
+            ["latest"] = { ref = "0.0.72" },
+            ["0.0.72"] = "XLINGS_RES",
             ["0.0.70"] = "XLINGS_RES",
             ["0.0.68"] = "XLINGS_RES",
             ["0.0.67"] = "XLINGS_RES",


### PR DESCRIPTION
Bumps `pkgs/m/mcpp.lua` (linux/macosx/windows) latest → 0.0.72, mirrored to xlings-res/mcpp (GitHub + GitCode).

0.0.72 adds interface-define propagation (a dependency's active-feature defines reach consumers along Public/Interface edges), completing the eigen[backend-openblas] feature/capability closed loop. Includes Stage 2a (feature-activated optional deps) from 0.0.71.