### PR TITLE
pkg(cc-switch): downgrade ci to update-only (universal assets)

### DIFF
--- a/pkgs/c/cc-switch.lua
+++ b/pkgs/c/cc-switch.lua
@@ -7,7 +7,11 @@ package = {
     maintainers = {"farion1231"},
     licenses = {"MIT"},
     repo = "https://github.com/farion1231/cc-switch",
-    ci = { mirror = true, update = true },
+    -- update only: cc-switch ships universal per-platform assets
+    -- (CC-Switch-*-macOS.zip / *-Windows-Portable.zip carry no arch token)
+    -- while declaring two arches, so it doesn't fit the per-arch mirror
+    -- model. It still auto-updates via url_template + latest.ref.
+    ci = { update = true },
     docs = "https://github.com/farion1231/cc-switch#readme",
 
     type = "app",


### PR DESCRIPTION
cc-switch 发的是**通用(universal)每平台资产** —— `CC-Switch-*-macOS.zip` / `*-Windows-Portable.zip` 不含 arch 标识 —— 却声明了 `archs = {x86_64, aarch64}`,materialize 无法定位 arch,不适用逐 arch 镜像模型。故降为 **update-only**(保留 url_template + latest.ref 自动更新)。

于 Tier A 镜像 rollout 真实执行中发现。