### PR TITLE
feat(pkg): add perl 5.44.0 (static musl on linux, relocatable on macOS)

### DIFF
--- a/pkgs/p/perl.lua
+++ b/pkgs/p/perl.lua
@@ -1,0 +1,157 @@
+package = {
+    spec = "2",
+
+    name = "perl",
+    description = "Perl — a complete, relocatable Perl 5 interpreter with the full core module set",
+
+    homepage = "https://www.perl.org",
+    maintainers = {"Perl 5 Porters"},
+    licenses = {"Artistic-1.0-Perl OR GPL-1.0-or-later"},
+    repo = "https://github.com/Perl/perl5",
+    docs = "https://perldoc.perl.org",
+
+    -- xim pkg info
+    type = "package",
+    archs = {"x86_64", "aarch64"},
+    status = "stable",
+    categories = {"language", "interpreter", "scripting", "toolchain"},
+    keywords = {"perl", "perl5", "interpreter", "script", "configure"},
+
+    programs = {"perl", "perldoc"},
+    xvm_enable = true,
+
+    -- WHY THIS PACKAGE EXISTS
+    --
+    -- Several source builds in the ecosystem are driven by Perl scripts —
+    -- OpenSSL's `./config`/`Configure` most prominently. Those builds do not
+    -- need "a perl binary on PATH", they need a perl whose CORE MODULES are
+    -- present: `Configure` opens with `use FindBin;`, and a distro perl that
+    -- was split into sub-packages (or a trimmed container image) has the
+    -- binary but not FindBin.pm. The failure then surfaces deep inside a
+    -- third-party build with a message nobody can act on
+    -- (mcpplibs/mcpp-index#140). A recipe can only declare its way out of that
+    -- by depending on a perl it brought itself — hence `xim:perl`.
+    --
+    -- So "complete" is the requirement, not a nicety: every asset here ships
+    -- the full core lib tree (FindBin, Config, File::Path, POSIX, ExtUtils::*,
+    -- Digest::*, …), not a minimal interpreter.
+    --
+    -- PROVENANCE — two build paths, one version (perl 5.44.0 everywhere).
+    --
+    --   linux x86_64 / aarch64 — built from the upstream CPAN source tarball
+    --     (perl-5.44.0.tar.gz) inside Alpine 3.22 as a FULLY STATIC musl
+    --     binary: `Configure -Uusedl -Duserelocatableinc -Aldflags=-static`.
+    --       * `-Uusedl` removes DynaLoader, so every core XS extension is
+    --         linked INTO the perl binary. That is what makes `-static`
+    --         usable at all — a static perl that still expected to dlopen
+    --         its own .so files would load nothing.
+    --       * `-Duserelocatableinc` stores @INC relative to the binary, so
+    --         the unpacked tree works from any install prefix.
+    --       * static musl means no glibc floor and no NSS caveat: the same
+    --         archive runs on Alpine, CentOS 7, and Fedora 44 alike. This is
+    --         the case that motivated the package, and it is the one platform
+    --         where a distro perl cannot be relied on.
+    --       TRADE-OFF: with no DynaLoader, this perl cannot load XS modules
+    --       built after the fact — `cpan Some::XS::Module` will not work.
+    --       Pure-perl modules are fine, and every core module is built in.
+    --       That is the deliberate cost of a single portable binary; anyone
+    --       who needs a CPAN-extensible perl wants their distro's.
+    --
+    --   macosx x86_64 / arm64 — repacked from skaji/relocatable-perl 5.44.0.0
+    --     (the same perl version), byte-identical payload, only the archive's
+    --     top-level directory is renamed to the xlings-res convention.
+    --     macOS cannot be served the linux treatment: Apple does not support
+    --     statically linking libSystem, so a "static macOS binary" does not
+    --     exist. relocatable-perl is the portable-and-complete build for that
+    --     platform, and it keeps DynaLoader (so macOS has no XS limitation).
+    --
+    --   windows — not shipped. The Windows answer is Strawberry Perl, which
+    --     is a ~250MB toolchain distribution rather than an interpreter, and
+    --     nothing in the index needs it yet.
+    --
+    -- RESOURCE SHAPE — `url = "XLINGS_RES"` + per-arch sha256, the mcpp.lua /
+    -- nasm.lua idiom, NOT the bare `source = "xlings-res"` form (mcpp#232):
+    -- deployed xlings engines don't parse a `source` key, so that form
+    -- resolves to no URL at all — nothing gets downloaded, the install hook
+    -- no-ops, and the package lands "installed" but empty with dangling shims.
+    -- The placeholder resolves at runtime to
+    -- `{res-server}/perl/releases/download/5.44.0/perl-5.44.0-<os>-<arch>.tar.gz`
+    -- with GLOBAL(github)→CN(gitcode) fallback.
+    --
+    -- Note the macosx arch spelling split, which is xlings's and not ours:
+    -- the ASSET name uses the raw host token (`arm64` on Apple, `aarch64` on
+    -- linux), while the sha256 table is keyed by the NORMALIZED arch
+    -- (`aarch64` on both). See installer.cppm detect_arch_() vs
+    -- normalize_arch().
+    xpm = {
+        linux = {
+            ["latest"] = { ref = "5.44.0" },
+            ["5.44.0"] = {
+                url = "XLINGS_RES",
+                sha256 = {
+                    x86_64 = "b9e884be3df92028df0d023b482f033440ade29c5b9e715313d971b1542eff72",
+                    aarch64 = "31b49b6b581b10d7d519ca358205cf4343c0ce1436ab443e421fd44be5ca4a9d",
+                },
+            },
+        },
+        macosx = {
+            ["latest"] = { ref = "5.44.0" },
+            ["5.44.0"] = {
+                url = "XLINGS_RES",
+                sha256 = {
+                    x86_64 = "c6b62e520fd9d4f733d6426d4adf0058675bb79bd9c36a77d9ae7909798436d7",
+                    aarch64 = "2daae82c24f114eb708cee183bf1fe1ba86e1acc33c897dad55268dd221472f4",
+                },
+            },
+        },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+
+function install()
+    -- Every asset — both build paths, all four os/arch pairs — expands to the
+    -- SAME top-level directory `perl-<ver>/`, so this hook needs no arch
+    -- knowledge. (Deliberate: `os.arch()` is the normalized token and would
+    -- not match a directory named after the raw one on macOS.)
+    --
+    -- Idempotent across xim engines (mcpp#232): some stage the extracted
+    -- payload into install_dir() before/without the hook, others leave it in
+    -- the hook CWD for us to move. Never wipe install_dir before a
+    -- replacement payload is confirmed, and never report success unless the
+    -- interpreter is actually in place — `return true` over an empty dir gets
+    -- stamped as installed and leaves dangling xvm shims behind.
+    local staged = path.join(pkginfo.install_dir(), "bin", "perl")
+    if os.isfile(staged) then return true end
+
+    local payload = "perl-" .. pkginfo.version()
+    if os.isdir(payload) then
+        os.tryrm(pkginfo.install_dir())
+        os.mv(payload, pkginfo.install_dir())
+    end
+    return os.isfile(staged)
+end
+
+function config()
+    local bindir = path.join(pkginfo.install_dir(), "bin")
+
+    -- Only `perl` and `perldoc` get shims. The tree also carries prove,
+    -- shasum, json_pp, ptar, splain and friends — generic names that would
+    -- shadow the host's own tools for every user who installs perl for one
+    -- build script. They stay reachable through <install>/bin.
+    --
+    -- `cpan` is deliberately NOT registered: on linux this perl has no
+    -- DynaLoader (see the provenance note), so cpan would install XS modules
+    -- that can never be loaded. A shim that only half-works is worse than no
+    -- shim.
+    xvm.add("perl", { bindir = bindir })
+    xvm.add("perldoc", { bindir = bindir, binding = "perl@" .. pkginfo.version() })
+    return true
+end
+
+function uninstall()
+    xvm.remove("perl")
+    xvm.remove("perldoc")
+    return true
+end

--- a/tests/p/test_perl.py
+++ b/tests/p/test_perl.py
@@ -1,0 +1,100 @@
+"""测试 perl 包"""
+import pytest
+from tests.lib.xpkg_parser import parse_xpkg
+from tests.lib.assertions import (
+    assert_required_fields, assert_valid_spec, assert_valid_type,
+    assert_no_typos, assert_no_exec_xvm, assert_no_bashrc_modification,
+    assert_no_direct_path_modification, assert_uses_new_api,
+    assert_xim_add_succeeds, assert_install_succeeds,
+    assert_command_output, assert_xvm_registered,
+)
+from tests.lib.platform_utils import skip_if_not
+
+PKG = "perl"
+PKG_FILE = "pkgs/p/perl.lua"
+
+
+@pytest.fixture(scope='module')
+def meta():
+    return parse_xpkg(PKG_FILE)
+
+
+class TestStatic:
+    @pytest.mark.static
+    def test_required_fields(self, meta):
+        assert_required_fields(meta)
+
+    @pytest.mark.static
+    def test_valid_spec(self, meta):
+        assert_valid_spec(meta)
+
+    @pytest.mark.static
+    def test_valid_type(self, meta):
+        assert_valid_type(meta)
+
+    @pytest.mark.static
+    def test_no_typos(self):
+        assert_no_typos(PKG_FILE)
+
+
+class TestIndex:
+    @pytest.mark.index
+    def test_xim_add(self):
+        assert_xim_add_succeeds(PKG_FILE)
+
+
+class TestIsolation:
+    @pytest.mark.isolation
+    def test_no_exec_xvm(self):
+        assert_no_exec_xvm(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_no_bashrc(self):
+        assert_no_bashrc_modification(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_no_path_modification(self):
+        assert_no_direct_path_modification(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_new_api(self):
+        assert_uses_new_api(PKG_FILE)
+
+
+class TestLifecycle:
+    @pytest.mark.lifecycle
+    @skip_if_not('linux')
+    def test_install(self):
+        # Perl's lib tree is ~2300 files; the default 180s can be tight on a
+        # cold cache.
+        assert_install_succeeds(PKG, timeout=600)
+
+
+class TestVerify:
+    @pytest.mark.verify
+    @skip_if_not('linux')
+    def test_perl_runs(self):
+        assert_command_output("perl -e 'print \"ok\\n\"'", contains="ok")
+
+    # The whole point of the package: a perl that HAS its core modules. A
+    # binary that runs but cannot `use FindBin` is the exact failure this
+    # package exists to prevent (mcpplibs/mcpp-index#140), and `perl
+    # --version` would pass right through it.
+    @pytest.mark.verify
+    @skip_if_not('linux')
+    def test_core_modules_load(self):
+        assert_command_output(
+            "perl -MFindBin -MConfig -MFile::Path -MPOSIX -MIO::File "
+            "-MDigest::MD5 -MExtUtils::MakeMaker -e 'print \"core-ok\\n\"'",
+            contains="core-ok",
+        )
+
+    @pytest.mark.verify
+    @skip_if_not('linux')
+    def test_xvm_perl(self):
+        assert_xvm_registered("perl")
+
+    @pytest.mark.verify
+    @skip_if_not('linux')
+    def test_xvm_perldoc(self):
+        assert_xvm_registered("perldoc")


### PR DESCRIPTION
## 用途

新增 `xim:perl` —— 一个**完整**(带全部 core module)且**尽可能静态**的 perl 5.44.0。

动机是 mcpplibs/mcpp-index#140:`compat.openssl` 的 `./config` 就是 perl 脚本,
开头 `use Config; use FindBin;`。在"有 perl 二进制、但 core module 被拆包/裁掉"的机器上
(复现于 Fedora 44 WSL,`/usr/sbin/perl` 找不到 `FindBin.pm`),失败发生在 OpenSSL
`Configure` 内部,报错完全看不出真实原因。descriptor 只能 `command -v perl` 探测,
没法把自己需要的 perl 带上 —— 因为**索引里没有 perl 包可以声明为 build dep**。
该包就是补这个洞;mcpp-index 的修复 PR 随后提交。

所以"完整"是硬要求,不是加分项:四个 asset 都带完整 core lib tree
(FindBin / Config / File::Path / POSIX / ExtUtils::\* / Digest::\* …)。

## 平台与架构

| platform | arch | 形态 |
|---|---|---|
| linux | x86_64, aarch64 | **完全静态** musl 二进制,无 glibc 下限 |
| macosx | x86_64, arm64 | relocatable(Apple 不支持静态链接 libSystem,不存在"静态 macOS 二进制") |

windows 不发:Windows 的答案是 Strawberry Perl,那是 ~250MB 的工具链发行版而非解释器,
索引里目前没有需求。

## 资源来源与校验

镜像 release:`xlings-res/perl@5.44.0`,GitHub(GLOBAL)+ GitCode(CN)两端同 tag。

| asset | sha256 | 来源 |
|---|---|---|
| `perl-5.44.0-linux-x86_64.tar.gz` | `b9e884be3df92028df0d023b482f033440ade29c5b9e715313d971b1542eff72` | CPAN 源码构建 |
| `perl-5.44.0-linux-aarch64.tar.gz` | `31b49b6b581b10d7d519ca358205cf4343c0ce1436ab443e421fd44be5ca4a9d` | CPAN 源码构建 |
| `perl-5.44.0-macosx-x86_64.tar.gz` | `c6b62e520fd9d4f733d6426d4adf0058675bb79bd9c36a77d9ae7909798436d7` | skaji/relocatable-perl 5.44.0.0 repack |
| `perl-5.44.0-macosx-arm64.tar.gz` | `2daae82c24f114eb708cee183bf1fe1ba86e1acc33c897dad55268dd221472f4` | skaji/relocatable-perl 5.44.0.0 repack |

上游源码:`https://www.cpan.org/src/5.0/perl-5.44.0.tar.gz`
sha256 `3b855066b92491cb40e86affb1ca57d1a388aa43e51b91c7806a32c2f65f96c3`。

四个 asset 均带 `.sha256` sidecar,release 里另有 `manifest.json`。
**GLOBAL 与 CN 各下载一次逐一比对,8 个 hash 全部一致**,且与 recipe 中声明的值一致。

linux 构建(Alpine 3.22 / gcc 14.2 musl):

```
./Configure -des -Dprefix=... -Duserelocatableinc \
    -Dd_procselfexe=define -Dprocselfexe='"/proc/self/exe"' \
    -Uusedl -Dusenm=false -Dcc=gcc \
    -Accflags='-O2 -fno-strict-aliasing -pipe' -Aldflags='-static' \
    -Dman1dir=none -Dman3dir=none
```

macosx 为 relocatable-perl 原始 payload 逐字节不变,只把 tar 顶层目录改名成 xlings-res 约定。
四个 asset 顶层目录统一为 `perl-5.44.0/`,所以 install hook 不需要知道 arch。

### 两个值得记录的坑

1. **`-Dd_procselfexe=define` 不是可选项。** 第一版没加,Configure 自己的探测返回
   `undef`,于是 perl 只能靠 argv[0] 定位自己 —— `env perl`(argv[0] = `"perl"`)和
   任何 symlink/xvm shim 下 @INC 都会退化成相对 CWD 的 `../lib/...`,
   `use strict` 都加载不了。而 OpenSSL 的 `Configure` 正是 `#!/usr/bin/env perl`。
   这个包如果那样发出去,恰好在它唯一要解决的场景里失效。
2. **`-Uusedl` 的代价**:没有 DynaLoader,这个 linux perl **装不了事后编译的 XS 模块**
   (`cpan Some::XS::Module` 不工作),纯 perl 模块和全部 core module 正常。
   这是"单个可移植二进制"的自觉取舍;`cpan` 因此**故意不注册 shim** —— 半可用的
   shim 比没有更糟。macOS 那版保留 DynaLoader,没有这个限制。

## 对用户环境的改动

`install()` 只把解包目录移进 install dir;`config()` 只 `xvm.add`;`uninstall()` 只
`xvm.remove`。不写 rc 文件、不改 PATH、不调用系统包管理器(L2 isolation 用例覆盖)。

只注册 `perl` 和 `perldoc` 两个 shim。目录里还有 `prove` / `shasum` / `json_pp` /
`ptar` / `splain` 这类通用名字,给它们建 shim 会让"为了一个构建脚本装了 perl"的用户
被静默遮蔽宿主同名工具;它们仍可通过 `<install>/bin` 访问。

## 验证结果

- `pytest tests/p/test_perl.py -m "static or isolation"` → 8 passed
- `python3 .github/scripts/version-check.py --workspace .` → 通过(本包未开 `ci.update`)
- **完整 CI job 本地复现**(容器内跑 `quick_install.sh` + `.github/scripts/posix-test.sh`,
  与 `linux-install-test` 同 xlings 版本 `v2026.7.29.0`):
  `tested: 1 / skipped: 0 / failures: 0`,install dir 落位,`perl`、`perldoc` 两个 shim
  创建并在 uninstall 后清理干净。
- **perl 自带测试套件**(静态 x86_64 构建,`make test_harness`):
  2793 个文件 / 1,113,058 个用例 **全部通过**。
  (构建容器不装 `tzdata` 时 `ext/POSIX/t/time.t` 有 4 条 DST 断言失败 —— 那是容器缺时区库,
  不是 perl 的问题:同一个二进制在有 tzdata 的宿主上,那 9 个 spring-forward 值逐条正确。)
- **端到端**:用构建出的静态 perl 跑 OpenSSL 3.5.1 `./config && make && make install_sw`
  → 产出 `libcrypto.a` (12MB) + `libssl.a` (2.1MB)。aarch64 那版在 qemu 下同样能跑通
  `./config`,且生成的 Makefile 里 `PERL=` 指向**真实二进制路径**(证明 `/proc/self/exe`
  解析生效,而不是那个 symlink)。

`latest` → `5.44.0`,即上表中已逐项验证的版本。
