### PR TITLE
fix(ci): fetch history for post-merge mirror scan

### DIFF
--- a/.github/workflows/xpkg-mirror.yml
+++ b/.github/workflows/xpkg-mirror.yml
@@ -31,6 +31,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+          fetch-depth: 0
 
       - uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
## Summary
- fetch full history in the post-merge xpkg mirror workflow
- allow workflow_run to diff the merged commit against its parent

## Validation
- YAML parse
- reproduces and fixes run 29184944487 failure

Refs: #354