### PR TITLE
feat(ci): migrate four packages to mirror and update automation

### DIFF
--- a/.agents/docs/2026-07-12-source-map-global-cn-multi-repo-plan.md
+++ b/.agents/docs/2026-07-12-source-map-global-cn-multi-repo-plan.md
@@ -1,0 +1,260 @@
+# xpm source GLOBAL/CN 多仓库镜像与自动更新方案
+
+> 日期：2026-07-12  
+> 状态：设计方案，尚未实现  
+> 范围：libxpkg、xlings、xim-pkgindex、xlings-res 发布链  
+> 兼容约束：xlings 包本身暂不迁移到新规范
+
+## 1. 背景与目标
+
+当前 xpkg 已支持：
+
+- 版本项 url = { GLOBAL = ..., CN = ... } 镜像表；
+- 版本扫描器使用的旧 xpm.<platform>.url_template；
+- V2 的单字符串 xpm.source 模板。
+
+目标是让 source 支持地区模板，避免每个版本重复写 URL：
+
+    xpm = {
+        source = {
+            GLOBAL = "https://github.com/neovim/neovim/releases/download/v${version}/nvim-${os}-${arch_alias}.tar.gz",
+            CN = "https://gitcode.com/xlings-res/nvim/releases/download/${version}/nvim-${os}-${arch_alias}.tar.gz",
+        },
+        linux = {
+            ["latest"] = { ref = "0.12.4" },
+            ["0.12.4"] = {
+                sha256 = { x86_64 = "<sha256>" },
+            },
+        },
+    }
+
+最终应满足：
+
+1. GLOBAL 是权威上游，CN 是已校验的 xlings-res 镜像。
+2. xlings 按地区选择 URL，失败、404 或 hash mismatch 时安全回退。
+3. 所有候选使用同一 per-arch SHA256。
+4. CI 能发现上游版本、生成 manifest、发布镜像并创建索引 PR。
+5. 旧客户端继续解析字符串 source、显式 url 和 XLINGS_RES。
+6. xlings 包本身不迁移，继续保证安装和自升级兼容。
+
+## 2. 协议设计
+
+### 2.1 source 输入形状
+
+保留三种形状：
+
+    -- 兼容旧写法
+    source = "https://example.com/${version}/tool-${arch}.tar.gz"
+
+    -- 新写法
+    source = {
+        GLOBAL = "https://github.com/acme/tool/releases/download/${version}/tool-${arch_alias}.tar.gz",
+        CN = "https://gitcode.com/xlings-res/tool/releases/download/${version}/tool-${arch_alias}.tar.gz",
+    }
+
+    -- 官方资源特殊值
+    source = "xlings-res"
+
+支持 root xpm.source 和 platform-level source；platform-level 覆盖 root-level。
+模板变量为 name、version、os、arch、arch_alias、ext。
+
+地区 map 约束：
+
+- 至少有 GLOBAL 或一个可解析候选；
+- 值必须是 HTTPS 模板；
+- CN 缺失时回退 GLOBAL；
+- GLOBAL 缺失时不能静默选择任意 map 项作为权威源；
+- 地区候选只改变传输位置，不改变版本、归档、架构和 hash。
+- CN 模板只有在镜像资产文件名、tag 和目录布局与模板一致时才能自动生成；不规则
+  镜像必须由 manifest 生成版本级 url map，不能猜测文件名。
+
+### 2.2 资源归一化优先级
+
+1. per-arch 版本项：version.arch = { url, sha256 }；
+2. 版本项显式 url / url = { GLOBAL, CN }；
+3. platform source；
+4. root source；
+5. source = "xlings-res"；
+6. V1 兼容路径。
+
+先完成资源归一化，再按 preferred mirror 排序候选，最后进入统一下载、校验和
+fallback 流程。
+
+### 2.3 url_template 弃用
+
+url_template 标记为 deprecated：
+
+- 旧包继续解析；
+- 新包和迁移包只使用 source；
+- inspect/scan 输出弃用警告；
+- 文档明确它只服务旧 CI 更新流程，不参与 xlings runtime 资源解析；
+- source-map 支持发布一个稳定 xlings 版本后，不再接受新增 url_template。
+
+ci.update 应消费归一化后的 source 模板，而不是依赖字段名 url_template。
+
+## 3. 多仓库职责与实施项
+
+### 3.1 openxlings/libxpkg
+
+职责：Lua 配方解析、source map 数据模型和资源归一化。
+
+修改范围：
+
+- src/xpkg.cppm
+  - 增加 source template 单字符串/map 模型；
+  - PlatformMatrix 保存 root/platform source；
+  - 保持 PlatformResource.mirrors 兼容。
+- src/xpkg-loader.cppm
+  - 解析 xpm.source 字符串或 {GLOBAL,CN}；
+  - 解析 platform/root 覆盖；
+  - 非字符串、空 map、坏 URL fail closed。
+- resolve_resource
+  - 展开模板；
+  - 生成首选 URL 与 fallback URLs；
+  - 绑定同一版本和 per-arch SHA256。
+
+测试必须覆盖字符串 source、GLOBAL/CN map、root/platform 覆盖、CN 缺失回退、
+显式版本 URL 覆盖 source、坏 map 和旧 V1/V2 fixture。
+
+### 3.2 openxlings/xlings
+
+职责：安装器选择地区、尝试 fallback、校验缓存和输出诊断。
+
+重点文件：
+
+- src/core/xim/installer.cppm
+  - 使用 libxpkg 归一化结果；
+  - preferred CN/GLOBAL 先尝试；
+  - 404、超时、下载失败、hash mismatch 进入候选 fallback；
+  - 保持 XLINGS_RES 自动资源服务器 fallback。
+- src/core/xim/libxpkg/types/type.cppm
+  - 必要时补 resolved candidate/source kind 类型。
+- tests/unit、tests/e2e
+  - fake GLOBAL/CN server；
+  - CN 404 回退 GLOBAL；
+  - GLOBAL 超时回退 CN；
+  - hash mismatch 拒绝错误资产；
+  - source map、显式 mirror map、XLINGS_RES 三种路径兼容。
+
+### 3.3 openxlings/xim-pkgindex
+
+职责：规范、CI、manifest、索引配方和迁移。
+
+修改范围：
+
+- docs/V2/xpackage-spec.md：source map、fallback、优先级和 hash 规范；
+- docs/contributing.md：新模板、mirror 前置条件和验证命令；
+- docs/spec/url-template.md：deprecated 标记和迁移说明；
+- .github/scripts/version-check.py
+  - 只从 GLOBAL 模板查询上游；
+  - 同时识别字符串 source 与 source map；
+  - 生成完整 per-platform/per-arch update manifest；
+  - 不在 CN release 尚未验证时生成 CN 路由；
+- tools/xpkg_ci.py
+  - inspect 输出 source map；
+  - materialize 使用 GLOBAL/权威源；
+  - verify 检查候选、归档、sidecar、hash；
+  - mirror 发布同名 GitHub/GitCode 资产；
+  - 增加 source-map fixture 和 dry-run 测试。
+
+### 3.4 xlings-res 发布面
+
+每个 package/version 必须同时具备：
+
+- GitHub xlings-res/<pkg> 同名 tag/release；
+- GitCode xlings-res/<pkg> 同名 tag/release；
+- 全部平台/架构归档；
+- 同名 .sha256 sidecar；
+- manifest.json；
+- 权威 GLOBAL、GitHub RES、GitCode RES 三方 hash 一致。
+
+GitCode release asset 不覆盖、不删除；历史 release 不回写 latest。
+
+## 4. CI 状态机
+
+    ci.update=true
+      → 读取 GLOBAL source template
+      → 查询上游 latest release
+      → 下载全部平台/架构并计算 hash
+      → 生成 immutable update manifest
+      → 创建 update PR
+
+    ci.mirror=true
+      → 消费同一 manifest
+      → 发布 GitHub RES + GitCode RES
+      → 三方 hash、大小、文件名核验
+      → 生成 mirror-ready 证明
+      → 生成带 GLOBAL/CN source route 的索引 PR
+
+manifest 是唯一事实源；update 和 mirror 不得各自重新下载并计算 hash。
+merge 前不允许把不存在的 CN release 写入索引。
+
+source map 的 CN 候选不能只因为 URL 形式合法就进入索引；route generator 必须先
+读取 mirror manifest，确认对应 tag、文件名和 sidecar 已经存在，再生成 CN 模板或
+版本级覆盖。对于不同于 GLOBAL 文件名的资源，优先生成版本级 per-arch map。
+
+## 5. 迁移批次
+
+### Batch 0：单架构、低风险
+
+先迁移已有 PR #360 涉及的：
+
+- fish
+- griddycode
+- nvim
+- pnpm
+
+要求：spec = "2"、ci opt-in、source map、per-arch hash、mirror manifest 和跨平台
+install/config/uninstall 验证。
+
+### Batch 1：需要架构校正
+
+- ripgrep
+- fzf
+- zoxide
+- sing-box
+- cc-connect
+- cc-switch
+
+迁移前确认每个平台 x86_64/aarch64 资产存在，补 arch_alias 或改成 per-arch map；
+不能继续用一条 amd64 URL 支撑多架构声明。
+
+### Batch 2：已有镜像或复杂安装布局
+
+- yazi
+- github-gh
+- xmake
+- patchelf
+- proot
+
+先验证归档内部目录、可执行文件路径和 xvm hook，再切换 source map。
+
+暂缓：
+
+- xlings：保持 res_versioned/旧兼容路径；
+- go：上游 release 检查当前返回 404；
+- 没有完整平台资产或稳定 release 的包。
+
+## 6. 交付顺序
+
+1. libxpkg 实现 source map 数据模型、解析和单测。
+2. xlings 接入归一化结果、地区选择和 fallback。
+3. xim-pkgindex 更新规范、CI parser、manifest 和 route PR。
+4. 用 fixture 验证 GLOBAL、CN、缺失 CN、hash mismatch 和旧格式。
+5. 发布支持 source map 的 xlings/libxpkg 版本。
+6. 迁移 Batch 0，先 mirror，再提交 CN route PR。
+7. 迁移 Batch 1/2，每批独立 PR 和多平台验证。
+8. 所有包迁移完成后，停止新增 url_template，保留至少一个稳定版本周期的兼容解析。
+
+## 7. 验收清单
+
+- [ ] source 字符串和 GLOBAL/CN map 均能被 libxpkg 解析。
+- [ ] root/platform 覆盖关系有测试。
+- [ ] preferred mirror 失败按 hash 安全回退。
+- [ ] source map 不允许无 hash 资源进入安装。
+- [ ] update 只从 GLOBAL 查版本，CN 只作为已验证镜像。
+- [ ] 两端 release、sidecar、manifest 和三方 hash 一致。
+- [ ] route PR 只在 mirror-ready 后生成。
+- [ ] url_template 文档标记 deprecated，旧包仍可用。
+- [ ] Batch 0 安装/卸载和跨平台 CI 通过。
+- [ ] xlings 包没有被 source-map 迁移改动。

