### PR TITLE
fix(ci): infer per-platform arch for non-arch-templated mirror URLs

### DIFF
--- a/tests/test_xpkg_ci.py
+++ b/tests/test_xpkg_ci.py
@@ -169,10 +169,28 @@ def test_cmd_mirror_execute_content_gate():
         mod._download_sha256 = orig_dl
 
 
+def test_resolve_platform_arches():
+    r = mod.resolve_platform_arches
+    # arch-parameterized template -> every declared arch
+    assert r(["x86_64", "aarch64"], "u/{arch}.tar.gz", {}) == (["x86_64", "aarch64"], None)
+    assert r(["x86_64", "aarch64"], "u/${arch}.tar.gz", {}) == (["x86_64", "aarch64"], None)
+    # single declared arch -> that arch
+    assert r(["x86_64"], "u/bat-x86_64-linux.tar.gz", {}) == (["x86_64"], None)
+    # multi declared, single arch baked into the URL -> infer it (bat's shape)
+    assert r(["x86_64", "aarch64"], "u/bat-x86_64-unknown-linux-musl.tar.gz", {}) == (["x86_64"], None)
+    assert r(["x86_64", "aarch64"], "u/bat-aarch64-apple-darwin.tar.gz", {}) == (["aarch64"], None)
+    # arch alias present in the URL (e.g. arm64) resolves to the declared arch
+    assert r(["x86_64", "aarch64"], "u/foo-arm64.zip", {"aarch64": "arm64"}) == (["aarch64"], None)
+    # non-parameterized URL with no matchable arch -> error, fail closed
+    arches, err = r(["x86_64", "aarch64"], "u/foo-universal.tar.gz", {})
+    assert arches is None and err and "cannot infer arch" in err, (arches, err)
+
+
 def main() -> int:
     test_verify_mirror_content()
     test_ensure_mirror_repos()
     test_cmd_mirror_execute_content_gate()
+    test_resolve_platform_arches()
     with tempfile.TemporaryDirectory() as d:
         root = Path(d)
         payload = root / "payload.txt"

--- a/tools/xpkg_ci.py
+++ b/tools/xpkg_ci.py
@@ -222,6 +222,31 @@ def expand_template(template: str, package: str, version: str,
     return template
 
 
+def resolve_platform_arches(arches: list[str], template: str,
+                            aliases: dict[str, str]) -> tuple[list[str] | None, str | None]:
+    """Decide which arches to materialize for one platform's URL template.
+
+    An arch-parameterized template (``${arch}``/``{arch}``) covers every declared
+    arch.  A non-parameterized URL bakes in exactly one arch, so infer which
+    declared arch it is (by the arch name or its alias appearing in the URL) and
+    record only that one — otherwise a package like bat, which declares
+    ``{x86_64, aarch64}`` globally but ships x86_64 on linux/windows and aarch64
+    on macOS, would be mislabelled as ``arches[0]`` or rejected outright.
+
+    Returns ``(arches, None)`` on success or ``(None, error)`` when a
+    non-parameterized URL cannot be pinned to exactly one declared arch.
+    """
+    if "${arch}" in template or "{arch}" in template:
+        return arches, None
+    if len(arches) == 1:
+        return [arches[0]], None
+    matched = [a for a in arches if a in template or aliases.get(a, a) in template]
+    if len(matched) != 1:
+        return None, (f"cannot infer arch from non-arch-templated URL "
+                      f"(declared {arches}, matched {matched})")
+    return matched, None
+
+
 def validate_archive(path: Path) -> str | None:
     try:
         if path.name.endswith(".tar.gz") or path.name.endswith(".tar.xz") or path.name.endswith(".tar.bz2"):
@@ -294,9 +319,9 @@ def materialize(args: argparse.Namespace) -> int:
         if not template:
             return fail(f"{platform}: URL/template missing")
         aliases = dict(re.findall(r'(x86_64|aarch64|x86)\s*=\s*"([^"]+)"', body))
-        if len(arches) > 1 and "${arch}" not in template and "{arch}" not in template:
-            return fail(f"{platform}: multi-arch package needs an arch-aware URL template")
-        use_arches = arches if ("${arch}" in template or "{arch}" in template) else [arches[0]]
+        use_arches, arch_error = resolve_platform_arches(arches, template, aliases)
+        if arch_error:
+            return fail(f"{platform}: {arch_error}")
         for arch in use_arches:
             final_url = expand_template(template, args.package, version, platform, arch, aliases)
             if not final_url.startswith("https://"):


### PR DESCRIPTION
## 背景
bat 试点(#370)暴露了 `materialize` 的一个缺口:声明了多 arch(`archs = {x86_64, aarch64}`)但每个平台把单一 arch 写死进 `url_template` 的包(bat/fd/fzf/ripgrep/zoxide/cc-* 在 linux/windows 发 x86_64、macOS 发 aarch64),会被 `multi-arch package needs an arch-aware URL template` 直接拒绝,且即便放行也会把 macOS 资产错标成 `arches[0]`(x86_64)。

## 修复
新增纯函数 `resolve_platform_arches`:当模板非 `${arch}` 参数化时,从 URL(按 arch 名或别名)推断该平台的单一 arch,manifest 记录正确 arch。单 arch 与 `${arch}` 模板包行为不变。

## 真实验证(本地 gh + gtc)
已端到端跑通:`xlings-res/bat@0.26.1` 已发布到 GitHub + GitCode,自动建仓(#369 `ensure_mirror_repos`)+ 上传 + 三方 sha256 复核全部通过;三个归档从两个 forge 独立下载的 sha256 均与 bat.lua 一致。

## 测试
新增 `test_resolve_platform_arches`(6 类:模板/单arch/bat linux/bat macos/别名/无法推断)。`static` 484 passed、`isolation` 含新测通过。