### PR TITLE
fix(ci): require dedicated xpkg bot token

### DIFF
--- a/.agents/docs/2026-07-12-xpkg-ci-mirror-update-design.md
+++ b/.agents/docs/2026-07-12-xpkg-ci-mirror-update-design.md
@@ -326,6 +326,8 @@ checkout
 - mirror workflow 使用最小化 `xlings-res` 发布 token；
 - 发布环境要求 protected branch/environment approval；
 - `GITHUB_TOKEN` 不得获得任意仓库写权限；GitCode token 只允许目标 release 仓库。
+- 更新 PR workflow 使用受保护的 `XPKG_BOT_TOKEN`；未配置时在发现更新后立即失败并给出
+  明确配置提示，不使用默认 `GITHUB_TOKEN` 绕过仓库的 PR 创建策略。
 
 ### 6.3 可靠性
 

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -84,14 +84,19 @@ jobs:
 
       - name: Bump each package on its own branch and open PR
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          XPKG_BOT_TOKEN: ${{ secrets.XPKG_BOT_TOKEN }}
         run: |
           set -euo pipefail
           if [ ! -s "$RUNNER_TEMP/to-bump.tsv" ]; then
             echo "No updates available — nothing to do."
             exit 0
           fi
+          if [ -z "$XPKG_BOT_TOKEN" ]; then
+            echo "error: configure protected secret XPKG_BOT_TOKEN to allow the bot to create PRs" >&2
+            exit 1
+          fi
+          export GH_TOKEN="$XPKG_BOT_TOKEN"
+          export GITHUB_TOKEN="$XPKG_BOT_TOKEN"
 
           while IFS=$'\t' read -r pkg current upstream; do
             branch="auto/bump-${pkg}-${upstream}"


### PR DESCRIPTION
## Summary
- require protected XPKG_BOT_TOKEN before an update workflow creates PRs
- document the permission contract and fail early when the secret is missing

## Validation
- real run 29185078667 demonstrated the default Actions token restriction
- YAML parse and local workflow review

Refs: #354