### PR TITLE
bump(mcpp): 0.0.72 -> 0.0.73

### DIFF
--- a/pkgs/m/mcpp.lua
+++ b/pkgs/m/mcpp.lua
@@ -39,7 +39,8 @@ package = {
     xpm = {
         linux = {
             url_template = "https://github.com/mcpp-community/mcpp/releases/download/v{version}/mcpp-{version}-linux-x86_64.tar.gz",
-            ["latest"] = { ref = "0.0.72" },
+            ["latest"] = { ref = "0.0.73" },
+            ["0.0.73"] = "XLINGS_RES",
             ["0.0.72"] = "XLINGS_RES",
             ["0.0.70"] = "XLINGS_RES",
             ["0.0.68"] = "XLINGS_RES",
@@ -105,7 +106,8 @@ package = {
             ["0.0.1"] = "XLINGS_RES",
         },
         macosx = {
-            ["latest"] = { ref = "0.0.72" },
+            ["latest"] = { ref = "0.0.73" },
+            ["0.0.73"] = "XLINGS_RES",
             ["0.0.72"] = "XLINGS_RES",
             ["0.0.70"] = "XLINGS_RES",
             ["0.0.68"] = "XLINGS_RES",
@@ -157,7 +159,8 @@ package = {
             ["0.0.16"] = "XLINGS_RES",
         },
         windows = {
-            ["latest"] = { ref = "0.0.72" },
+            ["latest"] = { ref = "0.0.73" },
+            ["0.0.73"] = "XLINGS_RES",
             ["0.0.72"] = "XLINGS_RES",
             ["0.0.70"] = "XLINGS_RES",
             ["0.0.68"] = "XLINGS_RES",


### PR DESCRIPTION
Bump mcpp to 0.0.73 (Windows runtime-DLL deployment beside the executable).

Assets mirrored to xlings-res/mcpp on GitHub + GitCode, byte-identical to upstream mcpp-community/mcpp v0.0.73 (linux-x86_64, linux-aarch64, macosx-arm64, windows-x86_64), GET-verified. `latest` -> 0.0.73 across all three platform blocks; each version resolves via the XLINGS_RES sentinel.