### PR TITLE
mcpp: 0.0.79

### DIFF
--- a/pkgs/m/mcpp.lua
+++ b/pkgs/m/mcpp.lua
@@ -39,7 +39,8 @@ package = {
     xpm = {
         linux = {
             url_template = "https://github.com/mcpp-community/mcpp/releases/download/v{version}/mcpp-{version}-linux-x86_64.tar.gz",
-            ["latest"] = { ref = "0.0.78" },
+            ["latest"] = { ref = "0.0.79" },
+            ["0.0.79"] = "XLINGS_RES",
             ["0.0.78"] = "XLINGS_RES",
             ["0.0.77"] = "XLINGS_RES",
             ["0.0.76"] = "XLINGS_RES",
@@ -111,7 +112,8 @@ package = {
             ["0.0.1"] = "XLINGS_RES",
         },
         macosx = {
-            ["latest"] = { ref = "0.0.78" },
+            ["latest"] = { ref = "0.0.79" },
+            ["0.0.79"] = "XLINGS_RES",
             ["0.0.78"] = "XLINGS_RES",
             ["0.0.77"] = "XLINGS_RES",
             ["0.0.76"] = "XLINGS_RES",
@@ -169,7 +171,8 @@ package = {
             ["0.0.16"] = "XLINGS_RES",
         },
         windows = {
-            ["latest"] = { ref = "0.0.78" },
+            ["latest"] = { ref = "0.0.79" },
+            ["0.0.79"] = "XLINGS_RES",
             ["0.0.78"] = "XLINGS_RES",
             ["0.0.77"] = "XLINGS_RES",
             ["0.0.76"] = "XLINGS_RES",


### PR DESCRIPTION
Bump mcpp latest → 0.0.79 in all 3 platform blocks; add `["0.0.79"] = "XLINGS_RES"`. Assets mirrored to xlings-res/mcpp on GitHub + GitCode, all 4 platforms GET-verified (200 + bytes match).