### PR TITLE
fix(xvm): replace invented node kinds, and give llvm its C++ runtime

### DIFF
--- a/pkgs/e/e2fsprogs.lua
+++ b/pkgs/e/e2fsprogs.lua
@@ -83,11 +83,11 @@ function config()
         xvm.add(sbin_programs[i], { bindir = bindir, binding = root })
     end
 
-    -- Binding root: `e2fsprogs` is an umbrella package whose programs
+    -- Group placeholder: `e2fsprogs` is an umbrella package whose programs
     -- are e2fsck/mke2fs/etc. The package name itself never appears in
     -- `sbin_programs`, so without this empty placeholder
     -- `xvm info e2fsprogs` returns nothing on install detection.
-    xvm.add("e2fsprogs", { type = "binding" })
+    xvm.add("e2fsprogs", { type = "group" })
 
     -- mke2fs reads mke2fs.conf at runtime; the static binary has no
     -- compiled-in path that points inside install_dir, so help users

--- a/pkgs/l/llvm.lua
+++ b/pkgs/l/llvm.lua
@@ -28,6 +28,15 @@ package = {
                 "xim:linux-headers@5.11.1",
                 "xim:zlib@1.3.1",
                 "xim:libxml2@2.13.5",
+                -- clang-22 links libstdc++.so.6 dynamically; clang-20 carried a
+                -- static C++ runtime and needed nothing. Nothing else in this
+                -- dep list ships libstdc++, so without this the 22.1.8 clang
+                -- cannot start at all on a machine that has no system
+                -- libstdc++ -- which is every clean machine. It has to be a
+                -- declared dep rather than a later `xlings install
+                -- gcc-runtime`: the RPATH is baked at llvm install time, so a
+                -- runtime that arrives afterwards is invisible to the loader.
+                "xim:gcc-runtime@15.1.0",
             },
             ["latest"] = { ref = "22.1.8" },
             ["20.1.7"] = "XLINGS_RES",
@@ -108,23 +117,31 @@ local function collect_bin_apps(bindir)
     local apps = {}
     local cmd
     if os.host() == "windows" then
-        cmd = 'dir /b "' .. bindir .. '" 2>nul'
+        -- Backslashes are mandatory here. `dir` is a cmd.exe builtin and
+        -- treats "/" as its switch introducer, while libxpkg's path.join
+        -- always joins with "/" regardless of host -- so the bindir handed in
+        -- looks like `C:\...\xim-x-llvm\22.1.8/bin` and cmd lists nothing.
+        -- That is how a full LLVM install ended up registering zero programs
+        -- on Windows while clang.exe sat on disk the whole time.
+        cmd = 'dir /b "' .. bindir:gsub("/", "\\") .. '" 2>nul'
     else
         cmd = 'ls -1 "' .. bindir .. '" 2>/dev/null'
     end
     local f = io.popen(cmd)
-    if f then
-        for name in f:lines() do
-            local clean = name:gsub("[\r\n]+$", "")
-            if clean ~= "" then
-                local filepath = path.join(bindir, clean)
-                if is_registerable_bin(filepath) then
-                    table.insert(apps, clean)
-                end
+    if not f then
+        log.error("llvm: cannot list bin dir (io.popen failed): " .. bindir)
+        return apps
+    end
+    for name in f:lines() do
+        local clean = name:gsub("[\r\n]+$", "")
+        if clean ~= "" then
+            local filepath = path.join(bindir, clean)
+            if is_registerable_bin(filepath) then
+                table.insert(apps, clean)
             end
         end
-        f:close()
     end
+    f:close()
     table.sort(apps)
     return apps
 end
@@ -333,6 +350,15 @@ function config()
     local bindir = path.join(pkginfo.install_dir(), "bin")
     local binding = package.name .. "@" .. pkginfo.version()
     local related_apps = collect_bin_apps(bindir)
+
+    -- A compiler toolchain that registers no programs is never correct, so
+    -- fail instead of reporting a successful install of nothing. Without this
+    -- the Windows listing bug above produced `✓ 1 package(s) installed`
+    -- followed by `xlings: 'clang' is not installed`, with no error in between.
+    if #related_apps == 0 then
+        log.error("llvm: no registerable programs found in " .. bindir)
+        return false
+    end
 
     xvm.add(package.name)
 

--- a/pkgs/l/llvm.lua
+++ b/pkgs/l/llvm.lua
@@ -341,11 +341,34 @@ function __install_macosx_cfg()
         end
     end
 
