### PR TITLE
fix(glibc): drop the duplicate librt.so.1 entry (glibc is uninstallable on current xlings)

### DIFF
--- a/pkgs/g/glibc.lua
+++ b/pkgs/g/glibc.lua
@@ -81,7 +81,10 @@ local glibc_libs = {
     -- rust-lld: error: unable to find library -lrt
     "Scrt1.o",
     "libutil.a", "libutil.so.1",
-    "librt.a", "librt.so.1",
+    -- librt.so.1 is already listed above with the realtime group; a
+    -- second entry makes config() call xvm.add for the same name and
+    -- version twice.
+    "librt.a",
 }
 
 function install()


### PR DESCRIPTION
**`xlings install glibc@2.39` 在当前客户端上直接失败**，并连带拖垮每一个依赖 glibc 的包。

## 根因：一行重复

`glibc_libs` 里 `librt.so.1` 写了两次 —— 一次在 realtime 分组，一次挨着 `librt.a`：

```lua
"librt.so.1", -- realtime
...
"librt.a", "librt.so.1",
```

于是 `config()` 用同一个 name + version 调了两次 `xvm.add`。

## 为什么现在才炸

| 客户端 | 行为 |
|---|---|
| 0.4.69 | 静默接受（后一次注册覆盖前一次） |
| ≥ 0.4.70 | `error: duplicate exact registration node` / `xvm-duplicate-registration` |

0.4.70 引入的注册校验**是对的** —— 同名同版本注册两次本来就没有意义。错的是 recipe。

## 实测

同一个 recipe、同一份 tarball 缓存、同样的隔离 HOME，只换二进制：

```
0.4.69       xlings install glibc@2.39 -y  →  rc=0  ✓ 1 package(s) installed
2026.7.27.2  xlings install glibc@2.39 -y  →  rc=1  duplicate exact registration node
```

下游影响是真实的：`openssl@3.1.5` 依赖 glibc，因此**同样装不上** —— 这是我在验证另一件事时撞上的。

## 影响面

这条修在索引里，**合入即对所有用户生效，不需要发客户端**。

那个重复项从来没有带来任何东西（第二次注册只是覆盖第一次），所以删掉它没有行为变化 —— 除了让安装重新成功。
