### PR TITLE
fix(git): pin GIT_SSL_CAINFO on linux — static build's CA default is absent on most distros

### DIFF
--- a/pkgs/g/git.lua
+++ b/pkgs/g/git.lua
@@ -84,6 +84,26 @@ function install()
     return true
 end
 
+-- Returns the host's CA bundle when the binary's compiled-in default
+-- (/etc/ssl/cert.pem) is missing, else nil (default is already correct).
+function find_ca_bundle()
+    if os.isfile("/etc/ssl/cert.pem") then
+        return nil
+    end
+    local candidates = {
+        "/etc/ssl/certs/ca-certificates.crt",              -- Debian/Ubuntu, Arch, openSUSE
+        "/etc/pki/tls/certs/ca-bundle.crt",                -- RHEL/CentOS/Fedora
+        "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem", -- Fedora (ca-trust)
+        "/etc/ssl/ca-bundle.pem",                          -- older openSUSE
+    }
+    for _, f in ipairs(candidates) do
+        if os.isfile(f) then
+            return f
+        end
+    end
+    return nil
+end
+
 function config()
     if is_host("windows") then
         xvm.add("git", {
@@ -97,9 +117,36 @@ function config()
             "--cd-to-home"
         ))
     else
-        xvm.add("git", {
+        local config = {
             bindir = path.join(pkginfo.install_dir(), "bin")
-        })
+        }
+
+        -- CA bundle: the static-builds tarball links OpenSSL with
+        -- OPENSSLDIR=/etc/ssl, so its default cert FILE is /etc/ssl/cert.pem
+        -- (the BSD/Alpine layout). Debian/Ubuntu/RHEL ship the bundle
+        -- elsewhere and never create that file, so every HTTPS transport
+        -- dies with:
+        --   fatal: unable to access '...': error adding trust anchors
+        --   from file: /etc/ssl/cert.pem
+        -- The string lives in libexec/git-core/git-remote-https (the helper
+        -- that actually runs curl), not in bin/git.
+        --
+        -- Only GIT_SSL_CAINFO fixes it: git passes CURLOPT_CAINFO from its
+        -- compiled-in default, which overrides SSL_CERT_FILE (OpenSSL-level)
+        -- and CURL_CA_BUNDLE (curl-level); GIT_SSL_CAPATH does not help
+        -- either, because curl fails on the missing CAINFO before it would
+        -- consult a CApath.
+        --
+        -- Left untouched when /etc/ssl/cert.pem exists (Alpine/BSD, and any
+        -- host that symlinked it): there the built-in default is correct.
+        local ca_bundle = find_ca_bundle()
+        if ca_bundle then
+            config.envs = { GIT_SSL_CAINFO = ca_bundle }
+            log.info("git: pinning GIT_SSL_CAINFO to " .. ca_bundle
+                     .. " (/etc/ssl/cert.pem absent)")
+        end
+
+        xvm.add("git", config)
     end
 
     return true


### PR DESCRIPTION
## 问题

linux 的 git 用的是社区静态构建(`supriyo-biswas/static-builds`),它链接的 OpenSSL 以 `OPENSSLDIR=/etc/ssl` 编译,默认 cert **文件**因此是 `/etc/ssl/cert.pem` —— 这是 BSD/Alpine 的布局。Debian/Ubuntu/RHEL 的证书包在别处,且**从不创建**这个文件,于是任何 HTTPS 传输都会死在:

```
fatal: unable to access 'https://github.com/...': error adding trust anchors from file: /etc/ssl/cert.pem
```

一个容易误判的点:这个字符串在 `libexec/git-core/git-remote-https`(真正跑 curl 的 helper)里,`bin/git` 里搜不到,所以很容易被当成系统 git 的问题。

## 为什么只能用 GIT_SSL_CAINFO

四种覆盖方式都实测过:

| 方式 | 结果 | 原因 |
|---|---|---|
| `SSL_CERT_FILE` | ❌ | OpenSSL 级别,被 curl 的显式 CAINFO 绕过 |
| `CURL_CA_BUNDLE` | ❌ | 被 git 传入的 CURLOPT_CAINFO 覆盖 |
| `GIT_SSL_CAPATH` | ❌ | git 仍设了那个不存在的 CAINFO,curl 先报错,不会回退到 CApath |
| **`GIT_SSL_CAINFO`** | ✅ | 唯一能改写 CURLOPT_CAINFO 的入口 |

## 改动

`config()` 探测宿主证书包并通过 xvm `envs` 注入。探测顺序覆盖 Debian/Ubuntu、RHEL/Fedora(含 ca-trust)、老 openSUSE。

**当 `/etc/ssl/cert.pem` 存在时(Alpine/BSD,或已自行 symlink 的主机)不做任何设置** —— 那里内置默认值本来就是对的,不该覆盖。

## 验证(Ubuntu,隔离 XLINGS_HOME)

安装时打印:
```
[xim:xpkg]: git: pinning GIT_SSL_CAINFO to /etc/ssl/certs/ca-certificates.crt (/etc/ssl/cert.pem absent)
```
随后在**没有** `--global http.sslCAInfo`、shell 里**没有**任何 CA 环境变量的情况下:
```
$ git ls-remote https://github.com/mcpplibs/mcpp-index.git HEAD
2e23e2085c66d4dbc94ab87d379439a484c82cf2	HEAD
```
修复前同一命令必然报上面的 trust anchors 错误。

## 遗留(不在本 PR 范围)

`mcpp index update` / `xlings` 的内部索引同步走的是 `xlings::compact::git`,**直接调二进制、绕过 xvm shim**,所以拿不到这里注入的 env,目前仍会失败;实测把 `GIT_SSL_CAINFO` 放进进程环境后即恢复正常(`index updated`)。这需要 xlings 侧在 compact git 调用处做同样的 CA 探测,属于 xlings 仓库的改动。临时可 `sudo ln -s /etc/ssl/certs/ca-certificates.crt /etc/ssl/cert.pem`。

descriptor 里那个 self-build 迁移 TODO 落地后,理想做法是自带 CA bundle 或构建时就指对路径,届时本探测可以去掉。