### PR TITLE
feat(pkg): add mcpp-short-cmd 0.0.1

### DIFF
--- a/pkgs/m/mcpp-short-cmd.lua
+++ b/pkgs/m/mcpp-short-cmd.lua
@@ -1,0 +1,130 @@
+package = {
+    spec = "2",
+
+    name = "mcpp-short-cmd",
+    description = "Short command aliases for mcpp (mp/mbuild/mrun/mtest/...)",
+
+    homepage = "https://github.com/mcpp-community/mcpp",
+    maintainers = {"xim team"},
+    licenses = {"Apache-2.0"},
+    repo = "https://github.com/mcpp-community/mcpp",
+    docs = "https://github.com/mcpp-community/mcpp#readme",
+
+    -- xim pkg info
+    type = "package",
+    status = "dev", -- follows mcpp's own CLI surface, which is pre-1.0
+    categories = {"cpp", "build-tool", "shortcut"},
+    keywords = {"mcpp", "alias", "shortcut", "cli", "cpp"},
+
+    programs = {
+        "mp",
+        "mnew", "mbuild", "mrun", "mtest", "mclean",
+        "madd", "mremove", "mupdate", "msearch", "mpublish", "mpack",
+        "mexpkg", "mxparse",
+        "mtinstall", "mtlist", "mtdefault",
+        "mcdir", "mclist", "mcinfo", "mcgc",
+        "milist", "miadd", "miremove", "miupdate",
+        "msdoctor", "msenv", "msconfig", "msversion", "msexplain",
+    },
+
+    xvm_enable = true,
+
+    -- Payload-free package: there is nothing to download. The whole package is
+    -- the set of xvm shims registered in config(), each one an alias onto the
+    -- `mcpp` shim (not a hardcoded binary path), so `xlings use mcpp <ver>`
+    -- keeps switching the version the short commands drive.
+    xpm = {
+        linux = {
+            deps = { "xim:mcpp" },
+            ["latest"] = { ref = "0.0.1" },
+            ["0.0.1"] = {},
+        },
+        macosx = {
+            deps = { "xim:mcpp" },
+            ["latest"] = { ref = "0.0.1" },
+            ["0.0.1"] = {},
+        },
+        windows = {
+            deps = { "xim:mcpp" },
+            ["latest"] = { ref = "0.0.1" },
+            ["0.0.1"] = {},
+        },
+    },
+}
+
+import("xim.libxpkg.log")
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+
+-- Naming rule: keep one letter for every word but the last, and the last word
+-- in full — `mcpp self doctor` -> m + s + doctor -> `msdoctor`. `mp` is the
+-- bare `mcpp` entry point (the one name the rule cannot derive).
+local SHORT_CMDS = {
+    { "mp",        "" },              -- mcpp
+
+    -- project lifecycle
+    { "mnew",      "new" },
+    { "mbuild",    "build" },
+    { "mrun",      "run" },
+    { "mtest",     "test" },
+    { "mclean",    "clean" },
+
+    -- dependencies / registry
+    { "madd",      "add" },
+    { "mremove",   "remove" },
+    { "mupdate",   "update" },
+    { "msearch",   "search" },
+    { "mpublish",  "publish" },
+    { "mpack",     "pack" },
+    { "mexpkg",    "emit xpkg" },
+    { "mxparse",   "xpkg parse" },
+
+    -- resource management
+    { "mtinstall", "toolchain install" },
+    { "mtlist",    "toolchain list" },
+    { "mtdefault", "toolchain default" },
+    { "mcdir",     "cache dir" },
+    { "mclist",    "cache list" },
+    { "mcinfo",    "cache info" },
+    { "mcgc",      "cache gc" },
+    { "milist",    "index list" },
+    { "miadd",     "index add" },
+    { "miremove",  "index remove" },
+    { "miupdate",  "index update" },
+
+    -- mcpp itself
+    { "msdoctor",  "self doctor" },
+    { "msenv",     "self env" },
+    { "msconfig",  "self config" },
+    { "msversion", "self version" },
+    { "msexplain", "self explain" },
+}
+
+function install()
+    -- Nothing to unpack: the package ships no files.
+    return true
+end
+
+function config()
+    -- Package-name placeholder so `xvm info mcpp-short-cmd` / `xlings remove`
+    -- find an entry. `group` avoids creating a bogus `mcpp-short-cmd` shim.
+    xvm.add(package.name, { type = "group" })
+
+    local binding = package.name .. "@" .. pkginfo.version()
+    for _, entry in ipairs(SHORT_CMDS) do
+        local short, sub = entry[1], entry[2]
+        local alias = (sub == "") and "mcpp" or ("mcpp " .. sub)
+        xvm.add(short, { alias = alias, binding = binding })
+    end
+
+    log.info("registered %d mcpp short commands (mp, mbuild, mrun, ...)", #SHORT_CMDS)
+    return true
+end
+
+function uninstall()
+    for _, entry in ipairs(SHORT_CMDS) do
+        xvm.remove(entry[1])
+    end
+    xvm.remove(package.name)
+    return true
+end

--- a/tests/m/test_mcpp_short_cmd.py
+++ b/tests/m/test_mcpp_short_cmd.py
@@ -1,0 +1,191 @@
+"""测试 mcpp-short-cmd 短命令包"""
+import re
+
+import pytest
+from tests.lib.xpkg_parser import parse_xpkg
+from tests.lib.assertions import (
+    assert_required_fields, assert_valid_spec, assert_valid_type,
+    assert_no_typos, assert_no_exec_xvm, assert_no_bashrc_modification,
+    assert_no_direct_path_modification, assert_uses_new_api,
+    assert_xim_add_succeeds, assert_install_succeeds,
+    assert_command_output, assert_xvm_shim_exists,
+)
+from tests.lib.platform_utils import skip_if_not
+
+PKG = "mcpp-short-cmd"
+INSTALL_PKG = "local:mcpp-short-cmd@0.0.1"
+PKG_FILE = "pkgs/m/mcpp-short-cmd.lua"
+
+# The contract this package exists for: short name -> the mcpp command line it
+# expands to. Rule: one letter per word except the last, which stays whole
+# (`mcpp self doctor` -> `msdoctor`); `mp` is the bare `mcpp` entry point.
+EXPECTED_ALIASES = {
+    "mp": "mcpp",
+    "mnew": "mcpp new",
+    "mbuild": "mcpp build",
+    "mrun": "mcpp run",
+    "mtest": "mcpp test",
+    "mclean": "mcpp clean",
+    "madd": "mcpp add",
+    "mremove": "mcpp remove",
+    "mupdate": "mcpp update",
+    "msearch": "mcpp search",
+    "mpublish": "mcpp publish",
+    "mpack": "mcpp pack",
+    "mexpkg": "mcpp emit xpkg",
+    "mxparse": "mcpp xpkg parse",
+    "mtinstall": "mcpp toolchain install",
+    "mtlist": "mcpp toolchain list",
+    "mtdefault": "mcpp toolchain default",
+    "mcdir": "mcpp cache dir",
+    "mclist": "mcpp cache list",
+    "mcinfo": "mcpp cache info",
+    "mcgc": "mcpp cache gc",
+    "milist": "mcpp index list",
+    "miadd": "mcpp index add",
+    "miremove": "mcpp index remove",
+    "miupdate": "mcpp index update",
+    "msdoctor": "mcpp self doctor",
+    "msenv": "mcpp self env",
+    "msconfig": "mcpp self config",
+    "msversion": "mcpp self version",
+    "msexplain": "mcpp self explain",
+}
+
+
+def _short_cmd_table(content: str) -> dict:
+    """解析 SHORT_CMDS 表 -> {short: 完整 mcpp 命令行}"""
+    block = re.search(r"local SHORT_CMDS = \{(.*?)\n\}", content, re.DOTALL)
+    assert block, "missing SHORT_CMDS table"
+    pairs = re.findall(r'\{\s*"([^"]+)",\s*"([^"]*)"\s*\}', block.group(1))
+    return {short: ("mcpp " + sub).strip() for short, sub in pairs}
+
+
+@pytest.fixture(scope='module')
+def meta():
+    return parse_xpkg(PKG_FILE)
+
+
+class TestStatic:
+    @pytest.mark.static
+    def test_required_fields(self, meta):
+        assert_required_fields(meta)
+
+    @pytest.mark.static
+    def test_valid_spec(self, meta):
+        assert_valid_spec(meta)
+
+    @pytest.mark.static
+    def test_valid_type(self, meta):
+        assert_valid_type(meta)
+
+    @pytest.mark.static
+    def test_no_typos(self):
+        assert_no_typos(PKG_FILE)
+
+    @pytest.mark.static
+    def test_alias_mapping_is_complete(self, meta):
+        assert _short_cmd_table(meta.raw_content) == EXPECTED_ALIASES
+
+    @pytest.mark.static
+    def test_short_names_are_unique(self, meta):
+        block = re.search(r"local SHORT_CMDS = \{(.*?)\n\}", meta.raw_content, re.DOTALL)
+        shorts = re.findall(r'\{\s*"([^"]+)",\s*"[^"]*"\s*\}', block.group(1))
+        assert len(shorts) == len(set(shorts)), "duplicate short command name"
+
+    @pytest.mark.static
+    def test_programs_match_alias_table(self, meta):
+        assert set(meta.programs) == set(EXPECTED_ALIASES)
+
+    @pytest.mark.static
+    def test_is_payload_free(self, meta):
+        # Nothing is downloaded: no url / sha256 anywhere, and every version
+        # entry is an empty table.
+        assert not re.search(r'\burl\s*=', meta.raw_content)
+        assert "sha256" not in meta.raw_content
+        assert '["0.0.1"] = {}' in meta.raw_content
+
+    @pytest.mark.static
+    def test_depends_on_mcpp_on_every_platform(self, meta):
+        for platform in ("linux", "macosx", "windows"):
+            block = re.search(
+                platform + r"\s*=\s*\{(.*?)\n        \}", meta.raw_content, re.DOTALL)
+            assert block, f"missing {platform} xpm block"
+            assert re.search(r'["\']xim:mcpp["\']', block.group(1)), \
+                f"{platform} missing dependency: xim:mcpp"
+
+    @pytest.mark.static
+    def test_aliases_target_the_mcpp_shim(self, meta):
+        # Aliases must go through the `mcpp` shim rather than a resolved binary
+        # path, so `xlings use mcpp <ver>` keeps switching what they drive.
+        assert '("mcpp " .. sub)' in meta.raw_content
+        assert re.search(r'xvm\.add\(short,\s*\{\s*alias\s*=\s*alias', meta.raw_content)
+        assert "pkginfo.install_dir()" not in meta.raw_content
+
+    @pytest.mark.static
+    def test_registers_package_name_as_group(self, meta):
+        # `group` is the package-name placeholder: it keeps `xlings remove`
+        # working without creating a bogus `mcpp-short-cmd` shim.
+        assert re.search(
+            r'xvm\.add\(package\.name,\s*\{\s*type\s*=\s*"group"\s*\}\)',
+            meta.raw_content)
+
+    @pytest.mark.static
+    def test_uninstall_removes_every_alias(self, meta):
+        hook = re.search(r"function uninstall\(\)(.*?)\nend", meta.raw_content, re.DOTALL)
+        assert hook, "missing uninstall hook"
+        body = hook.group(1)
+        assert "ipairs(SHORT_CMDS)" in body
+        assert "xvm.remove(entry[1])" in body
+        assert "xvm.remove(package.name)" in body
+
+
+class TestIndex:
+    @pytest.mark.index
+    def test_xim_add(self):
+        assert_xim_add_succeeds(PKG_FILE)
+
+
+class TestIsolation:
+    @pytest.mark.isolation
+    def test_no_exec_xvm(self):
+        assert_no_exec_xvm(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_no_bashrc(self):
+        assert_no_bashrc_modification(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_no_path_modification(self):
+        assert_no_direct_path_modification(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_new_api(self):
+        assert_uses_new_api(PKG_FILE)
+
+
+class TestLifecycle:
+    @pytest.mark.lifecycle
+    @skip_if_not('linux')
+    def test_install(self):
+        assert_install_succeeds(INSTALL_PKG, timeout=420)
+
+
+class TestVerify:
+    @pytest.mark.verify
+    @skip_if_not('linux')
+    def test_short_cmd_shims(self):
+        for short in ("mp", "mbuild", "mrun", "mtest", "msversion"):
+            assert_xvm_shim_exists(short)
+
+    @pytest.mark.verify
+    @skip_if_not('linux')
+    def test_mp_forwards_args(self):
+        # `mp` is the bare mcpp entry point; args must reach the real binary.
+        assert_command_output("mp --version", regex=r"mcpp \d")
+
+    @pytest.mark.verify
+    @skip_if_not('linux')
+    def test_subcommand_alias_expands(self):
+        # `msversion` -> `mcpp self version`
+        assert_command_output("msversion", regex=r"mcpp \d")


### PR DESCRIPTION
## 用途

`mcpp-short-cmd` 是一个**空包**（无任何下载产物），全部内容就是在 `config()` 里向
xvm 注册 30 个指向 `mcpp` 的短命令别名。

命名规则：**除最后一个词外每个词只保留首字母，最后一个词保留全名**
（`mcpp self doctor` → `msdoctor`）；`mp` 是规则推导不出来的 `mcpp` 裸入口。

| 短命令 | 展开 | 短命令 | 展开 |
|---|---|---|---|
| `mp` | `mcpp` | `mexpkg` | `mcpp emit xpkg` |
| `mnew` | `mcpp new` | `mxparse` | `mcpp xpkg parse` |
| `mbuild` | `mcpp build` | `mtinstall` | `mcpp toolchain install` |
| `mrun` | `mcpp run` | `mtlist` | `mcpp toolchain list` |
| `mtest` | `mcpp test` | `mtdefault` | `mcpp toolchain default` |
| `mclean` | `mcpp clean` | `mcdir` | `mcpp cache dir` |
| `madd` | `mcpp add` | `mclist` | `mcpp cache list` |
| `mremove` | `mcpp remove` | `mcinfo` | `mcpp cache info` |
| `mupdate` | `mcpp update` | `mcgc` | `mcpp cache gc` |
| `msearch` | `mcpp search` | `milist` | `mcpp index list` |
| `mpublish` | `mcpp publish` | `miadd` | `mcpp index add` |
| `mpack` | `mcpp pack` | `miremove` | `mcpp index remove` |
| `msdoctor` | `mcpp self doctor` | `miupdate` | `mcpp index update` |
| `msenv` | `mcpp self env` | `msconfig` | `mcpp self config` |
| `msversion` | `mcpp self version` | `msexplain` | `mcpp self explain` |

## 平台与架构

linux / macosx / windows，无架构限制（不分发任何二进制）。三个平台块都声明
`deps = { "xim:mcpp" }`。

## 资源来源

**无**。`["0.0.1"] = {}`，没有 url / sha256 / mirror。安装时 xlings 会打印一条
`[warn] skipping mcpp-short-cmd: resource has neither url nor source` —— 这是空包的
预期行为（`windows-acp` / `mcpp-vscode-clangd` 同样如此），install hook 直接返回 true。

## 设计要点

- 别名指向 **`mcpp` shim** 而不是解析出来的二进制路径，因此 `xlings use mcpp <ver>`
  切版本后短命令自动跟随。
- 包名用 `xvm.add(package.name, { type = "group" })` 注册为占位节点：`xlings remove`
  能找到包，同时不会生成一个没用的 `mcpp-short-cmd` shim。
- 每个别名带 `binding = mcpp-short-cmd@<version>`。

## 是否修改用户环境

不修改。只走 `xvm.add` / `xvm.remove`，不写 shell profile、不改 PATH、不动
`MCPP_HOME` / `XLINGS_HOME`。`uninstall()` 遍历同一张表移除全部 30 个别名 + group 根。

## 本地验证结果

隔离 home（`XLINGS_HOME=$(mktemp -d)` + `xlings update`），linux x86_64：

```
$ xlings install local:mcpp-short-cmd@0.0.1 -y
[xim:xpkg]: registered 30 mcpp short commands (mp, mbuild, mrun, ...)
  ✓ 2 package(s) installed          # mcpp-short-cmd + xim:mcpp@2026.7.30.3

$ ls $XLINGS_HOME/subos/current/bin
madd mbuild mcdir mcgc mcinfo mclean mclist mcpp mexpkg miadd milist miremove
miupdate mnew mp mpack mpublish mremove mrun msconfig msdoctor msearch msenv
msexplain msversion mtdefault mtest mtinstall mtlist mupdate mxparse
# 30 个短命令 + mcpp；没有 mcpp-short-cmd shim（group 节点，符合预期）
```

功能验证（含参数透传与多级子命令）：

```
$ mp --version         -> mcpp 2026.7.30.3
$ msversion            -> mcpp 2026.7.30.3                          # mcpp self version
$ mtlist               -> Toolchains: * gcc 16.1.0 (default) ...    # mcpp toolchain list
$ mclist               -> key/kind/size/last used/package 表         # mcpp cache list
$ mnew hello           -> Created bin package 'hello' at .../hello  # 参数透传
$ mbuild               -> Finished dev [unoptimized + debuginfo] in 1.67s
$ mrun                 -> Hello from hello!
$ mtest                -> test result ok. 1 passed; 0 failed
$ mclean               -> Cleaned: .../hello/target
$ mxparse              -> error: usage: mcpp xpkg parse <file.lua> ...  # 三级别名
```

卸载：

```
$ xlings -y remove mcpp-short-cmd
  ✓ mcpp-short-cmd removed  (subos: default)
$ ls $XLINGS_HOME/subos/current/bin   -> mcpp        # 30 个 shim 全部清除
$ .xlings.json workspace keys         -> ['mcpp']    # 注册项全部清除
```

静态检查与测试：

```
$ python3 .github/scripts/version-check.py --workspace .   -> exit 0
$ pytest -q tests/ -m "static or isolation"                -> 947 passed
$ pytest -q tests/m/test_mcpp_short_cmd.py -m "static or isolation or index"
                                                           -> 17 passed
```

## 测试

新增 `tests/m/test_mcpp_short_cmd.py`：静态测试把 30 条映射关系当成契约来断言
（解析 lua 里的 `SHORT_CMDS` 表并与期望字典逐条比对）、短名唯一性、`programs`
与映射表一致、无 url/sha256、三平台都依赖 `xim:mcpp`、别名指向 shim 而非
`install_dir()`、包名注册为 `group`、`uninstall` 覆盖全部别名；另有 lifecycle /
verify 用例（这两个 marker 目前未接入 CI，对应上面的手动验证）。

## latest

`latest -> 0.0.1`，即本 PR 引入的唯一版本。
