### PR TITLE
migrate(files): python + linux-headers, behind a shared declare_headers

### DIFF
--- a/docs/V2/xpackage-spec.md
+++ b/docs/V2/xpackage-spec.md
@@ -214,3 +214,45 @@ The probe is removed when the index drops support for clients older than the
 capability. That is a decision about shrinking the support surface, not a
 prerequisite for shipping.
 
+### Dropping the probe later — and why there is no `min_xlings`
+
+A probe is temporary by design. Removing one means the recipe declares the
+capability unconditionally, and clients without it stop being able to install
+the package. Before doing that, the package needs a way to *tell* those
+clients why.
+
+**A `min_xlings` field cannot do it.** A field is only read by clients that
+implement it, and the clients that need to be told are exactly the ones that
+do not. A version floor expressed as index data can never reach them; they
+would still hit the raw failure:
+
+```
+error: unsupported registration node kind 'files'
+       nothing was changed
+```
+
+The mechanism that does reach them is one they already run: `raise` from
+`config()`. Every client back to 0.4.29 prints it verbatim.
+
+```lua
+sysroot.require_capability(xvm.files, "xvm.files", "2026.7.27.0")
+```
+
+```
+[warn] config hook failed for foo: foo.lua:16: this package needs
+       xlings >= 2026.7.27.0 (this client has no xvm.files); run: xlings self update
+[error] [foo] failed: config hook failed
+```
+
+So the sequence for retiring a probe is:
+
+1. the capability has been released long enough for adoption;
+2. replace `if cap then ... else <legacy> end` with
+   `sysroot.require_capability(cap, ...)` plus the declared path;
+3. the legacy branch goes away, and clients that cannot install the package
+   are told what to do instead of being confused.
+
+`config()` runs after download and extraction, so step 2 costs a refused
+client one download. That is deliberate: a message they can act on is worth
+more than a field they cannot read.
+

--- a/libs/sysroot.lua
+++ b/libs/sysroot.lua
@@ -10,8 +10,90 @@
 -- error — that's the right signal to bump xlings.
 
 import("xim.libxpkg.fs")
+import("xim.libxpkg.xvm")
 
 local sysroot = {}
+
+-- Immediate children of DIR, enumerated with a single shell `ls`.
+--
+-- One fork and one readdir. See install_headers below for why this is not
+-- fs.entries: under proot, ~400 std::filesystem stat() calls on a 130-entry
+-- directory is enough to poison the talloc pool.
+function sysroot.entries(dir)
+    local names = {}
+    local f = io.popen(string.format([[ls -1 "%s" 2>/dev/null]], dir))
+    if not f then return names end
+    for line in f:lines() do
+        local name = line:gsub("[\r\n]+$", "")
+        if name ~= "" then table.insert(names, name) end
+    end
+    f:close()
+    return names
+end
+
+-- Refuse, readably, on a client that lacks a capability this package needs.
+--
+-- The counterpart to declare_headers: use that while a legacy fallback is
+-- still worth carrying, use this once it has been dropped.
+--
+-- Why this and not a `min_xlings` field in the recipe: a field can only be
+-- read by clients that implement it, and the clients that need to be told
+-- are precisely the ones that do not. A version floor expressed as data can
+-- never reach them. `raise` from config() can, because every client back to
+-- 0.4.29 already runs the hook and prints the message:
+--
+--     [warn] config hook failed for <pkg>: <file>:<line>: <message>
+--     [error] [<pkg>] failed: config hook failed
+--
+-- Verified against a released 0.4.69, not assumed.
+--
+-- Caveat worth knowing: config() runs after download and extraction, so the
+-- refusal costs the user a download. That is the price of a message they can
+-- act on; a field they cannot read would cost them a confusing failure
+-- instead ("unsupported registration node kind").
+function sysroot.require_capability(present, what, since)
+    if present then return end
+    raise(string.format(
+        "this package needs xlings >= %s (this client has no %s); "
+        .. "run: xlings self update", since, what))
+end
+
+-- Declare the immediate children of INSTALL_DIR/SRC_REL as file assets, so
+-- xlings owns them: they follow `xlings use` and are removed with the
+-- release instead of by a hand-written mirror of this call in uninstall().
+--
+-- Returns false when the running client has no `xvm.files`, so the caller
+-- falls back to install_headers and behaves exactly as it did before. That
+-- probe -- capability, never version -- is the contract in
+-- docs/V2/xpackage-spec.md; `xvm.files` arrived with the node kind it
+-- declares, in a libxpkg that is linked into the xlings binary.
+--
+-- SRC_REL is relative to the payload root and DST_REL to the subos root,
+-- and both must stay relative: a payload is shared between subos, so an
+-- absolute destination recorded against it would be right for the subos
+-- that installed it and wrong for every other one.
+--
+-- ONE SEMANTIC DIFFERENCE from install_headers, and it is deliberate:
+-- install_headers skips an entry that already exists, so the first package
+-- to claim a name keeps it. A declared asset is placed unconditionally, so
+-- the last one wins -- but it is now *recorded*, which is the point: two
+-- packages claiming one path becomes visible state rather than a silent
+-- race decided by install order. Only migrate a directory whose names are
+-- yours (`openssl/`, `python3.13/`); for a package that scatters entries
+-- into a shared namespace, check what else claims them first.
+function sysroot.declare_headers(install_dir, src_rel, dst_rel, binding)
+    if not xvm.files then return false end
+    local src_dir = path.join(install_dir, src_rel)
+    if not os.isdir(src_dir) then return true end
+    for _, name in ipairs(sysroot.entries(src_dir)) do
+        xvm.files{
+            src = path.join(src_rel, name),
+            dst = path.join(dst_rel, name),
+            binding = binding,
+        }
+    end
+    return true
+end
 
 -- Install headers from SRC_DIR into DST_DIR — strictly non-recursive.
 --
