### PR TITLE
feat(jetbrainsmono-nerd-font): add Nerd Font package

### DIFF
--- a/pkgs/j/jetbrainsmono-nerd-font.lua
+++ b/pkgs/j/jetbrainsmono-nerd-font.lua
@@ -1,0 +1,168 @@
+package = {
+    spec = "1",
+
+    name = "jetbrainsmono-nerd-font",
+    description = "JetBrainsMono Nerd Font patched with terminal icons and glyphs",
+    homepage = "https://www.nerdfonts.com/font-downloads",
+    maintainers = {"ryanoasis"},
+    licenses = {"OFL-1.1", "MIT"},
+    repo = "https://github.com/ryanoasis/nerd-fonts",
+    docs = "https://github.com/ryanoasis/nerd-fonts#readme",
+
+    type = "package",
+    archs = {"x86_64", "aarch64"},
+    status = "stable",
+    categories = {"font", "terminal"},
+    keywords = {"nerd-fonts", "jetbrainsmono", "font", "terminal", "icons"},
+    xvm_enable = true,
+
+    -- Data-only font package: only a package-name xvm entry is
+    -- registered for lifecycle tracking. No executable program is exposed.
+    -- The xlings-res asset is the arch-independent upstream font zip reused
+    -- under every supported OS/arch entry.
+    xpm = {
+        linux = {
+            ["latest"] = { ref = "3.4.0" },
+            ["3.4.0"] = {
+                url = {
+                    GLOBAL = "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/JetBrainsMono.zip",
+                    CN = "https://gitcode.com/xlings-res/jetbrainsmono-nerd-font/releases/download/3.4.0/JetBrainsMono.zip",
+                },
+                sha256 = "76f05ff3ace48a464a6ca57977998784ff7bdbb65a6d915d7e401cd3927c493c",
+            },
+        },
+        macosx = {
+            ["latest"] = { ref = "3.4.0" },
+            ["3.4.0"] = {
+                url = {
+                    GLOBAL = "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/JetBrainsMono.zip",
+                    CN = "https://gitcode.com/xlings-res/jetbrainsmono-nerd-font/releases/download/3.4.0/JetBrainsMono.zip",
+                },
+                sha256 = "76f05ff3ace48a464a6ca57977998784ff7bdbb65a6d915d7e401cd3927c493c",
+            },
+        },
+        windows = {
+            ["latest"] = { ref = "3.4.0" },
+            ["3.4.0"] = {
+                url = {
+                    GLOBAL = "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.4.0/JetBrainsMono.zip",
+                    CN = "https://gitcode.com/xlings-res/jetbrainsmono-nerd-font/releases/download/3.4.0/JetBrainsMono.zip",
+                },
+                sha256 = "76f05ff3ace48a464a6ca57977998784ff7bdbb65a6d915d7e401cd3927c493c",
+            },
+        },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+import("xim.libxpkg.system")
+import("xim.libxpkg.log")
+
+local function _sh(value)
+    return "'" .. tostring(value):gsub("'", [['"'"']]) .. "'"
+end
+
+local function _ps(value)
+    return "'" .. tostring(value):gsub("'", "''") .. "'"
+end
+
+local function _run_sh(script)
+    system.exec("sh -c " .. _sh(script))
+end
+
+local function _run_powershell(script)
+    system.exec('powershell -NoProfile -ExecutionPolicy Bypass -Command "' .. script .. '"')
+end
+
+local function _home_dir()
+    return os.getenv("HOME") or os.getenv("USERPROFILE")
+end
+
+local function _font_dir()
+    if is_host("windows") then
+        local base = os.getenv("LOCALAPPDATA")
+        if not base then
+            local home = _home_dir()
+            if not home then error("LOCALAPPDATA or USERPROFILE is required") end
+            base = path.join(home, "AppData", "Local")
+        end
+        -- Windows user font directory: Microsoft\Windows\Fonts
+        return path.join(base, "Microsoft", "Windows", "Fonts")
+    end
+
+    local home = _home_dir()
+    if not home then error("HOME is required") end
+
+    if is_host("macosx") then
+        return path.join(home, "Library", "Fonts")
+    end
+
+    local data_home = os.getenv("XDG_DATA_HOME") or path.join(home, ".local", "share")
+    return path.join(data_home, "fonts")
+end
+
+local function _refresh_linux_font_cache(font_dir)
+    if is_host("linux") then
+        _run_sh("command -v fc-cache >/dev/null 2>&1 && fc-cache -f " .. _sh(font_dir) .. " || true")
+    end
+end
+
+local function _copy_fonts_to(font_dir)
+    if is_host("windows") then
+        local script = table.concat({
+            "$src = " .. _ps(pkginfo.install_dir()),
+            "$dst = " .. _ps(font_dir),
+            "New-Item -ItemType Directory -Force -Path $dst | Out-Null",
+            "$reg = 'HKCU:\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Fonts'",
+            "Get-ChildItem -Path $src -Filter '*.ttf' | ForEach-Object { $target = Join-Path $dst $_.Name; Copy-Item -Path $_.FullName -Destination $target -Force; New-ItemProperty -Path $reg -Name ($_.Name + ' (TrueType)') -Value $target -PropertyType String -Force | Out-Null }",
+        }, "; ")
+        _run_powershell(script)
+    else
+        _run_sh("cp -f " .. _sh(pkginfo.install_dir()) .. "/*.ttf " .. _sh(font_dir) .. "/")
+    end
+end
+
+local function _remove_fonts_from(font_dir)
+    if is_host("windows") then
+        local script = table.concat({
+            "$dst = " .. _ps(font_dir),
+            "$reg = 'HKCU:\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Fonts'",
+            "Get-ChildItem -Path $dst -Filter 'JetBrainsMono*NerdFont*.ttf' -ErrorAction SilentlyContinue | ForEach-Object { Remove-ItemProperty -Path $reg -Name ($_.Name + ' (TrueType)') -ErrorAction SilentlyContinue; Remove-Item -Path $_.FullName -Force -ErrorAction SilentlyContinue }",
+        }, "; ")
+        _run_powershell(script)
+    else
+        _run_sh("rm -f " .. _sh(font_dir) .. "/JetBrainsMono*NerdFont*.ttf")
+    end
+end
+
+function installed()
+    return xvm.has(package.name)
+       and os.isfile(path.join(_font_dir(), "JetBrainsMonoNerdFont-Regular.ttf"))
+       and os.isfile(path.join(pkginfo.install_dir(), "JetBrainsMonoNerdFont-Regular.ttf"))
+end
+
+function install()
+    -- Keep the original extracted payload in pkginfo.install_dir().
+    -- The upstream zip is flat, and xlings stages its files into that
+    -- local xpkg install directory after this hook returns.
+    return true
+end
+
+function config()
+    local font_dir = _font_dir()
+    os.mkdir(font_dir)
+    _copy_fonts_to(font_dir)
+    _refresh_linux_font_cache(font_dir)
+    xvm.add(package.name)
+    log.info("JetBrainsMono Nerd Font installed to %s", font_dir)
+    return true
+end
+
+function uninstall()
+    local font_dir = _font_dir()
+    _remove_fonts_from(font_dir)
+    _refresh_linux_font_cache(font_dir)
+    xvm.remove(package.name)
+    return true
+end

--- a/pkgs/y/yazi.lua
+++ b/pkgs/y/yazi.lua
@@ -23,7 +23,10 @@ package = {
             url_template = "https://github.com/sxyazi/yazi/releases/download/v{version}/yazi-x86_64-unknown-linux-musl.zip",
             ["latest"] = { ref = "26.5.6" },
             ["26.5.6"] = {
-                url = "https://github.com/sxyazi/yazi/releases/download/v26.5.6/yazi-x86_64-unknown-linux-musl.zip",
+                url = {
+                    GLOBAL = "https://github.com/sxyazi/yazi/releases/download/v26.5.6/yazi-x86_64-unknown-linux-musl.zip",
+                    CN = "https://gitcode.com/xlings-res/yazi/releases/download/26.5.6/yazi-x86_64-unknown-linux-musl.zip",
+                },
                 sha256 = "1031a02560d053301537195a6661d227c15cb4ce5c30481050b31e2b88681bff",
             },
         },
@@ -31,7 +34,10 @@ package = {
             url_template = "https://github.com/sxyazi/yazi/releases/download/v{version}/yazi-aarch64-apple-darwin.zip",
             ["latest"] = { ref = "26.5.6" },
             ["26.5.6"] = {
-                url = "https://github.com/sxyazi/yazi/releases/download/v26.5.6/yazi-aarch64-apple-darwin.zip",
+                url = {
+                    GLOBAL = "https://github.com/sxyazi/yazi/releases/download/v26.5.6/yazi-aarch64-apple-darwin.zip",
+                    CN = "https://gitcode.com/xlings-res/yazi/releases/download/26.5.6/yazi-aarch64-apple-darwin.zip",
+                },
                 sha256 = "7abd71725e2fe27bed036becbf6ce79fa17964eb68491d34190011c94b8c7ca8",
             },
         },
@@ -39,7 +45,10 @@ package = {
             url_template = "https://github.com/sxyazi/yazi/releases/download/v{version}/yazi-x86_64-pc-windows-msvc.zip",
             ["latest"] = { ref = "26.5.6" },
             ["26.5.6"] = {
-                url = "https://github.com/sxyazi/yazi/releases/download/v26.5.6/yazi-x86_64-pc-windows-msvc.zip",
+                url = {
+                    GLOBAL = "https://github.com/sxyazi/yazi/releases/download/v26.5.6/yazi-x86_64-pc-windows-msvc.zip",
+                    CN = "https://gitcode.com/xlings-res/yazi/releases/download/26.5.6/yazi-x86_64-pc-windows-msvc.zip",
+                },
                 sha256 = "6c6c52a4b2648e179f917bdaa7c57e793d18561b380a8bfa025f10cd1b9b2ad1",
             },
         },

--- a/tests/j/test_jetbrainsmono_nerd_font.py
+++ b/tests/j/test_jetbrainsmono_nerd_font.py
@@ -1,0 +1,118 @@
+"""Tests for the jetbrainsmono-nerd-font package."""
+import re
+
+import pytest
+
+from tests.lib.assertions import (
+    assert_no_bashrc_modification,
+    assert_no_direct_path_modification,
+    assert_no_exec_xvm,
+    assert_no_typos,
+    assert_platform_supported,
+    assert_required_fields,
+    assert_uses_new_api,
+    assert_valid_spec,
+    assert_valid_type,
+    assert_xim_add_succeeds,
+)
+from tests.lib.xpkg_parser import parse_xpkg
+
+PKG = "jetbrainsmono-nerd-font"
+PKG_FILE = "pkgs/j/jetbrainsmono-nerd-font.lua"
+VERSION = "3.4.0"
+SHA256 = "76f05ff3ace48a464a6ca57977998784ff7bdbb65a6d915d7e401cd3927c493c"
+
+
+@pytest.fixture(scope="module")
+def meta():
+    return parse_xpkg(PKG_FILE)
+
+
+def _platform_block(raw_content: str, platform: str) -> str:
+    start = raw_content.index(f"        {platform} = {{")
+    tail = raw_content[start:]
+    next_match = re.search(r"\n        (linux|macosx|windows) = \{", tail[1:])
+    if next_match:
+        return tail[:1 + next_match.start()]
+    end_match = re.search(r"^    \},", tail, re.MULTILINE)
+    return tail[:end_match.start()]
+
+
+class TestStatic:
+    @pytest.mark.static
+    def test_required_fields(self, meta):
+        assert_required_fields(meta)
+
+    @pytest.mark.static
+    def test_valid_spec(self, meta):
+        assert_valid_spec(meta)
+
+    @pytest.mark.static
+    def test_valid_type(self, meta):
+        assert_valid_type(meta)
+
+    @pytest.mark.static
+    def test_no_typos(self):
+        assert_no_typos(PKG_FILE)
+
+    @pytest.mark.static
+    def test_supported_platforms(self, meta):
+        for platform in ("linux", "macosx", "windows"):
+            assert_platform_supported(meta, platform)
+
+    @pytest.mark.static
+    def test_latest_uses_official_global_and_gitcode_cn(self, meta):
+        for platform in ("linux", "macosx", "windows"):
+            block = _platform_block(meta.raw_content, platform)
+            assert re.search(rf'\["latest"\]\s*=\s*\{{\s*ref\s*=\s*"{VERSION}"\s*\}}', block)
+            assert f"github.com/ryanoasis/nerd-fonts/releases/download/v{VERSION}/JetBrainsMono.zip" in block
+            assert f"gitcode.com/xlings-res/{PKG}/releases/download/{VERSION}/JetBrainsMono.zip" in block
+            assert f'sha256 = "{SHA256}"' in block
+
+    @pytest.mark.static
+    def test_font_package_only_registers_empty_xvm_entry(self, meta):
+        assert meta.has_xvm_enable
+        assert meta.programs == []
+        assert "xvm.add(package.name)" in meta.raw_content
+        assert 'type = "marker"' not in meta.raw_content
+        assert "xvm.remove(package.name)" in meta.raw_content
+        assert "bindir" not in meta.raw_content
+
+    @pytest.mark.static
+    def test_installs_user_font_hooks(self, meta):
+        assert meta.has_install
+        assert meta.has_config
+        assert meta.has_uninstall
+        assert meta.has_installed
+        assert "Keep the original extracted payload in pkginfo.install_dir()" in meta.raw_content
+        assert "fc-cache -f" in meta.raw_content
+        assert 'path.join(home, "Library", "Fonts")' in meta.raw_content
+        assert 'path.join(base, "Microsoft", "Windows", "Fonts")' in meta.raw_content
+
+    @pytest.mark.static
+    def test_does_not_use_unavailable_directory_helpers(self, meta):
+        assert "os.files" not in meta.raw_content
+
+
+class TestIndex:
+    @pytest.mark.index
+    def test_xim_add(self):
+        assert_xim_add_succeeds(PKG_FILE)
+
+
+class TestIsolation:
+    @pytest.mark.isolation
+    def test_no_exec_xvm(self):
+        assert_no_exec_xvm(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_no_bashrc(self):
+        assert_no_bashrc_modification(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_no_path_modification(self):
+        assert_no_direct_path_modification(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_new_api(self):
+        assert_uses_new_api(PKG_FILE)

--- a/tests/y/test_yazi.py
+++ b/tests/y/test_yazi.py
@@ -1,0 +1,107 @@
+"""Tests for the yazi package."""
+import re
+
+import pytest
+
+from tests.lib.assertions import (
+    assert_no_bashrc_modification,
+    assert_no_direct_path_modification,
+    assert_no_exec_xvm,
+    assert_no_typos,
+    assert_platform_supported,
+    assert_required_fields,
+    assert_uses_new_api,
+    assert_valid_spec,
+    assert_valid_type,
+    assert_xim_add_succeeds,
+)
+from tests.lib.xpkg_parser import parse_xpkg
+
+PKG_FILE = "pkgs/y/yazi.lua"
+VERSION = "26.5.6"
+ASSETS = {
+    "linux": (
+        "yazi-x86_64-unknown-linux-musl.zip",
+        "1031a02560d053301537195a6661d227c15cb4ce5c30481050b31e2b88681bff",
+    ),
+    "macosx": (
+        "yazi-aarch64-apple-darwin.zip",
+        "7abd71725e2fe27bed036becbf6ce79fa17964eb68491d34190011c94b8c7ca8",
+    ),
+    "windows": (
+        "yazi-x86_64-pc-windows-msvc.zip",
+        "6c6c52a4b2648e179f917bdaa7c57e793d18561b380a8bfa025f10cd1b9b2ad1",
+    ),
+}
+
+
+@pytest.fixture(scope="module")
+def meta():
+    return parse_xpkg(PKG_FILE)
+
+
+def _platform_block(raw_content: str, platform: str) -> str:
+    start = raw_content.index(f"        {platform} = {{")
+    tail = raw_content[start:]
+    next_match = re.search(r"\n        (linux|macosx|windows) = \{", tail[1:])
+    if next_match:
+        return tail[:1 + next_match.start()]
+    end_match = re.search(r"^    \},", tail, re.MULTILINE)
+    return tail[:end_match.start()]
+
+
+class TestStatic:
+    @pytest.mark.static
+    def test_required_fields(self, meta):
+        assert_required_fields(meta)
+
+    @pytest.mark.static
+    def test_valid_spec(self, meta):
+        assert_valid_spec(meta)
+
+    @pytest.mark.static
+    def test_valid_type(self, meta):
+        assert_valid_type(meta)
+
+    @pytest.mark.static
+    def test_no_typos(self):
+        assert_no_typos(PKG_FILE)
+
+    @pytest.mark.static
+    def test_supported_platforms(self, meta):
+        for platform in ("linux", "macosx", "windows"):
+            assert_platform_supported(meta, platform)
+
+    @pytest.mark.static
+    def test_latest_uses_official_global_and_gitcode_cn(self, meta):
+        for platform in ("linux", "macosx", "windows"):
+            asset, sha256 = ASSETS[platform]
+            block = _platform_block(meta.raw_content, platform)
+            assert re.search(rf'\["latest"\]\s*=\s*\{{\s*ref\s*=\s*"{VERSION}"\s*\}}', block)
+            assert f"github.com/sxyazi/yazi/releases/download/v{VERSION}/{asset}" in block
+            assert f"gitcode.com/xlings-res/yazi/releases/download/{VERSION}/{asset}" in block
+            assert f'sha256 = "{sha256}"' in block
+
+
+class TestIndex:
+    @pytest.mark.index
+    def test_xim_add(self):
+        assert_xim_add_succeeds(PKG_FILE)
+
+
+class TestIsolation:
+    @pytest.mark.isolation
+    def test_no_exec_xvm(self):
+        assert_no_exec_xvm(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_no_bashrc(self):
+        assert_no_bashrc_modification(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_no_path_modification(self):
+        assert_no_direct_path_modification(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_new_api(self):
+        assert_uses_new_api(PKG_FILE)


### PR DESCRIPTION
## Summary
- Add `jetbrainsmono-nerd-font` xpkg for JetBrainsMono Nerd Font 3.4.0.
- Keep `GLOBAL` downloads on official upstream releases; add GitCode xlings-res `CN` mirrors for the font and yazi 26.5.6.
- Add focused static/isolation/index tests for the new font package and yazi mirror URL tables.

## Install behavior
- Downloads the upstream/mirrored font zip and lets xlings stage the extracted payload in the local xpkg install directory.
- Copies `.ttf` files to the current user font directory: Linux `XDG_DATA_HOME/fonts` or user data fonts, macOS user Fonts, Windows user Fonts.
- Refreshes Linux font cache when `fc-cache` is available.
- Registers only the package-name xvm entry for lifecycle tracking; it exposes no executable program.

## Uninstall behavior
- Removes `JetBrainsMono*NerdFont*.ttf` from the current user font directory.
- Removes the package-name xvm entry used for lifecycle tracking.
- On Windows, also removes the matching HKCU user-font registry entries.

## System impact
- User-scoped font installation only.
- Does not edit shell profile, PATH, or system package manager state.

## Mirror verification
- `xlings-res/jetbrainsmono-nerd-font@3.4.0`: `JetBrainsMono.zip` sha256 `76f05ff3ace48a464a6ca57977998784ff7bdbb65a6d915d7e401cd3927c493c`.
- `xlings-res/yazi@26.5.6`: linux sha256 `1031a02560d053301537195a6661d227c15cb4ce5c30481050b31e2b88681bff`; macOS sha256 `7abd71725e2fe27bed036becbf6ce79fa17964eb68491d34190011c94b8c7ca8`; Windows sha256 `6c6c52a4b2648e179f917bdaa7c57e793d18561b380a8bfa025f10cd1b9b2ad1`.

## Test plan
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/j/test_jetbrainsmono_nerd_font.py tests/y/test_yazi.py -m 'static or isolation or index' -q` -> 25 passed.
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/ -m 'static or isolation or index' --tb=short -q` -> 858 passed, 127 deselected, 2 xfailed, 4 xpassed.
- Smoke-installed and removed `jetbrainsmono-nerd-font`; verified the original extracted `.ttf` payload remains in the local xpkg install directory during install, copied user font file exists after install, and user font file is removed by `xlings -y remove`.
- Smoke-installed `local:yazi@26.5.6`; verified `Yazi 26.5.6` and removed it with `xlings -y remove`.