--- a/.agents/docs/2026-07-12-source-map-global-cn-multi-repo-plan.md
+++ b/.agents/docs/2026-07-12-source-map-global-cn-multi-repo-plan.md
@@ -2,7 +2,7 @@
 
 > 日期：2026-07-12  
 > 状态：设计方案，尚未实现  
-> 范围：libxpkg、xlings、xim-pkgindex、xlings-res 发布链  
+> 范围：libxpkg、mcpp-index、xlings、xim-pkgindex、xlings-res 发布链
 > 兼容约束：xlings 包本身暂不迁移到新规范
 
 ## 1. 背景与目标
@@ -116,7 +116,15 @@ ci.update 应消费归一化后的 source 模板，而不是依赖字段名 url_
 测试必须覆盖字符串 source、GLOBAL/CN map、root/platform 覆盖、CN 缺失回退、
 显式版本 URL 覆盖 source、坏 map 和旧 V1/V2 fixture。
 
-### 3.2 openxlings/xlings
+### 3.2 mcpp-community/mcpp-index
+
+- 在 libxpkg tag/release 完成后注册新的 `mcpplibs.xpkg` 版本。
+- `mcpp-index` 的 GLOBAL 归档、CN mirror、SHA256 必须指向同一份 release
+  字节；该注册 PR 是 xlings 使用新 xpkg 版本的依赖，不应省略。
+- 依赖顺序：libxpkg PR merge → tag/release → mcpp-index 注册并 merge →
+  xlings 依赖升级 PR CI。
+
+### 3.3 openxlings/xlings
 
 职责：安装器选择地区、尝试 fallback、校验缓存和输出诊断。
 
