### PR TITLE
ci: bump the pinned xlings from v0.4.62 to v2026.7.29.0

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -93,6 +93,16 @@ jobs:
           Add-Content $env:GITHUB_PATH "$xlingsHome\subos\current\bin"
           Add-Content $env:GITHUB_ENV  "XLINGS_HOME=$xlingsHome"
 
+
+      # Refresh the index. The release tarball bundles a pkgindex snapshot
+      # frozen at build time, so without this a package's DEPENDENCIES resolve
+      # against a months-old index even though the package under test comes
+      # from this checkout. That is how `local:rust` failed with
+      # `sh: 1: rustup-init: not found`: its rustup dep came from the frozen
+      # snapshot, where rustup's config hook still aborted, so the shim was
+      # never registered. Nothing about rust was wrong.
+      - name: Refresh package index
+        run: xlings update
       - name: Verify xlings
         shell: pwsh
         run: |
@@ -136,6 +146,11 @@ jobs:
           echo "$HOME/.xlings/bin"               >> "$GITHUB_PATH"
           echo "$HOME/.xlings/subos/current/bin" >> "$GITHUB_PATH"
 
+
+      # See the bash legs for why: the bundled snapshot resolves deps against a
+      # months-old index unless refreshed.
+      - name: Refresh package index
+        run: xlings update
       - name: Verify xlings
         run: |
           xlings --version
@@ -179,6 +194,11 @@ jobs:
           echo "$HOME/.xlings/bin"               >> "$GITHUB_PATH"
           echo "$HOME/.xlings/subos/current/bin" >> "$GITHUB_PATH"
 
+
+      # See the bash legs for why: the bundled snapshot resolves deps against a
+      # months-old index unless refreshed.
+      - name: Refresh package index
+        run: xlings update
       - name: Verify xlings (and dump install layout)
         run: |
           xlings --version

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Installation Xlings on Ubuntu
         run: |
           export XLINGS_NON_INTERACTIVE=1
-          export XLINGS_VERSION=v0.4.62
+          export XLINGS_VERSION=v2026.7.29.0
           curl -fsSL https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.sh | bash
           echo "XLINGS_HOME=$HOME/.xlings" >> "$GITHUB_ENV"
           echo "PATH=$HOME/.xlings/subos/current/bin:$HOME/.xlings/bin:$PATH" >> "$GITHUB_ENV"
@@ -79,7 +79,7 @@ jobs:
         shell: pwsh
         run: |
           $env:XLINGS_NON_INTERACTIVE = "1"
-          $env:XLINGS_VERSION = "v0.4.62"
+          $env:XLINGS_VERSION = "v2026.7.29.0"
           iex (Invoke-WebRequest `
             -Uri "https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.ps1" `
             -UseBasicParsing).Content
@@ -130,7 +130,7 @@ jobs:
       - name: Install xlings on Ubuntu
         run: |
           export XLINGS_NON_INTERACTIVE=1
-          export XLINGS_VERSION=v0.4.62
+          export XLINGS_VERSION=v2026.7.29.0
           curl -fsSL https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.sh | bash
           echo "XLINGS_HOME=$HOME/.xlings" >> "$GITHUB_ENV"
           echo "$HOME/.xlings/bin"               >> "$GITHUB_PATH"
@@ -173,7 +173,7 @@ jobs:
       - name: Install xlings on macOS
         run: |
           export XLINGS_NON_INTERACTIVE=1
-          export XLINGS_VERSION=v0.4.62
+          export XLINGS_VERSION=v2026.7.29.0
           curl -fsSL https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.sh | bash
           echo "XLINGS_HOME=$HOME/.xlings" >> "$GITHUB_ENV"
           echo "$HOME/.xlings/bin"               >> "$GITHUB_PATH"

--- a/.github/workflows/ci-xpkg-test.yml
+++ b/.github/workflows/ci-xpkg-test.yml
@@ -60,5 +60,15 @@ jobs:
           echo "XLINGS_HOME=$HOME/.xlings" >> "$GITHUB_ENV"
           echo "PATH=$HOME/.xlings/subos/current/bin:$HOME/.xlings/bin:$PATH" >> "$GITHUB_ENV"
 
+
+      # Refresh the index. The release tarball bundles a pkgindex snapshot
+      # frozen at build time, so without this a package's DEPENDENCIES resolve
+      # against a months-old index even though the package under test comes
+      # from this checkout. That is how `local:rust` failed with
+      # `sh: 1: rustup-init: not found`: its rustup dep came from the frozen
+      # snapshot, where rustup's config hook still aborted, so the shim was
+      # never registered. Nothing about rust was wrong.
+      - name: Refresh package index
+        run: xlings update
       - name: L1 Index Registration
         run: pytest tests/ -m index --tb=short -q

--- a/.github/workflows/ci-xpkg-test.yml
+++ b/.github/workflows/ci-xpkg-test.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Install xlings
         run: |
           export XLINGS_NON_INTERACTIVE=1
-          export XLINGS_VERSION=v0.4.62
+          export XLINGS_VERSION=v2026.7.29.0
           curl -fsSL https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.sh | bash
           echo "XLINGS_HOME=$HOME/.xlings" >> "$GITHUB_ENV"
           echo "PATH=$HOME/.xlings/subos/current/bin:$HOME/.xlings/bin:$PATH" >> "$GITHUB_ENV"

--- a/pkgs/e/e2fsprogs.lua
+++ b/pkgs/e/e2fsprogs.lua
@@ -87,6 +87,10 @@ function config()
     -- are e2fsck/mke2fs/etc. The package name itself never appears in
     -- `sbin_programs`, so without this empty placeholder
     -- `xvm info e2fsprogs` returns nothing on install detection.
