### PR TITLE
mcpp: 0.0.82

### DIFF
--- a/pkgs/m/mcpp.lua
+++ b/pkgs/m/mcpp.lua
@@ -39,7 +39,8 @@ package = {
     xpm = {
         linux = {
             url_template = "https://github.com/mcpp-community/mcpp/releases/download/v{version}/mcpp-{version}-linux-x86_64.tar.gz",
-            ["latest"] = { ref = "0.0.81" },
+            ["latest"] = { ref = "0.0.82" },
+            ["0.0.82"] = "XLINGS_RES",
             ["0.0.81"] = "XLINGS_RES",
             ["0.0.80"] = "XLINGS_RES",
             ["0.0.79"] = "XLINGS_RES",
@@ -114,7 +115,8 @@ package = {
             ["0.0.1"] = "XLINGS_RES",
         },
         macosx = {
-            ["latest"] = { ref = "0.0.81" },
+            ["latest"] = { ref = "0.0.82" },
+            ["0.0.82"] = "XLINGS_RES",
             ["0.0.81"] = "XLINGS_RES",
             ["0.0.80"] = "XLINGS_RES",
             ["0.0.79"] = "XLINGS_RES",
@@ -175,7 +177,8 @@ package = {
             ["0.0.16"] = "XLINGS_RES",
         },
         windows = {
-            ["latest"] = { ref = "0.0.81" },
+            ["latest"] = { ref = "0.0.82" },
+            ["0.0.82"] = "XLINGS_RES",
             ["0.0.81"] = "XLINGS_RES",
             ["0.0.80"] = "XLINGS_RES",
             ["0.0.79"] = "XLINGS_RES",


### PR DESCRIPTION
Bump mcpp to 0.0.82 across linux/macosx/windows blocks (latest ref + new `["0.0.82"] = XLINGS_RES`). Mirrored to xlings-res/mcpp (github + gitcode), all 4 platform tarballs GET-verified 200 + sha256 match on both ends. This release rebases the mcpp release pipeline on xlings 0.4.62 (aarch64 bundle + bootstrap).