### PR TITLE
fix(node): install hook crashes on os.arch under the C++ xim runtime

### DIFF
--- a/pkgs/n/node.lua
+++ b/pkgs/n/node.lua
@@ -22,7 +22,13 @@ local function _mac_url(ver)
 end
 
 -- node's release dir/file token per platform+arch (used by install()).
-local function _node_arch() return ({ x86_64 = "x64", aarch64 = "arm64" })[os.arch()] or "x64" end
+-- `os.arch` is not bound in the C++ xim hook runtime (xlings >= 0.4.6x,
+-- only os.host is) and _RUNTIME.arch is empty for install hooks, so this
+-- may return nil — install() then probes both arch tokens with os.isdir.
+local function _node_arch()
+    local arch = (os.arch and os.arch()) or (_RUNTIME and _RUNTIME.arch) or ""
+    return ({ x86_64 = "x64", x64 = "x64", aarch64 = "arm64", arm64 = "arm64" })[arch]
+end
 
 -- xpkg info
 
@@ -115,11 +121,23 @@ local node_dir_template = {
 function install()
     os.tryrm(pkginfo.install_dir())
     log.debug("Installing Node.js to %s ...", pkginfo.install_dir())
-    os.mv(
-        string.format(node_dir_template[os.host()], pkginfo.version(), _node_arch()),
-        pkginfo.install_dir()
-    )
-    return true
+    -- Probe candidate dirs with os.isdir (a native binding) rather than
+    -- os.dirs: the glob shells out to `ls`, which is not on the hook PATH
+    -- in the C++ xim runtime. The downloaded asset already matches the
+    -- host arch, so at most one candidate exists; trying the detected
+    -- arch first keeps the stale-leftover case deterministic.
+    local tokens = { "x64", "arm64" }
+    local arch = _node_arch()
+    if arch then table.insert(tokens, 1, arch) end
+    for _, tok in ipairs(tokens) do
+        local extracted = string.format(node_dir_template[os.host()], pkginfo.version(), tok)
+        if os.isdir(extracted) then
+            os.mv(extracted, pkginfo.install_dir())
+            return true
+        end
+    end
+    log.error("extracted node dir not found (version %s)", pkginfo.version())
+    return false
 end
 
 function config()


### PR DESCRIPTION
## Problem

Every `node` install fails on CI (xlings v0.4.62) — and locally on 0.4.68 — with:

```
[error] install hook failed for node: .../pkgs/n/node.lua:25: attempt to call a nil value (field 'arch')
```

This also breaks any package with a node dep (first seen as the claude install failure in #409).

## Root cause

The C++ xim runtime (mcpplibs/libxpkg lua-stdlib) binds `os.host` but **not** `os.arch` in the xpkg hook sandbox, and `_RUNTIME.arch` is never populated for install-hook ExecutionContexts (installer.cppm builds the hook ctx without `.arch`). `node.lua:25` (from #322) calls `os.arch()` unconditionally — it only ever passed CI because #322 merged while CI was pinned to the old v0.4.44 runtime; the pin moved to v0.4.62 in #343 and node hasn't been install-tested since.

## Fix

- `_node_arch()`: guard `os.arch` behind a nil check, fall back to `_RUNTIME.arch`, return nil when neither is usable (also accepts `x64`/`arm64` spellings).
- `install()`: probe the extracted `node-v<ver>-<os>-{x64,arm64}` candidates with `os.isdir` (native binding) instead of trusting one formatted name. Note `os.dirs` globbing is not an option — it shells out to `ls`, which is absent from the hook PATH.
- Fail with a clear `log.error` instead of a nil-arg `os.mv` when nothing matches.

## Verification

Reproduced and fixed locally on xlings 0.4.68: `xlings config --add-xpkg pkgs/n/node.lua` + `xlings install local:node@22.14.0 -y` failed with the exact CI error before, passes after (payload staged, `bin/node --version` → v22.14.0, uninstall clean).

## Follow-ups (upstream, separate repos)

- mcpplibs/libxpkg: bind `os.arch` in the hook lua-stdlib (its own elfpatch.lua already guards with `(os.arch and os.arch())`).
- openxlings/xlings: set `ctx.arch` when building hook ExecutionContexts.
- `pkgs/m/musl-cross-make.lua:321` has the same unguarded `os.arch()` in its `--static` config path — not touched here to keep this PR's CI scope to node.

After merge: rerun the failed CI run on #409 — its claude install resolves the `node` dep from this repo's main.