### PR TITLE
feat(nasm): add nasm 3.02 xpkg — linux/windows/macosx, multi-arch

### DIFF
--- a/pkgs/n/nasm.lua
+++ b/pkgs/n/nasm.lua
@@ -1,0 +1,96 @@
+package = {
+    spec = "2",
+
+    name = "nasm",
+    description = "NASM - the Netwide Assembler, an assembler targeting the x86/x86-64 CPU family",
+
+    homepage = "https://www.nasm.us",
+    maintainers = {"The NASM Development Team"},
+    licenses = {"BSD-2-Clause"},
+    repo = "https://github.com/netwide-assembler/nasm",
+    docs = "https://www.nasm.us/docs.php",
+
+    -- xim pkg info
+    type = "package",
+    archs = {"x86_64", "aarch64", "x86"},
+    status = "stable",
+    categories = {"assembler", "compiler", "toolchain"},
+    keywords = {"nasm", "assembler", "asm", "x86", "x86_64", "ndisasm", "disassembler"},
+
+    programs = {"nasm", "ndisasm"},
+    xvm_enable = true,
+
+    -- All assets live at xlings-res/nasm (GLOBAL → github, CN → gitcode),
+    -- release tag = upstream version, xlings-res naming
+    -- `nasm-<ver>-<os>-<arch>.<ext>`. Every archive expands to a uniform
+    -- top-level dir `nasm-<ver>/` with nasm(.exe) + ndisasm(.exe) at its
+    -- root, so one install hook covers every platform.
+    --
+    -- Provenance (upstream = https://www.nasm.us/pub/nasm/releasebuilds/<ver>/):
+    --   windows x86_64 / x86 — byte-identical upstream win64/win32 zips,
+    --     only the archive filename is renamed.
+    --   macosx x86_64 / aarch64 — byte-identical upstream macosx zip
+    --     (an i386+x86_64 universal binary; upstream ships no native
+    --     arm64 build). The aarch64 asset is the same file under the
+    --     res-convention name: on Apple Silicon the x86_64 slice runs
+    --     via Rosetta 2, which is upstream's only supported path.
+    --   linux x86_64 / aarch64 — built from the upstream source tarball
+    --     (nasm-<ver>.tar.xz) as fully-static musl binaries (musl-gcc /
+    --     aarch64-linux-musl-gcc, `-O2 -static`, stripped), so they are
+    --     portable across distributions with no glibc runtime dep.
+    xpm = {
+        linux = {
+            ["latest"] = { ref = "3.02" },
+            ["3.02"] = {
+                url = "XLINGS_RES",
+                sha256 = {
+                    x86_64 = "77f2e098291212c32b40c32706e03371a6629e847724cecc6f8c03d56ba7c04c",
+                    aarch64 = "a592df8b05c1b5552a90f22573f1132984788ec63bcae90d926573db27d0e407",
+                },
+            },
+        },
+        windows = {
+            ["latest"] = { ref = "3.02" },
+            ["3.02"] = {
+                url = "XLINGS_RES",
+                sha256 = {
+                    x86_64 = "161d0bfaff53c2f9e9f3e69fd0672323ebabafd1268976a5cec11be92a19aee7",
+                    x86 = "dca7d736580aafcf88a07838bb597a4f093fa157e56ce522891e86ab0a37c949",
+                },
+            },
+        },
+        macosx = {
+            ["latest"] = { ref = "3.02" },
+            ["3.02"] = {
+                url = "XLINGS_RES",
+                sha256 = {
+                    -- same universal binary zip for both arches (see header note)
+                    x86_64 = "4c1bbb09853f5f5ffc9b7832cbc9366c4761bc79ce7ffb148b0e427e5f3fa114",
+                    aarch64 = "4c1bbb09853f5f5ffc9b7832cbc9366c4761bc79ce7ffb148b0e427e5f3fa114",
+                },
+            },
+        },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+
+function install()
+    os.tryrm(pkginfo.install_dir())
+    os.mv("nasm-" .. pkginfo.version(), pkginfo.install_dir())
+    return true
+end
+
+function config()
+    -- nasm/ndisasm sit at the install root (no bin/ subdir in any archive)
+    xvm.add("nasm", { bindir = pkginfo.install_dir() })
+    xvm.add("ndisasm", { bindir = pkginfo.install_dir() })
+    return true
+end
+
+function uninstall()
+    xvm.remove("nasm")
+    xvm.remove("ndisasm")
+    return true
+end

--- a/pkgs/n/nasm.lua
+++ b/pkgs/n/nasm.lua
@@ -22,27 +22,28 @@ package = {
 
     -- All assets live at xlings-res/nasm (GLOBAL → github, CN → gitcode),
     -- release tag = upstream version, xlings-res naming
-    -- `nasm-<ver>-<os>-<arch>.<ext>`. Every archive expands to a uniform
-    -- top-level dir `nasm-<ver>/` with nasm(.exe) + ndisasm(.exe) at its
-    -- root, so one install hook covers every platform.
+    -- `nasm-<ver>-<os>-<arch>.<ext>` (zip on windows, tar.gz elsewhere).
+    -- Every archive expands to a uniform top-level dir `nasm-<ver>/` with
+    -- nasm(.exe) + ndisasm(.exe) at its root, so one install hook covers
+    -- every platform.
     --
     -- Provenance (upstream = https://www.nasm.us/pub/nasm/releasebuilds/<ver>/):
     --   windows x86_64 / x86 — byte-identical upstream win64/win32 zips,
     --     only the archive filename is renamed.
-    --   macosx x86_64 / aarch64 — byte-identical upstream macosx zip
-    --     (an i386+x86_64 universal binary; upstream ships no native
-    --     arm64 build). The aarch64 asset is the same file under the
-    --     res-convention name: on Apple Silicon the x86_64 slice runs
-    --     via Rosetta 2, which is upstream's only supported path.
+    --   macosx x86_64 / aarch64 — the upstream macosx zip (an i386+x86_64
+    --     universal binary; upstream ships no native arm64 build),
+    --     repacked file-identical into tar.gz to match the res ext rule.
+    --     Both arch assets are the same bytes: on Apple Silicon the
+    --     x86_64 slice runs via Rosetta 2, upstream's only supported path.
     --   linux x86_64 / aarch64 — built from the upstream source tarball
     --     (nasm-<ver>.tar.xz) as fully-static musl binaries (musl-gcc /
     --     aarch64-linux-musl-gcc, `-O2 -static`, stripped), so they are
     --     portable across distributions with no glibc runtime dep.
     xpm = {
+        source = "xlings-res",
         linux = {
             ["latest"] = { ref = "3.02" },
             ["3.02"] = {
-                url = "XLINGS_RES",
                 sha256 = {
                     x86_64 = "77f2e098291212c32b40c32706e03371a6629e847724cecc6f8c03d56ba7c04c",
                     aarch64 = "a592df8b05c1b5552a90f22573f1132984788ec63bcae90d926573db27d0e407",
@@ -52,7 +53,6 @@ package = {
         windows = {
             ["latest"] = { ref = "3.02" },
             ["3.02"] = {
-                url = "XLINGS_RES",
                 sha256 = {
                     x86_64 = "161d0bfaff53c2f9e9f3e69fd0672323ebabafd1268976a5cec11be92a19aee7",
                     x86 = "dca7d736580aafcf88a07838bb597a4f093fa157e56ce522891e86ab0a37c949",
@@ -62,11 +62,10 @@ package = {
         macosx = {
             ["latest"] = { ref = "3.02" },
             ["3.02"] = {
-                url = "XLINGS_RES",
                 sha256 = {
-                    -- same universal binary zip for both arches (see header note)
-                    x86_64 = "4c1bbb09853f5f5ffc9b7832cbc9366c4761bc79ce7ffb148b0e427e5f3fa114",
-                    aarch64 = "4c1bbb09853f5f5ffc9b7832cbc9366c4761bc79ce7ffb148b0e427e5f3fa114",
+                    -- same universal-binary tar.gz for both arches (see header note)
+                    x86_64 = "440d2cf13e32b6bcce79a7d933c037bbd47b4c4ae12f030f6efda539c0e34bcd",
+                    aarch64 = "440d2cf13e32b6bcce79a7d933c037bbd47b4c4ae12f030f6efda539c0e34bcd",
                 },
             },
         },

--- a/tests/n/test_nasm.py
+++ b/tests/n/test_nasm.py
@@ -1,0 +1,85 @@
+"""测试 nasm 包"""
+import pytest
+from tests.lib.xpkg_parser import parse_xpkg
+from tests.lib.assertions import (
+    assert_required_fields, assert_valid_spec, assert_valid_type,
+    assert_no_typos, assert_no_exec_xvm, assert_no_bashrc_modification,
+    assert_no_direct_path_modification, assert_uses_new_api,
+    assert_xim_add_succeeds, assert_install_succeeds,
+    assert_command_output, assert_xvm_registered,
+)
+from tests.lib.platform_utils import skip_if_not
+
+PKG = "nasm"
+PKG_FILE = "pkgs/n/nasm.lua"
+
+
+@pytest.fixture(scope='module')
+def meta():
+    return parse_xpkg(PKG_FILE)
+
+
+class TestStatic:
+    @pytest.mark.static
+    def test_required_fields(self, meta):
+        assert_required_fields(meta)
+
+    @pytest.mark.static
+    def test_valid_spec(self, meta):
+        assert_valid_spec(meta)
+
+    @pytest.mark.static
+    def test_valid_type(self, meta):
+        assert_valid_type(meta)
+
+    @pytest.mark.static
+    def test_no_typos(self):
+        assert_no_typos(PKG_FILE)
+
+
+class TestIndex:
+    @pytest.mark.index
+    def test_xim_add(self):
+        assert_xim_add_succeeds(PKG_FILE)
+
+
+class TestIsolation:
+    @pytest.mark.isolation
+    def test_no_exec_xvm(self):
+        assert_no_exec_xvm(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_no_bashrc(self):
+        assert_no_bashrc_modification(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_no_path_modification(self):
+        assert_no_direct_path_modification(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_new_api(self):
+        assert_uses_new_api(PKG_FILE)
+
+
+class TestLifecycle:
+    @pytest.mark.lifecycle
+    @skip_if_not('linux')
+    def test_install(self):
+        assert_install_succeeds(PKG)
+
+
+class TestVerify:
+    @pytest.mark.verify
+    @skip_if_not('linux')
+    def test_nasm(self):
+        assert_command_output("nasm --version")
+
+    @pytest.mark.verify
+    @skip_if_not('linux')
+    def test_xvm_nasm(self):
+        assert_xvm_registered("nasm")
+
+    @pytest.mark.verify
+    @skip_if_not('linux')
+    def test_xvm_ndisasm(self):
+        assert_xvm_registered("ndisasm")


### PR DESCRIPTION
## Summary

新增 **nasm**（Netwide Assembler）包，最新稳定版 **3.02**，spec V2 + **`xpm.source = "xlings-res"` 机制**（版本条目只带 per-arch sha256），多平台 + 多架构：

| 平台 | 架构 | 资产 | 来源 |
|------|------|------|------|
| linux | x86_64 / aarch64 | `nasm-3.02-linux-<arch>.tar.gz` | 上游源码 tarball 全静态 musl 构建（musl-gcc / aarch64-linux-musl-gcc, `-O2 -static`, stripped），跨发行版可移植，无 glibc 依赖 |
| windows | x86_64 / x86 | `nasm-3.02-windows-<arch>.zip` | 上游官方 win64/win32 zip，字节不变仅改名 |
| macosx | x86_64 / aarch64 | `nasm-3.02-macosx-{x86_64,arm64}.tar.gz` | 上游官方 macosx zip（i386+x86_64 universal 二进制）文件不变重打包为 tar.gz（res 命名 ext 规则）；上游无原生 arm64 构建，Apple Silicon 经 Rosetta 2 运行（上游唯一支持路径），两架构资产同字节 |

### 镜像发布（xlings-res）

- GitHub RES: https://github.com/xlings-res/nasm/releases/tag/3.02（6 资产 + .sha256 sidecar + manifest.json）
- GitCode RES: https://gitcode.com/xlings-res/nasm/releases/3.02（同名同字节）
- 通过 `tools/xpkg_ci.py mirror --execute` 发布，**三方 sha256 校验通过**（GitHub RES / GitCode RES / manifest 权威摘要一致）；windows 资产 sha256 与 nasm.us 上游下载件一致
- 索引对每个受支持架构写入与 sidecar 一致的 SHA256

### 安装 / 卸载行为

- **install**: 归档统一展开为 `nasm-<ver>/`（nasm、ndisasm 位于根目录），整体 mv 到 `pkginfo.install_dir()`
- **config**: `xvm.add("nasm")` + `xvm.add("ndisasm")`（bindir = 安装根目录），subos 隔离路由
- **uninstall**: `xvm.remove` 两个 program，干净移除
- **系统影响**: 不修改任何系统配置 / 环境变量 / shell profile

## Test plan

本地（linux x86_64, xlings 0.4.64）：
- [x] `xlings config --add-xpkg` 注册成功，`xlings search nasm` 可见
- [x] `xlings install nasm --yes` 成功（经 source="xlings-res" 解析下载 + sha256 校验）
- [x] `nasm --version` → `NASM version 3.02`；实测汇编 elf64 目标文件成功；`ndisasm` 可用
- [x] `xlings remove nasm --yes` 干净卸载，shim 移除
- [x] aarch64 静态二进制经 qemu-aarch64 冒烟验证（`nasm --version` OK）
- [x] `pytest tests/n/test_nasm.py`：static 4/4、index 1/1、isolation 4/4、lifecycle 1/1 通过；verify 中 2 个 `assert_xvm_registered` 失败为**本机环境预存问题**（对照包 ninja 同样失败，`xvm info` 在本机只输出 Runtime Tips），`nasm --version` verify 通过
- [x] 全仓 `pytest -m "static or isolation"` 807 passed；spec/CI 套件 131 passed

CI：首轮 macos-install-test 404 是因为初版 release 的 macOS 资产是 .zip 而 XLINGS_RES/source 解析对非 windows 平台用 .tar.gz——已重打包重发（同时切换到 source 机制），其余 job 首轮全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
