### PR TITLE
bump(d2x): track 2026.08.02.2 as latest

### DIFF
--- a/pkgs/d/d2x.lua
+++ b/pkgs/d/d2x.lua
@@ -24,7 +24,8 @@ package = {
 
     xpm = {
         windows = {
-            ["latest"] = { ref = "2026.08.02.1" },
+            ["latest"] = { ref = "2026.08.02.2" },
+            ["2026.08.02.2"] = "XLINGS_RES",
             ["2026.08.02.1"] = "XLINGS_RES",
             ["2026.07.24.1"] = "XLINGS_RES",
             ["0.1.5"] = "XLINGS_RES",
@@ -35,7 +36,8 @@ package = {
         },
         linux = {
             deps = { "xim:glibc@2.39", "xim:openssl@3.1.5" },
-            ["latest"] = { ref = "2026.08.02.1" },
+            ["latest"] = { ref = "2026.08.02.2" },
+            ["2026.08.02.2"] = "XLINGS_RES",
             ["2026.08.02.1"] = "XLINGS_RES",
             ["2026.07.24.1"] = "XLINGS_RES",
             ["0.1.5"] = "XLINGS_RES",
@@ -46,7 +48,8 @@ package = {
             ["0.1.0"] = "XLINGS_RES",
         },
         macosx = {
-            ["latest"] = { ref = "2026.08.02.1" },
+            ["latest"] = { ref = "2026.08.02.2" },
+            ["2026.08.02.2"] = "XLINGS_RES",
             ["2026.08.02.1"] = "XLINGS_RES",
             ["2026.07.24.1"] = "XLINGS_RES",
             ["0.1.5"] = "XLINGS_RES",


### PR DESCRIPTION
d2x `2026.08.02.2` 已发布,三平台把 `latest` 指过去并补上版本条目。

资源双源就位,**均以 GET 回拉校验 sha256 与源逐字节一致**(不用 HEAD —— GitCode API 返回的 `browser_download_url` 走 `api.gitcode.com`,实测 404,真正可服务的是 `gitcode.com/<repo>/releases/download/...`):

| 平台 | GitHub | GitCode |
| --- | --- | --- |
| linux-x86_64 | ✅ | ✅ |
| macosx-arm64 | ✅ | ✅ |
| windows-x86_64 | ✅ | ✅ |

## 该版内容

- Windows 活性超时终止后不再可能空转(5s 补一次直杀 / 15s 放弃等待并如实返回 `idle_killed`)—— 此前若终止没生效,防挂死的循环会自己以 50ms 一轮永远转下去
- checker 冒烟判据在 Windows 收紧到与 linux 同档(配合 d2mcpp 侧 Provider 的 cmd.exe 重定向修复)