### PR TITLE
bump(xlings): track 0.4.65 as latest

### DIFF
--- a/pkgs/x/xlings.lua
+++ b/pkgs/x/xlings.lua
@@ -38,7 +38,26 @@ package = {
             -- res_versioned: version-bump bot tracks openxlings/xlings releases and
             -- appends new ["x.y.z"] = "XLINGS_RES" entries (see version-check.py).
             res_versioned = true,
-            ["latest"] = { ref = "0.4.64" },
+            ["latest"] = { ref = "0.4.65" },
+            ["0.4.65"] = {
+                url = "XLINGS_RES",
+                sha256 = {
+                    aarch64 = "beaf1ab5758029c37aa962883b71ed58e2d9aca638d8a067c699093dfbb17ff8",
+                    x86_64 = "893b46dfa68d236079d5ec9383a12d4abdd7dc2f156197b2671f6c7eb7fde93d",
+                },
+            },
+            ["0.4.65"] = {
+                url = "XLINGS_RES",
+                sha256 = {
+                    aarch64 = "65ad3e3287de41905593a00216af1c493ba70db56d1f92fb9edc1021242309a8",
+                },
+            },
+            ["0.4.65"] = {
+                url = "XLINGS_RES",
+                sha256 = {
+                    x86_64 = "aa37912dd708f14bd3f94e6ba1b062d330938270b2ffee4f6da28ae53d5c7850",
+                },
+            },
             ["0.4.64"] = {
                 url = "XLINGS_RES",
                 sha256 = {
@@ -205,7 +224,7 @@ package = {
             -- res_versioned: version-bump bot tracks openxlings/xlings releases and
             -- appends new ["x.y.z"] = "XLINGS_RES" entries (see version-check.py).
             res_versioned = true,
-            ["latest"] = { ref = "0.4.64" },
+            ["latest"] = { ref = "0.4.65" },
             ["0.4.64"] = {
                 url = "XLINGS_RES",
                 sha256 = {
@@ -370,7 +389,7 @@ package = {
             -- res_versioned: version-bump bot tracks openxlings/xlings releases and
             -- appends new ["x.y.z"] = "XLINGS_RES" entries (see version-check.py).
             res_versioned = true,
-            ["latest"] = { ref = "0.4.64" },
+            ["latest"] = { ref = "0.4.65" },
             ["0.4.64"] = {
                 url = "XLINGS_RES",
                 sha256 = {

--- a/pkgs/x/xlings.lua
+++ b/pkgs/x/xlings.lua
@@ -46,18 +46,6 @@ package = {
                     x86_64 = "893b46dfa68d236079d5ec9383a12d4abdd7dc2f156197b2671f6c7eb7fde93d",
                 },
             },
-            ["0.4.65"] = {
-                url = "XLINGS_RES",
-                sha256 = {
-                    aarch64 = "65ad3e3287de41905593a00216af1c493ba70db56d1f92fb9edc1021242309a8",
-                },
-            },
-            ["0.4.65"] = {
-                url = "XLINGS_RES",
-                sha256 = {
-                    x86_64 = "aa37912dd708f14bd3f94e6ba1b062d330938270b2ffee4f6da28ae53d5c7850",
-                },
-            },
             ["0.4.64"] = {
                 url = "XLINGS_RES",
                 sha256 = {
@@ -225,6 +213,12 @@ package = {
             -- appends new ["x.y.z"] = "XLINGS_RES" entries (see version-check.py).
             res_versioned = true,
             ["latest"] = { ref = "0.4.65" },
+            ["0.4.65"] = {
+                url = "XLINGS_RES",
+                sha256 = {
+                    aarch64 = "65ad3e3287de41905593a00216af1c493ba70db56d1f92fb9edc1021242309a8",
+                },
+            },
             ["0.4.64"] = {
                 url = "XLINGS_RES",
                 sha256 = {
@@ -390,6 +384,12 @@ package = {
             -- appends new ["x.y.z"] = "XLINGS_RES" entries (see version-check.py).
             res_versioned = true,
             ["latest"] = { ref = "0.4.65" },
+            ["0.4.65"] = {
+                url = "XLINGS_RES",
+                sha256 = {
+                    x86_64 = "aa37912dd708f14bd3f94e6ba1b062d330938270b2ffee4f6da28ae53d5c7850",
+                },
+            },
             ["0.4.64"] = {
                 url = "XLINGS_RES",
                 sha256 = {


### PR DESCRIPTION
Manual bump to 0.4.65 (all 3 platform blocks + latest refs; sha256 from official release sidecars).

Why manual: `version-bump.yml` fails at PR creation — **XPKG_BOT_TOKEN secret is not configured** (daily runs only "pass" because they no-op before reaching the PR step). The release `bump-index` job also no-op'd on releases/latest API lag. Please (re)configure the secret to restore the bot.