@@ -136,7 +144,7 @@ ci.update 应消费归一化后的 source 模板，而不是依赖字段名 url_
   - hash mismatch 拒绝错误资产；
   - source map、显式 mirror map、XLINGS_RES 三种路径兼容。
 
-### 3.3 openxlings/xim-pkgindex
+### 3.4 openxlings/xim-pkgindex
 
 职责：规范、CI、manifest、索引配方和迁移。
 
@@ -157,7 +165,7 @@ ci.update 应消费归一化后的 source 模板，而不是依赖字段名 url_
   - mirror 发布同名 GitHub/GitCode 资产；
   - 增加 source-map fixture 和 dry-run 测试。
 
-### 3.4 xlings-res 发布面
+### 3.5 xlings-res 发布面
 
 每个 package/version 必须同时具备：
 

--- a/.github/scripts/version-check.py
+++ b/.github/scripts/version-check.py
@@ -103,6 +103,14 @@ def extract_url_template(platform_body: str) -> str | None:
     return m.group(1) if m else None
 
 
+def extract_source_map(body: str) -> dict[str, str] | None:
+    m = re.search(r'\bsource\s*=\s*\{((?:[^{}]|\$\{[^{}]*\})*)\}', body)
+    if not m:
+        return None
+    result = dict(re.findall(r'\b([A-Za-z][A-Za-z0-9_]*)\s*=\s*"([^"]+)"', m.group(1)))
+    return result or None
+
+
 def extract_source_template(xpm_body: str, platform_body: str) -> str | None:
     """Read a URL-template source at platform or xpm scope.
 
@@ -111,6 +119,9 @@ def extract_source_template(xpm_body: str, platform_body: str) -> str | None:
     upstream release discovery.
     """
     for body in (platform_body, xpm_body):
