### PR TITLE
fix(llvm): deterministic hermetic clang cfg + slim-package admission gate

### DIFF
--- a/.agents/skills/llvm-subpackaging/references/publish-resources.md
+++ b/.agents/skills/llvm-subpackaging/references/publish-resources.md
@@ -18,6 +18,21 @@
 
 例：`llvm-22.1.8-macosx-arm64.tar.xz`、`llvm-tools-22.1.8-windows-x86_64.zip`
 
+## 1.5 准入验收（上传前必做,Linux `llvm` 包)
+
+```bash
+.agents/tools/verify-toolchain.sh <llvm-*.tar.gz> \
+  --loader ~/.xlings/data/xpkgs/xim-x-glibc/2.39/lib64/ld-linux-x86-64.so.2
+```
+
+脚本内置 **llvm gate**,不通过一律不上传:
+1. **缺件**:`share/libc++/v1/std.cppm`、`libc++.so*`、`libatomic.so.1`
+   (历史事故:slim carve 漏 libatomic → 所有产物运行期
+   `libatomic.so.1: cannot open`,由用户端发现);
+2. **hermetic CRT**:`-###` 干跑断言 `Scrt1.o/crti.o/crtn.o` 全部解析进
+   glibc payload(`-B`),不落宿主 `/lib`、不裸名(mcpp issue #195 环境类);
+3. **import std 端到端**:std.cppm 预编译 → 编译链接 → 运行。
+
 ## 2. 发布命令
 
 ### GLOBAL（GitHub，支持覆盖）

--- a/.agents/tools/verify-toolchain.sh
+++ b/.agents/tools/verify-toolchain.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# verify-toolchain.sh — INTERP-independent functional check of a (stripped)
+# toolchain tarball. Extracts to a throwaway dir (never touches the shipped
+# artifact), patchelf's the driver+backend binaries to a working loader on THIS
+# machine, then runs a real end-to-end compile through the stripped cc1plus /
+# collect2 / ld and executes the result.
+#
+# Works regardless of the build-temp INTERP baked into the tarball (that path
+# usually does not exist on any other machine — xlings patches it at install
+# time; see T-f). Proves strip did not corrupt the compiler.
+#
+# Usage:  verify-toolchain.sh TARBALL [--loader LD]
+# Default loader: the xim glibc loader on this machine.
+set -uo pipefail
+
+TARBALL="${1:-}"; shift || true
+LOADER="$HOME/.xlings/data/xpkgs/xim-x-glibc/2.39/lib64/ld-linux-x86-64.so.2"
+while [ $# -gt 0 ]; do case "$1" in --loader) LOADER="$2"; shift 2;; *) shift;; esac; done
+[ -f "$TARBALL" ] || { echo "error: tarball not found: $TARBALL" >&2; exit 2; }
+command -v patchelf >/dev/null || { echo "error: patchelf required" >&2; exit 1; }
+
+T="$(mktemp -d)"; trap 'rm -rf "$T"' EXIT
+tar -xzf "$TARBALL" -C "$T" || { echo "FAIL: tarball does not extract" >&2; exit 1; }
+ROOT="$T/$(ls "$T")"
+GLIBC_LIB="$(dirname "$LOADER")"
+
+# detect compiler driver + libc flavor
+CXX="$(find "$ROOT" -maxdepth 2 -path '*/bin/g++' | head -1)"
+[ -n "$CXX" ] || CXX="$(find "$ROOT" -maxdepth 2 -path '*/bin/*-musl-g++' | head -1)"
+[ -n "$CXX" ] || CXX="$(find "$ROOT" -maxdepth 2 -path '*/bin/clang++' | head -1)"
+[ -n "$CXX" ] || { echo "SKIP: no g++/clang++ in $TARBALL"; exit 0; }
+
+is_musl=0
+case "$CXX" in *musl*) is_musl=1;; esac
+# glibc headers live next to the loader: <glibc>/lib64/ld... -> <glibc>/include
+GINC="${LOADER%/lib64/*}/include"
+# for musl, prefer the toolchain's own musl libc as loader (musl libc.so == loader)
+if [ "$is_musl" = 1 ]; then
+  ML="$(find "$ROOT" -path '*-linux-musl/lib/libc.so' -o -name 'ld-musl-x86_64.so.1' 2>/dev/null | head -1)"
+  [ -n "$ML" ] && LOADER="$ML" && GLIBC_LIB="$(dirname "$ML")"
+fi
+[ -e "$LOADER" ] || { echo "SKIP: loader not available: $LOADER (cannot run on this machine)"; exit 0; }
+echo "verify: $(basename "$TARBALL")  flavor=$([ $is_musl = 1 ] && echo musl || echo glibc)  loader=$LOADER"
+
+# patch interp + rpath on driver and backend executables (throwaway copy only).
+# Skip binaries whose baked interp already resolves on THIS machine (upstream
+# LLVM ships the standard /lib64 loader): they are runnable as-is, and
+# patchelf on the huge statically-linked clang driver corrupts it (observed:
+# clang --version goes silent after --set-interpreter/--set-rpath).
+while IFS= read -r -d '' f; do
+  case "$f" in *.a|*.o|*.so|*.so.*) continue;; esac
+  file -b "$f" 2>/dev/null | grep -q 'ELF.*executable' || continue
+  interp="$(patchelf --print-interpreter "$f" 2>/dev/null || true)"
+  [ -n "$interp" ] && [ -e "$interp" ] && continue
+  patchelf --set-interpreter "$LOADER" --set-rpath "$ROOT/lib64:$ROOT/lib:$GLIBC_LIB" "$f" 2>/dev/null || true
+done < <(find "$ROOT" \( -path '*/bin/*' -o -path '*/libexec/*' \) -type f -print0)
+
+printf '#include <cstdio>\n#include <vector>\n#include <string>\nint main(){std::vector<int>v{2,3,4};int s=0;for(int x:v)s+=x;std::string m="ok";std::printf("%%s sum=%%d\\n",m.c_str(),s);return s==9?0:1;}\n' > "$T/t.cpp"
+
+# ── LLVM slim-package admission gate ────────────────────────────────────
+# Catches the two release-blocking regression classes at the packaging
+# source instead of at users:
+#   1. missing payload files (a slim carve once shipped without
+#      libatomic.so.1 → every produced binary died at load time);
+#   2. non-hermetic CRT resolution (mcpp issue #195: the driver must find
+#      Scrt1.o/crti.o/crtn.o in the sandbox glibc via -B, never fall back
+#      to the host's /lib or pass bare names to lld).
+case "$CXX" in *clang++*)
+  echo "llvm gate: asset completeness"
+  [ -f "$ROOT/share/libc++/v1/std.cppm" ] \
+      || { echo "FAIL: slim package missing share/libc++/v1/std.cppm (import std unusable)"; exit 1; }
+  find "$ROOT/lib" -name 'libc++.so*'      | grep -q . \
+      || { echo "FAIL: slim package missing libc++.so"; exit 1; }
+  find "$ROOT/lib" -name 'libatomic.so.1'  | grep -q . \
+      || { echo "FAIL: slim package missing libatomic.so.1 (libc++ NEEDs it; every binary would die at load)"; exit 1; }
+
+  TRIPLE="$(ls "$ROOT/lib" | grep -- '-linux-' | head -1)"
+  CLANG_FLAGS="--no-default-config -nostdinc++ -stdlib=libc++ \
+    -isystem $ROOT/include/c++/v1 \
+    -fuse-ld=lld --rtlib=compiler-rt --unwindlib=libunwind \
+    -B$GLIBC_LIB -L$GLIBC_LIB -Wl,--dynamic-linker=$LOADER -Wl,-rpath,$GLIBC_LIB"
+  [ -d "$ROOT/include/$TRIPLE/c++/v1" ] && CLANG_FLAGS="$CLANG_FLAGS -isystem $ROOT/include/$TRIPLE/c++/v1"
+  [ -d "$GINC" ] && CLANG_FLAGS="$CLANG_FLAGS -isystem $GINC"
+  [ -d "$ROOT/lib/$TRIPLE" ] && CLANG_FLAGS="$CLANG_FLAGS -L$ROOT/lib/$TRIPLE -Wl,-rpath,$ROOT/lib/$TRIPLE"
+
+  echo "llvm gate: hermetic CRT resolution (-###)"
+  dry="$("$CXX" $CLANG_FLAGS -### -x c++ /dev/null -o /dev/null 2>&1)"
+  bad="$(echo "$dry" | tr ' ' '\n' | tr -d '"' \
+         | grep -E '(^|/)(S|g|r|M)?crt[1in]\.o$' | grep -v clang_rt \
+         | grep -v "^$GLIBC_LIB/" || true)"
+  [ -z "$bad" ] || { echo "FAIL: CRT resolves outside the glibc payload:"; echo "$bad" | sed 's/^/  /'; exit 1; }
+
+  echo "llvm gate: import std end-to-end"
+  printf 'import std;\nint main(){ std::println("ok import {}", 42); return 0; }\n' > "$T/m.cpp"
+  "$CXX" $CLANG_FLAGS -std=c++23 --precompile -x c++-module \
+      "$ROOT/share/libc++/v1/std.cppm" -o "$T/std.pcm" 2>"$T/err" \
+      || { echo "FAIL: std module precompile"; sed 's/^/  /' "$T/err"; exit 1; }
+  "$CXX" $CLANG_FLAGS -std=c++23 -fmodule-file=std="$T/std.pcm" \
+      "$T/m.cpp" "$T/std.pcm" -o "$T/m" 2>"$T/err" \
+      || { echo "FAIL: import std compile/link"; sed 's/^/  /' "$T/err"; exit 1; }
+  mout="$("$T/m" 2>&1)" || { echo "FAIL: import std binary run error: $mout"; exit 1; }
+  [ "$mout" = "ok import 42" ] || { echo "FAIL: import std wrong output: $mout"; exit 1; }
+  echo "llvm gate: PASS"
+  ;;
+esac
+
+if [ "$is_musl" = 1 ]; then
+  # static output: self-contained, exercises stripped backend + static libs
+  "$CXX" -O2 -std=c++17 -static "$T/t.cpp" -o "$T/t" 2>"$T/err" || { echo "FAIL: compile error"; sed 's/^/  /' "$T/err"; exit 1; }
+  out="$("$T/t" 2>&1)" || { echo "FAIL: run error: $out"; exit 1; }
+else
+  # Prefer a real subos sysroot (how gcc actually runs); fall back to -isystem.
+  SYSROOT="${VERIFY_SYSROOT:-$HOME/.xlings/subos/current}"
+  if [ -f "$SYSROOT/usr/include/stdlib.h" ]; then sr="--sysroot=$SYSROOT"
+  elif [ -d "$GINC" ]; then sr="-isystem $GINC"
+  else sr=""; fi
+  "$CXX" -O2 -std=c++17 $sr "$T/t.cpp" -o "$T/t" \
+      -Wl,--dynamic-linker="$LOADER" -Wl,-rpath,"$GLIBC_LIB" 2>"$T/err" \
+      || { echo "FAIL: compile error"; sed 's/^/  /' "$T/err"; exit 1; }
+  out="$(LD_LIBRARY_PATH="$ROOT/lib64:$GLIBC_LIB" "$T/t" 2>&1)" || { echo "FAIL: run error: $out"; exit 1; }
+fi
+
+[ "$out" = "ok sum=9" ] && { echo "PASS: compiled & ran ($out)"; exit 0; } \
+                        || { echo "FAIL: wrong output: $out"; exit 1; }

