### PR TITLE
fix(ci): use current mirror tooling for workflow runs

### DIFF
--- a/.github/workflows/xpkg-mirror.yml
+++ b/.github/workflows/xpkg-mirror.yml
@@ -30,7 +30,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+          # Publish with the current mainline mirror tooling. The event SHA is
+          # still used below to identify which package files changed.
+          ref: main
           fetch-depth: 0
 
       - uses: actions/setup-python@v5


### PR DESCRIPTION
## Summary
- use current mainline mirror tooling in workflow_run deployments
- continue calculating changed packages from the triggering workflow SHA

## Test plan
- `python3 -m py_compile tools/xpkg_ci.py`
- `python3 -m pytest -q tests/test_xpkg_ci.py tests/test_latest_ci_migrations.py`
- `git diff --check`