### PR TITLE
bump(mcpp): track 0.0.86 as latest

### DIFF
--- a/pkgs/m/mcpp.lua
+++ b/pkgs/m/mcpp.lua
@@ -41,7 +41,8 @@ package = {
             -- res_versioned: version-bump bot tracks mcpp-community/mcpp releases
             -- and appends new ["x.y.z"] = "XLINGS_RES" entries (see version-check.py).
             res_versioned = true,
-            ["latest"] = { ref = "0.0.85" },
+            ["latest"] = { ref = "0.0.86" },
+            ["0.0.86"] = "XLINGS_RES",
             ["0.0.85"] = "XLINGS_RES",
             ["0.0.84"] = "XLINGS_RES",
             ["0.0.83"] = "XLINGS_RES",
@@ -123,7 +124,8 @@ package = {
             -- res_versioned: version-bump bot tracks mcpp-community/mcpp releases
             -- and appends new ["x.y.z"] = "XLINGS_RES" entries (see version-check.py).
             res_versioned = true,
-            ["latest"] = { ref = "0.0.85" },
+            ["latest"] = { ref = "0.0.86" },
+            ["0.0.86"] = "XLINGS_RES",
             ["0.0.85"] = "XLINGS_RES",
             ["0.0.84"] = "XLINGS_RES",
             ["0.0.83"] = "XLINGS_RES",
@@ -191,7 +193,8 @@ package = {
             -- res_versioned: version-bump bot tracks mcpp-community/mcpp releases
             -- and appends new ["x.y.z"] = "XLINGS_RES" entries (see version-check.py).
             res_versioned = true,
-            ["latest"] = { ref = "0.0.85" },
+            ["latest"] = { ref = "0.0.86" },
+            ["0.0.86"] = "XLINGS_RES",
             ["0.0.85"] = "XLINGS_RES",
             ["0.0.84"] = "XLINGS_RES",
             ["0.0.83"] = "XLINGS_RES",


### PR DESCRIPTION
Automated by the mcpp release pipeline. Bumps `pkgs/*/mcpp.lua` `latest.ref` to `0.0.86` and appends the new version entry (via `version-check.py --apply --only mcpp`).

Merge to publish into the official index — the index repo then republishes its artifact and gitee-sync mirrors the change. Binaries are already live on `xlings-res/mcpp` (GitHub + GitCode).