### PR TITLE
fix(mcpp): verify XLINGS_RES artifacts before indexing

### DIFF
--- a/.github/scripts/test_version_check.py
+++ b/.github/scripts/test_version_check.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python3
-"""Offline tests for version-check.py — focused on the XLINGS_RES auto-bump
-path (and a guard that url_template behaviour is unchanged).
+"""Offline tests for version-check.py.
 
 Self-contained (no pytest): run `python3 .github/scripts/test_version_check.py`.
-Exit 0 = all pass, non-zero = failure. The res_versioned path needs no
-network (no artifact download / sha256), so these tests are deterministic.
+Exit 0 = all pass, non-zero = failure. Network/resource discovery is replaced
+with deterministic test data.
 """
 
 import importlib.util
@@ -72,23 +71,90 @@ def test_extract_res_versioned():
 
 
 def test_res_apply_bump():
-    print("test_res_apply_bump (offline, no network)")
-    with tempfile.TemporaryDirectory() as d:
-        p = Path(d) / "xlings.lua"
-        p.write_text(RES_FIXTURE, encoding="utf-8")
-        result = vc.apply_bump(
-            p, current="0.4.60", upstream="0.4.61",
-            proposed_urls={}, token=None,
-            res_platforms=["linux", "macosx", "windows"],
+    print("test_res_apply_bump writes dual-compatible checked entries")
+    original = vc.resolve_res_hashes
+    vc.resolve_res_hashes = lambda *args, **kwargs: {
+        "linux": {"x86_64": "a" * 64, "aarch64": "b" * 64},
+        "macosx": {"aarch64": "c" * 64},
+        "windows": {"x86_64": "d" * 64},
+    }
+    try:
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "xlings.lua"
+            p.write_text(RES_FIXTURE, encoding="utf-8")
+            result = vc.apply_bump(
+                p, current="0.4.60", upstream="0.4.61",
+                proposed_urls={}, token=None,
+                res_platforms=["linux", "macosx", "windows"],
+            )
+            out = p.read_text(encoding="utf-8")
+            check(result["status"] == "applied", f"status applied (got {result['status']})")
+            check(out.count('["latest"] = { ref = "0.4.61" }') == 3, "latest bumped on all 3 platforms")
+            check('["0.4.61"] = "XLINGS_RES"' not in out, "new target is never a bare sentinel")
+            check(out.count('url = "XLINGS_RES"') == 3, "keeps the V1-compatible URL sentinel")
+            check(out.count("sha256 = {") == 3, "writes per-arch checksum tables")
+            check('x86_64 = "' + "a" * 64 + '"' in out, "writes linux x86_64 hash")
+            check('aarch64 = "' + "b" * 64 + '"' in out, "writes linux aarch64 hash")
+            check('["0.4.60"] = "XLINGS_RES"' in out, "old version entry preserved")
+    finally:
+        vc.resolve_res_hashes = original
+
+
+def test_res_apply_bump_fails_closed_without_complete_hashes():
+    print("test_res_apply_bump fails closed when resource verification fails")
+    original = vc.resolve_res_hashes
+    vc.resolve_res_hashes = lambda *args, **kwargs: {
+        "status": "error", "reason": "missing sidecar for windows"
+    }
+    try:
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "xlings.lua"
+            p.write_text(RES_FIXTURE, encoding="utf-8")
+            before = p.read_text(encoding="utf-8")
+            result = vc.apply_bump(
+                p, current="0.4.60", upstream="0.4.61",
+                proposed_urls={}, token=None,
+                res_platforms=["linux", "macosx", "windows"],
+            )
+            check(result["status"] == "error", "verification error aborts bump")
+            check(p.read_text(encoding="utf-8") == before, "failure leaves recipe untouched")
+    finally:
+        vc.resolve_res_hashes = original
+
+
+def test_res_hash_discovery_rejects_architecture_regression():
+    print("test_res_hash_discovery rejects a missing architecture")
+    original_release = vc.github_release_by_tag
+    current_assets = [
+        "mcpp-1.0.0-linux-x86_64.tar.gz",
+        "mcpp-1.0.0-linux-aarch64.tar.gz",
+        "mcpp-1.0.0-macosx-arm64.tar.gz",
+        "mcpp-1.0.0-windows-x86_64.zip",
+    ]
+    upstream_assets = [
+        "mcpp-1.1.0-linux-x86_64.tar.gz",
+        "mcpp-1.1.0-macosx-arm64.tar.gz",
+        "mcpp-1.1.0-windows-x86_64.zip",
+    ]
+
+    def release(_owner, _name, tag, _token):
+        names = current_assets if tag == "1.0.0" else upstream_assets
+        assets = []
+        for name in names:
+            assets.append({"name": name, "browser_download_url": "https://example/" + name})
+            assets.append({"name": name + ".sha256", "browser_download_url": "https://example/" + name + ".sha256"})
+        return {"assets": assets}
+
+    vc.github_release_by_tag = release
+    try:
+        result = vc.resolve_res_hashes(
+            "mcpp", "1.0.0", "1.1.0",
+            ["linux", "macosx", "windows"], None,
         )
-        out = p.read_text(encoding="utf-8")
-        check(result["status"] == "applied", f"status applied (got {result['status']})")
-        check(out.count('["latest"] = { ref = "0.4.61" }') == 3, "latest bumped on all 3 platforms")
-        check(out.count('["0.4.61"] = "XLINGS_RES"') == 3, "new XLINGS_RES entry on all 3 platforms")
-        check('["0.4.60"] = "XLINGS_RES"' in out, "old version entry preserved")
-        check("sha256" not in out, "no sha256 written for res entries")
-        check(all(v == "XLINGS_RES" for v in result["platforms"].values()),
-              "per-platform reports XLINGS_RES")
+        check(result["status"] == "error", "arch set regression aborts verification")
+        check("architecture set changed" in result["reason"], "error identifies architecture set")
+    finally:
+        vc.github_release_by_tag = original_release
 
 
 def test_url_apply_bump_unaffected(monkeypatch_sha="deadbeef"):
@@ -116,6 +182,8 @@ def test_url_apply_bump_unaffected(monkeypatch_sha="deadbeef"):
 if __name__ == "__main__":
     test_extract_res_versioned()
     test_res_apply_bump()
+    test_res_apply_bump_fails_closed_without_complete_hashes()
+    test_res_hash_discovery_rejects_architecture_regression()
     test_url_apply_bump_unaffected()
     if _failures:
         print(f"\n{len(_failures)} FAILURE(S)")

--- a/.github/scripts/version-check.py
+++ b/.github/scripts/version-check.py
@@ -106,12 +106,9 @@ def extract_res_versioned(platform_body: str) -> bool:
     """True if the platform opts into XLINGS_RES-style auto-bump.
 
     Marked with `res_versioned = true`. Such a platform tracks its `repo`'s
