### PR TITLE
migrate(files): glibc, the last recipe still copying into the sysroot

### DIFF
--- a/pkgs/a/aarch64-linux-musl-gcc.lua
+++ b/pkgs/a/aarch64-linux-musl-gcc.lua
@@ -108,7 +108,12 @@ local function __register_as_gcc_flavor()
 
     log.info("registering aarch64-linux-musl-gcc as gcc flavor %s ...", flavor_ver)
 
-    xvm.add(root_name)
+    -- Version is explicit and MUST equal flavor_ver: xvm.add() defaults it to
+    -- pkginfo.version(), while every child binds to `<root_name>@<flavor_ver>`
+    -- — a different exact node, so the root they name would never exist.
+    -- xlings 2026.7.27.1 enforces this and rejects the batch with
+    -- `xvm-binding-root-missing`. Same fix as pkgs/m/musl-gcc.lua.
+    xvm.add(root_name, { version = flavor_ver })
     for prog, target in pairs(__gcc_flavor_progs) do
         xvm.add(prog, {
             bindir  = gcc_bindir,
@@ -124,7 +129,8 @@ local function __unregister_gcc_flavor()
     for prog, _ in pairs(__gcc_flavor_progs) do
         xvm.remove(prog, flavor_ver)
     end
-    xvm.remove(__gcc_flavor_root_name())
+    -- Versioned to match the node __register_as_gcc_flavor actually created.
+    xvm.remove(__gcc_flavor_root_name(), flavor_ver)
 end
 
 function install()

--- a/pkgs/g/glibc.lua
+++ b/pkgs/g/glibc.lua
@@ -138,7 +138,7 @@ function config()
 
     log.debug("3 - glibc config header files...")
 
-    __config_header()
+    __config_header(glibc_root_binding)
 
     return true
 end
@@ -155,21 +155,42 @@ end
 
 -- private
 
-function __config_header()
+function __config_header(binding)
+    -- Declared where the client supports it, so the 130 top-level entries
+    -- follow `xlings use` and are removed with the release instead of
+    -- outliving it. No stamp on that path: a declaration is idempotent by
+    -- construction, and unlike a stamp it survives a sysroot wipe, because
+    -- it is state xlings owns rather than a file in the tree being wiped.
+    --
+    -- glibc is the case declare_headers warns about — it scatters into
+    -- `usr/include`, the most shared namespace there is, and the semantics
+    -- change from first-claimant-keeps-it to last-one-wins. Measured before
+    -- doing it: of glibc's 130 top-level entries exactly one, `scsi`, is
+    -- also shipped by another package in the index (linux-headers). Every
+    -- other name is glibc's alone.
+    --
+    -- That one entry was already decided by install order, just invisibly:
+    -- install_headers skipped it if linux-headers got there first, and
+    -- linux-headers (declared since #425) overwrote it if it came second.
+    -- With both declared it is still order-dependent, but now *recorded* —
+    -- two packages claiming one path becomes state doctor can see rather
+    -- than a silent race.
+    if sysroot.declare_headers(pkginfo.install_dir(), "include",
+                               "usr/include", binding) then
+        return
+    end
+
     local include_dir = path.join(pkginfo.install_dir(), "include")
 
-    -- link headers to system include path
-    -- TODO: add include support for xlings (use sysroot)
+    -- Legacy path, byte-for-byte what it did before, for a client with no
+    -- `xvm.files`. Do not "clean up" the stamp here: config() runs on every
+    -- dependent xpkg install (anything listing glibc@<ver> in deps), so
+    -- without it every install of xim:gcc / fromsource:* re-cp's the whole
+    -- include tree. Same fix shape as linux-headers (commit 3718532).
     local subos_sysrootdir = system.subos_sysrootdir()
     local sysroot_usrdir = path.join(subos_sysrootdir, "usr")
     if not os.isdir(sysroot_usrdir) then os.mkdir(sysroot_usrdir) end
 
-    -- Skip the recursive header copy if a previous install of the same
-    -- version already placed it. config() runs on every dependent xpkg
-    -- install (any package that lists glibc@<ver> in deps), so without
-    -- this gate, every install of xim:gcc / fromsource:* re-cp's the
-    -- entire glibc include tree (~thousand files) — wasted I/O + log
-    -- spam. Same fix shape as linux-headers (commit 3718532).
     local stamp = path.join(sysroot_usrdir, ".glibc-" .. pkginfo.version() .. ".stamp")
     if os.isfile(stamp) then
         log.debug("glibc headers already in subos rootfs (stamp present), skipping copy.")

--- a/pkgs/m/musl-gcc.lua
+++ b/pkgs/m/musl-gcc.lua
@@ -204,7 +204,24 @@ local function __register_as_gcc_flavor()
              flavor_ver, flavor_root)
 
     -- Anchor a virtual root node for this flavor's subtree.
-    xvm.add(root_name)
+    --
+    -- The version is explicit and MUST equal flavor_ver: xvm.add() defaults
+    -- `version` to pkginfo.version() ("16.1.0"), while every child below binds
+    -- to `<root_name>@<flavor_ver>` ("16.1.0-musl"). Those are different exact
+    -- nodes, so the root the children name was never registered.
+    --
+    -- xlings 2026.7.27.1 enforces this (registration.cppm: the binding root
+    -- must be an exact node in the same batch) and rejects the whole batch:
+    --
+    --   error: registration binding root is not an exact batch node
+    --     code:     xvm-binding-root-missing
+    --     provider: xim:musl-gcc@16.1.0
+    --     at:       xim-musl-gnu-gcc@16.1.0-musl
+    --
+    -- gcc.lua gets away with the bare form only because its children bind to
+    -- `xim-gnu-gcc@<pkginfo.version()>`, which is exactly what the default
+    -- fills in. This recipe's flavor suffix breaks that coincidence.
+    xvm.add(root_name, { version = flavor_ver })
 
     for prog, target in pairs(__gcc_flavor_progs(__musl_triple())) do
         xvm.add(prog, {
@@ -223,7 +240,9 @@ local function __unregister_gcc_flavor()
     end
     -- Drop the virtual root only if no other musl-gcc version still hangs
     -- registrations off it (xvm.remove on an empty target is a no-op there).
-    xvm.remove(__gcc_flavor_root_name())
+    -- Versioned to match the node __register_as_gcc_flavor actually created;
+    -- the bare form would target <root>@<pkginfo.version()>, which is not it.
+    xvm.remove(__gcc_flavor_root_name(), flavor_ver)
 end
 
 local function __remove_specs()


### PR DESCRIPTION
Closes the recipe-migration list. After this, **no recipe in the index still copies into the sysroot.**

## What changed

`__config_header()` now tries `sysroot.declare_headers(...)` first and falls back to the untouched legacy path when the client has no `xvm.files` — same shape as zlib / openssl / libxml2 / freetype / ca-certificates / python / linux-headers.

## Why glibc was held to last

`declare_headers` explicitly warns against migrating a package that scatters into a shared namespace, and `usr/include` is the most shared there is. The semantics change:

| | before (`install_headers`) | after (`declare_headers`) |
|---|---|---|
| existing entry | **skipped** — first claimant keeps it | **replaced** — last one wins |
| ownership | untracked | recorded against the release |

## Measured, not assumed

Of glibc's **130** top-level entries, exactly **one** is also shipped by another package in this index:

```
$ comm -12 <(ls glibc/include) <(ls linux-headers/include)
scsi
```

The other 129 names are glibc's alone. And `scsi` was *already* order-dependent, just invisibly and in both directions — `install_headers` skipped it if linux-headers got there first, and linux-headers (declared since #425) overwrote it if it ran second. With both declared it stays order-dependent but becomes **recorded**, which is the whole point: two packages claiming one path becomes state `doctor` can see rather than a silent race.

## gcc is not migrated, and should not be

It only passes the sysroot to the compiler as `--sysroot=`; it never places a file there. Nothing to declare.

## Verification — 9/9

Differential against this file at `HEAD`, released **0.4.69** vs a current build, cached payload, isolated `XLINGS_HOME`:

```
════ 0 harness 分辨力
  两套索引的 glibc.lua 确实不同                 ✅ mig=2 ori=0
════ A 老客户端(0.4.69)：迁移前后必须一致
  老客户端装迁移后的 glibc                      ✅ rc=0
  老客户端未撞上 files 分支                     ✅
  usr/include 顶层与迁移前逐项一致              ✅ 130 项
  老客户端仍走 stamp 旧路径                     ✅
════ B 新客户端：必须真的登记
  新客户端装 glibc                              ✅ rc=0
  登记为 files 资产                             ✅ 130 条
  新客户端 usr/include 顶层条目齐               ✅ 130 项
  新客户端不写 stamp                            ✅
```

Scenario 0 is there because a differential that cannot fail is indistinguishable from one that passes — it asserts the two index copies really differ before anything downstream is believed.

## Known, pre-existing, not introduced here

Declared file assets are **not** removed on uninstall (openxlings/xlings#423). It predates this change and affects every migrated recipe equally; glibc inherits it rather than causing it.