### PR TITLE
bump(xlings): track 0.4.63 with verified resources

### DIFF
--- a/pkgs/x/xlings.lua
+++ b/pkgs/x/xlings.lua
@@ -37,7 +37,14 @@ package = {
             -- res_versioned: version-bump bot tracks openxlings/xlings releases and
             -- appends new ["x.y.z"] = "XLINGS_RES" entries (see version-check.py).
             res_versioned = true,
-            ["latest"] = { ref = "0.4.62" },
+            ["latest"] = { ref = "0.4.63" },
+            ["0.4.63"] = {
+                url = "XLINGS_RES",
+                sha256 = {
+                    aarch64 = "596a6f57577293ca533a701136227ce353e0d4e0d7a623b77f84a9e2bc95fcea",
+                    x86_64 = "3a435ae7ed58bd839053d9f5c72320a0123942ae9ccf920f424ce28f520076f6",
+                },
+            },
             ["0.4.62"] = "XLINGS_RES",
             ["0.4.60"] = "XLINGS_RES",
             ["0.4.55"] = "XLINGS_RES",
@@ -190,7 +197,13 @@ package = {
             -- res_versioned: version-bump bot tracks openxlings/xlings releases and
             -- appends new ["x.y.z"] = "XLINGS_RES" entries (see version-check.py).
             res_versioned = true,
-            ["latest"] = { ref = "0.4.62" },
+            ["latest"] = { ref = "0.4.63" },
+            ["0.4.63"] = {
+                url = "XLINGS_RES",
+                sha256 = {
+                    aarch64 = "e58e585836c26861ce470c2d519f5bba6f641bbc8691c1d668070bafbeaf0602",
+                },
+            },
             ["0.4.62"] = "XLINGS_RES",
             ["0.4.60"] = "XLINGS_RES",
             ["0.4.55"] = "XLINGS_RES",
@@ -343,7 +356,13 @@ package = {
             -- res_versioned: version-bump bot tracks openxlings/xlings releases and
             -- appends new ["x.y.z"] = "XLINGS_RES" entries (see version-check.py).
             res_versioned = true,
-            ["latest"] = { ref = "0.4.62" },
+            ["latest"] = { ref = "0.4.63" },
+            ["0.4.63"] = {
+                url = "XLINGS_RES",
+                sha256 = {
+                    x86_64 = "0ec7845bcc346439c46332676cb8430cea8384f31ee67256df5d58f38a08fe1c",
+                },
+            },
             ["0.4.62"] = "XLINGS_RES",
             ["0.4.60"] = "XLINGS_RES",
             ["0.4.55"] = "XLINGS_RES",

--- a/tests/x/test_xlings.py
+++ b/tests/x/test_xlings.py
@@ -51,12 +51,27 @@ class TestStatic:
             return meta.raw_content[start:end]
 
         stable_versions = ("0.4.44", "0.4.43", "0.4.42", "0.4.41", "0.4.40")
+        expected_arches = {
+            "linux": {"x86_64", "aarch64"},
+            "macosx": {"aarch64"},
+            "windows": {"x86_64"},
+        }
         for platform, next_platform in (("linux", "macosx"), ("macosx", "windows"), ("windows", None)):
             block = platform_block(platform, next_platform)
             m = re.search(r'\["latest"\]\s*=\s*\{\s*ref\s*=\s*"([0-9.]+)"\s*\}', block)
             assert m, f"no `latest` ref in {platform} block"
             latest = m.group(1)
-            assert re.search(rf'\["{re.escape(latest)}"\]\s*=\s*"XLINGS_RES"', block)
+            entry_start = block.index(f'["{latest}"]', m.end())
+            next_entry = re.search(r'\n\s*\["[0-9.]+' + r'"\]\s*=', block[entry_start + 1:])
+            entry_end = (entry_start + 1 + next_entry.start()) if next_entry else len(block)
+            entry = block[entry_start:entry_end]
+            assert re.search(r'url\s*=\s*"XLINGS_RES"', entry)
+            hashes = {
+                arch: digest.lower()
+                for arch, digest in re.findall(
+                    r'\b(x86_64|aarch64)\s*=\s*"([0-9a-fA-F]{64})"', entry)
+            }
+            assert set(hashes) == expected_arches[platform]
             for version in stable_versions:
                 assert re.search(rf'\["{re.escape(version)}"\]\s*=\s*"XLINGS_RES"', block)
 


### PR DESCRIPTION
Adds xlings 0.4.63 as latest using the legacy-compatible XLINGS_RES URL sentinel plus complete per-architecture SHA256 tables. All four upstream, GitHub mirror, and GitCode mirror binaries were streamed and matched their published sidecars.\n\nValidation: 476/476 static tests; version-check unit tests; parser; dry-run reports up-to-date.