-    latest GitHub release just like `url_template`, but on bump it appends
-    `["<ver>"] = "XLINGS_RES"` (resolved through the multi-mirror resource
-    service) instead of a hardcoded url+sha256 — so it keeps the mirror
-    fallback that XLINGS_RES gives and needs no artifact download. This is
-    what lets the bot keep `xlings` (and other XLINGS_RES packages) current
-    instead of silently going stale.
+    latest GitHub release just like `url_template`. Apply mode accepts a new
+    version only after the mirrored xlings-res release contains a binary and
+    matching sha256 sidecar for every opted-in platform resource.
     """
     return re.search(r'\bres_versioned\s*=\s*true\b', platform_body) is not None
 
@@ -321,6 +318,131 @@ def compute_sha256(url: str, token: str | None) -> str:
     return h.hexdigest()
 
 
+def fetch_text(url: str, token: str | None) -> str:
+    req = urllib.request.Request(
+        url, headers={"User-Agent": "xim-pkgindex-version-bump"}
+    )
+    if token and "github.com" in url:
+        req.add_header("Authorization", f"Bearer {token}")
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        return resp.read().decode("utf-8")
+
+
+def github_release_by_tag(owner: str, name: str, tag: str,
+                          token: str | None) -> dict[str, Any]:
+    url = f"https://api.github.com/repos/{owner}/{name}/releases/tags/{tag}"
+    req = urllib.request.Request(
+        url, headers={"User-Agent": "xim-pkgindex-version-bump"}
+    )
+    if token:
+        req.add_header("Authorization", f"Bearer {token}")
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        return json.loads(resp.read())
+
+
+def canonical_arch(arch: str) -> str:
+    value = arch.lower().replace("-", "_")
+    if value in {"amd64", "x64", "x86_64"}:
+        return "x86_64"
+    if value in {"arm64", "armv8", "aarch64"}:
+        return "aarch64"
+    return value
+
+
+def release_arches(package_name: str, version: str, platform: str,
+                   assets: dict[str, str]) -> set[str]:
+    prefix = f"{package_name}-{version}-{platform}-"
+    result = set()
+    for name in assets:
+        if (not name.startswith(prefix)
+                or name.endswith(".sha256")
+                or not (name.endswith(".tar.gz") or name.endswith(".zip"))):
+            continue
+        suffix = name[len(prefix):]
+        result.add(canonical_arch(
+            suffix.removesuffix(".tar.gz").removesuffix(".zip")))
+    return result
+
+
+def resolve_res_hashes(package_name: str, current: str, version: str,
+                       platforms: list[str], token: str | None) -> dict[str, Any]:
+    """Verify xlings-res release assets and return platform->arch->sha256.
+
+    The sidecar supplies the expected digest; the binary is streamed and
+    hashed independently. Missing platform assets, sidecars, malformed
+    digests, or mismatches abort the entire version bump.
+    """
+    try:
+        current_release = github_release_by_tag(
+            "xlings-res", package_name, current, token)
+        release = github_release_by_tag("xlings-res", package_name, version, token)
+    except (urllib.error.HTTPError, urllib.error.URLError, TimeoutError) as e:
+        return {"status": "error", "reason": f"resource release unavailable: {e}"}
+
+    assets = {
+        item.get("name", ""): item.get("browser_download_url", "")
+        for item in release.get("assets", [])
+        if item.get("name") and item.get("browser_download_url")
+    }
+    current_assets = {
+        item.get("name", ""): item.get("browser_download_url", "")
+        for item in current_release.get("assets", [])
+        if item.get("name") and item.get("browser_download_url")
+    }
+    result: dict[str, dict[str, str]] = {}
+    for platform in platforms:
+        expected_arches = release_arches(
+            package_name, current, platform, current_assets)
+        actual_arches = release_arches(package_name, version, platform, assets)
+        if not expected_arches:
+            return {
+                "status": "error",
+                "reason": f"current release has no resource asset for {platform}",
+            }
+        if actual_arches != expected_arches:
+            return {
+                "status": "error",
+                "reason": (
+                    f"architecture set changed for {platform}: "
+                    f"{sorted(expected_arches)} -> {sorted(actual_arches)}"
+                ),
+            }
+        prefix = f"{package_name}-{version}-{platform}-"
+        binaries = [
+            name for name in assets
+            if name.startswith(prefix)
+            and (name.endswith(".tar.gz") or name.endswith(".zip"))
+            and not name.endswith(".sha256")
+        ]
+        if not binaries:
+            return {"status": "error", "reason": f"no resource asset for {platform}"}
+        hashes: dict[str, str] = {}
+        for filename in sorted(binaries):
+            suffix = filename[len(prefix):]
+            arch = suffix.removesuffix(".tar.gz").removesuffix(".zip")
+            arch = canonical_arch(arch)
+            sidecar = filename + ".sha256"
+            if sidecar not in assets:
+                return {"status": "error", "reason": f"missing sidecar: {sidecar}"}
+            try:
+                sidecar_text = fetch_text(assets[sidecar], token).strip()
+                match = re.fullmatch(r"([0-9a-fA-F]{64})\s+\*?(.+)", sidecar_text)
+                if not match or match.group(2) != filename:
+                    return {"status": "error", "reason": f"invalid sidecar: {sidecar}"}
+                expected = match.group(1).lower()
+                actual = compute_sha256(assets[filename], token)
+            except (urllib.error.HTTPError, urllib.error.URLError, TimeoutError) as e:
+                return {"status": "error", "reason": f"failed to verify {filename}: {e}"}
+            if actual != expected:
+                return {
+                    "status": "error",
+                    "reason": f"sha256 mismatch for {filename}: got {actual}, want {expected}",
+                }
+            hashes[arch] = expected
+        result[platform] = hashes
+    return result
+
+
 def apply_bump(
     lua_path: Path,
     current: str,
@@ -337,9 +459,9 @@ def apply_bump(
       - url_template platforms (in `proposed_urls`): the artifact is
         downloaded, its sha256 computed, and a
         `["<upstream>"] = { url = ..., sha256 = ... }` block appended.
-      - res_versioned platforms (in `res_platforms`): a bare
-        `["<upstream>"] = "XLINGS_RES"` entry is appended — no download,
-        no sha256 (the resource service resolves + verifies it).
+      - res_versioned platforms (in `res_platforms`): mirrored binaries and
+        sidecars are verified first, then a V1-compatible `url = "XLINGS_RES"`
+        resource table with per-arch sha256 values is appended.
 
     Returns a record describing what happened (status + per-platform).
     """
