### PR TITLE
bump(mcpp): 0.0.73 -> 0.0.74

### DIFF
--- a/pkgs/m/mcpp.lua
+++ b/pkgs/m/mcpp.lua
@@ -39,7 +39,8 @@ package = {
     xpm = {
         linux = {
             url_template = "https://github.com/mcpp-community/mcpp/releases/download/v{version}/mcpp-{version}-linux-x86_64.tar.gz",
-            ["latest"] = { ref = "0.0.73" },
+            ["latest"] = { ref = "0.0.74" },
+            ["0.0.74"] = "XLINGS_RES",
             ["0.0.73"] = "XLINGS_RES",
             ["0.0.72"] = "XLINGS_RES",
             ["0.0.70"] = "XLINGS_RES",
@@ -106,7 +107,8 @@ package = {
             ["0.0.1"] = "XLINGS_RES",
         },
         macosx = {
-            ["latest"] = { ref = "0.0.73" },
+            ["latest"] = { ref = "0.0.74" },
+            ["0.0.74"] = "XLINGS_RES",
             ["0.0.73"] = "XLINGS_RES",
             ["0.0.72"] = "XLINGS_RES",
             ["0.0.70"] = "XLINGS_RES",
@@ -159,7 +161,8 @@ package = {
             ["0.0.16"] = "XLINGS_RES",
         },
         windows = {
-            ["latest"] = { ref = "0.0.73" },
+            ["latest"] = { ref = "0.0.74" },
+            ["0.0.74"] = "XLINGS_RES",
             ["0.0.73"] = "XLINGS_RES",
             ["0.0.72"] = "XLINGS_RES",
             ["0.0.70"] = "XLINGS_RES",


### PR DESCRIPTION
Bump mcpp to 0.0.74 (platform-conditional `[target.'cfg(...)'.build]` flags). Assets mirrored to xlings-res/mcpp (GitHub + GitCode), byte-verified. latest -> 0.0.74 across all three platform blocks.