### PR TITLE
feat(ci): mirror raw-binary release assets (not just archives)

### DIFF
--- a/tests/test_xpkg_ci.py
+++ b/tests/test_xpkg_ci.py
@@ -181,9 +181,21 @@ def test_resolve_platform_arches():
     assert r(["x86_64", "aarch64"], "u/bat-aarch64-apple-darwin.tar.gz", {}) == (["aarch64"], None)
     # arch alias present in the URL (e.g. arm64) resolves to the declared arch
     assert r(["x86_64", "aarch64"], "u/foo-arm64.zip", {"aarch64": "arm64"}) == (["aarch64"], None)
+    # default aliases apply even when the recipe declares none (jq's shape:
+    # jq-linux-amd64 / jq-macos-arm64, archs = {x86_64, aarch64}, aliases = {})
+    assert r(["x86_64", "aarch64"], "u/jq-linux-amd64", {}) == (["x86_64"], None)
+    assert r(["x86_64", "aarch64"], "u/jq-macos-arm64", {}) == (["aarch64"], None)
     # non-parameterized URL with no matchable arch -> error, fail closed
     arches, err = r(["x86_64", "aarch64"], "u/foo-universal.tar.gz", {})
     assert arches is None and err and "cannot infer arch" in err, (arches, err)
+
+
+def test_archive_suffix_gate():
+    # Recognized archives are validated; raw binaries are not (no container).
+    assert "jq-linux-amd64".endswith(mod.ARCHIVE_SUFFIXES) is False
+    assert "xmake-bundle-v3.0.7.win64.exe".endswith(mod.ARCHIVE_SUFFIXES) is False
+    assert "bat-v0.26.1-x86_64-unknown-linux-musl.tar.gz".endswith(mod.ARCHIVE_SUFFIXES) is True
+    assert "foo.zip".endswith(mod.ARCHIVE_SUFFIXES) is True
 
 
 def main() -> int:
@@ -191,6 +203,7 @@ def main() -> int:
     test_ensure_mirror_repos()
     test_cmd_mirror_execute_content_gate()
     test_resolve_platform_arches()
+    test_archive_suffix_gate()
     with tempfile.TemporaryDirectory() as d:
         root = Path(d)
         payload = root / "payload.txt"

--- a/tools/xpkg_ci.py
+++ b/tools/xpkg_ci.py
@@ -35,6 +35,12 @@ from typing import Any
 ROOT = Path(__file__).resolve().parents[1]
 VC_PATH = ROOT / ".github" / "scripts" / "version-check.py"
 GITCODE_RELEASE_TIMEOUT = 60
+# Canonical arch spellings used in release URLs when a recipe doesn't declare
+# its own per-version alias (e.g. jq ships jq-linux-amd64 / jq-macos-arm64).
+DEFAULT_ARCH_ALIASES = {"x86_64": "amd64", "aarch64": "arm64"}
+# Recognized release archive extensions; anything else is a raw binary asset
+# whose integrity is guaranteed by its sha256 rather than a structural check.
+ARCHIVE_SUFFIXES = (".tar.gz", ".tar.xz", ".tar.bz2", ".tgz", ".zip")
 # GitCode's upload callback is especially slow for large release assets.
 GITCODE_UPLOAD_TIMEOUT = 600
 GITCODE_VERIFY_TIMEOUT = 20
@@ -210,7 +216,7 @@ def declared_arches(text: str) -> list[str]:
 def expand_template(template: str, package: str, version: str,
                     platform: str, arch: str,
                     aliases: dict[str, str] | None = None) -> str:
-    aliases = aliases or {"x86_64": "amd64", "aarch64": "arm64"}
+    aliases = aliases or dict(DEFAULT_ARCH_ALIASES)
     values = {
         "name": package, "version": version, "os": platform,
         "arch": arch, "arch_alias": aliases.get(arch, arch),
@@ -240,7 +246,16 @@ def resolve_platform_arches(arches: list[str], template: str,
         return arches, None
     if len(arches) == 1:
         return [arches[0]], None
-    matched = [a for a in arches if a in template or aliases.get(a, a) in template]
+
+    def present(arch: str) -> bool:
+        # Match the arch by its own name, the recipe's declared alias, or the
+        # canonical default spelling (amd64/arm64), so jq-style URLs resolve.
+        for spelling in (arch, aliases.get(arch), DEFAULT_ARCH_ALIASES.get(arch)):
+            if spelling and spelling in template:
+                return True
+        return False
+
+    matched = [a for a in arches if present(a)]
     if len(matched) != 1:
         return None, (f"cannot infer arch from non-arch-templated URL "
                       f"(declared {arches}, matched {matched})")
@@ -340,10 +355,13 @@ def materialize(args: argparse.Namespace) -> int:
             except Exception as exc:
                 output.unlink(missing_ok=True)
                 return fail(f"failed to download {final_url}: {exc}")
-            archive_error = validate_archive(output)
-            if archive_error:
-                output.unlink(missing_ok=True)
-                return fail(f"invalid archive {filename}: {archive_error}")
+            # Archives get a structural check; raw binaries (jq, xmake bundles)
+            # have no container to validate, so their sha256 is the guarantee.
+            if filename.endswith(ARCHIVE_SUFFIXES):
+                archive_error = validate_archive(output)
+                if archive_error:
+                    output.unlink(missing_ok=True)
+                    return fail(f"invalid archive {filename}: {archive_error}")
             sidecar = output.with_name(output.name + ".sha256")
             sidecar.write_text(f"{digest.hexdigest()}  {output.name}\n", encoding="utf-8")
             assets.append({"os": platform, "arch": arch, "filename": filename,


### PR DESCRIPTION
## 目标
支持镜像**裸二进制**发布资产(jq/xmake/rosdep/vcstool 等),这些不是 tar/zip 归档,当前 `materialize` 的 `validate_archive` 会拒绝。

## 变更
- `materialize` 只对识别的归档扩展名(`ARCHIVE_SUFFIXES`)做结构校验;裸二进制没有容器可校验,其 **sha256 即完整性保证**(mirror 后仍走三方 sha256 复核)。
- arch 推断回退到规范别名 `amd64/arm64`(`DEFAULT_ARCH_ALIASES`),使 jq 这类用 `amd64/arm64`(而非 `x86_64/aarch64`)命名的 URL 能正确定位 arch。

## 真实验证
`materialize jq` → 3 个裸二进制资产,arch 正确(linux x86_64 / macosx aarch64 / windows x86_64),sha256 与 jq.lua 完全一致,无归档校验拒绝。

## 测试
新增别名回退与归档后缀门禁断言;`static` 484 passed、`isolation` 含新测通过。