### PR TITLE
fix(ci): give the GitCode repo seed commit a git identity

### DIFF
--- a/tests/test_xpkg_ci.py
+++ b/tests/test_xpkg_ci.py
@@ -26,11 +26,20 @@ class FakeRun:
     def __init__(self, route):
         self.route = route
         self.calls = []
+        self.envs = []
 
     def __call__(self, cmd, *args, **kwargs):
         self.calls.append(list(cmd))
+        self.envs.append(kwargs.get("env"))
         rc, out, err = self.route(list(cmd))
         return subprocess.CompletedProcess(cmd, rc, out, err)
+
+    def env_for(self, *prefix):
+        prefix = list(prefix)
+        for call, env in zip(self.calls, self.envs):
+            if call[: len(prefix)] == prefix:
+                return env
+        return None
 
     def ran(self, *prefix):
         prefix = list(prefix)
@@ -97,6 +106,10 @@ def test_ensure_mirror_repos():
         assert fake.ran("gh", "repo", "create")
         assert fake.ran("tools/gtc", "repo", "create")
         assert fake.ran("tools/gtc", "repo", "push")
+        # the seed push must carry a git identity so the commit works on a bare
+        # CI runner (no global git user.name/email)
+        push_env = fake.env_for("tools/gtc", "repo", "push")
+        assert push_env and push_env.get("GIT_AUTHOR_NAME") and push_env.get("GIT_COMMITTER_EMAIL"), push_env
 
         # GitCode seed push failure is reported, fail closed.
         def push_fails(cmd):

--- a/tools/xpkg_ci.py
+++ b/tools/xpkg_ci.py
@@ -19,6 +19,7 @@ import argparse
 import hashlib
 import importlib.util
 import json
+import os
 import re
 import subprocess
 import sys
@@ -489,9 +490,19 @@ def ensure_mirror_repos(package: str, repo: str, gitcode_repo: str) -> str | Non
         with tempfile.TemporaryDirectory() as seed:
             readme = Path(seed) / "README.md"
             readme.write_text(f"# {package}\n\n{description}.\n", encoding="utf-8")
+            # gtc repo push makes a git commit; a bare CI runner has no git
+            # identity configured, so pin one via env (git honours GIT_*_NAME/
+            # EMAIL without touching global config).
+            seed_env = {
+                **os.environ,
+                "GIT_AUTHOR_NAME": "xlings-res-bot",
+                "GIT_AUTHOR_EMAIL": "xlings-res-bot@users.noreply.github.com",
+                "GIT_COMMITTER_NAME": "xlings-res-bot",
+                "GIT_COMMITTER_EMAIL": "xlings-res-bot@users.noreply.github.com",
+            }
             pushed = subprocess.run(
                 ["tools/gtc", "repo", "push", gitcode_repo, seed, "-m", "seed mirror repo"],
-                text=True, capture_output=True,
+                text=True, capture_output=True, env=seed_env,
             )
             if pushed.returncode != 0:
                 return f"failed to seed GitCode repo {gitcode_repo}: {pushed.stderr.strip()}"


### PR DESCRIPTION
jq 镜像测试证明了 token 修复:**CI 现在能自动创建 GitHub 的 xlings-res 仓库**(403 消失)。但 GitCode 的播种步骤(`gtc repo push` → `git commit`)在 runner 上因 **'Author identity unknown'** 失败 —— 裸 CI runner 没有全局 git user.name/email(本地能过是因为开发机配了身份)。

修复:给播种 push 传 `GIT_AUTHOR/COMMITTER_*` 环境变量,commit 不依赖全局配置。含单测断言。