### PR TITLE
fix(ci): allow slow GitCode asset uploads

### DIFF
--- a/tools/xpkg_ci.py
+++ b/tools/xpkg_ci.py
@@ -34,7 +34,8 @@ from typing import Any
 ROOT = Path(__file__).resolve().parents[1]
 VC_PATH = ROOT / ".github" / "scripts" / "version-check.py"
 GITCODE_RELEASE_TIMEOUT = 60
-GITCODE_UPLOAD_TIMEOUT = 90
+# GitCode's upload callback is especially slow for large release assets.
+GITCODE_UPLOAD_TIMEOUT = 600
 GITCODE_VERIFY_TIMEOUT = 20
 
 


### PR DESCRIPTION
## Summary
- allow up to 10 minutes for large GitCode release uploads
- retain per-file upload and ranged-download verification

## Test plan
- `python3 -m py_compile tools/xpkg_ci.py`
- `python3 -m pytest -q tests/test_xpkg_ci.py tests/test_latest_ci_migrations.py`
- `git diff --check`