### PR TITLE
migrate(files): ca-certificates + freetype

### DIFF
--- a/pkgs/c/ca-certificates.lua
+++ b/pkgs/c/ca-certificates.lua
@@ -76,12 +76,26 @@ function config()
     local pem_link  = path.join(ssl_dir, _CANONICAL_LINK)
 
     log.info("installing CA bundle to subos sysroot...")
-    os.mkdir(certs_dir)
 
-    -- Use shell cp via system.exec so behavior is consistent with how
-    -- other xpkgs stage files into the sysroot (the xpkg sandbox's
-    -- builtin os.cp dest-as-dir semantics is unreliable for some hosts).
-    system.exec(string.format("cp -f %s %s", pem_src, pem_dst))
+    -- The bundle is a plain payload file placed under a different name, so
+    -- it declares directly. Capability probe, not a version check: xvm.files
+    -- exists only on a client that understands type = "files" entries.
+    if xvm.files then
+        xvm.files{
+            src = "cacert.pem",
+            dst = path.join("etc/ssl/certs", _CANONICAL_BUNDLE),
+            binding = package.name .. "@" .. pkginfo.version(),
+        }
+    else
+        os.mkdir(certs_dir)
+        -- Use shell cp via system.exec so behavior is consistent with how
+        -- other xpkgs stage files into the sysroot (the xpkg sandbox's
+        -- builtin os.cp dest-as-dir semantics is unreliable for some hosts).
+        system.exec(string.format("cp -f %s %s", pem_src, pem_dst))
+    end
+
+    -- The alias below needs its directory either way.
+    os.mkdir(certs_dir)
 
     -- Drop a `cert.pem` alias next to it for tools (curl, FreeBSD-style
     -- toolchains) that look there. Use a relative symlink so the link
@@ -96,7 +110,13 @@ function config()
 end
 
 function uninstall()
-    os.tryrm(path.join(_sys_etc_certs_dir(), _CANONICAL_BUNDLE))
+    -- The bundle is removed with the release when it was declared; only the
+    -- legacy copy needs taking out by hand.
+    if not xvm.files then
+        os.tryrm(path.join(_sys_etc_certs_dir(), _CANONICAL_BUNDLE))
+    end
+    -- The alias is hand-made on both paths, so it is always removed here --
+    -- and it must be, or it dangles once the bundle goes.
     os.tryrm(path.join(_sys_etc_ssl_dir(), _CANONICAL_LINK))
     return true
 end

--- a/pkgs/f/freetype.lua
+++ b/pkgs/f/freetype.lua
@@ -67,24 +67,55 @@ function config()
     end
 
     local sysroot = system.subos_sysrootdir()
-
-    -- headers → sysroot/usr/include/freetype2
-    local sys_inc = path.join(sysroot, "usr/include")
-    os.mkdir(sys_inc)
     local ft_inc = path.join(idir, "include/freetype2")
-    if os.isdir(ft_inc) then
-        os.cp(ft_inc, sys_inc, { force = true })
-    end
-
-    -- freetype2.pc → sysroot, with prefix rewritten to the install dir
-    local sys_pc = path.join(sysroot, "usr/lib/pkgconfig")
-    os.mkdir(sys_pc)
     local src_pc = path.join(libdir, "pkgconfig/freetype2.pc")
-    if os.isfile(src_pc) then
-        system.exec(string.format(
-            "sh -c 'sed \"s|^prefix=.*|prefix=%s|\" %s > %s/freetype2.pc'",
-            idir, src_pc, sys_pc
-        ))
+
+    -- Capability probe, not a version check: xvm.files exists only on a
+    -- client that understands type = "files" entries.
+    if xvm.files then
+        -- Headers: a payload directory, declared as-is.
+        if os.isdir(ft_inc) then
+            xvm.files{
+                src = "include/freetype2",
+                dst = "usr/include/freetype2",
+                binding = binding,
+            }
+        end
+
+        -- The .pc has to have its prefix rewritten, so it is not a payload
+        -- file to begin with -- but generating it INTO the payload makes it
+        -- one, and then it declares like anything else. The rewritten prefix
+        -- is the payload's own location, so it belongs there rather than in
+        -- the sysroot: one file per payload, not one per subos.
+        if os.isfile(src_pc) then
+            local staged = path.join(libdir, "pkgconfig/freetype2.sysroot.pc")
+            system.exec(string.format(
+                "sh -c 'sed \"s|^prefix=.*|prefix=%s|\" %s > %s'",
+                idir, src_pc, staged
+            ))
+            xvm.files{
+                src = path.join(LIBSUB, "pkgconfig/freetype2.sysroot.pc"),
+                dst = "usr/lib/pkgconfig/freetype2.pc",
+                binding = binding,
+            }
+        end
+    else
+        -- headers → sysroot/usr/include/freetype2
+        local sys_inc = path.join(sysroot, "usr/include")
+        os.mkdir(sys_inc)
+        if os.isdir(ft_inc) then
+            os.cp(ft_inc, sys_inc, { force = true })
+        end
+
+        -- freetype2.pc → sysroot, with prefix rewritten to the install dir
+        local sys_pc = path.join(sysroot, "usr/lib/pkgconfig")
+        os.mkdir(sys_pc)
+        if os.isfile(src_pc) then
+            system.exec(string.format(
+                "sh -c 'sed \"s|^prefix=.*|prefix=%s|\" %s > %s/freetype2.pc'",
+                idir, src_pc, sys_pc
+            ))
+        end
     end
 
     return true
@@ -95,8 +126,12 @@ function uninstall()
     for _, lib in ipairs(libs) do
         xvm.remove(lib)
     end
-    local sysroot = system.subos_sysrootdir()
-    os.tryrm(path.join(sysroot, "usr/include/freetype2"))
-    os.tryrm(path.join(sysroot, "usr/lib/pkgconfig/freetype2.pc"))
+    -- Declared assets go with the release; only the legacy copies need
+    -- taking out by hand.
+    if not xvm.files then
+        local sysroot = system.subos_sysrootdir()
+        os.tryrm(path.join(sysroot, "usr/include/freetype2"))
+        os.tryrm(path.join(sysroot, "usr/lib/pkgconfig/freetype2.pc"))
+    end
     return true
 end


### PR DESCRIPTION
这两个之前被我以"生成内容，无法声明"为由推迟。**那个理由只对了一半，对 ca-certificates 更是错的。**

## ca-certificates

bundle 是 payload 里现成的文件，只是换个名字落地（`cacert.pem` → `etc/ssl/certs/ca-certificates.crt`）—— **直接可声明**。

真正抗拒声明的是 `cert.pem` 别名，而且原因完全不同：它是 sysroot **内部的相对符号链接**，而声明式资产是 `dst → payload` 的链接，相对目标会在 payload 里解析而不是 sysroot 里。所以它保持手工创建，且 `uninstall` 里**无条件**删除 —— 否则 bundle 一走它就悬空。

## freetype

头文件是 payload 目录，直接声明。

`.pc` 确实是生成的（prefix 要重写），但**先生成到 payload 里**就让它变成了普通 payload 文件。重写后的 prefix 就是这个 payload 自己的位置，所以它本来就该待在那儿 —— 每个 payload 一份，而不是每个 subos 一份。

## 实测

真实安装、一次性 HOME，老客户端对着原版索引做差分：

| recipe | 结果 |
|---|---|
| `ca-certificates@2026.03.19` | 3/3 |
| `freetype@2.13.2` | 3/3 —— 声明 2 个资产（头文件目录 + staged `.pc`），老客户端 58 项逐项一致 |