### PR TITLE
fix(gcc): fail when glibc is missing instead of shipping an unrunnable binary (#415)

### DIFF
--- a/pkgs/g/gcc.lua
+++ b/pkgs/g/gcc.lua
@@ -173,8 +173,23 @@ function __config_linux()
         local rpath = glibc_lib .. ":" .. path.join(pkginfo.install_dir(), "lib64")
         __rewrite_specs_linux(rpath, dynamic_linker)
     else
-        log.warn("glibc payload not found (deps declare xim:glibc);"
-            .. " skip specs rewrite — gcc keeps its baked build-machine paths")
+        -- Fail, do not warn and continue.
+        --
+        -- Without the rewrite the binary keeps the ELF interpreter baked in
+        -- on the build machine -- a path that does not exist here -- so what
+        -- gets installed cannot run at all. Reporting that as a successful
+        -- install hands the user a broken toolchain and a warning they have
+        -- already scrolled past; the failure shows up later as
+        -- "No such file or directory" on a binary that is plainly present.
+        --
+        -- glibc is a declared dependency of this package on linux, so
+        -- reaching here means the dependency did not get installed. That is
+        -- worth stopping for. See openxlings/xlings#415.
+        log.error("glibc payload not found, but gcc needs it to rewrite its"
+            .. " ELF interpreter away from the build machine's path.")
+        log.error("  without it the installed gcc cannot run at all.")
+        log.error("  install it first: xlings install xim:glibc@2.39")
+        return false
     end
 
     -- HEADER axis: injected only on the xvm shim aliases. gcc's header


### PR DESCRIPTION
Fixes openxlings/xlings#415。

## 症状

`config()` 负责把 gcc 的 ELF interpreter 从**构建机路径**改写成本机 glibc payload 的路径。当 `__find_glibc_runtime()` 返回 nil 时，它只 `log.warn` 然后继续 —— 于是安装**报告成功**，留下一个 interpreter 指向本机不存在目录的 gcc。

它根本跑不起来，而且失败会在很久之后、以"明明文件就在那儿却 No such file or directory"的形式出现。

## 为什么该失败

`glibc` 是 gcc 在 linux 上**声明的依赖**。走到那个分支意味着依赖没装上 —— 这值得停下来。

现在给出三行可操作的信息并 `return false`：哪里不对、为什么不能继续、该跑什么命令。

## 验证：故障注入

现在 glibc 能正常装了，自然复现不出来，所以强制 `__find_glibc_runtime()` 返回 nil。**关键是 glibc@2.39 在测试 home 里确实装上了** —— 所以这条拒绝只可能来自注入，不可能是"glibc 真的没装"：

```
rc=1
[ERROR] glibc payload not found, but gcc needs it to rewrite its ELF
        interpreter away from the build machine's path.
[ERROR]   without it the installed gcc cannot run at all.
[ERROR]   install it first: xlings install xim:glibc@2.39
✗ 1 package(s) failed
```

（第一次注入验证是无效的 —— 测试 home 里 `data/xim-pkgindex` 是个指向另一份索引的符号链接，注入根本没被读到。已修正播种方式后重做。）

## 顺带说明 #415 是怎么对所有人变成必然的

glibc recipe 里 `librt.so.1` 重复注册，而 0.4.70 起的注册校验会拒绝它 —— 于是 **glibc 在当前客户端上根本装不上**，任何 gcc 安装都必然走进这条 fail-open 分支。那条已在 #424 单独修复；本 PR 修的是它暴露出来的 fail-open 本身。

## 同类

这是本轮第四个"该失败却选择继续"的缺陷（另外三个：`spec` 门禁不拦、arch 门禁不拦、被拒绝的包照样安装）。共同点是：**用户拿到一个看起来装好、实际不能用的东西**。