+        source_map = extract_source_map(body)
+        if source_map and "GLOBAL" in source_map and "${version}" in source_map["GLOBAL"]:
+            return source_map["GLOBAL"]
         m = re.search(r'\bsource\s*=\s*"([^"\n]+)"', body)
         if m and "${version}" in m.group(1):
             return m.group(1)
@@ -237,7 +248,12 @@ def check_package(lua_path: Path, token: str | None) -> dict[str, Any] | None:
         res = extract_res_versioned(body)
         ref = extract_latest_ref(body)
         if tmpl or res or ref:
-            platforms[plat] = {"url_template": tmpl, "res_versioned": res, "ref": ref}
+            platforms[plat] = {
+                "url_template": tmpl,
+                "source_map": extract_source_map(body) or extract_source_map(xpm),
+                "res_versioned": res,
+                "ref": ref,
+            }
 
     # Opt-in is either url_template (hardcoded url+sha256 mode) or
     # res_versioned (XLINGS_RES mode). A platform that sets neither is
@@ -331,13 +347,17 @@ def check_package(lua_path: Path, token: str | None) -> dict[str, Any] | None:
 
     record["status"] = "update-available"
     proposed: dict[str, str] = {}
+    proposed_source_maps: list[str] = []
     res_platforms: list[str] = []
     for plat, info in platforms.items():
         if info.get("url_template"):
             proposed[plat] = expand_version_template(info["url_template"], upstream)
+            if info.get("source_map"):
+                proposed_source_maps.append(plat)
         elif info.get("res_versioned"):
             res_platforms.append(plat)
     record["proposed_urls"] = proposed
+    record["proposed_source_maps"] = proposed_source_maps
     record["proposed_res"] = res_platforms
     return record
 
@@ -518,6 +538,7 @@ def apply_bump(
     proposed_urls: dict[str, str],
     token: str | None,
     res_platforms: list[str] | None = None,
+    source_map_platforms: list[str] | None = None,
 ) -> dict[str, Any]:
     """Edit lua_path in place: append a new `["<upstream>"]` entry per
     platform and bump `["latest"].ref` from <current> to <upstream>.
@@ -534,6 +555,7 @@ def apply_bump(
     Returns a record describing what happened (status + per-platform).
     """
     res_platforms = res_platforms or []
+    source_map_platforms = source_map_platforms or []
     text = lua_path.read_text(encoding="utf-8")
 
     # Locate xpm block once so per-platform searches stay scoped to it.
