### PR TITLE
bump(mcpp): track 0.0.83 as latest

### DIFF
--- a/pkgs/m/mcpp.lua
+++ b/pkgs/m/mcpp.lua
@@ -41,7 +41,8 @@ package = {
             -- res_versioned: version-bump bot tracks mcpp-community/mcpp releases
             -- and appends new ["x.y.z"] = "XLINGS_RES" entries (see version-check.py).
             res_versioned = true,
-            ["latest"] = { ref = "0.0.82" },
+            ["latest"] = { ref = "0.0.83" },
+            ["0.0.83"] = "XLINGS_RES",
             ["0.0.82"] = "XLINGS_RES",
             ["0.0.81"] = "XLINGS_RES",
             ["0.0.80"] = "XLINGS_RES",
@@ -120,7 +121,8 @@ package = {
             -- res_versioned: version-bump bot tracks mcpp-community/mcpp releases
             -- and appends new ["x.y.z"] = "XLINGS_RES" entries (see version-check.py).
             res_versioned = true,
-            ["latest"] = { ref = "0.0.82" },
+            ["latest"] = { ref = "0.0.83" },
+            ["0.0.83"] = "XLINGS_RES",
             ["0.0.82"] = "XLINGS_RES",
             ["0.0.81"] = "XLINGS_RES",
             ["0.0.80"] = "XLINGS_RES",
@@ -185,7 +187,8 @@ package = {
             -- res_versioned: version-bump bot tracks mcpp-community/mcpp releases
             -- and appends new ["x.y.z"] = "XLINGS_RES" entries (see version-check.py).
             res_versioned = true,
-            ["latest"] = { ref = "0.0.82" },
+            ["latest"] = { ref = "0.0.83" },
+            ["0.0.83"] = "XLINGS_RES",
             ["0.0.82"] = "XLINGS_RES",
             ["0.0.81"] = "XLINGS_RES",
             ["0.0.80"] = "XLINGS_RES",


### PR DESCRIPTION
mcpp 0.0.83 — hermetic toolchain link model (mcpp-community/mcpp#196, fixes mcpp issue #195). Binaries are live on xlings-res/mcpp (GitHub + GitCode). Manual application of the release pipeline's index bump (the automated step hit a version-check.py cwd assumption; tracked separately).