--- a/pkgs/l/llvm.lua
+++ b/pkgs/l/llvm.lua
@@ -65,7 +65,6 @@ package = {
 
 import("xim.libxpkg.pkginfo")
 import("xim.libxpkg.xvm")
-import("xim.libxpkg.system")
 import("xim.libxpkg.log")
 
 local alias_apps = {
@@ -148,7 +147,9 @@ function install()
     os.mv(llvmdir, pkginfo.install_dir())
 
     if os.host() == "linux" then
-        __install_linux_cfg()
+        if not __install_linux_cfg() then
+            return false
+        end
     elseif os.host() == "macosx" then
         __install_macosx_cfg()
     end
@@ -156,47 +157,114 @@ function install()
     return true
 end
 
+-- Locate the glibc payload runtime that this package's own `deps` declare
+-- (xim:glibc). Returns lib_dir, loader_path — or nil when absent.
+--
+-- The loader NAME is discovered from the payload contents (any `ld-*.so*`),
+-- mirroring glibc.lua's `exports.runtime.loader` declaration, so nothing
+-- here hardcodes an architecture.
+function __find_glibc_runtime()
+    local xpkgs_root = path.directory(path.directory(pkginfo.install_dir()))
+    local glibc_root = path.join(xpkgs_root, "xim-x-glibc")
+
+    local versions = {}
+    local f = io.popen('ls -1 "' .. glibc_root .. '" 2>/dev/null')
+    if f then
+        for line in f:lines() do
+            local v = line:gsub("[\r\n]+$", "")
+            if v:match("^%d") then table.insert(versions, v) end
+        end
+        f:close()
+    end
+    table.sort(versions)
+
+    for i = #versions, 1, -1 do
+        for _, libname in ipairs({"lib64", "lib"}) do
+            local libdir = path.join(glibc_root, versions[i], libname)
+            local g = io.popen('ls -1 "' .. libdir .. '" 2>/dev/null')
+            if g then
+                for line in g:lines() do
+                    local name = line:gsub("[\r\n]+$", "")
+                    if name:match("^ld%-") and name:find(".so", 1, true) then
+                        g:close()
+                        return libdir, path.join(libdir, name)
+                    end
+                end
+                g:close()
+            end
+        end
+    end
+    return nil, nil
+end
+
+-- Detect the target triple from the payload layout (lib/<triple>).
+function __detect_triple(install_dir)
+    local f = io.popen('ls -1 "' .. path.join(install_dir, "lib") .. '" 2>/dev/null')
+    if f then
+        for line in f:lines() do
+            local name = line:gsub("[\r\n]+$", "")
+            if name:find("-linux-", 1, true) then
+                f:close()
+                return name
+            end
+        end
+        f:close()
+    end
+    return nil
+end
+
+-- Deterministic, hermetic cfg: generated from the package's OWN deps (the
+-- glibc payload), never from whatever environment (subos, host sysroot)
+-- happened to exist at install time — the same package version produces the
+-- same cfg on every machine, and a human running the bundled clang++
+-- directly gets sandbox CRT discovery (-B: Scrt1.o/crti.o/crtn.o — the
+-- driver never consults -L for these), the sandbox loader, and bundled
+-- libc++. No silent host fallback: without the glibc payload the install
+-- fails loudly instead of writing a cfg that links the host's C runtime.
 function __install_linux_cfg()
     local install_dir = pkginfo.install_dir()
     local bindir = path.join(install_dir, "bin")
-    local cxxinc = path.join(install_dir, "include", "c++", "v1")
-    local cxxinc_triple = path.join(install_dir, "include", "x86_64-unknown-linux-gnu", "c++", "v1")
-    local libcxx_dir = path.join(install_dir, "lib", "x86_64-unknown-linux-gnu")
 
-    local sysroot_dir = system.subos_sysrootdir()
+    local glibc_lib, loader = __find_glibc_runtime()
+    if not glibc_lib then
+        log.error("glibc payload not found (this package's deps declare xim:glibc);"
+            .. " refusing to write a host-dependent clang cfg")
+        return false
+    end
 
-    -- Common flags: use bundled lld, compiler-rt, libunwind (no GCC dependency)
-    local common_flags = "-fuse-ld=lld\n"
+    local common_flags = "-B" .. glibc_lib .. "\n"
+        .. "-L" .. glibc_lib .. "\n"
+        .. "-Wl,--dynamic-linker=" .. loader .. "\n"
+        .. "-Wl,--enable-new-dtags,-rpath," .. glibc_lib .. "\n"
+        .. "-fuse-ld=lld\n"
         .. "--rtlib=compiler-rt\n"
         .. "--unwindlib=libunwind\n"
 
-    -- clang.cfg: C compiler config
     local clang_cfg = common_flags
-    -- clang++.cfg: C++ compiler config (use bundled libc++)
     local clangxx_cfg = common_flags
         .. "-nostdinc++\n"
         .. "-stdlib=libc++\n"
-        .. "-isystem " .. cxxinc .. "\n"
-        .. "-isystem " .. cxxinc_triple .. "\n"
-        .. "-L" .. libcxx_dir .. "\n"
-        .. "-Wl,-rpath," .. libcxx_dir .. "\n"
+        .. "-isystem " .. path.join(install_dir, "include", "c++", "v1") .. "\n"
 
-    if sysroot_dir and sysroot_dir ~= "" then
-        local sysroot_lib = path.join(sysroot_dir, "lib")
-        local dynamic_linker = path.join(sysroot_lib, "ld-linux-x86-64.so.2")
-        local sysroot_flags = "--sysroot=" .. sysroot_dir .. "\n"
-            .. "-Wl,--dynamic-linker=" .. dynamic_linker .. "\n"
-            .. "-Wl,--enable-new-dtags,-rpath," .. sysroot_lib .. "\n"
-            .. "-Wl,-rpath-link," .. sysroot_lib .. "\n"
-        clang_cfg = sysroot_flags .. clang_cfg
-        clangxx_cfg = sysroot_flags .. clangxx_cfg
-    else
-        log.warn("subos sysroot not detected; clang will use system sysroot")
+    local triple = __detect_triple(install_dir)
+    if triple then
+        local cxxinc_triple = path.join(install_dir, "include", triple, "c++", "v1")
+        if os.isdir(cxxinc_triple) then
+            clangxx_cfg = clangxx_cfg .. "-isystem " .. cxxinc_triple .. "\n"
+        end
+        local libcxx_dir = path.join(install_dir, "lib", triple)
+        clangxx_cfg = clangxx_cfg
+            .. "-L" .. libcxx_dir .. "\n"
+            .. "-Wl,-rpath," .. libcxx_dir .. "\n"
     end
 
+    local major = pkginfo.version():match("^(%d+)")
     io.writefile(path.join(bindir, "clang.cfg"), clang_cfg)
-    io.writefile(path.join(bindir, "clang-20.cfg"), clang_cfg)
     io.writefile(path.join(bindir, "clang++.cfg"), clangxx_cfg)
+    if major then
+        io.writefile(path.join(bindir, "clang-" .. major .. ".cfg"), clang_cfg)
+    end
+    return true
 end
 
 function __install_macosx_cfg()


### PR DESCRIPTION
Companion to the hermetic toolchain link model (mcpp-community/mcpp#196, fixes the ecosystem side of mcpp issue #195).

**llvm.lua — deterministic cfg.** The Linux cfg used to depend on whatever environment existed at install time: with a subos it wrote `--sysroot=<subos>` + a hardcoded x86_64 loader path; without one it warned and silently fell back to the HOST sysroot. Same package version ⇒ different (sometimes host-contaminated) cfgs per machine and per install path. Now the cfg is generated from the package's OWN deps: locate the `xim:glibc` payload, discover its loader by name (`ld-*.so*`, mirroring glibc.lua's `exports.runtime.loader` declaration — no arch hardcode), and write `-B/-L` + loader + rpath + lld/compiler-rt/libunwind (+ bundled libc++ for the C++ drivers). `-B` is the CRT-discovery fix: the driver never consults `-L` for `Scrt1.o/crti.o/crtn.o`. Versioned cfg follows the actual major (`clang-<major>.cfg`, was hardcoded `clang-20.cfg`). Missing glibc payload now fails the install loudly instead of writing a host-dependent cfg.

**verify-toolchain.sh — llvm admission gate** (wired into the publish SOP §1.5 as a mandatory pre-upload step): asserts slim-package completeness (std.cppm / libc++.so / libatomic.so.1 — the missing-libatomic incident class), hermetic CRT resolution via a `-###` dry-run (the #195 environment class), and a real import-std precompile → link → run. Verified locally against the current llvm 22.1.8 payload (PASS) and against a deliberately libatomic-stripped tarball (correctly rejected). Also: skip patchelf for binaries whose baked interp already resolves (patchelf corrupts the statically-linked clang driver; upstream LLVM ships the standard /lib64 loader).

Compatibility: older mcpp (≤0.0.82) never reads the regenerated cfg values it loses (`--sysroot`) on fixed-up installs anyway; humans running the bundled clang++ directly get a strictly better, hermetic experience.