### PR TITLE
pkg(sing-box): downgrade ci to update-only (GitCode blocks mirror)

### DIFF
--- a/pkgs/s/sing-box.lua
+++ b/pkgs/s/sing-box.lua
@@ -7,7 +7,10 @@ package = {
     maintainers = {"SagerNet"},
     licenses = {"GPL-3.0-or-later"},
     repo = "https://github.com/SagerNet/sing-box",
-    ci = { mirror = true, update = true },
+    -- update only: GitCode rejects an xlings-res/sing-box repo under its
+    -- content policy, so the two-forge mirror cannot complete. sing-box still
+    -- auto-updates via url_template + latest.ref.
+    ci = { update = true },
     docs = "https://sing-box.sagernet.org/",
 
     type = "package",


### PR DESCRIPTION
GitCode 以内容政策拒绝创建 `xlings-res/sing-box` 仓库(HTTP 400 违规内容),两个 forge 的不可变镜像无法完成。故 sing-box 降为 **update-only**(保留 url_template + latest.ref 自动更新,去掉 mirror)。

发现于批量 opt-in(#373)后的真实镜像执行:其余 7 个 mirror 包(fd/fzf/zoxide/cc-connect/cc-switch/go/uv)正常,仅 sing-box 被 GitCode 拦截。

注:合入 #373 前创建的空 `xlings-res/sing-box` GitHub 仓库需手动删除(当前 token 无 delete_repo 权限)。