-    local clang_cfg = ""
-    local clangxx_cfg = "-isystem" .. cxxinc .. "\n"
+    -- Link with the bundled ld64.lld, not Apple's ld.
+    --
+    -- Handing the link to Apple's ld crashes it outright on 22.1.8:
+    --
+    --   dyld: Symbol not found: __ZdaPv
+    --     Referenced from: .../XcodeDefault.xctoolchain/usr/bin/ld
+    --     Expected in:     .../xim-x-llvm/22.1.8/lib/libc++.1.0.dylib
+    --
+    -- The driver puts this toolchain's lib dir on DYLD_LIBRARY_PATH when it
+    -- spawns the linker, so ld can pick up libLTO from the toolchain. dyld
+    -- overrides by LEAF NAME, so ld's own dependency on
+    -- /usr/lib/libc++.1.dylib is then satisfied by OUR libc++.1.dylib -- and
+    -- libc++ 22 no longer exports operator delete[], which Apple's ld needs.
+    -- The slim build does not even ship libLTO.dylib, so nothing is gained in
+    -- exchange.
+    --
+    -- 20.1.7 is poisoned exactly the same way and survives only because
+    -- libc++ 20 still happened to export what ld wanted; this is a latent
+    -- failure there, not a 22-only bug. Using our own linker removes the
+    -- host-toolchain coupling entirely, which is what a "self-contained
+    -- toolchain" was supposed to mean.
+    local usr_lld = "-fuse-ld=lld\n"
+
+    local clang_cfg = usr_lld
+    local clangxx_cfg = usr_lld .. "-isystem" .. cxxinc .. "\n"
 
     if sdkroot and sdkroot ~= "" then
-        clang_cfg = "--sysroot=" .. sdkroot .. "\n"
+        clang_cfg = "--sysroot=" .. sdkroot .. "\n" .. clang_cfg
         clangxx_cfg = "--sysroot=" .. sdkroot .. "\n" .. clangxx_cfg
     else
         log.warn("macOS SDK path not detected; clang may need manual --sysroot")

--- a/pkgs/l/llvm.lua
+++ b/pkgs/l/llvm.lua
@@ -113,6 +113,16 @@ local function is_registerable_bin(pathname)
     return os.isfile(pathname)
 end
 
+-- Split a bin/ filename into the name to register and the alias to point at.
+-- Returns (name, alias) where alias is nil when the two are the same, so
+-- non-Windows registration is byte-for-byte what it was before.
+local function program_target_name(filename)
+    if os.host() == "windows" and filename:sub(-4):lower() == ".exe" then
+        return filename:sub(1, -5), filename
+    end
+    return filename, nil
+end
+
 local function collect_bin_apps(bindir)
     local apps = {}
     local cmd
@@ -341,8 +351,15 @@ function __install_macosx_cfg()
         log.warn("macOS SDK path not detected; clang may need manual --sysroot")
     end
 
+    -- clang reads <invoked-name>.cfg, so the versioned driver needs its own
+    -- copy. The major version has to come from pkginfo: hardcoding "clang-20"
+    -- put a clang-20.cfg inside the 22.1.8 install (where the driver is
+    -- clang-22), so the sysroot silently did not apply to it.
+    local major = pkginfo.version():match("^(%d+)") or ""
     io.writefile(path.join(pkginfo.install_dir(), "bin", "clang.cfg"), clang_cfg)
-    io.writefile(path.join(pkginfo.install_dir(), "bin", "clang-20.cfg"), clang_cfg)
+    if major ~= "" then
+        io.writefile(path.join(pkginfo.install_dir(), "bin", "clang-" .. major .. ".cfg"), clang_cfg)
+    end
     io.writefile(path.join(pkginfo.install_dir(), "bin", "clang++.cfg"), clangxx_cfg)
 end
 
@@ -363,8 +380,17 @@ function config()
     xvm.add(package.name)
 
     for _, app in ipairs(related_apps) do