@@ -52,15 +134,7 @@ function sysroot.install_headers(src_dir, dst_dir)
     -- syscalls total (one readdir + one stat per entry) and goes
     -- through proot's simpler absolute-path translation, not the
     -- dir-fd-relative openat path.
-    local f = io.popen(string.format([[ls -1 "%s" 2>/dev/null]], src_dir))
-    if not f then return end
-    local names = {}
-    for line in f:lines() do
-        local name = line:gsub("[\r\n]+$", "")
-        if name ~= "" then table.insert(names, name) end
-    end
-    f:close()
-    for _, name in ipairs(names) do
+    for _, name in ipairs(sysroot.entries(src_dir)) do
         local dst = path.join(dst_dir, name)
         -- Skip if anything already exists at dst (host bind-mount,
         -- prior package, or prior install). os.isdir/os.isfile cover

--- a/pkgs/l/linux-headers.lua
+++ b/pkgs/l/linux-headers.lua
@@ -65,22 +65,34 @@ function install()
 end
 
 function config()
-    local sysroot_usrdir = path.join(system.subos_sysrootdir(), "usr")
-    if not os.isdir(sysroot_usrdir) then os.mkdir(sysroot_usrdir) end
+    -- Declared where the client supports it. No stamp on that path: a
+    -- declaration is idempotent by construction (materialization skips an
+    -- entry that already points at the same payload file), so the marker
+    -- that existed purely to avoid repeating the copy has nothing left to
+    -- do -- and unlike the stamp, the declaration also survives a sysroot
+    -- wipe correctly, because it is state xlings owns rather than a file
+    -- in the tree being wiped.
+    if not sysroot.declare_headers(pkginfo.install_dir(), "include",
+                                   "usr/include",
+                                   "linux-headers@" .. pkginfo.version()) then
+        local sysroot_usrdir = path.join(system.subos_sysrootdir(), "usr")
+        if not os.isdir(sysroot_usrdir) then os.mkdir(sysroot_usrdir) end
 
-    -- Idempotent: skip the recursive header copy if this version is already
-    -- in the subos sysroot. The stamp lives next to the copied tree so that
-    -- switching subos / wiping the sysroot correctly invalidates it.
-    local stamp = path.join(sysroot_usrdir, ".linux-headers-" .. pkginfo.version() .. ".stamp")
-    if os.isfile(stamp) then
-        log.debug("Linux headers already in subos rootfs (stamp present), skipping copy.")
-    else
-        log.info("Installing linux headers into subos sysroot ...")
-        sysroot.install_headers(
-            path.join(pkginfo.install_dir(), "include"),
-            path.join(sysroot_usrdir, "include")
-        )
-        io.writefile(stamp, pkginfo.version())
+        -- Idempotent: skip the recursive header copy if this version is
+        -- already in the subos sysroot. The stamp lives next to the copied
+        -- tree so that switching subos / wiping the sysroot correctly
+        -- invalidates it.
+        local stamp = path.join(sysroot_usrdir, ".linux-headers-" .. pkginfo.version() .. ".stamp")
+        if os.isfile(stamp) then
+            log.debug("Linux headers already in subos rootfs (stamp present), skipping copy.")
+        else
+            log.info("Installing linux headers into subos sysroot ...")
+            sysroot.install_headers(
+                path.join(pkginfo.install_dir(), "include"),
+                path.join(sysroot_usrdir, "include")
+            )
+            io.writefile(stamp, pkginfo.version())
+        end
     end
 
     xvm.add("linux-headers")

--- a/pkgs/o/openssl.lua
+++ b/pkgs/o/openssl.lua
@@ -111,27 +111,11 @@ function config()
         -- arrived together in libxpkg 0.0.47 and libxpkg is linked into
         -- xlings. An older client takes the branch below and behaves exactly
         -- as it did before this migration.
