### PR TITLE
fix(musl-gcc): anchor the gcc-flavor root at the flavor version

### DIFF
--- a/pkgs/a/aarch64-linux-musl-gcc.lua
+++ b/pkgs/a/aarch64-linux-musl-gcc.lua
@@ -108,7 +108,12 @@ local function __register_as_gcc_flavor()
 
     log.info("registering aarch64-linux-musl-gcc as gcc flavor %s ...", flavor_ver)
 
-    xvm.add(root_name)
+    -- Version is explicit and MUST equal flavor_ver: xvm.add() defaults it to
+    -- pkginfo.version(), while every child binds to `<root_name>@<flavor_ver>`
+    -- — a different exact node, so the root they name would never exist.
+    -- xlings 2026.7.27.1 enforces this and rejects the batch with
+    -- `xvm-binding-root-missing`. Same fix as pkgs/m/musl-gcc.lua.
+    xvm.add(root_name, { version = flavor_ver })
     for prog, target in pairs(__gcc_flavor_progs) do
         xvm.add(prog, {
             bindir  = gcc_bindir,
@@ -124,7 +129,8 @@ local function __unregister_gcc_flavor()
     for prog, _ in pairs(__gcc_flavor_progs) do
         xvm.remove(prog, flavor_ver)
     end
-    xvm.remove(__gcc_flavor_root_name())
+    -- Versioned to match the node __register_as_gcc_flavor actually created.
+    xvm.remove(__gcc_flavor_root_name(), flavor_ver)
 end
 
 function install()

--- a/pkgs/m/musl-gcc.lua
+++ b/pkgs/m/musl-gcc.lua
@@ -204,7 +204,24 @@ local function __register_as_gcc_flavor()
              flavor_ver, flavor_root)
 
     -- Anchor a virtual root node for this flavor's subtree.
-    xvm.add(root_name)
+    --
+    -- The version is explicit and MUST equal flavor_ver: xvm.add() defaults
+    -- `version` to pkginfo.version() ("16.1.0"), while every child below binds
+    -- to `<root_name>@<flavor_ver>` ("16.1.0-musl"). Those are different exact
+    -- nodes, so the root the children name was never registered.
+    --
+    -- xlings 2026.7.27.1 enforces this (registration.cppm: the binding root
+    -- must be an exact node in the same batch) and rejects the whole batch:
+    --
+    --   error: registration binding root is not an exact batch node
+    --     code:     xvm-binding-root-missing
+    --     provider: xim:musl-gcc@16.1.0
+    --     at:       xim-musl-gnu-gcc@16.1.0-musl
+    --
+    -- gcc.lua gets away with the bare form only because its children bind to
+    -- `xim-gnu-gcc@<pkginfo.version()>`, which is exactly what the default
+    -- fills in. This recipe's flavor suffix breaks that coincidence.
+    xvm.add(root_name, { version = flavor_ver })
 
     for prog, target in pairs(__gcc_flavor_progs(__musl_triple())) do
         xvm.add(prog, {
@@ -223,7 +240,9 @@ local function __unregister_gcc_flavor()
     end
     -- Drop the virtual root only if no other musl-gcc version still hangs
     -- registrations off it (xvm.remove on an empty target is a no-op there).
-    xvm.remove(__gcc_flavor_root_name())
+    -- Versioned to match the node __register_as_gcc_flavor actually created;
+    -- the bare form would target <root>@<pkginfo.version()>, which is not it.
+    xvm.remove(__gcc_flavor_root_name(), flavor_ver)
 end
 
 local function __remove_specs()


### PR DESCRIPTION
两个 musl gcc 配方用裸 `xvm.add(root_name)` 锚定 flavor 子树的虚拟根，然后把每个子节点绑定到 `<root_name>@<flavor_ver>`。

`xvm.add()` 的 `version` 默认取 `pkginfo.version()`，所以**实际创建的根**是 `<root_name>@16.1.0`，而子节点指向的是 `<root_name>@16.1.0-musl` —— 两个不同的精确节点。子节点指向的那个根从未被注册。

xlings `2026.7.27.1` 开始校验这一点并整批拒绝：

```
error: registration binding root is not an exact batch node
  code:     xvm-binding-root-missing
  provider: xim:musl-gcc@16.1.0
  at:       xim-musl-gnu-gcc@16.1.0-musl
  field:    /nodes/37/binding
  hint:     a binding points at something the recipe never registers
```

对用户呈现为 `[musl-gcc] failed: config hook failed`，`xlings install musl-gcc` 退出 1。

`gcc.lua` 用同样的裸写法却没事，只是因为它的子节点绑定到 `xim-gnu-gcc@<pkginfo.version()>` —— 恰好就是默认值填进去的那个。musl 配方的 flavor 后缀打破了这个巧合。**这个 bug 自 flavor root 引入起就潜伏着**，只是直到 xlings 开始检查才显形。

`__unregister_gcc_flavor` 犯了对称的错误：它移除的是裸根（即 `<root>@<pkginfo.version()>`），从来不是真正创建的那个节点。一并改为带版本。

## 验证（xlings 2026.7.27.2 + musl-gcc@15.1.0）

修复前：

```
$ xlings install musl-gcc@15.1.0 -y
[error] registration binding root is not an exact batch node
        code:  xvm-binding-root-missing
[error] [musl-gcc] failed: config hook failed
```

修复后：

```
$ xlings install musl-gcc@15.1.0 -y
xim:musl-gcc@15.1.0 is already installed          (exit 0，无 binding 报错)

$ musl-gcc --version
x86_64-linux-musl-gcc (GCC) 15.1.0

$ musl-gcc -static a.c -o a && ./a
(exit 0)
```

## 影响面

全索引扫过一遍同型写法：其余带 `binding` 的配方都把它构造成 `package.name .. "@" .. pkginfo.version()`，与默认值一致，因此**只有这两个**受影响。

## 上下文

发现于 mcpp 把 xlings pin 从 `0.4.69` 升到 `2026.7.27.2`（[mcpp-community/mcpp#292](https://github.com/mcpp-community/mcpp/pull/292)），CI 的 `toolchain: musl + llvm` 与两个 linux e2e 分片因此变红。合入本 PR 后那条链路才能通。