-        xvm.add(app, {
+        -- The registered NAME must not carry the extension: users type
+        -- `clang`, and `xlings use` looks the target up by that name.
+        -- collect_bin_apps returns real filenames, which on Windows means
+        -- `clang.exe` -- registering that verbatim produced a target called
+        -- "clang.exe" and left `clang --version` reporting
+        -- "'clang' is not installed". The alias carries the filename, exactly
+        -- as the hand-written alias_apps_windows table above already does.
+        local target, alias = program_target_name(app)
+        xvm.add(target, {
             bindir = bindir,
+            alias = alias,
             binding = binding,
         })
     end
@@ -426,7 +452,11 @@ function uninstall()
     xvm.remove(package.name)
 
     for _, app in ipairs(related_apps) do
-        xvm.remove(app)
+        -- Must strip exactly as config() did, or removal asks for a target
+        -- name ("clang.exe") that was never registered and silently removes
+        -- nothing, leaving the real shim behind.
+        local target = program_target_name(app)
+        xvm.remove(target)
     end
 
     local aliases = alias_apps

--- a/pkgs/m/mingw-w64.lua
+++ b/pkgs/m/mingw-w64.lua
@@ -79,11 +79,11 @@ function config()
     xvm.add("c++", config)
     xvm.add("g++", config)
 
-    -- Binding root: `mingw-w64` is an umbrella toolchain package whose
+    -- Group placeholder: `mingw-w64` is an umbrella toolchain package whose
     -- registered programs are the gcc/g++/c++ multilib triples.
     -- Empty placeholder under the package name so install detection
     -- (`xvm info mingw-w64`) finds an entry.
-    xvm.add("mingw-w64", { type = "binding" })
+    xvm.add("mingw-w64", { type = "group" })
 
     __config_mingw_bin(mingw_bindir)
 

--- a/pkgs/r/ripgrep.lua
+++ b/pkgs/r/ripgrep.lua
@@ -72,10 +72,10 @@ end
 
 function config()
     xvm.add("rg", { bindir = pkginfo.install_dir() })
-    -- Marker: the binary is `rg` but the package name is `ripgrep`.
+    -- Group placeholder: the binary is `rg` but the package name is `ripgrep`.
     -- Empty placeholder so install detection (`xvm info ripgrep`)
     -- finds an entry instead of treating the package as missing.
-    xvm.add("ripgrep", { type = "marker" })
+    xvm.add("ripgrep", { type = "group" })
     return true
 end
 

--- a/pkgs/r/rust.lua
+++ b/pkgs/r/rust.lua
@@ -72,11 +72,11 @@ function config()
     xvm.add("rustfmt", { bindir = cargo_bin, binding = "rustc@" .. "latest" })
     xvm.add("clippy-driver", { bindir = cargo_bin, binding = "rustc@" .. "latest" })
     xvm.add("rust-analyzer", { bindir = cargo_bin, binding = "rustc@" .. "latest" })
-    -- Binding root: `rust` is an umbrella package whose `programs` are
+    -- Group placeholder: `rust` is an umbrella package whose `programs` are
     -- rustc/cargo/rustup. Empty placeholder under the package name so
     -- install detection (`xvm info rust`) finds an entry; type
     -- distinguishes it from concrete program / lib registrations.
-    xvm.add("rust", { type = "binding" })
+    xvm.add("rust", { type = "group" })
 
     return true
 end

--- a/pkgs/r/rustup.lua
+++ b/pkgs/r/rustup.lua
@@ -70,10 +70,10 @@ end
 
 function config()
     xvm.add("rustup-init")
-    -- Marker: the package ships only the `rustup-init` bootstrap
+    -- Group placeholder: the package ships only the `rustup-init` bootstrap
     -- binary, but xlings searches for a `rustup` entry on `xim:rustup`
     -- install detection. Empty placeholder so the lookup succeeds.
-    xvm.add("rustup", { type = "marker" })
+    xvm.add("rustup", { type = "group" })
     return true
 end
 

--- a/pkgs/v/vcstool.lua
+++ b/pkgs/v/vcstool.lua
@@ -96,10 +96,10 @@ end
 
 function config()
     xvm.add("vcs", { bindir = __venv_bindir() })
-    -- Marker: the binary is `vcs` (upstream's CLI command) but the
+    -- Group placeholder: the binary is `vcs` (upstream's CLI command) but the
     -- package name is `vcstool`. Empty placeholder so install
     -- detection (`xvm info vcstool`) finds an entry.
-    xvm.add("vcstool", { type = "marker" })
+    xvm.add("vcstool", { type = "group" })
     return true
 end
 

--- a/tests/lib/assertions.py
+++ b/tests/lib/assertions.py
@@ -304,3 +304,37 @@ def assert_xvm_shim_exists(target: str):
 def assert_platform_supported(meta: XpkgMeta, platform: str):
     """包支持指定平台"""
     assert platform in meta.platforms, f"不支持平台: {platform}, 支持: {list(meta.platforms.keys())}"
+
+
+# xlings validates the registration node kind in src/core/xvm/registration.cppm
+# and rejects anything outside this set with "unsupported registration node
+# kind '<x>'", which aborts the whole config hook -- taking every registration
+# made before it down too. An empty type is fine: it defaults to "program".
+#
+# This check exists because six packages (mingw-w64, rust, e2fsprogs, ripgrep,
+# rustup, vcstool) shipped invented kinds -- "binding" and "marker" -- and were
+# completely uninstallable as a result. Nothing caught it: the kind is only
+# validated on the user's machine, at install time.
+VALID_XVM_NODE_KINDS = {"program", "lib", "group", "files"}
+
+
+def assert_valid_xvm_node_kinds(meta: XpkgMeta):
+    """xvm.add() 的 type 必须是 xlings 支持的注册节点类型
+
+    用 "group" 表示"包名占位符"(umbrella / marker) —— 它不指向任何要分发的
+    产物, 正是这个用途需要的类型。
+    """
+    if meta.is_ref:
+        return
+    bad = [
+        kind for kind in re.findall(
+            r'xvm[.:]\s*add\s*\([^)]*?\btype\s*=\s*["\']([^"\']+)["\']',
+            meta.raw_content,
+        )
+        if kind not in VALID_XVM_NODE_KINDS
+    ]
+    assert not bad, (
+        f"xvm.add() 使用了 xlings 不支持的注册类型: {sorted(set(bad))}; "
+        f"合法值为 {sorted(VALID_XVM_NODE_KINDS)}。"
+        f"包名占位符请用 \"group\""
+    )

--- a/tests/test_xpkg_spec.py
+++ b/tests/test_xpkg_spec.py
@@ -12,7 +12,10 @@ import glob
 import os
 import pytest
 from tests.lib.xpkg_parser import parse_xpkg
-from tests.lib.assertions import assert_config_registers_package_name
+from tests.lib.assertions import (
+    assert_config_registers_package_name,
+    assert_valid_xvm_node_kinds,
+)
 
 
 def _discover_xpkg_files():
@@ -30,3 +33,11 @@ def test_spec_d1_package_name_registered(pkg_file):
     """[Spec D1/D3] 包必须在 config hook 中注册 package.name"""
     meta = parse_xpkg(pkg_file)
     assert_config_registers_package_name(meta)
+
+
+@pytest.mark.static
+@pytest.mark.parametrize("pkg_file", _discover_xpkg_files(), ids=lambda f: os.path.basename(f).replace(".lua", ""))
+def test_spec_xvm_node_kind_supported(pkg_file):
+    """[Spec] xvm.add() 的 type 必须是 xlings 支持的注册节点类型"""
+    meta = parse_xpkg(pkg_file)
+    assert_valid_xvm_node_kinds(meta)


### PR DESCRIPTION
Fixes #442, fixes #443, fixes #444.

Six packages were completely uninstallable, one shipped a compiler with no compilers, and one could not link on macOS. All found by the new xlings fresh-install CI (openxlings/xlings#446), which installs the released binary on a clean machine — a path no existing workflow covered.

## Verification: 11/11 cells green

Run against this branch via the fresh-install workflow's `index_ref` input, on real runners:

| Suite | Linux | CentOS 7 | Windows | macOS |
|---|---|---|---|---|
| `core` | ✅ | ✅ | ✅ | ✅ |
| `gcc` | ✅ | ✅ | ✅ | n/a |
| `llvm` | ✅ | ✅ | ✅ | ✅ |

## 1. Invented xvm node kinds (#442)

xlings validates the registration node kind in `src/core/xvm/registration.cppm` and accepts exactly four — `program`, `lib`, `group`, `files`. Anything else aborts the **whole config hook**, taking every registration made before it down too:

```
$ xlings install ripgrep -y -g
[error] unsupported registration node kind 'marker'
[error] [ripgrep] failed: config hook failed
✗ 1 package(s) failed
```

Six packages used kinds that have never existed:

| Kind | Packages |
|---|---|
| `binding` | `e2fsprogs`, `mingw-w64`, `rust` |
| `marker` | `ripgrep`, `rustup`, `vcstool` |

All six wanted the same thing — an empty placeholder under the package name so install detection (`xvm info <pkg>`) finds an entry. That is precisely what `group` is: `registration.cppm` treats `group` and `files` as naming no artifact to dispatch, so it needs no `sourceName`.

**On Windows this was worse than six broken packages.** `mingw-w64` is what registers the `gcc`/`g++`/`c++` shims, and `gcc.lua`'s `install()` delegates to it via `pkgmanager.install()`. With mingw-w64's hook aborting, there was no way to get a C++ compiler on Windows at all.

### The guard

`tests/test_xpkg_spec.py` now rejects any other kind, and it is falsifiable — reverting ripgrep to `marker` fails it:

```
E  AssertionError: xvm.add() 使用了 xlings 不支持的注册类型: ['marker'];
   合法值为 ['files', 'group', 'lib', 'program']。包名占位符请用 "group"
```

That matters, because until now the kind was only ever validated on the user's machine, at install time.

## 2. llvm cannot start on a clean Linux machine (#443)

`clang-20` carried a static C++ runtime; `clang-22` links `libstdc++.so.6` dynamically. Nothing in llvm's dep list ships libstdc++:

```
.../xim-x-llvm/22.1.8/bin/clang: error while loading shared libraries:
libstdc++.so.6: cannot open shared object file: No such file or directory
```

`latest` resolves to 22.1.8, so plain `xlings install llvm` was broken on **every clean host** — unnoticed because dev machines and CI images all have gcc installed.

Declaring `xim:gcc-runtime@15.1.0` fixes it. It has to be a declared dep rather than a later `xlings install gcc-runtime`: the RPATH is baked at llvm install time, so a runtime that arrives afterwards is invisible to the loader (verified — installing it after does not help).

## 3. llvm registers zero programs on Windows (#444)

Two layers, the second only visible once the first was fixed.

**Layer 1 — the listing.** `dir` is a cmd.exe builtin and treats `/` as its switch introducer, while libxpkg's `path.join` always joins with `/` regardless of host. So `collect_bin_apps` ran

```
dir /b "C:\Users\runneradmin\.xlings\data\xpkgs\xim-x-llvm\22.1.8/bin"
```

and listed nothing — while `clang.exe` sat in that directory the whole time (proven by the failure-state dump in openxlings/xlings#446).

**Layer 2 — the registered name.** With the listing fixed, `collect_bin_apps` returned real filenames, which on Windows carry `.exe`. Registering those verbatim created a target called `clang.exe`, so `clang --version` *still* said `'clang' is not installed`. The name is now stripped and the filename carried as the alias — exactly what the hand-written `alias_apps_windows` table already does. `uninstall()` strips identically, or removal asks for a name that was never registered, removes nothing, and leaves the shim behind.

**Hardening that goes with it:** `config()` now fails when the listing is empty instead of registering a toolchain with no compilers, and `io.popen` returning nil is reported instead of silently yielding an empty list.

## 4. llvm cannot link on macOS (#443, macOS half)

The version switch worked; compilation died in Apple's linker:

```
dyld: Symbol not found: __ZdaPv
  Referenced from: /Applications/Xcode_15.4.app/.../usr/bin/ld
  Expected in:     /Users/runner/.xlings/data/xpkgs/xim-x-llvm/22.1.8/lib/libc++.1.0.dylib
```

`clang -v` shows the mechanism: the driver hands Apple's `ld` a `-lto_library` pointing into this toolchain, and puts the toolchain lib dir on `DYLD_LIBRARY_PATH` so ld can load it. **dyld overrides by leaf name**, so ld's own dependency on `/usr/lib/libc++.1.dylib` is then satisfied by *our* `libc++.1.dylib` — and libc++ 22 no longer exports `operator delete[]`, which Apple's ld needs. Nothing is even gained in exchange: the slim build does not ship `libLTO.dylib` at all.

Confirmed on a macOS runner rather than inferred:

- `ld -v` runs clean standalone, and reproduces the crash under `DYLD_LIBRARY_PATH=<toolchain>/lib`
- the **unshimmed** clang binary fails identically to the shimmed one, ruling out xlings's shim
- nothing registers DYLD envs anywhere, and the parent env has none
- both 20.1.7 and 22.1.8 ship a libc++ with `install_name @rpath/libc++.1.dylib` that does **not** export `__ZdaPv` — so the symbol is not what differs between them; whether our copy is loaded is

**20.1.7 is poisoned exactly the same way** and survives only because libc++ 20 still happened to export what ld wanted. This is a latent failure there, not a 22-only bug.

The payload ships `ld64.lld`, so `-fuse-ld=lld` removes the coupling to the host toolchain entirely — which is what "self-contained toolchain" was supposed to mean.

## Also

`__install_macosx_cfg` hardcoded `clang-20.cfg`, so a 22.1.8 install got a config file for a driver it does not have (`clang-22`) and `--sysroot` silently did not apply to the versioned driver. The major version now comes from `pkginfo`.