-        if xvm.files then
-            -- Declared, so the headers follow `xlings use` and are removed
-            -- with the release. Enumerated the same way uninstall() does,
-            -- because install_headers links top-level entries, not a tree.
-            for _, subdir in ipairs(os.dirs(path.join(includedir, "*"))) do
-                local name = path.filename(subdir)
-                xvm.files{
-                    src = path.join("include", name),
-                    dst = path.join("usr/include", name),
-                    binding = binding_tree_version_tag,
-                }
-            end
-            for _, file in ipairs(list_files(path.join(includedir, "*.h"))) do
-                local name = path.filename(file)
-                xvm.files{
-                    src = path.join("include", name),
-                    dst = path.join("usr/include", name),
-                    binding = binding_tree_version_tag,
-                }
-            end
-        else
+        -- declare_headers returns false on a client with no xvm.files, so
+        -- the legacy path below still runs there, byte for byte.
+        if not sysroot.declare_headers(pkginfo.install_dir(), "include",
+                                       "usr/include",
+                                       binding_tree_version_tag) then
             sysroot.install_headers(includedir, get_sys_usr_includedir())
         end
     end

--- a/pkgs/p/python.lua
+++ b/pkgs/p/python.lua
@@ -75,10 +75,19 @@ function config()
         local includedir = path.join(pkginfo.install_dir(), "include")
         local sysrootdir = system.subos_sysrootdir()
         if sysrootdir and os.isdir(includedir) then
-            local sysroot_usrdir = path.join(sysrootdir, "usr")
-            if not os.isdir(sysroot_usrdir) then os.mkdir(sysroot_usrdir) end
+            -- Declared where the client supports it, so the headers follow
+            -- `xlings use` between python versions instead of being
+            -- whichever version was installed last -- which matters here,
+            -- because the directory name carries the version
+            -- (include/python3.13) and two of them can coexist.
             log.info("Linking Python dev headers into subos sysroot ...")
-            sysroot.install_headers(includedir, path.join(sysroot_usrdir, "include"))
+            if not sysroot.declare_headers(pkginfo.install_dir(), "include",
+                                           "usr/include",
+                                           "python@" .. pkginfo.version()) then
+                local sysroot_usrdir = path.join(sysrootdir, "usr")
+                if not os.isdir(sysroot_usrdir) then os.mkdir(sysroot_usrdir) end
+                sysroot.install_headers(includedir, path.join(sysroot_usrdir, "include"))
+            end
         end
     end
     return true


### PR DESCRIPTION
第二批迁移，外加一条我认为应当**否决**的设计。

## 共享 helper

四个 recipe 现在都在声明"include 目录的顶层项"，所以枚举逻辑收进 `libs/sysroot.lua`：

```lua
sysroot.declare_headers(install_dir, src_rel, dst_rel, binding)
```

客户端没有 `xvm.files` 时返回 false，调用方保留 legacy 分支，老客户端行为不变。**openssl 也一并切过来** —— 它是第一个迁移的、循环是内联的，折进来等于让 helper 立刻被一个行为已验证的包覆盖。

枚举沿用既有的 `ls -1`（抽成 `sysroot.entries`），**不用 `fs.entries`** —— `install_headers` 上的注释记着：130 项目录上约 400 次 `std::filesystem` stat 会毒化 proot 的 talloc 池。

## linux-headers 的 stamp 在声明路径上消失了

stamp 存在的唯一目的是防止重复拷贝。声明**天然幂等**（物化时若已指向同一 payload 文件就跳过），而且它比 stamp 更正确：sysroot 被清空时，stamp 跟着树一起没了，而声明是 xlings 自己持有的状态。legacy 分支保留 stamp。

## 一处语义差异，写在 helper 上

`install_headers` 遇到已存在的项会跳过（**先到先得**）；声明的资产是无条件放置（**后到覆盖**）—— 但它现在**被记录**了，这正是重点：两个包争同一个路径变成可见状态，而不是由安装顺序决定的静默竞争。

## 实测

真实安装、一次性 HOME，老客户端一律**对着原版索引做差分**（不是"文件必须存在"）：

| recipe | 结果 |
|---|---|
| `linux-headers@5.11.1` | 3/3 —— 声明 11 个资产，老客户端 13 项逐项一致 |
| `openssl@3.1.5` | 3/3 —— 老客户端 173 项逐项一致 |
| `python@3.13.12` | 3/3 —— 声明 1 个资产（`python3.13/`） |

## 为什么没有 `min_xlings`

它被设想成"删掉探测的前提"。**它做不到。**

字段只有实现了它的客户端才读得到，而需要被告知的**恰恰是没实现它的那些**。用索引数据表达的版本下限永远够不到它们 —— 它们仍然只会撞上：

```
error: unsupported registration node kind 'files'
       nothing was changed
```

能够到它们的机制是它们已经在跑的东西：`config()` 里的 `raise`。**用released 的 0.4.69 实测**：

```
[warn] config hook failed for raisefix: raisefix.lua:16: this package needs
       xlings >= 2026.7.27.0 (this client has no xvm.files); run: xlings self update
[error] [raisefix] failed: config hook failed
```

所以本 PR 给的是 `sysroot.require_capability(present, what, since)`，并在规范里写清删探测的三步流程。

代价如实记下：`config()` 在下载解包**之后**才跑，所以被拒绝的客户端会白下一次。这是自觉的取舍 —— 一条能照着做的消息，比一个它读不到的字段值钱。