### PR TITLE
pkg(aarch64-linux-musl-gcc): add 16.1.0

### DIFF
--- a/pkgs/a/aarch64-linux-musl-gcc.lua
+++ b/pkgs/a/aarch64-linux-musl-gcc.lua
@@ -56,6 +56,9 @@ package = {
             -- XLINGS_RES picks the host-matching asset:
             -- aarch64-linux-musl-gcc-<ver>-linux-{x86_64,aarch64}.tar.gz
             ["latest"] = { ref = "15.1.0" },
+            -- gcc 16: fixes the GCC-15 module-instantiation link bug that
+            -- forced an anchor workaround in mcpp (remediation doc A2).
+            ["16.1.0"] = "XLINGS_RES",
             ["15.1.0"] = "XLINGS_RES",
         },
     },


### PR DESCRIPTION
Assets live on xlings-res/aarch64-linux-musl-gcc release 16.1.0 (cross linux-x86_64 + native linux-aarch64, both smoke-tested in the builder). Consumer: mcpp cross floor bump (GCC-15 module link bug, mcpp remediation doc §A2). latest unchanged.