### PR TITLE
pkg: opt Tier A + uv into ci mirror+update, xmake into update

### DIFF
--- a/pkgs/c/cc-connect.lua
+++ b/pkgs/c/cc-connect.lua
@@ -7,6 +7,7 @@ package = {
     maintainers = {"chenhg5"},
     licenses = {"MIT"},
     repo = "https://github.com/chenhg5/cc-connect",
+    ci = { mirror = true, update = true },
     docs = "https://github.com/chenhg5/cc-connect#readme",
 
     type = "package",

--- a/pkgs/c/cc-switch.lua
+++ b/pkgs/c/cc-switch.lua
@@ -7,6 +7,7 @@ package = {
     maintainers = {"farion1231"},
     licenses = {"MIT"},
     repo = "https://github.com/farion1231/cc-switch",
+    ci = { mirror = true, update = true },
     docs = "https://github.com/farion1231/cc-switch#readme",
 
     type = "app",

--- a/pkgs/f/fd.lua
+++ b/pkgs/f/fd.lua
@@ -7,6 +7,7 @@ package = {
     maintainers = {"David Peter"},
     licenses = {"MIT", "Apache-2.0"},
     repo = "https://github.com/sharkdp/fd",
+    ci = { mirror = true, update = true },
     docs = "https://github.com/sharkdp/fd#readme",
 
     type = "package",

--- a/pkgs/f/fzf.lua
+++ b/pkgs/f/fzf.lua
@@ -7,6 +7,7 @@ package = {
     maintainers = {"Junegunn Choi"},
     licenses = {"MIT"},
     repo = "https://github.com/junegunn/fzf",
+    ci = { mirror = true, update = true },
     docs = "https://junegunn.github.io/fzf/",
 
     type = "package",

--- a/pkgs/g/go.lua
+++ b/pkgs/g/go.lua
@@ -9,6 +9,7 @@ package = {
     contributors = "https://github.com/golang/go/graphs/contributors",
     licenses = {"BSD-3-Clause"},
     repo = "https://github.com/golang/go",
+    ci = { mirror = true, update = true },
     docs = "https://go.dev/doc",
 
     type = "package",

--- a/pkgs/s/sing-box.lua
+++ b/pkgs/s/sing-box.lua
@@ -7,6 +7,7 @@ package = {
     maintainers = {"SagerNet"},
     licenses = {"GPL-3.0-or-later"},
     repo = "https://github.com/SagerNet/sing-box",
+    ci = { mirror = true, update = true },
     docs = "https://sing-box.sagernet.org/",
 
     type = "package",

--- a/pkgs/u/uv.lua
+++ b/pkgs/u/uv.lua
@@ -7,7 +7,7 @@ package = {
     maintainers = {"Astral"},
     licenses = {"MIT", "Apache-2.0"},
     repo = "https://github.com/astral-sh/uv",
-    ci = { update = true },
+    ci = { mirror = true, update = true },
     docs = "https://docs.astral.sh/uv",
 
     type = "package",

--- a/pkgs/x/xmake.lua
+++ b/pkgs/x/xmake.lua
@@ -8,6 +8,7 @@ package = {
     maintainers = {"ruki"},
     licenses = {"Apache-2.0"},
     repo = "https://github.com/xmake-io/xmake",
+    ci = { update = true },
     homepage = "https://xmake.io",
     docs = "https://xmake.io/#/getting_started",
 

--- a/pkgs/z/zoxide.lua
+++ b/pkgs/z/zoxide.lua
@@ -7,6 +7,7 @@ package = {
     maintainers = {"ajeetdsouza"},
     licenses = {"MIT"},
     repo = "https://github.com/ajeetdsouza/zoxide",
+    ci = { mirror = true, update = true },
     docs = "https://github.com/ajeetdsouza/zoxide#readme",
 
     type = "package",


### PR DESCRIPTION
## 批量启用自动镜像 + 自动更新
在镜像链路已被 bat(#370)验证、两处缺口已补齐(arch 推断 #371、裸二进制 #372)后,批量 opt-in:

- **mirror + update**:fd, fzf, ripgrep, zoxide, cc-connect, cc-switch, go, sing-box(均 url_template + latest.ref + 归档;多 arch/单平台单 arch 形态由 #371 处理)+ uv(原 update-only)。
- **update only**:xmake —— 其 bundle 是裸二进制且配方无 sha256,尚不满足镜像前提;仍通过 url_template + ref 自动更新。

## 兼容性
纯元数据 opt-in:libxpkg/installer 忽略 `ci`,每平台 `latest` 指针与版本块不动,安装来源仍为上游(镜像只额外发布 xlings-res release)。

## 后续
合入后 `xpkg-mirror-release` 将为 9 个 mirror 包自动建仓(#369)并上传 + 三方复核。