### PR TITLE
feat(ci): auto-bootstrap xlings-res repos and verify mirror content

### DIFF
--- a/.agents/docs/2026-07-12-xpkg-ci-mirror-update-design.md
+++ b/.agents/docs/2026-07-12-xpkg-ci-mirror-update-design.md
@@ -409,3 +409,15 @@ checkout
   当前没有包声明 `mirror=true`，因此该次运行安全地无发布并完成 changed-package 审计。
 - 发布链路仍可通过 `workflow_dispatch` 提交经过 `verify` 的 manifest；重复 GitHub release
   只接受完整同名资产，GitCode 创建幂等且上传带有限重试，不覆盖既有资产。
+- 2026-07-13：一次真实的 per-package mirror run（fish/griddycode/nvim/pnpm 四个独立
+  matrix job）全部成功；pnpm 三个约 40–50 MB 的 bundled-Node 资产在 GitCode 上传约 14 分钟
+  后通过校验，验证了 §6.3 的单文件上传 + 指数退避 + ranged-GET 校验路径。四个包的资产均已
+  在 GitHub RES 与 GitCode RES 上以 ranged GET 复核为可下载（206）。
+- §3.3 的两处实现缺口已在 `tools/xpkg_ci.py` 补齐：
+  - `ensure_mirror_repos`（也暴露为 `ensure-repo` 子命令）在发布前幂等地保证
+    `xlings-res/<pkg>` 在 GitHub 与 GitCode 均存在且 `main` 非空——已存在的包只做只读探测，
+    不产生写调用，也不需要建仓 token 权限；仅全新的 mirror 包会触发建仓并在 GitCode 播种
+    README 以创建 `main`。这消除了「新增 mirror 包需先手工建两个仓库」的前置条件。
+  - `verify_mirror_content` 把原先只做「对象存在」的 ranged-GET 探测升级为三方哈希复核：
+    发布成功前从 GitHub RES 与 GitCode RES 实际下载每个归档资产并与 manifest（源自权威上游）
+    的 sha256 逐一比对，任一不一致即 fail closed。可用 `--no-content-verify` 作为应急旁路。

--- a/tests/test_xpkg_ci.py
+++ b/tests/test_xpkg_ci.py
@@ -3,6 +3,7 @@
 
 import importlib.util
 import json
+import subprocess
 import tarfile
 import tempfile
 from pathlib import Path
