### PR TITLE
bump(mcpp): 0.0.76 -> 0.0.77

### DIFF
--- a/pkgs/m/mcpp.lua
+++ b/pkgs/m/mcpp.lua
@@ -39,7 +39,8 @@ package = {
     xpm = {
         linux = {
             url_template = "https://github.com/mcpp-community/mcpp/releases/download/v{version}/mcpp-{version}-linux-x86_64.tar.gz",
-            ["latest"] = { ref = "0.0.76" },
+            ["latest"] = { ref = "0.0.77" },
+            ["0.0.77"] = "XLINGS_RES",
             ["0.0.76"] = "XLINGS_RES",
             ["0.0.75"] = "XLINGS_RES",
             ["0.0.74"] = "XLINGS_RES",
@@ -109,7 +110,8 @@ package = {
             ["0.0.1"] = "XLINGS_RES",
         },
         macosx = {
-            ["latest"] = { ref = "0.0.76" },
+            ["latest"] = { ref = "0.0.77" },
+            ["0.0.77"] = "XLINGS_RES",
             ["0.0.76"] = "XLINGS_RES",
             ["0.0.75"] = "XLINGS_RES",
             ["0.0.74"] = "XLINGS_RES",
@@ -165,7 +167,8 @@ package = {
             ["0.0.16"] = "XLINGS_RES",
         },
         windows = {
-            ["latest"] = { ref = "0.0.76" },
+            ["latest"] = { ref = "0.0.77" },
+            ["0.0.77"] = "XLINGS_RES",
             ["0.0.76"] = "XLINGS_RES",
             ["0.0.75"] = "XLINGS_RES",
             ["0.0.74"] = "XLINGS_RES",


### PR DESCRIPTION
Bump mcpp to 0.0.77 ([xlings] build environment → .xlings.json). Mirrored to xlings-res (gh+gtc), GET-verified 200. latest -> 0.0.77.