### PR TITLE
fix(gcc): the three virtual binding roots are groups, not programs

### DIFF
--- a/pkgs/a/aarch64-linux-musl-gcc.lua
+++ b/pkgs/a/aarch64-linux-musl-gcc.lua
@@ -113,7 +113,10 @@ local function __register_as_gcc_flavor()
     -- — a different exact node, so the root they name would never exist.
     -- xlings 2026.7.27.1 enforces this and rejects the batch with
     -- `xvm-binding-root-missing`. Same fix as pkgs/m/musl-gcc.lua.
-    xvm.add(root_name, { version = flavor_ver })
+    --
+    -- `type = "group"` because this node names no artifact -- see
+    -- pkgs/m/musl-gcc.lua for the full note (openxlings/xlings#452).
+    xvm.add(root_name, { version = flavor_ver, type = "group" })
     for prog, target in pairs(__gcc_flavor_progs) do
         xvm.add(prog, {
             bindir  = gcc_bindir,

--- a/pkgs/g/gcc.lua
+++ b/pkgs/g/gcc.lua
@@ -205,7 +205,14 @@ function __config_linux()
         log.warn("subos dir is empty, skip alias sysroot injection")
     end
 
-    xvm.add("xim-gnu-gcc") -- root
+    -- Root of the release's binding group. `type = "group"` because it names
+    -- no artifact: no bindir, no alias, nothing under it to exec. As the
+    -- default `program` it got a shim at `bin/xim-gnu-gcc` that answered
+    -- `executable 'xim-gnu-gcc' not found` -- and, on any home where the name
+    -- had no active version, `self doctor` called it an orphan shim
+    -- (openxlings/xlings#452). Version stays the default: the children below
+    -- bind to `xim-gnu-gcc@<pkginfo.version()>`.
+    xvm.add("xim-gnu-gcc", { type = "group" }) -- root
 
     local config = {
         bindir = gcc_bindir,

--- a/pkgs/m/musl-gcc.lua
+++ b/pkgs/m/musl-gcc.lua
@@ -221,7 +221,16 @@ local function __register_as_gcc_flavor()
     -- gcc.lua gets away with the bare form only because its children bind to
     -- `xim-gnu-gcc@<pkginfo.version()>`, which is exactly what the default
     -- fills in. This recipe's flavor suffix breaks that coincidence.
-    xvm.add(root_name, { version = flavor_ver })
+    --
+    -- `type = "group"` because this node names no artifact: no bindir, no
+    -- alias, nothing to dispatch to. Left as the default `program` it got a
+    -- shim under `bin/xim-musl-gnu-gcc` that could only ever print "no active
+    -- version" -- openxlings/xlings#452, where `self doctor` called it an
+    -- orphan, `--fix` deleted it, and the next install wrote it again.
+    -- Same idiom, same reason as ripgrep.lua / rust.lua / e2fsprogs.lua.
+    -- Verified against a released 0.4.68: an old client accepts a
+    -- group-typed binding root and simply ignores it.
+    xvm.add(root_name, { version = flavor_ver, type = "group" })
 
     for prog, target in pairs(__gcc_flavor_progs(__musl_triple())) do
         xvm.add(prog, {


### PR DESCRIPTION
Refs openxlings/xlings#452 — the index half of the fix.

## What

`xim-gnu-gcc` (gcc.lua), `xim-musl-gnu-gcc` (musl-gcc.lua) and
`xim-aarch64-musl-gnu-gcc` (aarch64-linux-musl-gcc.lua) exist only to anchor
their release's binding group. None has a `bindir` or an `alias`. Registered
with the default `type = "program"`, each got a shim in the subos bin dir that
can only fail:

```
$ bin/xim-gnu-gcc --version
[error] xlings: executable 'xim-gnu-gcc' not found

$ bin/xim-musl-gnu-gcc --version
[error] xlings: no active version of 'xim-musl-gnu-gcc' in current subos
```

The second form is the reported bug. Installing musl-gcc on a home where the
glibc gcc owns `gcc` leaves the whole flavor release inactive — correctly, so
that the install does not steal the name from the active release — and the
root's shim then had no active version to resolve against. `xlings self
doctor` reported `✗ orphan shim`, `--fix` deleted the file, and the next
install wrote it straight back.

## Why `group`

It is the kind that means "this node names no artifact": it emits no shim
effect at all, and `xlings remove` still finds the package by it. Six recipes
already use it for the same reason — `ripgrep.lua`, `rust.lua`, `rustup.lua`,
`vcstool.lua`, `mingw-w64.lua`, `e2fsprogs.lua`.

Those six are standalone placeholders. These three are the first group-typed
**binding roots**, so both directions were verified by hand rather than
assumed, with a fixture pair reproducing the exact shape (one package owning a
name, a second publishing a flavor of it under a group root):

| client | result |
| --- | --- |
| built from openxlings/xlings#453 | root registered and **not** shimmed; `xlings use <name> <flavor>` switches the whole group including the root; `remove` takes it back out; `self doctor` exits 0 at every step |
| released **0.4.68** | accepts a group-typed binding root, installs, shims only the real programs, doctor clean — old clients are not stranded |

`apply_registration_batch` places no kind constraint on a binding root; it
requires only that the root be an exact node in the same batch, which is
unchanged here.

## Scope note

`VInfo::type` is only written when empty, so a home that already recorded
`xim-gnu-gcc` as a `program` keeps that record. This change therefore fixes
**new** registrations; existing homes are covered by the client-side half in
openxlings/xlings#453 (which stops writing the file and stops erroring on one
that is already there). The two are complementary, not alternatives.

## Test plan

- `pytest -m static tests/g/test_gcc.py tests/m/test_musl_gcc.py` — 8 passed
- `toolchain consumer smoke` fires on all three paths (gcc.lua, musl-gcc.lua)
  and builds a real consumer with the toolchain from this tree
- the compat matrix above, run against a real 0.4.68 binary rather than by
  reading code