### PR TITLE
pkg(vim,khistory): opt into ci mirror

### DIFF
--- a/pkgs/k/khistory.lua
+++ b/pkgs/k/khistory.lua
@@ -10,6 +10,7 @@ package = {
     maintainers = {"Sunrisepeak"},
     licenses = {"GPL-3.0"},
     repo = "https://github.com/Sunrisepeak/KHistory",
+    ci = { mirror = true },
 
     -- xim pkg info
     type = "package",

--- a/pkgs/v/vim.lua
+++ b/pkgs/v/vim.lua
@@ -7,6 +7,7 @@ package = {
     contributors = "https://github.com/vim/vim/graphs/contributors",
     licenses = {"Vim"},
     repo = "https://github.com/vim/vim",
+    ci = { mirror = true },
     docs = "https://www.vim.org/docs.php",
 
     type = "package",


### PR DESCRIPTION
迁移剩余候选(第二批)。vim(linux/x86_64)、khistory(linux+windows x86_64)本地 materialize 干净、shim 对称,走现在全自动的 CI 镜像路径(自动建仓 + 上传 + 三方复核)。mirror-only(无 url_template)。

其余候选多数需先做配方工作:rosdep/vcstool 是 arch 无关的 PyPI wheel(py3-none-any),brew/node/project-graph 配方结构不同,materialize 直接失败 —— 单独处理。