### PR TITLE
bump(xlings): track 2026.7.27.0 as latest

### DIFF
--- a/pkgs/x/xlings.lua
+++ b/pkgs/x/xlings.lua
@@ -38,7 +38,14 @@ package = {
             -- res_versioned: version-bump bot tracks openxlings/xlings releases and
             -- appends new ["x.y.z"] = "XLINGS_RES" entries (see version-check.py).
             res_versioned = true,
-            ["latest"] = { ref = "0.4.69" },
+            ["latest"] = { ref = "2026.7.27.0" },
+            ["2026.7.27.0"] = {
+                url = "XLINGS_RES",
+                sha256 = {
+                    aarch64 = "0e3fa8ee53b69b552fee72c9f93f36af8327d01349145490eb12917b1c095bd6",
+                    x86_64 = "0764db9b338633a25bb4bfd67681a8af0de7c3ef56a60a1967917d346502dce8",
+                },
+            },
             ["0.4.69"] = {
                 url = "XLINGS_RES",
                 sha256 = {
@@ -240,7 +247,13 @@ package = {
             -- res_versioned: version-bump bot tracks openxlings/xlings releases and
             -- appends new ["x.y.z"] = "XLINGS_RES" entries (see version-check.py).
             res_versioned = true,
-            ["latest"] = { ref = "0.4.69" },
+            ["latest"] = { ref = "2026.7.27.0" },
+            ["2026.7.27.0"] = {
+                url = "XLINGS_RES",
+                sha256 = {
+                    aarch64 = "c46b2538a359fb7e2d3f566c52aba1ae150dae28f35db4febe986ac5ce738c69",
+                },
+            },
             ["0.4.69"] = {
                 url = "XLINGS_RES",
                 sha256 = {
@@ -435,7 +448,13 @@ package = {
             -- res_versioned: version-bump bot tracks openxlings/xlings releases and
             -- appends new ["x.y.z"] = "XLINGS_RES" entries (see version-check.py).
             res_versioned = true,
-            ["latest"] = { ref = "0.4.69" },
+            ["latest"] = { ref = "2026.7.27.0" },
+            ["2026.7.27.0"] = {
+                url = "XLINGS_RES",
+                sha256 = {
+                    x86_64 = "fb5996a85c4dfc0c757ce3b29458911bf765f75f4d28d4f043ad330622243a9d",
+                },
+            },
             ["0.4.69"] = {
                 url = "XLINGS_RES",
                 sha256 = {


### PR DESCRIPTION
把 `latest` 指向 **2026.7.27.0**（openxlings/xlings 已发布）。

## 为什么是手工补的

release workflow 的 `bump-index` **报了 success，但什么都没改**。

`bump-index` 和 `mirror-binaries` 都只 `needs: [create-release]`，**并行执行**。而 `version-check.py` 在写入前会逐个下载 `xlings-res` 的产物、对着 sidecar 独立校验 sha256 —— 镜像还没传完时它没东西可校验，于是 `bump_index.sh` 走"no change"分支 `exit 0`，外层又包了 `|| echo "(non-blocking)"`。**两层都把"漏 bump"变成绿勾。**

镜像完成后重跑 `version-check.py --apply`：

```
scanned 1, update_available 1, errors 0, applied 1
```

本 PR 的内容就是这次运行的产物，**每个 digest 都是脚本独立下载并哈希出来的**，不是我手抄的。

## 影响

不合这个 PR，`latest` 停在 `0.4.69`，**没有任何用户能通过 `xlings self update` 拿到新版**。

## 内容

三个平台段各加一条 `["2026.7.27.0"]`，`latest.ref` 统一指过去：

| 平台 | arch |
|---|---|
| linux | x86_64 + aarch64 |
| macosx | arm64 |
| windows | x86_64 |

## 上游需要修的（另开）

`release.yml` 里 `bump-index` 应该 `needs: [mirror-binaries]`，否则每次发布都会撞同一个竞态。已记录，随 0.4.71 修。
