### PR TITLE
fix(ci): pass mirror credentials to workflow-run job

### DIFF
--- a/.github/workflows/xpkg-mirror.yml
+++ b/.github/workflows/xpkg-mirror.yml
@@ -43,6 +43,11 @@ jobs:
 
       - name: Materialize opted-in mirror packages
         if: github.event_name == 'workflow_run'
+        env:
+          # xpkg_ci.py --execute invokes both gh and gtc.  workflow_run jobs
+          # do not inherit the token from the manual-dispatch step below.
+          GH_TOKEN: ${{ secrets.XLINGS_RES_TOKEN }}
+          GITCODE_TOKEN: ${{ secrets.GITCODE_TOKEN }}
         run: |
           set -euo pipefail
           mkdir -p "$RUNNER_TEMP/xpkg-manifests"


### PR DESCRIPTION
## Summary
- inject `GH_TOKEN` and `GITCODE_TOKEN` into the automatic `workflow_run` mirror path
- keep manual-dispatch publishing behavior unchanged

## Test plan
- `python3 -m pytest -q tests/test_xpkg_ci.py tests/test_latest_ci_migrations.py`
- YAML parse and `git diff --check` passed