### PR TITLE
pkg(jq): opt into ci mirror (verify CI auto-repo-create)

### DIFF
--- a/pkgs/j/jq.lua
+++ b/pkgs/j/jq.lua
@@ -9,6 +9,11 @@ package = {
     repo = "https://github.com/jqlang/jq",
     docs = "https://jqlang.org/manual/",
 
+    -- mirror only: jq ships raw-binary assets (jq-linux-amd64 etc.) which the
+    -- mirror tool now handles; its release tag is jq-<version> with no
+    -- url_template, so auto-update is not wired here.
+    ci = { mirror = true },
+
     type = "package",
     archs = {"x86_64", "aarch64"},
     status = "stable",


### PR DESCRIPTION
验证 CI 用新授权的 `XLINGS_RES_TOKEN` **自动建仓**:jq 的 `xlings-res/jq` 仓库两个 forge 都还不存在,合入后 `xpkg-mirror-release` 的 `ensure_mirror_repos` 需自行创建。同时验证裸二进制镜像路径(#372,jq 发 jq-linux-amd64 等)。mirror-only:jq-<version> tag 无 url_template,不接自动更新。