### PR TITLE
feat(pkg): add jdk-temurin 25.0.4+7

### DIFF
--- a/pkgs/j/jdk-temurin.lua
+++ b/pkgs/j/jdk-temurin.lua
@@ -30,17 +30,38 @@ package = {
     -- (`openjdk-25-jdk`) / dnf (`java-25-openjdk`) / Arch (`jdk25-openjdk`)
     -- all embed the flavor in the name.
     --
+    -- VERSION STRING — the canonical version key carries the OpenJDK build
+    -- number (JEP 322: `$FEATURE.$INTERIM.$UPDATE+$BUILD`), matching the
+    -- upstream tag `jdk-25.0.4+7`, the Adoptium API semver `25.0.4+7.0.LTS`
+    -- and what mise/asdf call this build. But `java --version` prints only
+    -- `openjdk 25.0.4` on its first line (the `+7` shows up further down, in
+    -- `Temurin-25.0.4+7 (build 25.0.4+7-LTS)`), and `java.version` is plain
+    -- `25.0.4` -- so users reasonably type what they see. Hence the
+    -- `["25.0.4"] = { ref = "25.0.4+7" }` alias on every platform: both
+    -- `xlings install jdk-temurin@25.0.4` and `@25.0.4+7` resolve to the same
+    -- resource. Future security updates add their own pair (25.0.5 -> ...).
+    --
     -- PROVENANCE — Temurin (Eclipse Adoptium) 25.0.4+7, released 2026-07-29.
     -- Per-arch sha256 fetched from the Adoptium API
-    -- (api.adoptium.net/v3/assets/latest/25/hotspot).
+    -- (api.adoptium.net/v3/assets/release_name/eclipse/jdk-25.0.4%2B7) and
+    -- re-verified against the downloaded archives.
     --
     -- RESOURCE SHAPE — Shape B per-arch resource maps, because Adoptium's
     -- release tag and archive filename encode the build number differently:
     --   tag  jdk-25.0.4+7                  (URL-escaped as %2B)
     --   file OpenJDK25U-jdk_..._25.0.4_7.  (build joined with '_')
     -- A URL template cannot express both encodings, so each os/arch URL is
-    -- explicit. (The `+` version string itself is fine: it registers and
-    -- resolves under current xlings, verified locally.)
+    -- explicit. That also rules out `ci.update` / `ci.mirror`, which both
+    -- need a `${version}`-parameterized template; bumps stay manual, one
+    -- version block + one `latest`/alias edit per quarterly security update.
+    --
+    -- CN MIRROR — every URL is a {GLOBAL, CN} pair. GLOBAL is the Adoptium
+    -- release itself (no reason to re-host 648MB for the global path); CN is
+    -- gitcode.com/xlings-res/jdk-temurin, byte-identical copies of the same
+    -- five archives, each with a `.sha256` sidecar. The GitCode release tag
+    -- is `25.0.4_7`, not `25.0.4+7`: GitCode's release API decodes `+` in a
+    -- path segment back to a space and then 404s, so the mirror reuses the
+    -- underscore spelling Adoptium already uses in the archive filenames.
     --
     -- ARCH COVERAGE — Temurin 25 ships linux + macosx on x86_64/aarch64 but
     -- only x86_64 on windows (no windows-aarch64 JDK image for 25), so the
@@ -48,44 +69,68 @@ package = {
     -- union; a windows-aarch64 host fails closed with a clear error, which is
     -- the intended fail-closed behavior.
     --
-    -- RUNTIME DEPS — deliberately NONE on linux, unlike node.lua. The Temurin
-    -- JDK dynamically links host glibc, and every host in CI has it. Rewriting
-    -- INTERP/RPATH across the JDK's large ELF tree (libjvm & co.) via the
-    -- predicate-driven elfpatch is unvalidated at index time and risky; Alpine
-    -- / distroless support can add `deps = { runtime = {...} }` once a
-    -- real-machine elfpatch pass is verified.
+    -- RUNTIME DEPS — deliberately NONE, and the ELF tree says why: a full
+    -- readelf sweep of the linux x86_64 build shows the only hard external
+    -- DT_NEEDED set is glibc (libc/libdl/libm/libpthread/librt + the
+    -- ld-linux INTERP). There is no libstdc++/libgcc_s anywhere in the tree
+    -- (HotSpot links them statically), so this package does NOT need
+    -- node.lua's `xim:gcc-runtime`. libX11/libXext/libXi/libXrender/libXtst,
+    -- libasound and libfreetype appear only in libawt_xawt / libjsound /
+    -- libfontmanager / libsplashscreen, which a headless JVM never dlopens.
+    -- `bin/java` already carries RPATH `$ORIGIN:$ORIGIN/../lib`, so the tree
+    -- is relocatable as shipped. Alpine / distroless support means an
+    -- INTERP rewrite across that tree; that is a separate, real-machine
+    -- verified change, not something to declare blind here.
     xpm = {
         linux = {
             ["latest"] = { ref = "25.0.4+7" },
+            ["25.0.4"] = { ref = "25.0.4+7" },
             ["25.0.4+7"] = {
                 x86_64 = {
-                    url = "https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.4%2B7/OpenJDK25U-jdk_x64_linux_hotspot_25.0.4_7.tar.gz",
+                    url = {
+                        GLOBAL = "https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.4%2B7/OpenJDK25U-jdk_x64_linux_hotspot_25.0.4_7.tar.gz",
+                        CN = "https://gitcode.com/xlings-res/jdk-temurin/releases/download/25.0.4_7/OpenJDK25U-jdk_x64_linux_hotspot_25.0.4_7.tar.gz",
+                    },
                     sha256 = "e58fcdcd637b25c03ca84cbbcefc70d11efb8f4b4cbd05decc9f661769d77f94",
                 },
                 aarch64 = {
-                    url = "https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.4%2B7/OpenJDK25U-jdk_aarch64_linux_hotspot_25.0.4_7.tar.gz",
+                    url = {
+                        GLOBAL = "https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.4%2B7/OpenJDK25U-jdk_aarch64_linux_hotspot_25.0.4_7.tar.gz",
+                        CN = "https://gitcode.com/xlings-res/jdk-temurin/releases/download/25.0.4_7/OpenJDK25U-jdk_aarch64_linux_hotspot_25.0.4_7.tar.gz",
+                    },
                     sha256 = "621f7196f0b682fb557da58bec89bd7dfe5419811fe1c0ba75c9cc8432f084c7",
                 },
             },
         },
         macosx = {
             ["latest"] = { ref = "25.0.4+7" },
+            ["25.0.4"] = { ref = "25.0.4+7" },
             ["25.0.4+7"] = {
                 x86_64 = {
-                    url = "https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.4%2B7/OpenJDK25U-jdk_x64_mac_hotspot_25.0.4_7.tar.gz",
+                    url = {
+                        GLOBAL = "https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.4%2B7/OpenJDK25U-jdk_x64_mac_hotspot_25.0.4_7.tar.gz",
+                        CN = "https://gitcode.com/xlings-res/jdk-temurin/releases/download/25.0.4_7/OpenJDK25U-jdk_x64_mac_hotspot_25.0.4_7.tar.gz",
+                    },
                     sha256 = "a5ac9c46dad47ac06df35e36d096913195d8da1f3f71918828bcc2cfe33869b7",
                 },
                 aarch64 = {
-                    url = "https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.4%2B7/OpenJDK25U-jdk_aarch64_mac_hotspot_25.0.4_7.tar.gz",
+                    url = {
+                        GLOBAL = "https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.4%2B7/OpenJDK25U-jdk_aarch64_mac_hotspot_25.0.4_7.tar.gz",
+                        CN = "https://gitcode.com/xlings-res/jdk-temurin/releases/download/25.0.4_7/OpenJDK25U-jdk_aarch64_mac_hotspot_25.0.4_7.tar.gz",
+                    },
                     sha256 = "5a101c54abf5a9f16c0f70d8c38ba99e6567c1ba213378f0bb04497284f051bd",
                 },
             },
         },
         windows = {
             ["latest"] = { ref = "25.0.4+7" },
+            ["25.0.4"] = { ref = "25.0.4+7" },
             ["25.0.4+7"] = {
                 x86_64 = {
-                    url = "https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.4%2B7/OpenJDK25U-jdk_x64_windows_hotspot_25.0.4_7.zip",
+                    url = {
+                        GLOBAL = "https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.4%2B7/OpenJDK25U-jdk_x64_windows_hotspot_25.0.4_7.zip",
+                        CN = "https://gitcode.com/xlings-res/jdk-temurin/releases/download/25.0.4_7/OpenJDK25U-jdk_x64_windows_hotspot_25.0.4_7.zip",
+                    },
                     sha256 = "7caab7db43bf4b94a2e6252c699e70d90084f9aa7c943cd3414761fd540937ae",
                 },
             },
@@ -97,11 +142,29 @@ import("xim.libxpkg.pkginfo")
 import("xim.libxpkg.xvm")
 import("xim.libxpkg.log")
 
+-- Every Temurin archive expands to a top-level `jdk-<version>/`, but what
+-- sits under it is NOT uniform: linux and windows put the runtime right
+-- there (`jdk-25.0.4+7/bin/java`), while macOS ships a signed .jdk bundle
+-- and buries it one level down:
+--
+--   linux/windows  jdk-25.0.4+7/bin/java
+--   macosx         jdk-25.0.4+7/Contents/Home/bin/java
+--                  jdk-25.0.4+7/Contents/_CodeSignature/...
+--
+-- Moving the bundle root into install_dir on macOS would leave every shim
+-- (and JAVA_HOME) pointing at a directory with no `bin/`, so the macOS
+-- payload is the inner `Contents/Home`. After this, install_dir() IS
+-- JAVA_HOME on all three platforms and the rest of the recipe is
+-- arch/os-agnostic.
+local function payload_dir()
+    local root = "jdk-" .. pkginfo.version()
+    if os.host() == "macosx" then
+        return path.join(root, "Contents", "Home")
+    end
+    return root
+end
+
 function install()
-    -- Every Temurin archive — all os/arch pairs — expands to the SAME
-    -- top-level directory `jdk-<version>/` (e.g. jdk-25.0.4+7), so this hook
-    -- needs no arch knowledge.
-    --
     -- Idempotent across xim engines (same rationale as perl.lua): some stage
     -- the extracted payload into install_dir() before/without the hook, others
     -- leave it in the hook CWD for us to move. Never wipe install_dir before a
@@ -112,37 +175,98 @@ function install()
     local staged = path.join(pkginfo.install_dir(), "bin", exe)
     if os.isfile(staged) then return true end
 
-    local payload = "jdk-" .. pkginfo.version()
+    local payload = payload_dir()
     if os.isdir(payload) then
         os.tryrm(pkginfo.install_dir())
         os.mv(payload, pkginfo.install_dir())
     end
-    return os.isfile(staged)
+
+    if not os.isfile(staged) then
+        log.error("jdk-temurin: no java launcher at %s (payload dir: %s)", staged, payload)
+        return false
+    end
+    return true
+end
+
+-- Shared launcher names, and the flavor-tagged version they register under.
+--
+-- `java`/`javac`/... are NOT owned by Temurin: jdk-zulu, jdk-oracle,
+-- jdk-microsoft and friends are all builds of the SAME upstream OpenJDK tag,
+-- so a sibling recipe would want to register `java` at the very same
+-- "25.0.4+7". xvm refuses that outright -- the second package's whole config
+-- batch is rejected:
+--
+--   field: /nodes/0
+--   hint:  another package already owns this exact name and version;
+--          uninstall that package first, or install this one at a different
+--          version
+--   Error: [jdk-<other>] failed: config hook failed
+--
+-- i.e. with the plain numeric version, installing Temurin would make every
+-- other JDK distribution uninstallable, which defeats the whole point of
+-- putting the flavor in the package name. So the shared names register as
+-- `<version>-temurin`, exactly the idiom musl-gcc.lua uses to share `gcc`
+-- with gcc.lua ("16.1.0-musl"). `xlings use java 25.0.4+7-temurin` then names
+-- one flavor unambiguously, and the whole set still switches together via the
+-- binding root below.
+local PROGRAMS = { "java", "javac", "jar", "javadoc", "jshell" }
+local FLAVOR = "temurin"
+
+local function flavor_version()
+    return pkginfo.version() .. "-" .. FLAVOR
 end
 
 function config()
-    local bindir = path.join(pkginfo.install_dir(), "bin")
-    local binding = "jdk-temurin@" .. pkginfo.version()
+    -- install_dir() is the JDK home on every platform (see payload_dir).
+    local java_home = pkginfo.install_dir()
+    local bindir = path.join(java_home, "bin")
 
-    -- Register the package name itself so `xlings use jdk-temurin` can switch
-    -- between installed JDK versions.
-    xvm.add("jdk-temurin", { bindir = bindir })
+    -- Root of this release's binding group. The package name already carries
+    -- the flavor, so the root keeps the plain version and `xlings use
+    -- jdk-temurin 25.0.4+7` switches every program bound to it in one step.
+    -- `type = "group"` because the node names no artifact: there is no
+    -- `bin/jdk-temurin` to exec, and left as the default `program` kind it
+    -- becomes a shim that can only ever fail, which `self doctor` then reports
+    -- as an orphan (openxlings/xlings#452). Same idiom as gcc.lua / rust.lua.
+    local binding = "jdk-temurin@" .. pkginfo.version()
+    xvm.add("jdk-temurin", { type = "group" })
+
+    -- Nearly every JVM-ecosystem tool (maven, gradle, the wrappers, IDE
+    -- launchers) locates a JDK through JAVA_HOME rather than PATH, so a JDK
+    -- that only registers shims is half-installed. xvm attaches these to the
+    -- shim, so they apply to processes started through `java`/`javac`/... and
+    -- follow `xlings use` automatically instead of pinning one JDK in a
+    -- profile file. Note the boundary: this does NOT export JAVA_HOME into
+    -- the user's interactive shell, so a tool invoked outside these shims
+    -- still needs its own JAVA_HOME (printed below once at install time).
+    local env = { JAVA_HOME = java_home }
 
     -- Core developer-facing launchers. The tree also carries ~90 more tools
     -- (jlink, jmod, jpackage, keytool, ...); they stay reachable through
     -- <install>/bin and are deliberately NOT registered, so installing the
     -- JDK doesn't shadow unrelated system tools.
-    for _, prog in ipairs({ "java", "javac", "jar", "javadoc", "jshell" }) do
-        xvm.add(prog, { bindir = bindir, binding = binding })
+    for _, prog in ipairs(PROGRAMS) do
+        xvm.add(prog, {
+            bindir = bindir,
+            version = flavor_version(),
+            binding = binding,
+            envs = env,
+        })
     end
+
+    log.info("jdk-temurin: JAVA_HOME = %s", java_home)
+    log.info("jdk-temurin: java/javac/jar/javadoc/jshell registered as %s; other JDK tools live in %s",
+             flavor_version(), bindir)
 
     return true
 end
 
 function uninstall()
-    xvm.remove("jdk-temurin")
-    for _, prog in ipairs({ "java", "javac", "jar", "javadoc", "jshell" }) do
-        xvm.remove(prog)
+    -- Both removals are version-scoped: another installed JDK version (or, for
+    -- the shared names, another JDK distribution) must keep its nodes.
+    for _, prog in ipairs(PROGRAMS) do
+        xvm.remove(prog, flavor_version())
     end
+    xvm.remove("jdk-temurin", pkginfo.version())
     return true
 end

--- a/pkgs/j/jdk-temurin.lua
+++ b/pkgs/j/jdk-temurin.lua
@@ -1,0 +1,148 @@
+package = {
+    spec = "2",
+
+    -- base info
+    name = "jdk-temurin",
+    description = "Eclipse Temurin JDK 25 — a production-ready binary build of OpenJDK (LTS)",
+
+    homepage = "https://adoptium.net",
+    repo = "https://github.com/adoptium/temurin25-binaries",
+    docs = "https://adoptium.net/docs",
+    authors = {"Eclipse Adoptium"},
+    licenses = {"GPL-2.0-with-classpath-exception"},
+
+    -- xim pkg info
+    type = "package",
+    archs = {"x86_64", "aarch64"},
+    status = "stable",
+    categories = {"language", "jvm", "runtime", "toolchain"},
+    keywords = {"java", "jdk", "openjdk", "temurin", "jvm", "hotspot"},
+
+    programs = {"java", "javac", "jar", "javadoc", "jshell"},
+    xvm_enable = true,
+
+    -- WHY THE NAME
+    --
+    -- The flavor is in the package name (`jdk-temurin`) so other
+    -- distributions can coexist as jdk-oracle / jdk-microsoft / jdk-zulu
+    -- later; the JDK version lives in the version dimension (25.0.4+7), so
+    -- future JDK 26/27 land in this same package. This mirrors how apt
+    -- (`openjdk-25-jdk`) / dnf (`java-25-openjdk`) / Arch (`jdk25-openjdk`)
+    -- all embed the flavor in the name.
+    --
+    -- PROVENANCE — Temurin (Eclipse Adoptium) 25.0.4+7, released 2026-07-29.
+    -- Per-arch sha256 fetched from the Adoptium API
+    -- (api.adoptium.net/v3/assets/latest/25/hotspot).
+    --
+    -- RESOURCE SHAPE — Shape B per-arch resource maps, because Adoptium's
+    -- release tag and archive filename encode the build number differently:
+    --   tag  jdk-25.0.4+7                  (URL-escaped as %2B)
+    --   file OpenJDK25U-jdk_..._25.0.4_7.  (build joined with '_')
+    -- A URL template cannot express both encodings, so each os/arch URL is
+    -- explicit. (The `+` version string itself is fine: it registers and
+    -- resolves under current xlings, verified locally.)
+    --
+    -- ARCH COVERAGE — Temurin 25 ships linux + macosx on x86_64/aarch64 but
+    -- only x86_64 on windows (no windows-aarch64 JDK image for 25), so the
+    -- windows entry has a single arch. `archs = {x86_64, aarch64}` is the
+    -- union; a windows-aarch64 host fails closed with a clear error, which is
+    -- the intended fail-closed behavior.
+    --
+    -- RUNTIME DEPS — deliberately NONE on linux, unlike node.lua. The Temurin
+    -- JDK dynamically links host glibc, and every host in CI has it. Rewriting
+    -- INTERP/RPATH across the JDK's large ELF tree (libjvm & co.) via the
+    -- predicate-driven elfpatch is unvalidated at index time and risky; Alpine
+    -- / distroless support can add `deps = { runtime = {...} }` once a
+    -- real-machine elfpatch pass is verified.
+    xpm = {
+        linux = {
+            ["latest"] = { ref = "25.0.4+7" },
+            ["25.0.4+7"] = {
+                x86_64 = {
+                    url = "https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.4%2B7/OpenJDK25U-jdk_x64_linux_hotspot_25.0.4_7.tar.gz",
+                    sha256 = "e58fcdcd637b25c03ca84cbbcefc70d11efb8f4b4cbd05decc9f661769d77f94",
+                },
+                aarch64 = {
+                    url = "https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.4%2B7/OpenJDK25U-jdk_aarch64_linux_hotspot_25.0.4_7.tar.gz",
+                    sha256 = "621f7196f0b682fb557da58bec89bd7dfe5419811fe1c0ba75c9cc8432f084c7",
+                },
+            },
+        },
+        macosx = {
+            ["latest"] = { ref = "25.0.4+7" },
+            ["25.0.4+7"] = {
+                x86_64 = {
+                    url = "https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.4%2B7/OpenJDK25U-jdk_x64_mac_hotspot_25.0.4_7.tar.gz",
+                    sha256 = "a5ac9c46dad47ac06df35e36d096913195d8da1f3f71918828bcc2cfe33869b7",
+                },
+                aarch64 = {
+                    url = "https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.4%2B7/OpenJDK25U-jdk_aarch64_mac_hotspot_25.0.4_7.tar.gz",
+                    sha256 = "5a101c54abf5a9f16c0f70d8c38ba99e6567c1ba213378f0bb04497284f051bd",
+                },
+            },
+        },
+        windows = {
+            ["latest"] = { ref = "25.0.4+7" },
+            ["25.0.4+7"] = {
+                x86_64 = {
+                    url = "https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.4%2B7/OpenJDK25U-jdk_x64_windows_hotspot_25.0.4_7.zip",
+                    sha256 = "7caab7db43bf4b94a2e6252c699e70d90084f9aa7c943cd3414761fd540937ae",
+                },
+            },
+        },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+import("xim.libxpkg.log")
+
+function install()
+    -- Every Temurin archive — all os/arch pairs — expands to the SAME
+    -- top-level directory `jdk-<version>/` (e.g. jdk-25.0.4+7), so this hook
+    -- needs no arch knowledge.
+    --
+    -- Idempotent across xim engines (same rationale as perl.lua): some stage
+    -- the extracted payload into install_dir() before/without the hook, others
+    -- leave it in the hook CWD for us to move. Never wipe install_dir before a
+    -- replacement payload is confirmed, and never report success unless the
+    -- launcher is actually in place — `return true` over an empty dir gets
+    -- stamped as installed and leaves dangling xvm shims behind.
+    local exe = os.host() == "windows" and "java.exe" or "java"
+    local staged = path.join(pkginfo.install_dir(), "bin", exe)
+    if os.isfile(staged) then return true end
+
+    local payload = "jdk-" .. pkginfo.version()
+    if os.isdir(payload) then
+        os.tryrm(pkginfo.install_dir())
+        os.mv(payload, pkginfo.install_dir())
+    end
+    return os.isfile(staged)
+end
+
+function config()
+    local bindir = path.join(pkginfo.install_dir(), "bin")
+    local binding = "jdk-temurin@" .. pkginfo.version()
+
+    -- Register the package name itself so `xlings use jdk-temurin` can switch
+    -- between installed JDK versions.
+    xvm.add("jdk-temurin", { bindir = bindir })
+
+    -- Core developer-facing launchers. The tree also carries ~90 more tools
+    -- (jlink, jmod, jpackage, keytool, ...); they stay reachable through
+    -- <install>/bin and are deliberately NOT registered, so installing the
+    -- JDK doesn't shadow unrelated system tools.
+    for _, prog in ipairs({ "java", "javac", "jar", "javadoc", "jshell" }) do
+        xvm.add(prog, { bindir = bindir, binding = binding })
+    end
+
+    return true
+end
+
+function uninstall()
+    xvm.remove("jdk-temurin")
+    for _, prog in ipairs({ "java", "javac", "jar", "javadoc", "jshell" }) do
+        xvm.remove(prog)
+    end
+    return true
+end

--- a/tests/j/test_jdk_temurin.py
+++ b/tests/j/test_jdk_temurin.py
@@ -1,0 +1,93 @@
+"""测试 jdk-temurin 包"""
+import pytest
+from tests.lib.xpkg_parser import parse_xpkg
+from tests.lib.assertions import (
+    assert_required_fields, assert_valid_spec, assert_valid_type,
+    assert_no_typos, assert_no_exec_xvm, assert_no_bashrc_modification,
+    assert_no_direct_path_modification, assert_uses_new_api,
+    assert_xim_add_succeeds, assert_install_succeeds,
+    assert_command_output, assert_xvm_registered,
+)
+from tests.lib.platform_utils import skip_if_not
+
+PKG = "jdk-temurin"
+PKG_FILE = "pkgs/j/jdk-temurin.lua"
+
+
+@pytest.fixture(scope='module')
+def meta():
+    return parse_xpkg(PKG_FILE)
+
+
+class TestStatic:
+    @pytest.mark.static
+    def test_required_fields(self, meta):
+        assert_required_fields(meta)
+
+    @pytest.mark.static
+    def test_valid_spec(self, meta):
+        assert_valid_spec(meta)
+
+    @pytest.mark.static
+    def test_valid_type(self, meta):
+        assert_valid_type(meta)
+
+    @pytest.mark.static
+    def test_no_typos(self):
+        assert_no_typos(PKG_FILE)
+
+
+class TestIndex:
+    @pytest.mark.index
+    def test_xim_add(self):
+        assert_xim_add_succeeds(PKG_FILE)
+
+
+class TestIsolation:
+    @pytest.mark.isolation
+    def test_no_exec_xvm(self):
+        assert_no_exec_xvm(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_no_bashrc(self):
+        assert_no_bashrc_modification(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_no_path_modification(self):
+        assert_no_direct_path_modification(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_new_api(self):
+        assert_uses_new_api(PKG_FILE)
+
+
+class TestLifecycle:
+    @pytest.mark.lifecycle
+    @skip_if_not('linux')
+    def test_install(self):
+        # The JDK 25 tarball is ~200MB; the default 180s can be tight on a
+        # cold cache.
+        assert_install_succeeds(PKG, timeout=420)
+
+
+class TestVerify:
+    @pytest.mark.verify
+    @skip_if_not('linux')
+    def test_java_version(self):
+        # java prints its version banner on stderr.
+        assert_command_output("java -version 2>&1", contains="25")
+
+    @pytest.mark.verify
+    @skip_if_not('linux')
+    def test_javac_version(self):
+        assert_command_output("javac -version", contains="25")
+
+    @pytest.mark.verify
+    @skip_if_not('linux')
+    def test_xvm_java(self):
+        assert_xvm_registered("java")
+
+    @pytest.mark.verify
+    @skip_if_not('linux')
+    def test_xvm_javac(self):
+        assert_xvm_registered("javac")

--- a/tests/j/test_jdk_temurin.py
+++ b/tests/j/test_jdk_temurin.py
@@ -1,4 +1,6 @@
 """测试 jdk-temurin 包"""
+import re
+
 import pytest
 from tests.lib.xpkg_parser import parse_xpkg
 from tests.lib.assertions import (
@@ -12,6 +14,17 @@ from tests.lib.platform_utils import skip_if_not
 
 PKG = "jdk-temurin"
 PKG_FILE = "pkgs/j/jdk-temurin.lua"
+
+PLATFORMS = ("linux", "macosx", "windows")
+# One resource per (platform, arch): linux x2, macosx x2, windows x1.
+RESOURCE_COUNT = 5
+
+
+def _code(content: str) -> str:
+    """去掉 lua 行注释, 让下面的静态断言只看真实声明 (注释里也写了这些字面量)"""
+    return "\n".join(
+        line for line in content.splitlines() if not line.lstrip().startswith("--")
+    )
 
 
 @pytest.fixture(scope='module')
@@ -35,6 +48,61 @@ class TestStatic:
     @pytest.mark.static
     def test_no_typos(self):
         assert_no_typos(PKG_FILE)
+
+    @pytest.mark.static
+    def test_plain_version_alias(self, meta):
+        """`java --version` 只显示 25.0.4, 所以每个平台都要有 25.0.4 -> 25.0.4+7 别名"""
+        aliases = re.findall(
+            r'\["25\.0\.4"\]\s*=\s*\{\s*ref\s*=\s*"25\.0\.4\+7"\s*\}',
+            _code(meta.raw_content),
+        )
+        assert len(aliases) == len(PLATFORMS), \
+            f"25.0.4 别名应覆盖 {PLATFORMS}, 实际 {len(aliases)} 个"
+
+    @pytest.mark.static
+    def test_every_resource_has_cn_mirror(self, meta):
+        """每个资源都要有 GLOBAL(upstream) + CN(gitcode) 两个源, 且 sha256 齐全"""
+        content = _code(meta.raw_content)
+        global_urls = re.findall(
+            r'GLOBAL = "https://github\.com/adoptium/temurin25-binaries/[^"]+"', content)
+        cn_urls = re.findall(
+            r'CN = "https://gitcode\.com/xlings-res/jdk-temurin/[^"]+"', content)
+        shas = re.findall(r'sha256 = "[0-9a-f]{64}"', content)
+        assert len(global_urls) == RESOURCE_COUNT, f"GLOBAL 源数量: {len(global_urls)}"
+        assert len(cn_urls) == RESOURCE_COUNT, f"CN 源数量: {len(cn_urls)}"
+        assert len(shas) == RESOURCE_COUNT, f"sha256 数量: {len(shas)}"
+        # GitCode 的 release API 会把路径里的 `+` 解成空格然后 404, 镜像 tag 用 `_`。
+        assert "%2B" not in "".join(cn_urls), "CN 镜像 tag 不能带 URL 编码的 '+'"
+
+    @pytest.mark.static
+    def test_macos_bundle_layout(self, meta):
+        """macOS 是 .jdk bundle: bin 在 Contents/Home 下, 不能按 linux 布局搬运"""
+        content = _code(meta.raw_content)
+        assert re.search(r'os\.host\(\)\s*==\s*"macosx"', content), \
+            "install 必须区分 macosx 布局"
+        assert re.search(r'"Contents"\s*,\s*"Home"', content), \
+            "macOS payload 必须是 jdk-<ver>/Contents/Home"
+
+    @pytest.mark.static
+    def test_shared_names_are_flavor_scoped(self, meta):
+        """java/javac 等是所有 JDK 发行版共享的名字, 必须带 flavor 版本
+
+        用裸的数字版本注册的话, jdk-zulu/jdk-oracle 想注册同一个 `java@25.0.4+7`
+        会被 xvm 直接拒绝 (another package already owns this exact name and
+        version), 整个 config 批次失败 —— 等于 Temurin 一装, 别的发行版就装不上。
+        """
+        code = _code(meta.raw_content)
+        assert re.search(r'version\s*=\s*flavor_version\(\)', code), \
+            "共享程序名必须用 flavor_version() 注册"
+        assert re.search(r'pkginfo\.version\(\)\s*\.\.\s*"-"\s*\.\.\s*FLAVOR', code), \
+            "flavor_version 必须是 <version>-<flavor>"
+        assert 'type = "group"' in code, \
+            "binding root 应为 group 节点, 否则会留下永远失败的孤儿 shim"
+
+    @pytest.mark.static
+    def test_java_home_registered(self, meta):
+        """JDK 只注册 shim 不给 JAVA_HOME 的话, maven/gradle 之类工具找不到它"""
+        assert "JAVA_HOME" in _code(meta.raw_content), "config 应通过 xvm envs 提供 JAVA_HOME"
 
 
 class TestIndex:
@@ -74,13 +142,33 @@ class TestVerify:
     @pytest.mark.verify
     @skip_if_not('linux')
     def test_java_version(self):
-        # java prints its version banner on stderr.
-        assert_command_output("java -version 2>&1", contains="25")
+        # java prints its version banner on stderr. Assert the full build
+        # string: "25" alone would also match a pre-existing system JDK.
+        assert_command_output("java -version 2>&1", contains="25.0.4+7")
 
     @pytest.mark.verify
     @skip_if_not('linux')
     def test_javac_version(self):
-        assert_command_output("javac -version", contains="25")
+        assert_command_output("javac -version", contains="25.0.4")
+
+    @pytest.mark.verify
+    @skip_if_not('linux')
+    def test_java_home_points_at_xpkg(self):
+        """java.home 必须落在本包的安装目录里 (macOS 上即 Contents/Home 那一层)"""
+        assert_command_output(
+            "java -XshowSettings:properties -version 2>&1",
+            regex=r"java\.home = .*jdk-temurin",
+        )
+
+    @pytest.mark.verify
+    @skip_if_not('linux')
+    def test_java_home_env_reaches_jvm(self):
+        """config 注册的 JAVA_HOME 必须真的进到 java 进程的环境里 (maven/gradle 靠它)"""
+        assert_command_output(
+            '''echo 'System.out.println("JH=[" + System.getenv("JAVA_HOME") + "]");' '''
+            '''| jshell -s - 2>&1''',
+            regex=r"JH=\[.*jdk-temurin.*\]",
+        )
 
     @pytest.mark.verify
     @skip_if_not('linux')


### PR DESCRIPTION
## 用途

新增 `jdk-temurin` —— Eclipse Adoptium 构建的 **Temurin OpenJDK 25**（LTS）JDK 包，
提供可版本管理的 Java 运行时 + 编译工具链：`xlings install jdk-temurin@25.0.4+7`。

命名带发行版标记：`jdk-temurin`，后续 `jdk-oracle` / `jdk-microsoft` / `jdk-zulu` 可
并存区分（apt `openjdk-25-jdk` / dnf `java-25-openjdk` / Arch `jdk25-openjdk` 均把发行版
放进名字）；JDK 版本走版本维度，未来 JDK 26/27 落在同一包。

## 平台与架构

| platform | arch |
|---|---|
| linux | x86_64, aarch64 |
| macosx | x86_64, aarch64 |
| windows | x86_64（Temurin 25 **无** windows-aarch64 JDK image，仅发 x64） |

`archs = {"x86_64", "aarch64"}` 为并集；windows-aarch64 主机按 spec 的 fail-closed
规则明确报错，而非错误安装。

## 资源来源与校验

资源直接来自 Adoptium 官方 release `adoptium/temurin25-binaries`，tag `jdk-25.0.4+7`
（2026-07-29 发布）。per-arch SHA256 取自 Adoptium API
(`api.adoptium.net/v3/assets/latest/25/hotspot`) 并本地核验一致。

| platform | arch | sha256 |
|---|---|---|
| linux | x86_64 | `e58fcdcd637b25c03ca84cbbcefc70d11efb8f4b4cbd05decc9f661769d77f94` |
| linux | aarch64 | `621f7196f0b682fb557da58bec89bd7dfe5419811fe1c0ba75c9cc8432f084c7` |
| macosx | x86_64 | `a5ac9c46dad47ac06df35e36d096913195d8da1f3f71918828bcc2cfe33869b7` |
| macosx | aarch64 | `5a101c54abf5a9f16c0f70d8c38ba99e6567c1ba213378f0bb04497284f051bd` |
| windows | x86_64 | `7caab7db43bf4b94a2e6252c699e70d90084f9aa7c943cd3414761fd540937ae` |

URL 均为 GitHub release 直链（tag 中 `+` 编码为 `%2B`，归档文件名中 build 用 `_`）。

### 两个值得记录的坑

1. **Adoptium 的 tag / 文件名双重编码**（`jdk-25.0.4+7` vs `OpenJDK25U-..._25.0.4_7.tar.gz`），
   URL 模板无法同时表达，因此用 **Shape B per-arch resource map** 显式写 URL。这也意味着
   该包**无法接入自动升级**（`version-check.py` 依赖 `url_template`/`res_versioned`），
   保持手动维护，每季度随安全更新（25.0.5 …）手动加版本项 + 更新 `latest`。
2. **无 linux runtime deps**：Temurin JDK 动态链接 glibc，但对该大型 ELF 树（`libjvm` 等）
   做 predicate-driven elfpatch 未经真机验证、有风险；CI 跑在标准 glibc 主机上无需依赖。
   Alpine / distroless 支持可在后续真机验证 elfpatch 后再补 `deps = { runtime = {...} }`。

## 对用户环境的改动

`install()` 只把解包目录 `jdk-<version>/` 重命名进 install dir（`os.tryrm` + `os.mv`）；
`config()` 只 `xvm.add`；`uninstall()` 只 `xvm.remove`。不写 rc 文件、不改 PATH、
不调用系统包管理器（L2 isolation 用例覆盖）。

注册 shim：`jdk-temurin`（包名，支持 `xlings use` 切换版本）、`java`、`javac`、`jar`、
`javadoc`、`jshell`。JDK 目录里还有约 90 个其它工具（`jlink`/`jmod`/`jpackage`/`keytool`…），
故意不注册，避免遮蔽宿主工具；仍可通过 `<install>/bin` 访问。

## 验证结果

- `pytest tests/j/test_jdk_temurin.py -m "static or isolation or index"` + 全局 spec
  D1/D3 → **11 passed**
- `python3 .github/scripts/version-check.py --workspace .` → 通过（本包未开 `ci.update`）
- 下载 URL → HTTP 200；下载文件 SHA256 与 Adoptium API 声明逐字节一致
- 归档顶层目录 `jdk-25.0.4+7/` → 与 install hook 假设一致
- 解压后实测：`java -version` → `openjdk 25.0.4 (build 25.0.4+7-LTS)`，`javac 25.0.4`
- `25.0.4+7` 含 `+` 的版本号已被 xlings 实测可正常注册/解析
- **完整 install/uninstall 生命周期**：本机到 GitHub 仅 ~47KB/s，200MB 归档下载无法在
  超时内完成，交由本仓库 CI（`posix-test.sh`，GitHub Actions ubuntu）验证

`latest` → `25.0.4+7`，即上表中已核验的版本。

---

## 维护者跟进 — commit `fix(jdk-temurin): macOS bundle layout, JAVA_HOME, flavor-scoped xvm nodes, CN mirror`

评审后在本分支上直接补了 5 处，每一处都在真机上验证过（Linux x86_64 实装 / 直接核对上游归档）。上面原始描述里有两条已经被这次跟进推翻，见「更正」。

### 1. macOS 布局（阻塞级修复）

Temurin 的 macOS 归档是签名过的 `.jdk` bundle，不是 linux 那种扁平树：

```
linux/windows   jdk-25.0.4+7/bin/java
macosx          jdk-25.0.4+7/Contents/Home/bin/java
                jdk-25.0.4+7/Contents/_CodeSignature/...
```

原 `install()` 把 bundle 根目录搬进 `install_dir()`，于是 `install_dir/bin/java` 不存在 → `os.isfile(staged)` 为 false → **install() 返回 false，macOS 必装失败**；就算放过，`config()` 的 `bindir` 也会指向一个没有 `bin/` 的目录。现在 macOS 的 payload 取内层 `Contents/Home`，副作用是 `install_dir()` 在三个平台上都正好等于 JDK home。

### 2. `25.0.4` 版本别名

`java --version` 第一行只有 `openjdk 25.0.4`，`java.version` 也是 `25.0.4`，`+7` 只出现在 runtime/VM 行（`Temurin-25.0.4+7 (build 25.0.4+7-LTS)`）。用户按看到的敲，所以三个平台都加了 `["25.0.4"] = { ref = "25.0.4+7" }`，`@25.0.4` 和 `@25.0.4+7` 落到同一份资源。版本键本身保持上游拼写（Adoptium tag `jdk-25.0.4+7`、API semver `25.0.4+7.0.LTS`，mise/asdf 也带 build 号）。

### 3. `JAVA_HOME`

maven / gradle / `mvnw` / `gradlew` / IDE 找 JDK 靠的是 `JAVA_HOME` 而不是 PATH，只注册 shim 等于装了一半。现在通过 xvm 的 `envs` 挂在 shim 上，跟着 `xlings use` 走，不写 profile。实测（`System.getenv` 在 JVM 里读）：

```
$ echo 'System.out.println("JH=["+System.getenv("JAVA_HOME")+"]");' | jshell -s -
JH=[.../xpkgs/local-x-jdk-temurin/25.0.4+7]
$ echo "shell: [$JAVA_HOME]"
shell: []            # 交互 shell 不受污染，隔离照旧
```

边界写进注释了：只对经由本包 shim 启动的进程生效。

### 4. 共享程序名改用 flavor 版本（多发行版共存）

`java`/`javac`/… 不是 Temurin 独占的名字——Zulu / Corretto / Microsoft 构建的是**同一个上游 OpenJDK tag**，也会想注册 `java@25.0.4+7`。用一个临时探针包实测，xvm 直接 fail-closed：

```
field: /nodes/0
hint:  another package already owns this exact name and version;
       uninstall that package first, or install this one at a different version
Error: [jdk-zulu-probe] failed: config hook failed
```

整批 config 被拒 → **只要装了 Temurin，别的 JDK 发行版就装不上**，这跟「把发行版放进包名以便共存」的设计目标正好相反。所以共享名改成注册 `25.0.4+7-temurin`，就是 `musl-gcc.lua` 跟 `gcc.lua` 共享 `gcc` 时用的写法（`16.1.0-musl`）。改完再跑探针：

```
java: active=local:25.0.4+7-temurin  installed=[local:25.0.4+7, local:25.0.4+7-temurin]
$ xlings use java 25.0.4+7          → openjdk 21.0.11   (另一个发行版)
$ xlings use java 25.0.4+7-temurin  → openjdk 25.0.4 (build 25.0.4+7-LTS)
$ xlings use jdk-temurin 25.0.4+7   → 整组一起切
```

顺带把 binding root 改成 `xvm.add("jdk-temurin", { type = "group" })`。原来的 `program` 型根节点会在 `bin/` 里留一个永远执行失败的 `jdk-temurin` shim（`self doctor` 判为孤儿，openxlings/xlings#452）；改完 `bin/` 里不再出现它，`xlings use jdk-temurin` 照常工作。`uninstall()` 的两处 remove 也都带上版本，避免误删别的版本/别的发行版的节点。

### 5. CN 镜像（GitCode）

每个资源现在是 `{ GLOBAL, CN }`：GLOBAL 仍是 Adoptium 官方 release（全球路径没必要再存一份 648MB），CN 是 `gitcode.com/xlings-res/jdk-temurin`，5 个归档 + 5 个 `.sha256` sidecar，字节一致。

三方核对（Adoptium API == 上游下载 == GitCode 回读）全部一致：

| 资源 | sha256 |
|---|---|
| linux x86_64 | `e58fcdcd…9d77f94` |
| linux aarch64 | `621f7196…2f084c7` |
| macosx x86_64 | `a5ac9c46…e33869b7` |
| macosx aarch64 | `5a101c54…84f051bd` |
| windows x86_64 | `7caab7db…40937ae` |

镜像 tag 用 `25.0.4_7` 而不是 `25.0.4+7`：GitCode 的 release API 会把路径段里的 `+` 解码成空格然后 404（第一次用 `+` 建的 release 上传直接失败，已删除重建）。两条路径都端到端验证过：

```
$ xlings config --mirror CN     → downloading … from https://gitcode.com/xlings-res/jdk-temurin/…/25.0.4_7/…
$ xlings config --mirror GLOBAL → downloading … from https://github.com/adoptium/…/jdk-25.0.4%2B7/…
```

### 6. runtime deps 仍然为空，但理由换成实测

对装好的树做了一遍 readelf 扫描：唯一的硬外部依赖是 glibc（`libc/libdl/libm/libpthread/librt` + `ld-linux` INTERP）。**整棵树里没有 `libstdc++.so.6` / `libgcc_s.so.1`**（HotSpot 静态链接），所以不需要 `node.lua` 那条 `xim:gcc-runtime`。`libX11/libXext/libXi/libXrender/libXtst`、`libasound`、`libfreetype` 只出现在 `libawt_xawt` / `libjsound` / `libfontmanager` / `libsplashscreen` 里，headless JVM 不会加载。`bin/java` 自带 `RPATH=$ORIGIN:$ORIGIN/../lib`。Alpine / distroless 需要的是对这棵树做 INTERP 重写，单独开 PR 真机验证再说。

### 更正原描述里的两条

- ~~「完整 install/uninstall 生命周期交由本仓库 CI（posix-test.sh）验证」~~ —— `pkgindex test`（含 linux/macos/windows 装卸测试）只在 `push` 上触发，**没有 `pull_request`**，fork 来的 PR 根本不会跑到它，此前这个 PR 只跑了 `xpkg test` 的 L0/L1/L2。这次把同一个 commit 推到本仓库的临时分支 `ci/jdk-temurin-473` 上，check runs 按 SHA 挂回本 PR，所以现在 `linux-install-test` / `macos-install-test` / `windows-test` 是真的跑过的。
- ~~「本机到 GitHub 仅 ~47KB/s，200MB 归档下载无法在超时内完成」~~ —— 维护者机器实测 2.8MB/s，本地完整跑通了 install → `java -version` → `xlings use` → uninstall（无残留 shim、安装目录清空）。

### 本地验证记录

```
pytest tests/ -m "static or isolation"                     → 970 passed
pytest tests/j/test_jdk_temurin.py -m "static or isolation or index or verify"
                                                           → 18 passed, 2 failed*
python3 .github/scripts/version-check.py --workspace .     → exit 0
xlings install local:jdk-temurin@25.0.4  → 解析到 25.0.4+7，安装成功
java --version / javac --version / JAVA_HOME / xlings use  → 全部符合预期
xlings remove                                              → shim 与安装目录清理干净
```

\* 那 2 个是 `assert_xvm_registered`，本机 `xvm info` 坏了导致对**所有**包都失败（拿 ninja/cmake/git 做对照确认过），不是本包问题，CI 上正常。

测试文件同步补了 6 条静态断言，把上面这些决定钉住：`25.0.4` 别名覆盖三平台、每个资源都有 GLOBAL+CN+sha256、CN tag 不含 `%2B`、macOS 走 `Contents/Home`、共享名必须 flavor 化 + group 根、`JAVA_HOME` 必须注册；外加 2 条 verify（`java -version` 断言完整 build 串 `25.0.4+7`，以及 `JAVA_HOME` 真的进到 JVM 环境里）。