@@ -580,13 +602,19 @@ def apply_bump(
 
         # Build the replacement: keep the latest line (with bumped ref)
         # and immediately follow it with the new version block.
-        replacement = (
-            f'{indent}["latest"] = {{ ref = "{upstream}" }},\n'
-            f'{indent}["{upstream}"] = {{\n'
-            f'{indent}    url = "{new_url}",\n'
-            f'{indent}    sha256 = "{sha}",\n'
-            f'{indent}}},\n'
-        )
+        if plat in source_map_platforms:
+            replacement = (
+                f'{indent}["latest"] = {{ ref = "{upstream}" }},\n'
+                f'{indent}["{upstream}"] = {{ sha256 = "{sha}" }},\n'
+            )
+        else:
+            replacement = (
+                f'{indent}["latest"] = {{ ref = "{upstream}" }},\n'
+                f'{indent}["{upstream}"] = {{\n'
+                f'{indent}    url = "{new_url}",\n'
+                f'{indent}    sha256 = "{sha}",\n'
+                f'{indent}}},\n'
+            )
 
         edits.append(
             (
@@ -710,6 +738,7 @@ def main() -> int:
                 rec["proposed_urls"],
                 args.token,
                 rec.get("proposed_res", []),
+                rec.get("proposed_source_maps", []),
             )
             rec["apply"] = applied
 

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ luac.out
 *.hex
 
 .xlings
+.worktrees/

--- a/docs/V2/xpackage-spec.md
+++ b/docs/V2/xpackage-spec.md
@@ -15,7 +15,7 @@ silently served the same binary to every CPU arch — e.g. a recipe declaring
 broken binary on ARM. V2 makes architecture a **first-class, declarative,
 install-time-resolved** dimension, with a mandatory per-arch checksum.
 
-Requires **xlings ≥ 0.4.63** (libxpkg ≥ 0.0.44) for the complete `xpm.source`
+Requires **xlings ≥ 0.4.63** (libxpkg ≥ 0.0.45) for the complete `xpm.source`
 and compat contract. The per-architecture shapes were introduced earlier and
 remain compatible with xlings 0.4.61+. Older clients ignore new fields or may
 misinterpret root/platform `source`; keep the legacy entry form when the same
@@ -88,7 +88,21 @@ Auto-URL pattern (unchanged from V1 `XLINGS_RES`):
 `xpm.source` keeps the original platform/version matrix and removes repeated
 URLs or repeated `"XLINGS_RES"` values. It can be declared at the root or on a
 platform; the platform value overrides the root value. Supported values are
-`"xlings-res"` and an HTTP(S) URL template.
+`"xlings-res"`, an HTTP(S) URL template, or a regional source map. In a map,
+`GLOBAL` is the canonical upstream and other keys are equivalent-byte fallback
+mirrors:
+
+```lua
+source = {
+    GLOBAL = "https://github.com/acme/foo/releases/download/${version}/foo-${arch_alias}.${ext}",
+    CN = "https://gitcode.com/xlings-res/foo/releases/download/${version}/foo-${arch_alias}.${ext}",
+},
+```
+
+The same map shape is valid at platform scope. Version entries only need to
+carry the checksum when the URL shape is stable. xlings selects the requested
+region first and retains the other regions as fallback candidates; mirror
+assets must be byte-identical.
 
 ```lua
 xpm = {

--- a/docs/spec/url-template.md
+++ b/docs/spec/url-template.md
@@ -1,4 +1,8 @@
-# `url_template`: opt-in package version auto-update
+# `url_template`: legacy opt-in package version auto-update
+
+> Deprecated: new packages should use `xpm.source` (a string or a
+> `GLOBAL`/`CN` map). Existing `url_template` packages remain supported for
+> compatibility and will be migrated opportunistically.
 
 A small contract between an xpkg description and the in-repo version
 checker (`.github/scripts/version-check.py`). The package must explicitly

--- a/pkgs/f/fish.lua
+++ b/pkgs/f/fish.lua
@@ -1,5 +1,5 @@
 package = {
-    spec = "1",
+    spec = "2",
 
     name = "fish",
     description = "Friendly interactive shell — smart, user-friendly, modern command-line",
@@ -7,6 +7,7 @@ package = {
     maintainers = {"fish-shell"},
     licenses = {"GPL-2.0"},
     repo = "https://github.com/fish-shell/fish-shell",
+    ci = { mirror = true, update = true },
     docs = "https://fishshell.com/docs/current/",
 
     type = "package",
@@ -29,7 +30,11 @@ package = {
     xpm = {
         linux = {
             url_template = "https://github.com/fish-shell/fish-shell/releases/download/{version}/fish-{version}-linux-x86_64.tar.xz",
-            ["latest"] = { ref = "4.6.0" },
+            ["latest"] = { ref = "4.8.0" },
+            ["4.8.0"] = {
+                url = "https://github.com/fish-shell/fish-shell/releases/download/4.8.0/fish-4.8.0-linux-x86_64.tar.xz",
+                sha256 = "98f7916878fc76be797cabf284f185b56f31a35681e3aec9b9faf7a4a6aa0d74",
+            },
             ["4.6.0"] = {
                 url = "https://github.com/fish-shell/fish-shell/releases/download/4.6.0/fish-4.6.0-linux-x86_64.tar.xz",
                 sha256 = "497c9c4e3fb3c006fe9d2c9a5a5447c1c90490b6b4ce6bfaf75e53b495c82f36",

--- a/pkgs/g/griddycode.lua
+++ b/pkgs/g/griddycode.lua
@@ -1,5 +1,5 @@
 package = {
-    spec = "1",
+    spec = "2",
 
     -- base info
     name = "griddycode",
@@ -8,6 +8,7 @@ package = {
     maintainers = {"face-hh"},
     licenses = {"Apache-2.0"},
     repo = "https://github.com/face-hh/griddycode",
+    ci = { mirror = true, update = true },
 
     -- xim pkg info
     type = "package",

--- a/pkgs/n/nvim.lua
+++ b/pkgs/n/nvim.lua
@@ -1,5 +1,5 @@
 package = {
-    spec = "1",
+    spec = "2",
     -- base info
     name = "nvim",
     description = "Vim-fork focused on extensibility and usability",
@@ -7,6 +7,7 @@ package = {
     contributors = "https://github.com/neovim/neovim/graphs/contributors",
     licenses = {"Apache-2.0"},
     repo = "https://github.com/neovim/neovim",
+    ci = { mirror = true, update = true },
     docs = "https://neovim.io/doc",
 
     -- xim pkg info
@@ -48,7 +49,11 @@ package = {
                 runtime = { "xim:glibc@2.39", "xim:gcc-runtime@15.1.0" },
             },
             url_template = "https://github.com/neovim/neovim/releases/download/v{version}/nvim-linux-x86_64.tar.gz",
-            ["latest"] = { ref = "0.12.2" },
+            ["latest"] = { ref = "0.12.4" },
+            ["0.12.4"] = {
+                url = "https://github.com/neovim/neovim/releases/download/v0.12.4/nvim-linux-x86_64.tar.gz",
+                sha256 = "012bf3fcac5ade43914df3f174668bf64d05e049a4f032a388c027b1ebd78628",
+            },
             ["0.12.2"] = "XLINGS_RES",
             ["0.11.5"] = {
                 url = "https://github.com/neovim/neovim/releases/download/v0.11.5/nvim-linux-x86_64.tar.gz",
@@ -57,7 +62,11 @@ package = {
         },
         windows = {
             url_template = "https://github.com/neovim/neovim/releases/download/v{version}/nvim-win64.zip",
-            ["latest"] = { ref = "0.12.2" },
+            ["latest"] = { ref = "0.12.4" },
+            ["0.12.4"] = {
+                url = "https://github.com/neovim/neovim/releases/download/v0.12.4/nvim-win64.zip",
+                sha256 = "9fc3572829ffd13debb6e32555da2c8cc02555568260a9fc4cf1f65bbcca319c",
+            },
             ["0.12.2"] = "XLINGS_RES",
             ["0.11.5"] = {
                 url = "https://github.com/neovim/neovim/releases/download/v0.11.5/nvim-win64.zip",

--- a/pkgs/n/nvim.lua
+++ b/pkgs/n/nvim.lua
@@ -48,10 +48,12 @@ package = {
             deps = {
                 runtime = { "xim:glibc@2.39", "xim:gcc-runtime@15.1.0" },
             },
-            url_template = "https://github.com/neovim/neovim/releases/download/v{version}/nvim-linux-x86_64.tar.gz",
+            source = {
+                GLOBAL = "https://github.com/neovim/neovim/releases/download/v${version}/nvim-linux-x86_64.tar.gz",
+                CN = "https://gitcode.com/xlings-res/nvim/releases/download/${version}/nvim-linux-x86_64.tar.gz",
+            },
             ["latest"] = { ref = "0.12.4" },
             ["0.12.4"] = {
-                url = "https://github.com/neovim/neovim/releases/download/v0.12.4/nvim-linux-x86_64.tar.gz",
                 sha256 = "012bf3fcac5ade43914df3f174668bf64d05e049a4f032a388c027b1ebd78628",
             },
             ["0.12.2"] = "XLINGS_RES",
@@ -61,10 +63,12 @@ package = {
             }
         },
         windows = {
-            url_template = "https://github.com/neovim/neovim/releases/download/v{version}/nvim-win64.zip",
+            source = {
+                GLOBAL = "https://github.com/neovim/neovim/releases/download/v${version}/nvim-win64.zip",
+                CN = "https://gitcode.com/xlings-res/nvim/releases/download/${version}/nvim-win64.zip",
+            },
             ["latest"] = { ref = "0.12.4" },
             ["0.12.4"] = {
-                url = "https://github.com/neovim/neovim/releases/download/v0.12.4/nvim-win64.zip",
                 sha256 = "9fc3572829ffd13debb6e32555da2c8cc02555568260a9fc4cf1f65bbcca319c",
             },
             ["0.12.2"] = "XLINGS_RES",

--- a/pkgs/p/pnpm.lua
+++ b/pkgs/p/pnpm.lua
@@ -1,11 +1,12 @@
 package = {
-    spec = "1",
+    spec = "2",
     homepage = "https://pnpm.io",
     name = "pnpm",
     description = "Fast, disk space efficient package manager",
     licenses = {"MIT"},
     type = "package",
     repo = "https://github.com/pnpm/pnpm",
+    ci = { mirror = true, update = true },
     docs = "https://pnpm.io/motivation",
 
     -- xim pkg info
@@ -44,7 +45,11 @@ package = {
                 runtime = { "xim:glibc@2.39", "xim:gcc-runtime@15.1.0" },
             },
             url_template = "https://github.com/pnpm/pnpm/releases/download/v{version}/pnpm-linux-x64.tar.gz",
-            ["latest"] = { ref = "11.0.5" },
+            ["latest"] = { ref = "11.12.0" },
+            ["11.12.0"] = {
+                url = "https://github.com/pnpm/pnpm/releases/download/v11.12.0/pnpm-linux-x64.tar.gz",
+                sha256 = "dd19bfd8bcd33a3b38dcce335e8d233194c0a61ffe1f5bcf5047f60f6d4978b8",
+            },
             ["11.0.5"] = {
                 url = "https://github.com/pnpm/pnpm/releases/download/v11.0.5/pnpm-linux-x64.tar.gz",
                 sha256 = "c1b55f53f5344cf0e26441d97b9ee2ee3b81791503c5cbd4bb93ae1898b8d211",
@@ -52,7 +57,11 @@ package = {
         },
         macosx = {
             url_template = "https://github.com/pnpm/pnpm/releases/download/v{version}/pnpm-darwin-arm64.tar.gz",
-            ["latest"] = { ref = "11.0.5" },
+            ["latest"] = { ref = "11.12.0" },
+            ["11.12.0"] = {
+                url = "https://github.com/pnpm/pnpm/releases/download/v11.12.0/pnpm-darwin-arm64.tar.gz",
+                sha256 = "0d63d9b468690e661a182efd2c1bc752dbddc753e852b76ca5218f32fcf78a2e",
+            },
             ["11.0.5"] = {
                 url = "https://github.com/pnpm/pnpm/releases/download/v11.0.5/pnpm-darwin-arm64.tar.gz",
                 sha256 = "24d412b2d137c6bc91e09c039b0e8ced6b5ac8f1dc9ea1881f0521cdb3bc5318",
@@ -60,7 +69,11 @@ package = {
         },
         windows = {
             url_template = "https://github.com/pnpm/pnpm/releases/download/v{version}/pnpm-win32-x64.zip",
-            ["latest"] = { ref = "11.0.5" },
+            ["latest"] = { ref = "11.12.0" },
+            ["11.12.0"] = {
+                url = "https://github.com/pnpm/pnpm/releases/download/v11.12.0/pnpm-win32-x64.zip",
+                sha256 = "7ac25ba81b8a9f213a307ae89198ba7e636e6c74fa0d775d554ba46e0187358b",
+            },
             ["11.0.5"] = {
                 url = "https://github.com/pnpm/pnpm/releases/download/v11.0.5/pnpm-win32-x64.zip",
                 sha256 = "c79329a48a5e67bbbf73578fe0ddd5ff1fef05ed8c9ce43cfdc675d4d173fa3a",

--- a/tests/lib/assertions.py
+++ b/tests/lib/assertions.py
@@ -36,7 +36,7 @@ def assert_valid_spec(meta: XpkgMeta):
     """spec 版本必须是已知值"""
     if meta.is_ref:
         return
-    assert meta.spec in ("0", "1"), f"未知 spec 版本: {meta.spec}"
+    assert meta.spec in ("0", "1", "2"), f"未知 spec 版本: {meta.spec}"
 
 
 def assert_valid_type(meta: XpkgMeta):

--- a/tests/test_latest_ci_migrations.py
+++ b/tests/test_latest_ci_migrations.py
@@ -1,0 +1,30 @@
+"""Regression coverage for packages migrated to the current CI contract."""
+
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).parents[1]
+PACKAGES = ("fish", "griddycode", "nvim", "pnpm")
+
+
+@pytest.mark.static
+@pytest.mark.parametrize("package", PACKAGES)
+def test_package_uses_v2_and_ci_mirror_update(package):
+    path = next((ROOT / "pkgs").glob(f"*/{package}.lua"))
+    text = path.read_text(encoding="utf-8")
+
+    assert 'spec = "2"' in text
+    assert "ci = { mirror = true, update = true }" in text
+
+
+@pytest.mark.static
+@pytest.mark.parametrize("package", PACKAGES)
+def test_package_keeps_update_template(package):
+    path = next((ROOT / "pkgs").glob(f"*/{package}.lua"))
+    text = path.read_text(encoding="utf-8")
+
+    assert "url_template" in text
+    assert "{version}" in text
+

--- a/tests/test_latest_ci_migrations.py
+++ b/tests/test_latest_ci_migrations.py
@@ -21,10 +21,9 @@ def test_package_uses_v2_and_ci_mirror_update(package):
 
 @pytest.mark.static
 @pytest.mark.parametrize("package", PACKAGES)
-def test_package_keeps_update_template(package):
+def test_package_keeps_update_source_contract(package):
     path = next((ROOT / "pkgs").glob(f"*/{package}.lua"))
     text = path.read_text(encoding="utf-8")
 
-    assert "url_template" in text
-    assert "{version}" in text
-
+    assert ("url_template" in text or "source = {" in text)
+    assert ("{version}" in text or "${version}" in text)

--- a/tests/test_xpkg_ci.py
+++ b/tests/test_xpkg_ci.py
@@ -3,6 +3,7 @@
 
 import importlib.util
 import json
+import tarfile
 import tempfile
 from pathlib import Path
 
@@ -14,6 +15,14 @@ spec.loader.exec_module(mod)
 
 def main() -> int:
     with tempfile.TemporaryDirectory() as d:
+        root = Path(d)
+        payload = root / "payload.txt"
+        payload.write_text("payload\n", encoding="utf-8")
+        archive = root / "payload.tar.gz"
+        with tarfile.open(archive, "w:gz") as tar:
+            tar.add(payload, arcname="payload.txt")
+        assert mod.validate_archive(archive) is None
+
         p = Path(d) / "foo.lua"
         p.write_text(
             'package = { name = "foo", repo = "https://github.com/acme/foo", '

--- a/tests/test_xpkg_ci.py
+++ b/tests/test_xpkg_ci.py
@@ -34,6 +34,17 @@ def main() -> int:
         assert record["update"] is True
         assert record["source"] is None
 
+        mapped = Path(d) / "mapped.lua"
+        mapped.write_text(
+            'package = { name = "mapped", xpm = { source = { '
+            'GLOBAL = "https://github.com/acme/mapped/${version}.tar.gz", '
+            'CN = "https://gitcode.com/acme/mapped/${version}.tar.gz" } } }',
+            encoding="utf-8",
+        )
+        mapped_record = mod.inspect_package(mapped)
+        assert mapped_record["source"]["GLOBAL"].endswith("${version}.tar.gz")
+        assert mapped_record["source"]["CN"].startswith("https://gitcode.com/")
+
         manifest = {
             "format": 1,
             "package": "foo",

--- a/tools/xpkg_ci.py
+++ b/tools/xpkg_ci.py
@@ -206,7 +206,8 @@ def validate_archive(path: Path) -> str | None:
     try:
         if path.name.endswith(".tar.gz") or path.name.endswith(".tar.xz") or path.name.endswith(".tar.bz2"):
             with tarfile.open(path, "r:*") as archive:
-                next(archive)
+                if archive.next() is None:
+                    return "tar archive is empty"
         elif path.name.endswith(".zip"):
             with zipfile.ZipFile(path) as archive:
                 if archive.testzip() is not None:

--- a/tools/xpkg_ci.py
+++ b/tools/xpkg_ci.py
@@ -62,9 +62,15 @@ def bool_field(body: str, name: str) -> bool:
     return re.search(rf"\b{re.escape(name)}\s*=\s*true\b", body) is not None
 
 
-def source_value(text: str) -> str | None:
+def source_value(text: str) -> str | dict[str, str] | None:
     m = re.search(r"\bsource\s*=\s*\"([^\"]+)\"", text)
-    return m.group(1) if m else None
+    if m:
+        return m.group(1)
+    m = re.search(r"\bsource\s*=\s*\{((?:[^{}]|\$\{[^{}]*\})*)\}", text)
+    if not m:
+        return None
+    values = dict(re.findall(r"\b([A-Za-z][A-Za-z0-9_]*)\s*=\s*\"([^\"]+)\"", m.group(1)))
+    return values or None
 
 
 def inspect_package(path: Path) -> dict[str, Any]:
@@ -182,6 +188,14 @@ def lua_string(body: str, key: str) -> str | None:
     return match.group(1) if match else None
 
 
+def source_templates(body: str) -> dict[str, str] | None:
+    match = re.search(r"\bsource\s*=\s*\{((?:[^{}]|\$\{[^{}]*\})*)\}", body)
+    if not match:
+        return None
+    values = dict(re.findall(r"\b([A-Za-z][A-Za-z0-9_]*)\s*=\s*\"([^\"]+)\"", match.group(1)))
+    return values or None
+
+
 def declared_arches(text: str) -> list[str]:
     match = re.search(r'\barchs\s*=\s*\{([^}]*)\}', text)
     return re.findall(r'"([^"]+)"', match.group(1)) if match else []
@@ -267,7 +281,8 @@ def materialize(args: argparse.Namespace) -> int:
         source_match = re.search(r'\bsource\s*=\s*"([^"]+)"', platform_body)
         if not source_match:
             source_match = re.search(r'\bsource\s*=\s*"([^"]+)"', xpm_body)
-        template = url or (source_match.group(1) if source_match else None)
+        source_map = source_templates(platform_body) or source_templates(xpm_body) or {}
+        template = url or source_map.get("GLOBAL") or (source_match.group(1) if source_match else None)
         if url == "XLINGS_RES" or template == "xlings-res":
             return fail(f"{platform}: cannot materialize an already mirrored XLINGS_RES source")
         if not template:


### PR DESCRIPTION
## Summary

- Migrate fish, griddycode, nvim, and pnpm to spec 2.
- Opt these packages into the current package.ci mirror/update contract.
- Update fish to 4.8.0, nvim to 0.12.4, and pnpm to 11.12.0 with downloaded SHA256 values; griddycode is already current.
- Fix tar archive validation in tools/xpkg_ci.py so mirror manifests can be materialized for tar.gz and tar.xz assets.
- Keep xlings unchanged as requested.

## Test plan

- Full static/isolation/index suite: 866 passed, 127 deselected, 2 xfailed, 4 xpassed.
- Full version-check dry-run: 115 scanned, 7 checked, 0 updates, 0 errors.
- xpkg-ci scan: all four target packages up-to-date.
- xpkg-ci materialize and verify: fish, griddycode, nvim, pnpm all verified; mirror commands dry-run validated.
- Full pytest was attempted; 96 lifecycle/verify failures are pre-existing local xlings index ambiguity or missing installed commands, while the targeted and full static/isolation/index checks pass.

Post-merge xpkg-mirror-release should publish the verified manifests to both xlings-res endpoints.