### PR TITLE
fix(toolchain): payload-direct gcc specs + complete llvm cfg header axis

### DIFF
--- a/pkgs/g/gcc.lua
+++ b/pkgs/g/gcc.lua
@@ -160,20 +160,34 @@ end
 
 function __config_linux()
     local gcc_bindir = path.join(pkginfo.install_dir(), "bin")
+
+    -- LINK axis (loader + rpath): baked into the SPECS, pointing directly at
+    -- this package's own dep payloads — the glibc payload's loader/lib plus
+    -- gcc's own lib64 (libstdc++/libgcc_s at run time). Payload-direct, no
+    -- subos indirection: the specs govern every invocation style (xvm shim,
+    -- direct <install_dir>/bin/gcc, and downstream tools), so they must not
+    -- depend on an environment directory that may be absent or belong to a
+    -- different home. Mirrors llvm.lua's payload-direct cfg.
+    local glibc_lib, dynamic_linker = __find_glibc_runtime()
+    if glibc_lib then
+        local rpath = glibc_lib .. ":" .. path.join(pkginfo.install_dir(), "lib64")
+        __rewrite_specs_linux(rpath, dynamic_linker)
+    else
+        log.warn("glibc payload not found (deps declare xim:glibc);"
+            .. " skip specs rewrite — gcc keeps its baked build-machine paths")
+    end
+
+    -- HEADER axis: injected only on the xvm shim aliases. gcc's header
+    -- search (include-fixed, #include_next) needs an FHS-shaped tree, which
+    -- individual payloads are not — the subos is exactly xlings' FHS
+    -- composite view for this purpose. Consumers that bypass the shim
+    -- (e.g. mcpp) supply their own header flags.
     local sysroot_dir = system.subos_sysrootdir()
-    local sysroot_lib = nil
-    local dynamic_linker = nil
     local alias_args = ""
     if sysroot_dir and sysroot_dir ~= "" then
-        sysroot_lib = path.join(sysroot_dir, "lib")
-        dynamic_linker = path.join(sysroot_lib, "ld-linux-x86-64.so.2")
-        alias_args = string.format(
-            ' --sysroot=%s -Wl,--dynamic-linker=%s -Wl,--enable-new-dtags,-rpath,%s -Wl,-rpath-link,%s',
-            sysroot_dir, dynamic_linker, sysroot_lib, sysroot_lib
-        )
-        __rewrite_specs_linux(sysroot_dir, sysroot_lib, dynamic_linker)
+        alias_args = string.format(' --sysroot=%s', sysroot_dir)
     else
-        log.warn("subos dir is empty, skip alias linker/sysroot injection")
+        log.warn("subos dir is empty, skip alias sysroot injection")
     end
 
     xvm.add("xim-gnu-gcc") -- root
@@ -244,10 +258,13 @@ end
 -- stamp lives inside install_dir and is wiped on `xim reinstall
 -- gcc` along with the rest of the payload, so version bumps and
 -- forced reinstalls naturally re-rewrite.
-function __rewrite_specs_linux(sysroot_dir, sysroot_lib, dynamic_linker)
+function __rewrite_specs_linux(rpath, dynamic_linker)
+    -- The "-payload" suffix versions the specs SCHEMA: pre-existing installs
+    -- carry the old subos-form stamp, which no longer matches, so the next
+    -- config() re-fire converges them to the payload-direct form.
     local stamp = path.join(
         pkginfo.install_dir(),
-        ".specs-rewritten-" .. pkginfo.version() .. ".stamp"
+        ".specs-rewritten-" .. pkginfo.version() .. "-payload.stamp"
     )
     if os.isfile(stamp) then
         log.debug("gcc specs already rewritten (stamp present), skipping.")
@@ -257,11 +274,36 @@ function __rewrite_specs_linux(sysroot_dir, sysroot_lib, dynamic_linker)
     local gcc_bin = path.join(pkginfo.install_dir(), "bin/gcc")
     local specs_config_bin = path.join(system.bindir(), "gcc-specs-config")
 
-    log.info("Rewriting gcc specs to install-machine paths via gcc-specs-config...")
+    log.info("Rewriting gcc specs to payload-direct paths via gcc-specs-config...")
     system.exec(string.format(
         "%s %s --dynamic-linker %s --rpath %s --linker-type gnu",
-        specs_config_bin, gcc_bin, dynamic_linker, sysroot_lib
+        specs_config_bin, gcc_bin, dynamic_linker, rpath
     ))
 
     io.writefile(stamp, pkginfo.version())
+end
+
+-- Locate the glibc payload runtime (this package's own dep, xim:glibc) via
+-- pkginfo.dep_install_dir, and discover the loader NAME from the payload
+-- contents (any `ld-*.so*`) — no architecture hardcodes, no directory
+-- layout assumptions. Same helper shape as llvm.lua's.
+function __find_glibc_runtime()
+    local glibc_dir = pkginfo.dep_install_dir("glibc")
+    if not glibc_dir then return nil, nil end
+
+    for _, libname in ipairs({"lib64", "lib"}) do
+        local libdir = path.join(glibc_dir, libname)
+        local g = io.popen('ls -1 "' .. libdir .. '" 2>/dev/null')
+        if g then
+            for line in g:lines() do
+                local name = line:gsub("[\r\n]+$", "")
+                if name:match("^ld%-") and name:find(".so", 1, true) then
+                    g:close()
+                    return libdir, path.join(libdir, name)
+                end
+            end
+            g:close()
+        end
+    end
+    return nil, nil
 end

--- a/pkgs/l/llvm.lua
+++ b/pkgs/l/llvm.lua
@@ -160,41 +160,47 @@ end
 -- Locate the glibc payload runtime that this package's own `deps` declare
 -- (xim:glibc). Returns lib_dir, loader_path — or nil when absent.
 --
--- The loader NAME is discovered from the payload contents (any `ld-*.so*`),
--- mirroring glibc.lua's `exports.runtime.loader` declaration, so nothing
--- here hardcodes an architecture.
+-- Resolution goes through pkginfo.dep_install_dir (store scan with
+-- namespace matching + xvm fallback) instead of hand-derived directory
+-- layout assumptions. The loader NAME is discovered from the payload
+-- contents (any `ld-*.so*`), mirroring glibc.lua's `exports.runtime.loader`
+-- declaration, so nothing here hardcodes an architecture.
 function __find_glibc_runtime()
-    local xpkgs_root = path.directory(path.directory(pkginfo.install_dir()))
-    local glibc_root = path.join(xpkgs_root, "xim-x-glibc")
+    local glibc_dir = pkginfo.dep_install_dir("glibc")
+    if not glibc_dir then return nil, nil end
 
-    local versions = {}
-    local f = io.popen('ls -1 "' .. glibc_root .. '" 2>/dev/null')
-    if f then
-        for line in f:lines() do
-            local v = line:gsub("[\r\n]+$", "")
-            if v:match("^%d") then table.insert(versions, v) end
-        end
-        f:close()
-    end
-    table.sort(versions)
-
-    for i = #versions, 1, -1 do
-        for _, libname in ipairs({"lib64", "lib"}) do
-            local libdir = path.join(glibc_root, versions[i], libname)
-            local g = io.popen('ls -1 "' .. libdir .. '" 2>/dev/null')
-            if g then
-                for line in g:lines() do
-                    local name = line:gsub("[\r\n]+$", "")
-                    if name:match("^ld%-") and name:find(".so", 1, true) then
-                        g:close()
-                        return libdir, path.join(libdir, name)
-                    end
+    for _, libname in ipairs({"lib64", "lib"}) do
+        local libdir = path.join(glibc_dir, libname)
+        local g = io.popen('ls -1 "' .. libdir .. '" 2>/dev/null')
+        if g then
+            for line in g:lines() do
+                local name = line:gsub("[\r\n]+$", "")
+                if name:match("^ld%-") and name:find(".so", 1, true) then
+                    g:close()
+                    return libdir, path.join(libdir, name)
                 end
-                g:close()
             end
+            g:close()
         end
     end
     return nil, nil
+end
+
+-- Locate the linux-headers payload's include dir (this package's own dep).
+-- xim:linux-headers is a thin delegator to scode:linux-headers, so the
+-- xim-namespaced store entry can be a metadata-only husk — require the
+-- actual payload marker (include/linux/limits.h) and fall back to the
+-- scode namespace explicitly. Returns nil when absent (warn-level: the
+-- cfg then omits the kernel-header line; compiles that need <linux/*.h>
+-- surface a clear missing-header error instead of a broken install).
+function __find_linux_headers_include()
+    for _, name in ipairs({"linux-headers", "scode:linux-headers"}) do
+        local dir = pkginfo.dep_install_dir(name)
+        if dir and os.isfile(path.join(dir, "include", "linux", "limits.h")) then
+            return path.join(dir, "include")
+        end
+    end
+    return nil
 end
 
 -- Detect the target triple from the payload layout (lib/<triple>).
@@ -240,7 +246,25 @@ function __install_linux_cfg()
         .. "--rtlib=compiler-rt\n"
         .. "--unwindlib=libunwind\n"
 
-    local clang_cfg = common_flags
+    -- Header axis (C and C++ drivers alike): the C library and kernel
+    -- headers come from the same dep payloads the link axis uses. Without
+    -- these a direct `clang hello.c` only works when the HOST happens to
+    -- ship /usr/include — i.e. silently non-hermetic, and broken on
+    -- header-less machines. Ordering matters for C++: libc++'s headers
+    -- must be searched BEFORE the glibc headers (its C-header wrappers
+    -- reach libc via #include_next), so these lines are appended AFTER the
+    -- libc++ -isystem block below — same ordering mcpp's link model emits.
+    local c_hdr_flags = "-isystem "
+        .. path.join(path.directory(glibc_lib), "include") .. "\n"
+    local linux_inc = __find_linux_headers_include()
+    if linux_inc then
+        c_hdr_flags = c_hdr_flags .. "-isystem " .. linux_inc .. "\n"
+    else
+        log.warn("linux-headers payload not found; cfg omits kernel headers"
+            .. " (compiles needing <linux/*.h> will report missing headers)")
+    end
+
+    local clang_cfg = common_flags .. c_hdr_flags
     local clangxx_cfg = common_flags
         .. "-nostdinc++\n"
         .. "-stdlib=libc++\n"
@@ -252,6 +276,9 @@ function __install_linux_cfg()
         if os.isdir(cxxinc_triple) then
             clangxx_cfg = clangxx_cfg .. "-isystem " .. cxxinc_triple .. "\n"
         end
+    end
+    clangxx_cfg = clangxx_cfg .. c_hdr_flags
+    if triple then
         local libcxx_dir = path.join(install_dir, "lib", triple)
         clangxx_cfg = clangxx_cfg
             .. "-L" .. libcxx_dir .. "\n"


### PR DESCRIPTION
Follow-up to #338, closing the two gaps found in review:

1. **gcc specs → payload-direct** (the gcc half of what #338 did for llvm's cfg): loader/rpath in the specs now point at the glibc payload + gcc's own lib64, resolved via `pkginfo.dep_install_dir`. The xvm shim alias slims to `--sysroot=<subos>` only (header axis — gcc's include-fixed/#include_next needs the FHS view that subos exists to provide); loader/rpath injection lives in exactly one place (the specs). Stamp gains a `-payload` schema suffix so existing installs re-converge on the next config() re-fire; `gcc -dumpspecs` emits built-in specs, so regeneration is naturally convergent (verified).

2. **llvm cfg header axis completed**: #338's cfg covered the link axis but omitted the C library / kernel headers — a direct `clang hello.c` only worked when the host happened to ship `/usr/include`. The cfg now carries `-isystem` for the glibc payload headers + linux-headers (located via `dep_install_dir`, with a scode-namespace fallback past the xim delegator husk), ordered after the libc++ block to preserve the `#include_next` chain — byte-consistent with mcpp's link model rendering.

**Verified locally on real payloads**: (a) host headers masked via `--sysroot=<empty dir>` — C and C++ compile+run green on cfg-equivalent flags, negative control fails as expected; (b) real `gcc-specs-config` run with payload-direct values — direct `bin/g++` products carry payload INTERP/RUNPATH (colon-list rpath works) and run; (c) mcpp full self-host build + unit suite green on the rewritten specs. mcpp's fixup treats the new forms as already-converged (idempotent skip).