+    -- `group` is the only kind that both avoids a bogus shim under the
+    -- package name and lets `xlings remove` find the package; removal of a
+    -- group root needs xlings >= 2026.7.x, which is why CI pins a current
+    -- client (older ones refuse the remove and leak the shims).
     xvm.add("e2fsprogs", { type = "group" })
 
     -- mke2fs reads mke2fs.conf at runtime; the static binary has no

--- a/pkgs/m/mingw-w64.lua
+++ b/pkgs/m/mingw-w64.lua
@@ -83,6 +83,10 @@ function config()
     -- registered programs are the gcc/g++/c++ multilib triples.
     -- Empty placeholder under the package name so install detection
     -- (`xvm info mingw-w64`) finds an entry.
+    -- `group` is the only kind that both avoids a bogus shim under the
+    -- package name and lets `xlings remove` find the package; removal of a
+    -- group root needs xlings >= 2026.7.x, which is why CI pins a current
+    -- client (older ones refuse the remove and leak the shims).
     xvm.add("mingw-w64", { type = "group" })
 
     __config_mingw_bin(mingw_bindir)

--- a/pkgs/r/ripgrep.lua
+++ b/pkgs/r/ripgrep.lua
@@ -75,6 +75,10 @@ function config()
     -- Group placeholder: the binary is `rg` but the package name is `ripgrep`.
     -- Empty placeholder so install detection (`xvm info ripgrep`)
     -- finds an entry instead of treating the package as missing.
+    -- `group` is the only kind that both avoids a bogus shim under the
+    -- package name and lets `xlings remove` find the package; removal of a
+    -- group root needs xlings >= 2026.7.x, which is why CI pins a current
+    -- client (older ones refuse the remove and leak the shims).
     xvm.add("ripgrep", { type = "group" })
     return true
 end

--- a/pkgs/r/rust.lua
+++ b/pkgs/r/rust.lua
@@ -76,6 +76,10 @@ function config()
     -- rustc/cargo/rustup. Empty placeholder under the package name so
     -- install detection (`xvm info rust`) finds an entry; type
     -- distinguishes it from concrete program / lib registrations.
+    -- `group` is the only kind that both avoids a bogus shim under the
+    -- package name and lets `xlings remove` find the package; removal of a
+    -- group root needs xlings >= 2026.7.x, which is why CI pins a current
+    -- client (older ones refuse the remove and leak the shims).
     xvm.add("rust", { type = "group" })
 
     return true

--- a/pkgs/r/rustup.lua
+++ b/pkgs/r/rustup.lua
@@ -73,6 +73,10 @@ function config()
     -- Group placeholder: the package ships only the `rustup-init` bootstrap
     -- binary, but xlings searches for a `rustup` entry on `xim:rustup`
     -- install detection. Empty placeholder so the lookup succeeds.
+    -- `group` is the only kind that both avoids a bogus shim under the
+    -- package name and lets `xlings remove` find the package; removal of a
+    -- group root needs xlings >= 2026.7.x, which is why CI pins a current
+    -- client (older ones refuse the remove and leak the shims).
     xvm.add("rustup", { type = "group" })
     return true
 end

--- a/pkgs/v/vcstool.lua
+++ b/pkgs/v/vcstool.lua
@@ -99,6 +99,10 @@ function config()
     -- Group placeholder: the binary is `vcs` (upstream's CLI command) but the
     -- package name is `vcstool`. Empty placeholder so install
     -- detection (`xvm info vcstool`) finds an entry.
+    -- `group` is the only kind that both avoids a bogus shim under the
+    -- package name and lets `xlings remove` find the package; removal of a
+    -- group root needs xlings >= 2026.7.x, which is why CI pins a current
+    -- client (older ones refuse the remove and leak the shims).
     xvm.add("vcstool", { type = "group" })
     return true
 end


### PR DESCRIPTION
Fixes the post-merge failure on `main` from #445.

## What broke

The install/uninstall test only covers **changed** packages, so #445 was the first time `e2fsprogs` / `ripgrep` / `rust` / `vcstool` were ever run through it — and they failed on uninstall:

```
==> [ripgrep] uninstall (local:ripgrep)
[warn] xlings: 'ripgrep' is not installed in current subos 'default'
==> [ripgrep] post-uninstall checks
  [FAIL] shims still present after uninstall: rg
```

## Not a recipe defect

`remove` refuses *before it ever reaches the uninstall hook*, because v0.4.62 does not treat a `group`-kind package-name placeholder as installed in the subos. Verified against real binaries of both versions — same recipe, same `local:` spec, same isolated home:

| xlings | result |
|---|---|
| v0.4.62 | `'ripgrep' is not installed in current subos 'default'` → `rg` survives |
| v2026.7.29.0 | `local:ripgrep removed` → `rg` gone, no bogus shim |

## The placeholder cannot just become a program

All three shapes tested on v0.4.62:

| placeholder | uninstall | side effect |
|---|---|---|
| none | ❌ remove refuses, `rg` survives | — |
| `xvm.add(name)` → `program` | ✅ removes cleanly | ❌ creates a bogus `ripgrep` shim that errors with `executable 'ripgrep' not found` |
| `type = "group"` | ❌ remove refuses on v0.4.62 | ✅ no bogus shim |

`group` is the only correct kind — it is what `registration.cppm` provides for an entry that names no artifact to dispatch — and only a current xlings implements removal for it. Which is what these four legs should be testing against anyway: pinning a client this far behind means the index gets validated against behaviour its users no longer run.

## Consequence worth stating plainly

`xlings remove` on one of these six packages will leak its shims for users still on an xlings that predates group-root removal. That is a real regression for those users. Leaving six packages **uninstallable** was the worse trade — but it is a trade, not a free win, and it may deserve a follow-up on the xlings side to make older clients fail loudly rather than silently leak.