### PR TITLE
mcpp: 0.0.78 (L3 build.mcpp)

### DIFF
--- a/pkgs/m/mcpp.lua
+++ b/pkgs/m/mcpp.lua
@@ -39,7 +39,8 @@ package = {
     xpm = {
         linux = {
             url_template = "https://github.com/mcpp-community/mcpp/releases/download/v{version}/mcpp-{version}-linux-x86_64.tar.gz",
-            ["latest"] = { ref = "0.0.77" },
+            ["latest"] = { ref = "0.0.78" },
+            ["0.0.78"] = "XLINGS_RES",
             ["0.0.77"] = "XLINGS_RES",
             ["0.0.76"] = "XLINGS_RES",
             ["0.0.75"] = "XLINGS_RES",
@@ -110,7 +111,8 @@ package = {
             ["0.0.1"] = "XLINGS_RES",
         },
         macosx = {
-            ["latest"] = { ref = "0.0.77" },
+            ["latest"] = { ref = "0.0.78" },
+            ["0.0.78"] = "XLINGS_RES",
             ["0.0.77"] = "XLINGS_RES",
             ["0.0.76"] = "XLINGS_RES",
             ["0.0.75"] = "XLINGS_RES",
@@ -167,7 +169,8 @@ package = {
             ["0.0.16"] = "XLINGS_RES",
         },
         windows = {
-            ["latest"] = { ref = "0.0.77" },
+            ["latest"] = { ref = "0.0.78" },
+            ["0.0.78"] = "XLINGS_RES",
             ["0.0.77"] = "XLINGS_RES",
             ["0.0.76"] = "XLINGS_RES",
             ["0.0.75"] = "XLINGS_RES",


### PR DESCRIPTION
Bump mcpp latest → 0.0.78 in all 3 platform blocks; add `["0.0.78"] = "XLINGS_RES"`. Assets mirrored to xlings-res/mcpp on GitHub + GitCode, all 4 platforms GET-verified (200 + bytes match).