### PR TITLE
pkg(sourcetrail,seeme-server,seeme-report): opt into ci mirror

### DIFF
--- a/pkgs/s/seeme-report.lua
+++ b/pkgs/s/seeme-report.lua
@@ -8,6 +8,7 @@ package = {
     contributors = "https://github.com/2412322029/seeme",
     licenses = {""},
     repo = "https://github.com/2412322029/seeme",
+    ci = { mirror = true },
     docs = "https://github.com/2412322029/seeme",
 
     -- xim pkg info

--- a/pkgs/s/seeme-server.lua
+++ b/pkgs/s/seeme-server.lua
@@ -8,6 +8,7 @@ package = {
     contributors = "https://github.com/2412322029/seeme",
     licenses = {""},
     repo = "https://github.com/2412322029/seeme",
+    ci = { mirror = true },
     docs = "https://github.com/2412322029/seeme",
 
     -- xim pkg info

--- a/pkgs/s/sourcetrail.lua
+++ b/pkgs/s/sourcetrail.lua
@@ -7,6 +7,7 @@ package = {
     contributors = "https://github.com/CoatiSoftware/Sourcetrail/graphs/contributors",
     licenses = {"GPL-3.0"},
     repo = "https://github.com/CoatiSoftware/Sourcetrail",
+    ci = { mirror = true },
 
     -- xim pkg info
     type = "package",


### PR DESCRIPTION
迁移剩余候选(第三批,已本地 materialize 验证干净、shim 安全)。sourcetrail(linux+win x86_64,~240MB,GitCode 上传较慢但幂等)、seeme-server / seeme-report(win x86_64,小)。mirror-only。

**已 defer 的候选(需配方工作,非 1 行)**:ollama(二进制过大)、hermes-agent/media-crawler/trendradar(arch 无关的源码归档 URL)、rosdep/vcstool(arch 无关 PyPI wheel)、brew/node/project-graph(结构不符)、ripgrep(leftover-shim xvm bug)。