@@ -352,7 +474,14 @@ def apply_bump(
         return {"status": "error", "reason": "xpm block not found"}
 
     edits: list[tuple[int, int, str]] = []
-    per_platform: dict[str, str] = {}
+    per_platform: dict[str, Any] = {}
+
+    res_hashes: dict[str, Any] = {}
+    if res_platforms:
+        res_hashes = resolve_res_hashes(
+            lua_path.stem, current, upstream, res_platforms, token)
+        if res_hashes.get("status") == "error":
+            return res_hashes
     for plat, new_url in proposed_urls.items():
         plat_range = find_block_range(text, plat, xpm[0])
         if not plat_range or plat_range[1] > xpm[1]:
@@ -400,7 +529,8 @@ def apply_bump(
         )
         per_platform[plat] = sha
 
-    # XLINGS_RES platforms: append a bare entry, no download/sha256.
+    # XLINGS_RES platforms: retain the sentinel URL for V1 readers while
+    # supplying architecture hashes to V2/current readers.
     for plat in res_platforms:
         plat_range = find_block_range(text, plat, xpm[0])
         if not plat_range or plat_range[1] > xpm[1]:
@@ -415,14 +545,26 @@ def apply_bump(
         if not m:
             continue
         indent = m.group("indent")
+        hashes = res_hashes.get(plat, {})
+        if not hashes:
+            return {"status": "error", "reason": f"no verified hashes for {plat}"}
+        hash_lines = "".join(
+            f'{indent}        {arch} = "{digest}",\n'
+            for arch, digest in sorted(hashes.items())
+        )
         replacement = (
             f'{indent}["latest"] = {{ ref = "{upstream}" }},\n'
-            f'{indent}["{upstream}"] = "XLINGS_RES",\n'
+            f'{indent}["{upstream}"] = {{\n'
+            f'{indent}    url = "XLINGS_RES",\n'
+            f'{indent}    sha256 = {{\n'
+            f'{hash_lines}'
+            f'{indent}    }},\n'
+            f'{indent}}},\n'
         )
         edits.append(
             (plat_range[0] + m.start(), plat_range[0] + m.end(), replacement)
         )
-        per_platform[plat] = "XLINGS_RES"
+        per_platform[plat] = hashes
 
     if not edits:
         return {"status": "no-edit", "reason": "no matching latest line on any platform"}

--- a/pkgs/m/mcpp.lua
+++ b/pkgs/m/mcpp.lua
@@ -37,18 +37,31 @@ package = {
     -- xvm registers `bindir = <install>/bin` so the binary is invoked
     -- directly; the shell launcher is only useful from the bundle root.
     xpm = {
+        source = "xlings-res",
         linux = {
             -- res_versioned: version-bump bot tracks mcpp-community/mcpp releases
-            -- and appends new ["x.y.z"] = "XLINGS_RES" entries (see version-check.py).
+            -- and appends checked XLINGS_RES entries (see version-check.py).
             res_versioned = true,
             ["latest"] = { ref = "0.0.87" },
-            ["0.0.87"] = "XLINGS_RES",
+            ["0.0.87"] = {
+                url = "XLINGS_RES",
+                sha256 = {
+                    x86_64 = "2130c29785e427bd888963408d2dcc1825696a229c3ff642adf52d5e08d5923e",
+                    aarch64 = "acc5c2af4274a6c3ca69462f271d96d161ae68c9421a0ff5048add6077479a9b",
+                },
+            },
             ["0.0.86"] = "XLINGS_RES",
             ["0.0.85"] = "XLINGS_RES",
             ["0.0.84"] = "XLINGS_RES",
             ["0.0.83"] = "XLINGS_RES",
             ["0.0.82"] = "XLINGS_RES",
-            ["0.0.81"] = "XLINGS_RES",
+            ["0.0.81"] = {
+                url = "XLINGS_RES",
+                sha256 = {
+                    x86_64 = "47c41529a00930ad701a76bb53e0847220c0764eb1f8e6cf6d515c45fea8cfcc",
+                    aarch64 = "27894adfdafd841436fb6c7342e81c107ae7131345bbb249e31483b0452ff5cc",
+                },
+            },
             ["0.0.80"] = "XLINGS_RES",
             ["0.0.79"] = "XLINGS_RES",
             ["0.0.78"] = "XLINGS_RES",
@@ -60,7 +73,13 @@ package = {
             ["0.0.72"] = "XLINGS_RES",
             ["0.0.70"] = "XLINGS_RES",
             ["0.0.68"] = "XLINGS_RES",
-            ["0.0.67"] = "XLINGS_RES",
+            ["0.0.67"] = {
+                url = "XLINGS_RES",
+                sha256 = {
+                    x86_64 = "db7d00564ec33b7ecd22e2294f805c0245b8107b42dd256e9db4e982e838a5a9",
+                    aarch64 = "4690fcefbe356ecd090948899d30c1ca1904d34efc72217268d7113db87aa63a",
+                },
+            },
             ["0.0.66"] = "XLINGS_RES",
             ["0.0.65"] = "XLINGS_RES",
             ["0.0.64"] = "XLINGS_RES",
@@ -123,16 +142,26 @@ package = {
         },
         macosx = {
             -- res_versioned: version-bump bot tracks mcpp-community/mcpp releases
-            -- and appends new ["x.y.z"] = "XLINGS_RES" entries (see version-check.py).
+            -- and appends checked XLINGS_RES entries (see version-check.py).
             res_versioned = true,
             ["latest"] = { ref = "0.0.87" },
-            ["0.0.87"] = "XLINGS_RES",
+            ["0.0.87"] = {
+                url = "XLINGS_RES",
+                sha256 = {
+                    aarch64 = "4b85c5600e4ac1c26eb88feedcf50bdfd5bfbc8ce2d3993585a1cf98cb115f12",
+                },
+            },
             ["0.0.86"] = "XLINGS_RES",
             ["0.0.85"] = "XLINGS_RES",
             ["0.0.84"] = "XLINGS_RES",
             ["0.0.83"] = "XLINGS_RES",
             ["0.0.82"] = "XLINGS_RES",
-            ["0.0.81"] = "XLINGS_RES",
+            ["0.0.81"] = {
+                url = "XLINGS_RES",
+                sha256 = {
+                    aarch64 = "a9678b69f39e536cd9bea861cca268956e04d1b573b6aa48ca4f193a218b28dd",
+                },
+            },
             ["0.0.80"] = "XLINGS_RES",
             ["0.0.79"] = "XLINGS_RES",
             ["0.0.78"] = "XLINGS_RES",
@@ -144,7 +173,12 @@ package = {
             ["0.0.72"] = "XLINGS_RES",
             ["0.0.70"] = "XLINGS_RES",
             ["0.0.68"] = "XLINGS_RES",
-            ["0.0.67"] = "XLINGS_RES",
+            ["0.0.67"] = {
+                url = "XLINGS_RES",
+                sha256 = {
+                    aarch64 = "8b851022a02f80062c3a4c752828d6c78a7be777e91a42287434219f8f8c8802",
+                },
+            },
             ["0.0.66"] = "XLINGS_RES",
             ["0.0.65"] = "XLINGS_RES",
             ["0.0.64"] = "XLINGS_RES",
@@ -193,16 +227,26 @@ package = {
         },
         windows = {
             -- res_versioned: version-bump bot tracks mcpp-community/mcpp releases
-            -- and appends new ["x.y.z"] = "XLINGS_RES" entries (see version-check.py).
+            -- and appends checked XLINGS_RES entries (see version-check.py).
             res_versioned = true,
             ["latest"] = { ref = "0.0.87" },
-            ["0.0.87"] = "XLINGS_RES",
+            ["0.0.87"] = {
+                url = "XLINGS_RES",
+                sha256 = {
+                    x86_64 = "5fa21e75b3212614877c50d9aa3f230b6c5b68fe8fab46e1e46eb48729985929",
+                },
+            },
             ["0.0.86"] = "XLINGS_RES",
             ["0.0.85"] = "XLINGS_RES",
             ["0.0.84"] = "XLINGS_RES",
             ["0.0.83"] = "XLINGS_RES",
             ["0.0.82"] = "XLINGS_RES",
-            ["0.0.81"] = "XLINGS_RES",
+            ["0.0.81"] = {
+                url = "XLINGS_RES",
+                sha256 = {
+                    x86_64 = "19ce6993fa82043a9e79448635547f6127624568893fdd8e12e71b9e7d78bb43",
+                },
+            },
             ["0.0.80"] = "XLINGS_RES",
             ["0.0.79"] = "XLINGS_RES",
             ["0.0.78"] = "XLINGS_RES",
@@ -214,7 +258,12 @@ package = {
             ["0.0.72"] = "XLINGS_RES",
             ["0.0.70"] = "XLINGS_RES",
             ["0.0.68"] = "XLINGS_RES",
-            ["0.0.67"] = "XLINGS_RES",
+            ["0.0.67"] = {
+                url = "XLINGS_RES",
+                sha256 = {
+                    x86_64 = "60941ad9e1ff0b9fcc93c291d7accbb07f1b008285fc4f9d7c8e5375015e810f",
+                },
+            },
             ["0.0.66"] = "XLINGS_RES",
             ["0.0.65"] = "XLINGS_RES",
             ["0.0.64"] = "XLINGS_RES",

--- a/tests/m/test_mcpp.py
+++ b/tests/m/test_mcpp.py
@@ -40,26 +40,36 @@ class TestStatic:
 
     @pytest.mark.static
     def test_latest_uses_xlings_res(self, meta):
-        # mcpp assets are distributed through the XLINGS_RES mirrors. Assert the
-        # `latest` ref (whatever version it currently points at) maps to an
-        # XLINGS_RES entry in every platform block — version-agnostic so it
-        # doesn't go stale on each release bump.
+        # The latest target must keep the legacy URL sentinel while adding the
+        # complete per-platform architecture checksum set.
         def platform_block(platform, next_marker):
             start = meta.raw_content.index(f"        {platform} = {{")
             end = meta.raw_content.index(next_marker, start)
             return meta.raw_content[start:end]
 
         platforms = (
-            ("linux", "        macosx = {"),
-            ("macosx", "        windows = {"),
-            ("windows", "\n        },\n    },"),
+            ("linux", "        macosx = {", {"x86_64", "aarch64"}),
+            ("macosx", "        windows = {", {"aarch64"}),
+            ("windows", "\n        },\n    },", {"x86_64"}),
         )
-        for platform, next_marker in platforms:
+        for platform, next_marker, expected_arches in platforms:
             block = platform_block(platform, next_marker)
             m = re.search(r'\["latest"\]\s*=\s*\{\s*ref\s*=\s*"([0-9.]+)"\s*\}', block)
             assert m, f"no `latest` ref in {platform} block"
             latest = m.group(1)
-            assert re.search(rf'\["{re.escape(latest)}"\]\s*=\s*"XLINGS_RES"', block)
+            entry_start = block.index(f'["{latest}"]', m.end())
+            next_entry = re.search(r'\n\s*\["[0-9.]+' + r'"\]\s*=', block[entry_start + 1:])
+            entry_end = (entry_start + 1 + next_entry.start()) if next_entry else len(block)
+            entry = block[entry_start:entry_end]
+            assert re.search(r'url\s*=\s*"XLINGS_RES"', entry)
+            hashes = {
+                arch: digest.lower()
+                for arch, digest in re.findall(
+                    r'\b(x86_64|aarch64)\s*=\s*"([0-9a-fA-F]{64})"', entry)
+            }
+            assert set(hashes) == expected_arches
+
+        assert re.search(r'\bxpm\s*=\s*\{\s*source\s*=\s*"xlings-res"', meta.raw_content)
 
     @pytest.mark.static
     def test_install_uses_runtime_dir(self, meta):


### PR DESCRIPTION
## Summary

- add verified per-architecture SHA256 values for mcpp 0.0.67, 0.0.81, and 0.0.87 while retaining the legacy `url = "XLINGS_RES"` sentinel
- add the backward-compatible `xpm.source = "xlings-res"` default after validating it with released xlings 0.4.49 and 0.4.62
- make `res_versioned` bumps fail closed unless the xlings-res release has the same platform/architecture matrix, valid sidecars, and binaries matching those sidecars
- preserve all other historical mcpp entries unchanged

Refs: openxlings/xlings#356

## Compatibility

The migrated entry remains readable by V1 clients through its string `url` field. Newer clients additionally select the host architecture checksum. Isolated installs passed for:

- xlings 0.4.49: mcpp 0.0.67, 0.0.81, 0.0.87
- xlings 0.4.62: mcpp 0.0.67, 0.0.81, 0.0.87
- the issue #356 fixed xlings build: mcpp 0.0.67, 0.0.81, 0.0.87

All nine installs produced runnable `bin/mcpp` binaries and cache files matching the declared hashes. The fixed client also replaced a pre-seeded 116,736-byte corrupt 0.0.81 cache with the verified 12,628,937-byte artifact.

## Resource verification

For each of the three versions, four release assets were downloaded in full from both GLOBAL (GitHub) and CN (GitCode): Linux x86_64, Linux aarch64, macOS arm64, and Windows x86_64.

- 24/24 complete downloads matched the authoritative SHA256
- GLOBAL and CN files were byte-identical for every asset
- every archive contained `bin/mcpp` or `bin/mcpp.exe`
- 0.0.81 and 0.0.87 upstream/GLOBAL/CN sidecars were identical
- 0.0.67 mirror sidecars are absent; its upstream sidecars were checked against both complete mirror downloads

## Tests

- `python3 .github/scripts/test_version_check.py`
- `python3 -m py_compile .github/scripts/version-check.py .github/scripts/test_version_check.py`
- `python3 .github/scripts/parse-xpkg-meta.py pkgs/m/mcpp.lua`
- `.github/scripts/check-no-direct-ld-libpath.sh`
- `git diff --check`
- live `resolve_res_hashes("mcpp", "0.0.81", "0.0.87", ...)` verification

This is a draft and must not merge until repository CI and the cross-ecosystem release gates are green.
