### PR TITLE
mcpp: 0.0.81

### DIFF
--- a/pkgs/m/mcpp.lua
+++ b/pkgs/m/mcpp.lua
@@ -39,7 +39,8 @@ package = {
     xpm = {
         linux = {
             url_template = "https://github.com/mcpp-community/mcpp/releases/download/v{version}/mcpp-{version}-linux-x86_64.tar.gz",
-            ["latest"] = { ref = "0.0.80" },
+            ["latest"] = { ref = "0.0.81" },
+            ["0.0.81"] = "XLINGS_RES",
             ["0.0.80"] = "XLINGS_RES",
             ["0.0.79"] = "XLINGS_RES",
             ["0.0.78"] = "XLINGS_RES",
@@ -113,7 +114,8 @@ package = {
             ["0.0.1"] = "XLINGS_RES",
         },
         macosx = {
-            ["latest"] = { ref = "0.0.80" },
+            ["latest"] = { ref = "0.0.81" },
+            ["0.0.81"] = "XLINGS_RES",
             ["0.0.80"] = "XLINGS_RES",
             ["0.0.79"] = "XLINGS_RES",
             ["0.0.78"] = "XLINGS_RES",
@@ -173,7 +175,8 @@ package = {
             ["0.0.16"] = "XLINGS_RES",
         },
         windows = {
-            ["latest"] = { ref = "0.0.80" },
+            ["latest"] = { ref = "0.0.81" },
+            ["0.0.81"] = "XLINGS_RES",
             ["0.0.80"] = "XLINGS_RES",
             ["0.0.79"] = "XLINGS_RES",
             ["0.0.78"] = "XLINGS_RES",


### PR DESCRIPTION
Bump mcpp latest → 0.0.81 (typed import mcpp; build module). Assets mirrored to xlings-res/mcpp on GitHub + GitCode, all 4 platforms GET-verified (200).