### PR TITLE
pkg(musl-gcc): add 16.1.0 (stripped, dual-arch)

### DIFF
--- a/pkgs/m/musl-gcc.lua
+++ b/pkgs/m/musl-gcc.lua
@@ -47,6 +47,9 @@ package = {
 
             -- toolchain build based on musl-gcc-static
             ["latest"] = { ref = "15.1.0" },
+            -- gcc 16: fixes the GCC-15 module-instantiation link bug
+            -- (mcpp remediation doc A2/R5b); stripped ~105MB assets.
+            ["16.1.0"] = "XLINGS_RES",
             ["15.1.0"] = "XLINGS_RES", -- deps musl-gcc
             ["13.3.0"] = "XLINGS_RES",
             ["11.5.0"] = "XLINGS_RES",


### PR DESCRIPTION
Assets on xlings-res/musl-gcc 16.1.0 (GitHub; GitCode mirror in flight). This PR is also the first live run of the toolchain consumer-smoke gate (#343).