@@ -12,8 +13,166 @@ spec = importlib.util.spec_from_file_location("xpkg_ci", ROOT / "tools" / "xpkg_
 mod = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(mod)
 
+try:  # under pytest these run in the L2 isolation pass; standalone still works
+    import pytest
+    pytestmark = pytest.mark.isolation
+except ImportError:
+    pytest = None
+
+
+class FakeRun:
+    """Records subprocess.run calls and answers from a routing callback."""
+
+    def __init__(self, route):
+        self.route = route
+        self.calls = []
+
+    def __call__(self, cmd, *args, **kwargs):
+        self.calls.append(list(cmd))
+        rc, out, err = self.route(list(cmd))
+        return subprocess.CompletedProcess(cmd, rc, out, err)
+
+    def ran(self, *prefix):
+        prefix = list(prefix)
+        return any(call[: len(prefix)] == prefix for call in self.calls)
+
+
+def test_verify_mirror_content():
+    good = "a" * 64
+    assets = [{"os": "linux", "arch": "x86_64", "filename": "foo.tar.gz",
+               "size": 10, "sha256": good, "source_url": "https://x.test/foo.tar.gz"}]
+    original = mod._download_sha256
+    try:
+        # Both mirrors serve the authoritative bytes -> pass.
+        mod._download_sha256 = lambda url, timeout=300: (good, "")
+        assert mod.verify_mirror_content("xlings-res/foo", "xlings-res/foo", "1.0.0", assets) is None
+
+        # GitCode serves different bytes -> fail closed.
+        def mismatched(url, timeout=300):
+            return (good if "github.com" in url else "b" * 64, "")
+        mod._download_sha256 = mismatched
+        problem = mod.verify_mirror_content("xlings-res/foo", "xlings-res/foo", "1.0.0", assets)
+        assert problem and "GitCode content mismatch" in problem, problem
+
+        # A mirror that cannot be fetched fails closed too.
+        mod._download_sha256 = lambda url, timeout=300: (None, "boom")
+        problem = mod.verify_mirror_content("xlings-res/foo", "xlings-res/foo", "1.0.0", assets)
+        assert problem and "content fetch failed" in problem, problem
+    finally:
+        mod._download_sha256 = original
+
+
+def test_ensure_mirror_repos():
+    original = mod.subprocess.run
+    try:
+        # Both repos already present and non-empty -> no write calls.
+        def both_exist(cmd):
+            if cmd[:3] == ["gh", "repo", "view"]:
+                return (0, "{}", "")
+            if cmd[:2] == ["git", "ls-remote"]:
+                return (0, "abc123\trefs/heads/main\n", "")
+            raise AssertionError(f"unexpected call: {cmd}")
+        fake = FakeRun(both_exist)
+        mod.subprocess.run = fake
+        assert mod.ensure_mirror_repos("foo", "xlings-res/foo", "xlings-res/foo") is None
+        assert not fake.ran("gh", "repo", "create")
+        assert not fake.ran("tools/gtc", "repo", "create")
+
+        # Neither repo exists -> create both, seed GitCode.
+        def none_exist(cmd):
+            if cmd[:3] == ["gh", "repo", "view"]:
+                return (1, "", "not found")
+            if cmd[:3] == ["gh", "repo", "create"]:
+                return (0, "", "")
+            if cmd[:2] == ["git", "ls-remote"]:
+                return (0, "", "")  # empty -> no main branch
+            if cmd[:3] == ["tools/gtc", "repo", "create"]:
+                return (0, "created", "")
+            if cmd[:3] == ["tools/gtc", "repo", "push"]:
+                return (0, "pushed", "")
+            raise AssertionError(f"unexpected call: {cmd}")
+        fake = FakeRun(none_exist)
+        mod.subprocess.run = fake
+        assert mod.ensure_mirror_repos("foo", "xlings-res/foo", "xlings-res/foo") is None
+        assert fake.ran("gh", "repo", "create")
+        assert fake.ran("tools/gtc", "repo", "create")
+        assert fake.ran("tools/gtc", "repo", "push")
+
+        # GitCode seed push failure is reported, fail closed.
+        def push_fails(cmd):
+            if cmd[:3] == ["gh", "repo", "view"]:
+                return (0, "{}", "")
+            if cmd[:2] == ["git", "ls-remote"]:
+                return (0, "", "")
+            if cmd[:3] == ["tools/gtc", "repo", "create"]:
+                return (0, "created", "")
+            if cmd[:3] == ["tools/gtc", "repo", "push"]:
+                return (1, "", "auth denied")
+            raise AssertionError(f"unexpected call: {cmd}")
+        mod.subprocess.run = FakeRun(push_fails)
+        problem = mod.ensure_mirror_repos("foo", "xlings-res/foo", "xlings-res/foo")
+        assert problem and "seed GitCode repo" in problem, problem
+    finally:
+        mod.subprocess.run = original
+
+
+class FakeResp:
+    status = 206
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+    def read(self, n=-1):
+        return b"x"
+
+
+def test_cmd_mirror_execute_content_gate():
+    good = "a" * 64
+    manifest = {
+        "format": 1, "package": "foo", "version": "1.0.0",
+        "assets": [{"os": "linux", "arch": "x86_64", "filename": "foo.tar.gz",
+                    "size": 10, "sha256": good, "source_url": "https://x.test/foo.tar.gz"}],
+    }
+
+    def route(cmd):
+        if cmd[:3] == ["gh", "repo", "view"]:
+            return (0, "{}", "")
+        if cmd[:2] == ["git", "ls-remote"]:
+            return (0, "ref\trefs/heads/main\n", "")
+        if cmd[:3] == ["gh", "release", "view"]:
+            return (0, json.dumps({"assets": [{"name": "manifest.json"}]}), "")
+        raise AssertionError(f"unexpected call: {cmd}")
+
+    orig_run = mod.subprocess.run
+    orig_urlopen = mod.urllib.request.urlopen
+    orig_dl = mod._download_sha256
+    try:
+        with tempfile.TemporaryDirectory() as d:
+            mpath = Path(d) / "manifest.json"
+            mpath.write_text(json.dumps(manifest), encoding="utf-8")
+            mod.subprocess.run = FakeRun(route)
+            mod.urllib.request.urlopen = lambda req, timeout=None: FakeResp()
+            args = type("A", (), {"manifest": str(mpath), "execute": True,
+                                  "ensure_repos": True, "content_verify": True})()
+            # Mirrors serve the authoritative bytes -> publish succeeds.
+            mod._download_sha256 = lambda url, timeout=300: (good, "")
+            assert mod.cmd_mirror(args) == 0
+            # A mirror serving wrong bytes must block publication.
+            mod._download_sha256 = lambda url, timeout=300: ("b" * 64, "")
+            assert mod.cmd_mirror(args) == 2
+    finally:
+        mod.subprocess.run = orig_run
+        mod.urllib.request.urlopen = orig_urlopen
+        mod._download_sha256 = orig_dl
+
 
 def main() -> int:
+    test_verify_mirror_content()
+    test_ensure_mirror_repos()
+    test_cmd_mirror_execute_content_gate()
     with tempfile.TemporaryDirectory() as d:
         root = Path(d)
         payload = root / "payload.txt"

--- a/tools/xpkg_ci.py
+++ b/tools/xpkg_ci.py
@@ -22,6 +22,7 @@ import json
 import re
 import subprocess
 import sys
+import tempfile
 import time
 import tarfile
 import zipfile
@@ -350,6 +351,120 @@ def cmd_verify(args: argparse.Namespace) -> int:
     return 0
 
 
+GITHUB_RELEASE_BASE = "https://github.com"
+GITCODE_RELEASE_BASE = "https://gitcode.com"
+
+
+def _download_sha256(url: str, timeout: int = 300) -> tuple[str | None, str]:
+    """Stream a mirror asset and return (hex_digest, "") or (None, error)."""
+    request = urllib.request.Request(url, headers={"User-Agent": "xim-pkgindex-xpkg-ci"})
+    digest = hashlib.sha256()
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            while True:
+                chunk = response.read(1024 * 1024)
+                if not chunk:
+                    break
+                digest.update(chunk)
+    except (OSError, urllib.error.URLError) as exc:
+        return None, str(exc) or "download failed"
+    return digest.hexdigest(), ""
+
+
+def verify_mirror_content(repo: str, gitcode_repo: str, tag: str,
+                          assets: list[dict[str, Any]]) -> str | None:
+    """Fail-closed three-way check: the bytes actually served by GitHub RES and
+    GitCode RES must hash to the authoritative sha256 recorded in the manifest.
+
+    A ranged-GET availability probe only proves an object exists at the URL; it
+    does not prove the mirror stored the correct bytes.  This downloads every
+    archive asset from both mirrors and compares against the manifest digest,
+    which was computed from the authoritative upstream source at materialize
+    time.  Returns an error string on the first mismatch, or None when all
+    mirrors agree with the manifest.
+    """
+    for asset in assets:
+        expected = str(asset["sha256"])
+        filename = asset["filename"]
+        sources = (
+            ("GitHub", f"{GITHUB_RELEASE_BASE}/{repo}/releases/download/{tag}/{filename}"),
+            ("GitCode", f"{GITCODE_RELEASE_BASE}/{gitcode_repo}/releases/download/{tag}/{filename}"),
+        )
+        for host, url in sources:
+            actual, error = _download_sha256(url)
+            if actual is None:
+                return f"{host} content fetch failed for {filename}: {error}"
+            if actual != expected:
+                return (f"{host} content mismatch for {filename}: "
+                        f"expected {expected}, served {actual}")
+    return None
+
+
+def _gh_repo_exists(repo: str) -> bool:
+    result = subprocess.run(
+        ["gh", "repo", "view", repo, "--json", "name"],
+        text=True, capture_output=True,
+    )
+    return result.returncode == 0
+
+
+def _gitcode_main_exists(repo: str) -> bool:
+    result = subprocess.run(
+        ["git", "ls-remote", "--heads", f"https://gitcode.com/{repo}.git", "main"],
+        text=True, capture_output=True,
+    )
+    return result.returncode == 0 and bool(result.stdout.strip())
+
+
+def ensure_mirror_repos(package: str, repo: str, gitcode_repo: str) -> str | None:
+    """Idempotently ensure both mirror repos exist and are non-empty.
+
+    A brand-new mirror package has no xlings-res repo yet, and both `gh release
+    create` and `gtc release create --target main` need a repo that already has
+    a commit on `main`.  Existence is probed read-only first, so an already
+    provisioned package makes no write call and needs no repo-create token
+    scope.  Only a genuinely new package triggers creation (and a README seed on
+    GitCode so its `main` branch exists).  Returns an error string on failure,
+    or None when both repos are ready.
+    """
+    description = f"xlings-res immutable mirror for {package}"
+    if not _gh_repo_exists(repo):
+        created = subprocess.run(
+            ["gh", "repo", "create", repo, "--public", "--add-readme",
+             "--description", description],
+            text=True, capture_output=True,
+        )
+        if created.returncode != 0:
+            return f"failed to create GitHub repo {repo}: {created.stderr.strip()}"
+    if not _gitcode_main_exists(gitcode_repo):
+        created = subprocess.run(
+            ["tools/gtc", "repo", "create", gitcode_repo, "--description", description],
+            text=True, capture_output=True,
+        )
+        if created.returncode != 0:
+            return f"failed to create GitCode repo {gitcode_repo}: {created.stderr.strip()}"
+        with tempfile.TemporaryDirectory() as seed:
+            readme = Path(seed) / "README.md"
+            readme.write_text(f"# {package}\n\n{description}.\n", encoding="utf-8")
+            pushed = subprocess.run(
+                ["tools/gtc", "repo", "push", gitcode_repo, seed, "-m", "seed mirror repo"],
+                text=True, capture_output=True,
+            )
+            if pushed.returncode != 0:
+                return f"failed to seed GitCode repo {gitcode_repo}: {pushed.stderr.strip()}"
+    return None
+
+
+def cmd_ensure_repo(args: argparse.Namespace) -> int:
+    package = args.package
+    repo = f"xlings-res/{package}"
+    problem = ensure_mirror_repos(package, repo, repo)
+    if problem:
+        return fail(problem)
+    print(json.dumps({"status": "ready", "package": package, "repo": repo}, indent=2))
+    return 0
+
+
 def cmd_mirror(args: argparse.Namespace) -> int:
     path = Path(args.manifest)
     try:
@@ -376,6 +491,10 @@ def cmd_mirror(args: argparse.Namespace) -> int:
     if not args.execute:
         print(json.dumps({"status": "dry-run", "github": gh_command, "gitcode": gtc_command}, indent=2))
         return 0
+    if getattr(args, "ensure_repos", True):
+        problem = ensure_mirror_repos(package, repo, gitcode_repo)
+        if problem:
+            return fail(problem)
     view = subprocess.run(
         ["gh", "release", "view", tag, "--repo", repo, "--json", "assets"],
         text=True, capture_output=True,
@@ -410,13 +529,23 @@ def cmd_mirror(args: argparse.Namespace) -> int:
         except (OSError, urllib.error.URLError):
             return False
 
+    def finalize(message: str) -> int:
+        # Availability probes above only prove the objects exist. Before
+        # declaring success, confirm the bytes GitHub RES and GitCode RES
+        # actually serve hash to the authoritative manifest digest.
+        if getattr(args, "content_verify", True):
+            problem = verify_mirror_content(repo, gitcode_repo, tag, manifest["assets"])
+            if problem:
+                return fail(problem)
+        print(result.stdout)
+        print(message)
+        return 0
+
     # GitCode's release-create endpoint is idempotent. If every immutable
     # asset is already downloadable, the package is fully mirrored and this
     # job should succeed without calling gtc again.
     if all(asset_available(Path(file).name) for file in files):
-        print(result.stdout)
-        print(f"GitCode assets already verified for {gitcode_repo}@{tag}; skipping upload")
-        return 0
+        return finalize(f"GitCode assets already verified for {gitcode_repo}@{tag}; skipping upload")
 
     # Otherwise create the release and upload only the missing assets.
     try:
@@ -461,9 +590,7 @@ def cmd_mirror(args: argparse.Namespace) -> int:
         if not uploaded:
             return fail(f"GitCode asset upload failed for {filename}: {last_error}")
 
-    print(result.stdout)
-    print(f"GitCode assets verified for {gitcode_repo}@{tag}")
-    return 0
+    return finalize(f"GitCode assets verified for {gitcode_repo}@{tag}")
 
 
 def cmd_propose(args: argparse.Namespace) -> int:
@@ -501,7 +628,14 @@ def main() -> int:
     p = sub.add_parser("mirror")
     p.add_argument("manifest")
     p.add_argument("--execute", action="store_true")
-    p.set_defaults(func=cmd_mirror)
+    p.add_argument("--no-ensure-repos", dest="ensure_repos", action="store_false",
+                   help="skip bootstrapping missing xlings-res repos")
+    p.add_argument("--no-content-verify", dest="content_verify", action="store_false",
+                   help="skip the three-way GitHub/GitCode byte-hash verification")
+    p.set_defaults(func=cmd_mirror, ensure_repos=True, content_verify=True)
+    p = sub.add_parser("ensure-repo")
+    p.add_argument("package")
+    p.set_defaults(func=cmd_ensure_repo)
     p = sub.add_parser("materialize")
     p.add_argument("package")
     p.add_argument("--version")


### PR DESCRIPTION
## 背景

承接 per-package mirror 架构落地后的收尾:一次真实的 mirror run（fish/griddycode/nvim/pnpm 四个独立 matrix job）已全部成功,pnpm 三个约 40–50 MB 的 bundled-Node 资产在 GitCode 上传约 14 分钟后通过校验。四个包的资产均已在 GitHub RES 与 GitCode RES 以 ranged GET 复核为可下载(206)。

本 PR 补齐设计文档 §3.3 的两处实现缺口,均只改 `tools/xpkg_ci.py`,`mirror --execute` 默认启用,**无需改动 workflow**。

## 变更

**1. `ensure_mirror_repos` / `ensure-repo` 子命令 — 自动建仓**
- 发布前幂等地保证 `xlings-res/<pkg>` 在 GitHub 与 GitCode 均存在且 `main` 非空。
- 已存在的包只做**只读探测**(`gh repo view` + `git ls-remote`),不产生写调用,也不需要建仓 token 权限。
- 仅**全新**的 mirror 包会触发建仓,并在 GitCode 播种 README 以创建 `main`。
- 消除了「新增 mirror 包需先手工建两个仓库」的前置条件。

**2. `verify_mirror_content` — 三方哈希复核**
- 把原先只做「对象存在」的 ranged-GET 探测,升级为:发布成功前从 GitHub RES 与 GitCode RES **实际下载**每个归档资产并与 manifest(源自权威上游)的 sha256 逐一比对。
- 任一不一致即 **fail closed**;`--no-content-verify` 作为应急旁路。

## 测试

- 新增离线单测(isolation 层级,mock subprocess/urllib),覆盖:三方复核成功/不匹配/拉取失败;建仓的「均已存在/均不存在/播种失败」三条路径;`mirror --execute` 内容门禁拦截错误字节。
- `pytest tests/ -m static` → 484 passed;`-m isolation` → 308 passed(含 3 个新测试);`python3 tests/test_xpkg_ci.py` standalone → PASS。

## 待维护者注意的两点

1. 建仓路径**无法在不创建真实 org 仓库的前提下端到端测试**,目前仅由单测 + 逻辑复核覆盖;首个真正的新 mirror 包上线时请关注。
2. `gh repo create` / `gtc repo create` 需要发布 token(`XLINGS_RES_TOKEN` / `GITCODE_TOKEN`)在 xlings-res 组织具备**建仓权限**——仅新包会触发;若缺权限会 fail-closed。
