### PR TITLE
fix(linux-headers): self-contained prebuilt + mirror, drop scode dep

### DIFF
--- a/pkgs/l/linux-headers.lua
+++ b/pkgs/l/linux-headers.lua
@@ -2,7 +2,7 @@ package = {
     spec = "1",
     -- base info
     name = "linux-headers",
-    description = "Linux Kernel Header",
+    description = "Linux Kernel Headers (prebuilt)",
 
     licenses = {"GPL"},
     repo = "https://github.com/torvalds/linux",
@@ -17,38 +17,50 @@ package = {
 
     xpm = {
         linux = {
-            -- TODO: Temporary workaround for pkgmanager.install() install-dir resolution issue.
-            deps = {
-                "scode:linux-headers@5.11.1",
-            },
             ["latest"] = { ref = "5.11.1" },
-            ["5.11.1"] = { },
+            -- Self-contained PREBUILT kernel headers, mirror-aware.
+            --
+            -- Previously this was a thin delegator that depended on
+            -- `scode:linux-headers@<ver>`, whose payload came from a single
+            -- gitcode-only URL (no GLOBAL mirror, sha256=nil). On GLOBAL
+            -- networks / CI that fetch raced the toolchain sysroot population
+            -- (the `std` module precompile needs `linux/limits.h`), and it
+            -- also required the scode sub-index to be synced first. Both are
+            -- gone: the prebuilt tarball is referenced directly with a
+            -- GLOBAL/CN mirror map + sha256; install = extract, config = copy
+            -- into the sysroot. No `make`, no sub-index dependency.
+            -- (openxlings/xlings#366)
+            ["5.11.1"] = {
+                url = {
+                    GLOBAL = "https://github.com/xlings-res/scode-res/releases/download/linux-headers/linux-headers-5.11.1.tar.gz",
+                    CN     = "https://gitcode.com/xlings-res/scode-res/releases/download/linux-headers/linux-headers-5.11.1.tar.gz",
+                },
+                sha256 = "abb59208aee1bc585bcc9fba3fd7c481c570cdb1f29f56369229b1601917d497",
+            },
         },
     },
 }
 
 import("xim.libxpkg.pkginfo")
 import("xim.libxpkg.system")
-import("xim.libxpkg.pkgmanager")
 import("xim.libxpkg.xvm")
 import("xim.libxpkg.log")
 import("xim.pkgindex.sysroot")
 
 function install()
-    -- This package is a thin delegator: the real header payload is provided
-    -- by `scode:linux-headers@<version>` (declared in deps), which xlings
-    -- installs first. Without writing anything into our own install_dir,
-    -- xlings's "installed?" probe (which checks install_dir for content)
-    -- always reports `installed: no`, causing every dependent package
-    -- (xim:gcc, xim:glibc, fromsource:gcc, ...) to re-trigger this install
-    -- + config on every fresh dep resolution, which in turn re-copies the
-    -- whole kernel-header tree into the subos sysroot via config().
-    --
-    -- Drop a tiny stamp file so install_dir is non-empty and the package
-    -- registers as installed.
-    local install_dir = pkginfo.install_dir()
-    if not os.isdir(install_dir) then os.mkdir(install_dir) end
-    io.writefile(path.join(install_dir, ".xim-installed"), pkginfo.version())
+    -- The prebuilt tarball extracts to `linux-headers-<ver>/include/...`.
+    -- Move that tree into our own install_dir so the "installed?" probe
+    -- (which checks install_dir for content) reports installed and dependent
+    -- packages (xim:gcc / xim:glibc / fromsource:gcc, ...) don't re-trigger
+    -- this install + config on every fresh dependency resolution.
+    local srcdir = pkginfo.install_file()
+        :replace(".tar.gz", "")
+        :replace(".tar.xz", "")
+        :replace(".zip", "")
+
+    os.tryrm(pkginfo.install_dir())
+    os.trymv(srcdir, pkginfo.install_dir())
+
     return true
 end
 
@@ -56,18 +68,16 @@ function config()
     local sysroot_usrdir = path.join(system.subos_sysrootdir(), "usr")
     if not os.isdir(sysroot_usrdir) then os.mkdir(sysroot_usrdir) end
 
-    -- Skip the recursive header copy if a previous install of the same
-    -- version already placed it in the subos sysroot. The stamp lives
-    -- next to the copied tree so that switching subos / wiping sysroot
-    -- correctly invalidates it.
+    -- Idempotent: skip the recursive header copy if this version is already
+    -- in the subos sysroot. The stamp lives next to the copied tree so that
+    -- switching subos / wiping the sysroot correctly invalidates it.
     local stamp = path.join(sysroot_usrdir, ".linux-headers-" .. pkginfo.version() .. ".stamp")
     if os.isfile(stamp) then
         log.debug("Linux headers already in subos rootfs (stamp present), skipping copy.")
     else
-        local scodedir = pkginfo.install_dir("scode:linux-headers", pkginfo.version())
-        log.info("Linking linux headers into subos sysroot ...")
+        log.info("Installing linux headers into subos sysroot ...")
         sysroot.install_headers(
-            path.join(scodedir, "include"),
+            path.join(pkginfo.install_dir(), "include"),
             path.join(sysroot_usrdir, "include")
         )
         io.writefile(stamp, pkginfo.version())


### PR DESCRIPTION
`xim:linux-headers` was a thin delegator depending on `scode:linux-headers@5.11.1`, whose payload came from a **single gitcode-only URL** (no GLOBAL mirror, `sha256=nil`). On GLOBAL networks / CI (e.g. the aarch64 release job that builds mcpp from source) that fetch **raced the toolchain sysroot population** — the `std` module precompile needs `linux/limits.h` — and it also required the **scode sub-index to be synced first**. This is what broke the v0.4.65 aarch64 release build (`fatal error: linux/limits.h: No such file`).

**Fix (simplest, no workaround):** reference the prebuilt tarball directly with a **GLOBAL(github)/CN(gitcode) mirror map + sha256** (both mirrors verified byte-identical, `abb59208…`). `install` = extract, `config` = copy into the subos sysroot. **No `make`, no sub-index dependency.**

Idiomatic — matches the existing `url = {GLOBAL,CN}` mirror form used by llvm-tools/libffi/zlib/… (and adds a real `sha256`, which those leave `nil`).

**Verified end-to-end** with a real `xlings install linux-headers` (isolated HOME, mirror fetch): `install_dir/include/linux/limits.h` present, symlinked into `subos/default/usr/include/linux/limits.h`, and **no `scode:linux-headers` pulled**.

Refs openxlings/xlings#366