### PR TITLE
fix(gcc): alias sysroot records subos/current, not the install-time subos

### DIFF
--- a/pkgs/g/gcc.lua
+++ b/pkgs/g/gcc.lua
@@ -197,10 +197,28 @@ function __config_linux()
     -- individual payloads are not — the subos is exactly xlings' FHS
     -- composite view for this purpose. Consumers that bypass the shim
     -- (e.g. mcpp) supply their own header flags.
+    --
+    -- Written as `<home>/subos/current`, not as whichever subos happens to be
+    -- active while this hook runs. The xvm database is shared by every subos
+    -- in the home, so a path naming one of them is right for the subos that
+    -- installed gcc and wrong for all the others -- the user switches subos
+    -- and their g++ keeps compiling against the old one's headers.
+    --
+    -- `subos/current` is the symlink `xlings self init` creates and
+    -- `xlings subos use --global` maintains, so it needs no placeholder and
+    -- no new xvm field: it is a path, and every client understands paths.
+    --
+    -- xlings >= 2026.7.31.1 does better still -- it lifts this flag out of
+    -- the alias at registration and re-composes it per invocation, so the
+    -- record holds the intent and no path at all. This spelling is what an
+    -- OLDER client gets, and following a symlink beats freezing at install
+    -- time. Both readings are correct; neither needs to know about the other.
     local sysroot_dir = system.subos_sysrootdir()
     local alias_args = ""
     if sysroot_dir and sysroot_dir ~= "" then
-        alias_args = string.format(' --sysroot=%s', sysroot_dir)
+        local portable = sysroot_dir:gsub("([/\\])subos([/\\])[^/\\]+",
+                                          "%1subos%2current", 1)
+        alias_args = string.format(' --sysroot=%s', portable)
     else
         log.warn("subos dir is empty, skip alias sysroot injection")
     end

--- a/tests/g/test_gcc.py
+++ b/tests/g/test_gcc.py
@@ -61,6 +61,42 @@ class TestIsolation:
         assert_uses_new_api(PKG_FILE)
 
 
+class TestSubosPath:
+    """gcc 记录到 xvm 的 subos 路径必须是可移植写法。
+
+    xvm 版本库是**整个 home 共享**的一份，而 sysroot 是 per-subos 的。写死安装
+    那一刻活动的 subos，对装 gcc 的那个 subos 正确、对其余全部错误 —— 用户切了
+    subos，g++ 还在对着旧的头文件编译。写 `subos/current`（`self init` 建立、
+    `subos use --global` 维护的 symlink）不需要占位符也不需要新字段。
+
+    LINK 轴（loader/rpath，写进 payload 的 specs）方向相反：payload 全 home 共享
+    且可以被绕过 shim 直接调用，所以那里**不许**出现 subos 路径。两条轴一起断言，
+    否则改对一条会掩盖另一条。
+    """
+
+    @pytest.mark.static
+    def test_alias_sysroot_uses_portable_spelling(self):
+        src = open(PKG_FILE, encoding='utf-8').read()
+        assert 'subos%2current' in src, (
+            "alias 的 --sysroot 必须重写成 <home>/subos/current；"
+            "写死活动 subos 会让其他 subos 里的 g++ 用错头文件"
+        )
+        # 断言它作用在 alias 上，而不是碰巧出现在注释里
+        assert 'alias_args = string.format' in src
+
+    @pytest.mark.static
+    def test_specs_rewrite_stays_payload_direct(self):
+        src = open(PKG_FILE, encoding='utf-8').read()
+        # specs 走 rpath + 动态链接器，两者都必须指向 payload
+        assert 'pkginfo.install_dir(), "lib64"' in src, (
+            "specs 的 rpath 必须是 payload-direct"
+        )
+        assert 'subos_sysrootdir' not in src.split('__rewrite_specs_linux')[-1], (
+            "specs 重写路径里不得出现 subos —— payload 是全 home 共享的，"
+            "而且直接调用 <install_dir>/bin/gcc 时根本不经过任何 subos"
+        )
+
+
 class TestLifecycle:
     @pytest.mark.lifecycle
     @skip_if_not('linux')


### PR DESCRIPTION
> **配套 openxlings/xlings#457，两边都先不合。** 顺序不敏感 —— 先合哪个都不会坏。

## 问题

xvm 版本库是**整个 home 共享**的一份，而 sysroot 是 **per-subos** 的：

```lua
alias = "g++ --sysroot=" .. system.subos_sysrootdir()   -- config() 运行时活动的那个 subos
```

对装 gcc 的那个 subos 正确，对其余**全部**错误 —— 用户切了 subos，g++ 还在对着旧的头文件编译，而且**没有任何提示**。

## 改法

写 `<home>/subos/current` —— `xlings self init` 建立、`xlings subos use --global` 维护的 symlink。**不需要占位符、不需要 capability probe、不需要新 xvm 字段** —— 它就是一个路径，所有客户端都认识路径。

```lua
local portable = sysroot_dir:gsub("([/\\])subos([/\\])[^/\\]+", "%1subos%2current", 1)
```

xlings ≥ `2026.7.31.1`（#457）做得更彻底：注册时把这个 flag 从 alias 里**提取**出来存成意图，每次调用再合成，记录里一个 subos 路径都不剩。本 PR 这个写法是**老客户端**看到的形态 —— 跟着 symlink 走，总好过冻结在安装那一刻。

**两种读法都正确，互不需要知道对方** —— 所以先合哪个都行。

## 测试同时钉住两条轴

两条轴的正确答案是**相反的**，只修一条会掩盖另一条：

| 轴 | 值在哪 | 能不能有 subos |
|---|---|---|
| **HEADER**（`--sysroot`） | xvm alias | **要**，但必须是可移植写法 |
| **LINK**（loader + rpath） | payload 自己的 `specs` | **不许** —— payload 全 home 共享，且直接调 `<install_dir>/bin/gcc` 根本不经过任何 subos |

LINK 轴那条尤其重要：**没有任何诊断能看见 payload 内部**（`self doctor` 从不读 payload 文件内容 —— openxlings/xlings#458），一旦烧进去只能靠重装修。

## 验证

- 用 lua5.4 跑了真实路径形态：posix、项目 subos（`<proj>/.xlings/subos/pa`）、Windows 分隔符、已经是 `current` 的值、以及 `/opt/...` 这种外部 sysroot 原样不动；
- 把 recipe 还原成改前状态，新测试**确实变红**（不是顺带通过）。
