### PR TITLE
chore(ci): allow manual xpkg workflow dispatch

### DIFF
--- a/.github/workflows/ci-xpkg-test.yml
+++ b/.github/workflows/ci-xpkg-test.yml
@@ -1,6 +1,7 @@
 name: xpkg test
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - '**'


### PR DESCRIPTION
## Summary
- add workflow_dispatch to xpkg test so post-merge mirror workflow can be replayed safely

## Validation
- YAML parse
- used to validate the workflow_run mirror chain after a release

Refs: #354