### PR TITLE
pkg(bat): opt into ci mirror + update (pilot for #369 auto-bootstrap)

### DIFF
--- a/pkgs/b/bat.lua
+++ b/pkgs/b/bat.lua
@@ -9,6 +9,11 @@ package = {
     repo = "https://github.com/sharkdp/bat",
     docs = "https://github.com/sharkdp/bat#readme",
 
+    -- CI automation opt-in (metadata only; ignored by libxpkg/installer).
+    -- mirror: publish the declared version to xlings-res after merge.
+    -- update: enroll in the central scanner to PR new upstream releases.
+    ci = { mirror = true, update = true },
+
     type = "package",
     archs = {"x86_64", "aarch64"},
     status = "stable",


### PR DESCRIPTION
首个真正启用 `ci = { mirror = true, update = true }` 的包,用于端到端验证 #369 新增的自动建仓(`ensure_mirror_repos`)与三方哈希复核。

- bat 已是规范形态(url_template + 每版本 {url,sha256} + latest.ref),本 PR 仅加元数据 `ci`,libxpkg/installer 忽略,index pointer 与版本块不动,安装来源仍为上游(镜像只额外发布 xlings-res release)。
- 合入后 `xpkg-mirror-release` 将自动创建 `xlings-res/bat`(GitHub + GitCode)并上传 + 三方复核。