### PR TITLE
fix(mcpp): mark all platforms res_versioned (consistent XLINGS_RES auto-bump)

### DIFF
--- a/pkgs/m/mcpp.lua
+++ b/pkgs/m/mcpp.lua
@@ -38,7 +38,9 @@ package = {
     -- directly; the shell launcher is only useful from the bundle root.
     xpm = {
         linux = {
-            url_template = "https://github.com/mcpp-community/mcpp/releases/download/v{version}/mcpp-{version}-linux-x86_64.tar.gz",
+            -- res_versioned: version-bump bot tracks mcpp-community/mcpp releases
+            -- and appends new ["x.y.z"] = "XLINGS_RES" entries (see version-check.py).
+            res_versioned = true,
             ["latest"] = { ref = "0.0.82" },
             ["0.0.82"] = "XLINGS_RES",
             ["0.0.81"] = "XLINGS_RES",
@@ -115,6 +117,9 @@ package = {
             ["0.0.1"] = "XLINGS_RES",
         },
         macosx = {
+            -- res_versioned: version-bump bot tracks mcpp-community/mcpp releases
+            -- and appends new ["x.y.z"] = "XLINGS_RES" entries (see version-check.py).
+            res_versioned = true,
             ["latest"] = { ref = "0.0.82" },
             ["0.0.82"] = "XLINGS_RES",
             ["0.0.81"] = "XLINGS_RES",
@@ -177,6 +182,9 @@ package = {
             ["0.0.16"] = "XLINGS_RES",
         },
         windows = {
+            -- res_versioned: version-bump bot tracks mcpp-community/mcpp releases
+            -- and appends new ["x.y.z"] = "XLINGS_RES" entries (see version-check.py).
+            res_versioned = true,
             ["latest"] = { ref = "0.0.82" },
             ["0.0.82"] = "XLINGS_RES",
             ["0.0.81"] = "XLINGS_RES",


### PR DESCRIPTION
## Why
Enables the mcpp release pipeline's **automated index bump** (mcpp-community/mcpp#194) to produce entries consistent with how mcpp is actually maintained.

Today `pkgs/m/mcpp.lua` is inconsistent:
- **linux**: opted into the bot via `url_template` → `version-check.py --apply` would emit `["<ver>"] = { url = github.com/mcpp-community/..., sha256 }` — **github-only, no CN/GitCode fallback**, and unlike every existing entry.
- **macosx / windows**: no marker → the bot **skips them** (manual bumps).
- Yet all existing entries are `["<ver>"] = "XLINGS_RES"` (mcpp is mirrored to `xlings-res/mcpp`).

## What
Drop linux's `url_template`, add `res_versioned = true` to all three platforms. Now `version-check.py --apply --only mcpp` appends `["<ver>"] = "XLINGS_RES"` on **all three** and bumps `latest.ref` — matching the existing convention (and how `xlings` itself is configured).

## Safe
The client never reads platform-level `url_template` (verified: `src/core/xim/installer.cppm` only expands *version-entry-level* Scheme-C templates; mcpp resolves via the `XLINGS_RES` sentinel → `build_xlings_res_url_`). Only the bot reads it. Not related to the github-gh V2 `url_template` migration (#347).

## Verified
Simulated `--apply --only mcpp` against a rolled-back copy → `{'linux':'XLINGS_RES','macosx':'XLINGS_RES','windows':'XLINGS_RES'}`, `latest.ref` bumped. `lua` parse OK.

Companion: openxlings/xlings#349, mcpp-community/mcpp#194.