### PR TITLE
bump(xlings): track 0.4.62 as latest (index stale at 0.4.60)

### DIFF
--- a/pkgs/x/xlings.lua
+++ b/pkgs/x/xlings.lua
@@ -37,7 +37,8 @@ package = {
             -- res_versioned: version-bump bot tracks openxlings/xlings releases and
             -- appends new ["x.y.z"] = "XLINGS_RES" entries (see version-check.py).
             res_versioned = true,
-            ["latest"] = { ref = "0.4.60" },
+            ["latest"] = { ref = "0.4.62" },
+            ["0.4.62"] = "XLINGS_RES",
             ["0.4.60"] = "XLINGS_RES",
             ["0.4.55"] = "XLINGS_RES",
             ["0.4.54"] = "XLINGS_RES",
@@ -189,7 +190,8 @@ package = {
             -- res_versioned: version-bump bot tracks openxlings/xlings releases and
             -- appends new ["x.y.z"] = "XLINGS_RES" entries (see version-check.py).
             res_versioned = true,
-            ["latest"] = { ref = "0.4.60" },
+            ["latest"] = { ref = "0.4.62" },
+            ["0.4.62"] = "XLINGS_RES",
             ["0.4.60"] = "XLINGS_RES",
             ["0.4.55"] = "XLINGS_RES",
             ["0.4.54"] = "XLINGS_RES",
@@ -341,7 +343,8 @@ package = {
             -- res_versioned: version-bump bot tracks openxlings/xlings releases and
             -- appends new ["x.y.z"] = "XLINGS_RES" entries (see version-check.py).
             res_versioned = true,
-            ["latest"] = { ref = "0.4.60" },
+            ["latest"] = { ref = "0.4.62" },
+            ["0.4.62"] = "XLINGS_RES",
             ["0.4.60"] = "XLINGS_RES",
             ["0.4.55"] = "XLINGS_RES",
             ["0.4.54"] = "XLINGS_RES",


### PR DESCRIPTION
## Why
`xlings update` reports `xim:xlings@0.4.60 is already the latest`, even though **0.4.62** (and 0.4.61) shipped.

Root cause: the index was stale, **not** xlings-res.
- ✅ Releases `0.4.61`/`0.4.62` are published on `openxlings/xlings` and mirrored to `xlings-res/xlings` on **both GitHub and GitCode** with all platform assets — `XLINGS_RES` resolves fine.
- ❌ `pkgs/x/xlings.lua` still pinned `latest.ref = 0.4.60` with no newer entries, so the git index **and** the published artifact both resolve latest = 0.4.60.

Why the bot didn't catch it: the daily `version-check` workflow runs **Phase-1 dry-run only** (`cron 0 1 * * *`). Today's run correctly detected `xlings current=0.4.60 upstream=0.4.62 → update-available`, but only uploaded `version-report.json` as an artifact — there is no apply/commit/PR step wired in.

## What
Generated with `version-check.py --apply --only xlings`: append `["0.4.62"] = "XLINGS_RES"` and set `latest.ref = 0.4.62` on linux/macosx/windows. `lua` parse OK.

After merge, **Publish Index Artifact** republishes the artifact and **gitee-sync** mirrors to the Gitee index, so `xlings update` will resolve 0.4.62.

## Follow-up (separate)
Promote `version-check.yml` from Phase-1 dry-run to Phase-2 (auto `--apply` + open PR) so future releases don't go stale by hand.