### PR TITLE
bump(d2x): track 2026.08.02.1 as latest

### DIFF
--- a/pkgs/d/d2x.lua
+++ b/pkgs/d/d2x.lua
@@ -24,7 +24,8 @@ package = {
 
     xpm = {
         windows = {
-            ["latest"] = { ref = "2026.07.24.1" },
+            ["latest"] = { ref = "2026.08.02.1" },
+            ["2026.08.02.1"] = "XLINGS_RES",
             ["2026.07.24.1"] = "XLINGS_RES",
             ["0.1.5"] = "XLINGS_RES",
             ["0.1.4"] = "XLINGS_RES",
@@ -34,7 +35,8 @@ package = {
         },
         linux = {
             deps = { "xim:glibc@2.39", "xim:openssl@3.1.5" },
-            ["latest"] = { ref = "2026.07.24.1" },
+            ["latest"] = { ref = "2026.08.02.1" },
+            ["2026.08.02.1"] = "XLINGS_RES",
             ["2026.07.24.1"] = "XLINGS_RES",
             ["0.1.5"] = "XLINGS_RES",
             ["0.1.4"] = "XLINGS_RES",
@@ -44,7 +46,8 @@ package = {
             ["0.1.0"] = "XLINGS_RES",
         },
         macosx = {
-            ["latest"] = { ref = "2026.07.24.1" },
+            ["latest"] = { ref = "2026.08.02.1" },
+            ["2026.08.02.1"] = "XLINGS_RES",
             ["2026.07.24.1"] = "XLINGS_RES",
             ["0.1.5"] = "XLINGS_RES",
             ["0.1.4"] = "XLINGS_RES",


### PR DESCRIPTION
d2x `2026.08.02.1` 已发布,三平台把 `latest` 指过去并补上版本条目。

## 资源就位情况(已实测,非假设)

两源都用 **GET** 拉回来比对 sha256(不是 HEAD —— API 返回的
`browser_download_url` 走 `api.gitcode.com`,实测是 404,真正可服务的路径是
`gitcode.com/<repo>/releases/download/...`):

| 平台 | GitHub `xlings-res/d2x` | GitCode `xlings-res/d2x` |
| --- | --- | --- |
| linux-x86_64 | ✅ 与源一致 | ✅ 与源一致 |
| macosx-arm64 | ✅ 与源一致 | ✅ 与源一致 |
| windows-x86_64 | ✅ 与源一致 | ✅ 与源一致 |

GitCode 侧由 CN 主机经 `gtc` 上传(20 MB 的 linux 包 19s 传完)—— 按
`.agents/docs/2026-07-15-gitcode-large-asset-mirror-runbook.md`,GitHub runner
传不上去大文件,这步本就是维护者手动完成的。

## 该版内容

- Win10 / Win11 双 CI job,跑完整测试段(构建 → 版本自检 → 协议 e2e → d2mcpp 真课程 checker 冒烟)
- 修复 Windows 上 `normalize_path` 留下前导分隔符(`\src\...` → `src/...`)
- 补上 Windows 活性超时(Job Object 终止整棵进程树),协议 e2e 五组自此三平台同跑