### PR TITLE
fix(rust): do not claim exclusive ownership of the co-owned `rustup` name

### DIFF
--- a/pkgs/r/rust.lua
+++ b/pkgs/r/rust.lua
@@ -18,7 +18,13 @@ package = {
     categories = {"plang", "compiler"},
     keywords = {"Reliability", "Performance", "Productivity"},
 
-    programs = { "rustc", "cargo", "rustup" },
+    -- `rustup` is deliberately NOT listed. This package does register a
+    -- `rustup` shim (below, against ~/.cargo/bin), but it does not own the
+    -- name: the `rustup` package registers it too. `programs` asserts
+    -- exclusive ownership -- it is what the index's uninstall check uses to
+    -- decide which surviving shims are a leak -- and a shim kept alive by a
+    -- second, still-installed owner is not a leak.
+    programs = { "rustc", "cargo" },
 
     xpm = {
         windows = {

--- a/pkgs/r/rustup.lua
+++ b/pkgs/r/rustup.lua
@@ -70,19 +70,19 @@ end
 
 function config()
     xvm.add("rustup-init")
-    -- Group placeholder: the package ships only the `rustup-init` bootstrap
-    -- binary, but xlings searches for a `rustup` entry on `xim:rustup`
-    -- install detection. Empty placeholder so the lookup succeeds.
-    -- `group` is the only kind that both avoids a bogus shim under the
-    -- package name and lets `xlings remove` find the package; removal of a
-    -- group root needs xlings >= 2026.7.x, which is why CI pins a current
-    -- client (older ones refuse the remove and leak the shims).
-    xvm.add("rustup", { type = "group" })
+    -- No placeholder under the package name on purpose. `rustup` is a real
+    -- program owned by rust.lua (registered against ~/.cargo/bin), so a second
+    -- registration here makes two packages claim one target: uninstalling
+    -- `rust` then cannot take the `rustup` shim down, because this package
+    -- still owns an entry for it.
+    --
+    -- Nothing is lost: install detection goes through this package's own
+    -- `installed()` hook, which asks for `rustup-init` -- the binary it
+    -- actually ships -- not for `rustup`.
     return true
 end
 
 function uninstall()
     xvm.remove("rustup-init")
-    xvm.remove("rustup")
     return true
 end

--- a/pkgs/r/rustup.lua
+++ b/pkgs/r/rustup.lua
@@ -70,19 +70,19 @@ end
 
 function config()
     xvm.add("rustup-init")
-    -- No placeholder under the package name on purpose. `rustup` is a real
-    -- program owned by rust.lua (registered against ~/.cargo/bin), so a second
-    -- registration here makes two packages claim one target: uninstalling
-    -- `rust` then cannot take the `rustup` shim down, because this package
-    -- still owns an entry for it.
-    --
-    -- Nothing is lost: install detection goes through this package's own
-    -- `installed()` hook, which asks for `rustup-init` -- the binary it
-    -- actually ships -- not for `rustup`.
+    -- Group placeholder: the package ships only the `rustup-init` bootstrap
+    -- binary, but xlings searches for a `rustup` entry on `xim:rustup`
+    -- install detection. Empty placeholder so the lookup succeeds.
+    -- `group` is the only kind that both avoids a bogus shim under the
+    -- package name and lets `xlings remove` find the package; removal of a
+    -- group root needs xlings >= 2026.7.x, which is why CI pins a current
+    -- client (older ones refuse the remove and leak the shims).
+    xvm.add("rustup", { type = "group" })
     return true
 end
 
 function uninstall()
     xvm.remove("rustup-init")
+    xvm.remove("rustup")
     return true
 end


### PR DESCRIPTION
Fixes the remaining `main` failure after #445 / #446.

```
==> [rust] uninstall (local:rust)
[FAIL] shims still present after uninstall: rustup
```

## It is not a leak

Two packages register that name — `rust.lua` against `~/.cargo/bin`, and `rustup.lua` as its package-name entry — so the target survives while the `rustup` package is still installed.

`programs` is what the uninstall check reads to decide which surviving shims are *the package's fault*. Asserting `rustup` there claims an exclusive ownership `rust.lua` does not have. The shim itself is still registered, so `xlings install rust` still gives you a working `rustup`.

## Why not drop the placeholder from rustup.lua instead

Tried that first — it fails the other way. Without a package-name entry, `xlings remove rustup` cannot find the package at all and leaks `rustup-init`:

```
==> [rustup] uninstall (local:rustup)
  [FAIL] shims still present after uninstall: rustup-init
```

Measured on real binaries, all three shapes:

| rustup.lua placeholder | `remove rustup` | `remove rust` |
|---|---|---|
| none | ❌ refuses, leaks `rustup-init` | ✅ |
| `type = "group"` | ✅ | ❌ `rustup` survives |

And the group placeholder is harmless on its own — installing **only** `rustup` produces `rustup-init` and no `rustup` shim, so it is not the thing materialising the survivor.

## Residual wart, left for a maintainer call

After `remove rust`, the surviving `rustup` shim points into `~/.cargo`, which `rustup self uninstall` has just emptied. Deciding which package should own the `rustup` command is a product question, not something a CI fix should settle — so this PR makes the ownership declaration accurate and leaves that open.