### PR TITLE
bump(mcpp): 0.0.75 -> 0.0.76

### DIFF
--- a/pkgs/m/mcpp.lua
+++ b/pkgs/m/mcpp.lua
@@ -39,7 +39,8 @@ package = {
     xpm = {
         linux = {
             url_template = "https://github.com/mcpp-community/mcpp/releases/download/v{version}/mcpp-{version}-linux-x86_64.tar.gz",
-            ["latest"] = { ref = "0.0.75" },
+            ["latest"] = { ref = "0.0.76" },
+            ["0.0.76"] = "XLINGS_RES",
             ["0.0.75"] = "XLINGS_RES",
             ["0.0.74"] = "XLINGS_RES",
             ["0.0.73"] = "XLINGS_RES",
@@ -108,7 +109,8 @@ package = {
             ["0.0.1"] = "XLINGS_RES",
         },
         macosx = {
-            ["latest"] = { ref = "0.0.75" },
+            ["latest"] = { ref = "0.0.76" },
+            ["0.0.76"] = "XLINGS_RES",
             ["0.0.75"] = "XLINGS_RES",
             ["0.0.74"] = "XLINGS_RES",
             ["0.0.73"] = "XLINGS_RES",
@@ -163,7 +165,8 @@ package = {
             ["0.0.16"] = "XLINGS_RES",
         },
         windows = {
-            ["latest"] = { ref = "0.0.75" },
+            ["latest"] = { ref = "0.0.76" },
+            ["0.0.76"] = "XLINGS_RES",
             ["0.0.75"] = "XLINGS_RES",
             ["0.0.74"] = "XLINGS_RES",
             ["0.0.73"] = "XLINGS_RES",


### PR DESCRIPTION
Bump mcpp to 0.0.76 (default build profile = dev, mainstream; --release opt-in). Mirrored to xlings-res (gh+gtc), all 4 assets GET-verified 200. latest -> 0.0.76.