### PR TITLE
fix(ci): verify GitCode assets with ranged GET

### DIFF
--- a/tools/xpkg_ci.py
+++ b/tools/xpkg_ci.py
@@ -415,9 +415,13 @@ def cmd_mirror(args: argparse.Namespace) -> int:
             f"{tag}/{filename}"
         )
         try:
-            request = urllib.request.Request(url, method="HEAD")
+            # GitCode's release endpoint may not implement HEAD reliably. A
+            # one-byte ranged GET validates the actual download path without
+            # fetching the complete asset.
+            request = urllib.request.Request(url, headers={"Range": "bytes=0-0"})
             with urllib.request.urlopen(request, timeout=GITCODE_VERIFY_TIMEOUT) as response:
-                return response.status == 200
+                response.read(1)
+                return response.status in (200, 206)
         except (OSError, urllib.error.URLError):
             return False
 


### PR DESCRIPTION
## Summary
- replace unreliable GitCode HEAD verification with a one-byte ranged GET
- accept HTTP 200/206 after gtc upload callback failures

## Test plan
- `python3 -m py_compile tools/xpkg_ci.py`
- `python3 -m pytest -q tests/test_xpkg_ci.py tests/test_latest_ci_migrations.py`
- `git diff --check`