### PR TITLE
feat(pkg): add jdk-corretto 25/21 and jdk-zulu 25/21

### DIFF
--- a/pkgs/j/jdk-corretto.lua
+++ b/pkgs/j/jdk-corretto.lua
@@ -1,0 +1,282 @@
+package = {
+    spec = "2",
+
+    -- base info
+    name = "jdk-corretto",
+    description = "Amazon Corretto — a no-cost, production-ready distribution of OpenJDK (LTS)",
+
+    homepage = "https://aws.amazon.com/corretto/",
+    repo = "https://github.com/corretto/corretto-25",
+    docs = "https://docs.aws.amazon.com/corretto/",
+    authors = {"Amazon Web Services"},
+    licenses = {"GPL-2.0-with-classpath-exception"},
+
+    -- xim pkg info
+    type = "package",
+    archs = {"x86_64", "aarch64"},
+    status = "stable",
+    categories = {"language", "jvm", "runtime", "toolchain"},
+    keywords = {"java", "jdk", "openjdk", "corretto", "amazon", "aws", "jvm", "hotspot"},
+
+    programs = {"java", "javac", "jar", "javadoc", "jshell"},
+    xvm_enable = true,
+
+    -- Second JDK distribution in the index, same shape as jdk-temurin.lua; only
+    -- the parts that genuinely differ from it are spelled out below.
+    --
+    -- VERSION STRING — Corretto versions are five-part,
+    -- `<feature>.<interim>.<update>.<build>.<revision>` (25.0.4.7.1 = OpenJDK
+    -- 25.0.4+7, Corretto revision 1), so the version key is NOT what
+    -- `java --version` prints (`openjdk 25.0.4`). Both spellings are accepted:
+    -- `["25.0.4"] = { ref = "25.0.4.7.1" }` on every platform, same reason as
+    -- jdk-temurin's `25.0.4` alias.
+    --
+    -- PROVENANCE — Corretto publishes no per-file checksum sidecar (the
+    -- `.sha256` URL next to the archive is 403), but every GitHub release body
+    -- in corretto/corretto-<feature> carries a version-pinned MD5/SHA256 table
+    -- per artifact. The hashes below come from those tables (25.0.4.7.1 and
+    -- 21.0.12.8.1) and were re-verified against the downloaded archives while
+    -- publishing the CN mirror.
+    --
+    -- PAYLOAD LAYOUT — the one genuinely awkward part: each platform names its
+    -- top-level directory from a different slice of the version, and none of
+    -- them is the version key itself (see payload_candidates below).
+    --
+    -- ARCH / PLATFORM COVERAGE — linux and macosx ship x86_64 + aarch64,
+    -- windows ships x86_64 only. Alpine (musl) tarballs exist upstream and are
+    -- deliberately not wired up here; that needs the same real-machine elfpatch
+    -- work jdk-temurin defers.
+    --
+    -- RUNTIME DEPS — none, for the reason recorded in jdk-temurin.lua: the only
+    -- hard external dependency of a HotSpot JDK tree is glibc, libstdc++/libgcc
+    -- are linked statically, and the X11/alsa/freetype users are the AWT/sound
+    -- libs a headless JVM never loads.
+    xpm = {
+        linux = {
+            ["latest"] = { ref = "25.0.4.7.1" },
+            ["25.0.4"] = { ref = "25.0.4.7.1" },
+            ["21.0.12"] = { ref = "21.0.12.8.1" },
+            ["25.0.4.7.1"] = {
+                x86_64 = {
+                    url = {
+                        GLOBAL = "https://corretto.aws/downloads/resources/25.0.4.7.1/amazon-corretto-25.0.4.7.1-linux-x64.tar.gz",
+                        CN = "https://gitcode.com/xlings-res/jdk-corretto/releases/download/25.0.4.7.1/amazon-corretto-25.0.4.7.1-linux-x64.tar.gz",
+                    },
+                    sha256 = "1d03a3bd5091728492d92f0ef341aca7d8885ece9a150119558f3e3d62b58745",
+                },
+                aarch64 = {
+                    url = {
+                        GLOBAL = "https://corretto.aws/downloads/resources/25.0.4.7.1/amazon-corretto-25.0.4.7.1-linux-aarch64.tar.gz",
+                        CN = "https://gitcode.com/xlings-res/jdk-corretto/releases/download/25.0.4.7.1/amazon-corretto-25.0.4.7.1-linux-aarch64.tar.gz",
+                    },
+                    sha256 = "90a07c1c693ac9333a8a6ec79432f0d13c0564fec6617b0222d43f86858f65b8",
+                },
+            },
+            ["21.0.12.8.1"] = {
+                x86_64 = {
+                    url = {
+                        GLOBAL = "https://corretto.aws/downloads/resources/21.0.12.8.1/amazon-corretto-21.0.12.8.1-linux-x64.tar.gz",
+                        CN = "https://gitcode.com/xlings-res/jdk-corretto/releases/download/21.0.12.8.1/amazon-corretto-21.0.12.8.1-linux-x64.tar.gz",
+                    },
+                    sha256 = "75faed442d38a89c27f920e45ab24f9f71ff8ca6b732bfea90cdb500decd3c6b",
+                },
+                aarch64 = {
+                    url = {
+                        GLOBAL = "https://corretto.aws/downloads/resources/21.0.12.8.1/amazon-corretto-21.0.12.8.1-linux-aarch64.tar.gz",
+                        CN = "https://gitcode.com/xlings-res/jdk-corretto/releases/download/21.0.12.8.1/amazon-corretto-21.0.12.8.1-linux-aarch64.tar.gz",
+                    },
+                    sha256 = "fd94500b0d3d7e6e040a9dc1b34cbe25046454e5e3047b68c1842fa6894e9bbc",
+                },
+            },
+        },
+        macosx = {
+            ["latest"] = { ref = "25.0.4.7.1" },
+            ["25.0.4"] = { ref = "25.0.4.7.1" },
+            ["21.0.12"] = { ref = "21.0.12.8.1" },
+            ["25.0.4.7.1"] = {
+                x86_64 = {
+                    url = {
+                        GLOBAL = "https://corretto.aws/downloads/resources/25.0.4.7.1/amazon-corretto-25.0.4.7.1-macosx-x64.tar.gz",
+                        CN = "https://gitcode.com/xlings-res/jdk-corretto/releases/download/25.0.4.7.1/amazon-corretto-25.0.4.7.1-macosx-x64.tar.gz",
+                    },
+                    sha256 = "840b857016f2ab1a60a2aa5a68584b1da55f4ab953c1e2a207bde0a5114f683d",
+                },
+                aarch64 = {
+                    url = {
+                        GLOBAL = "https://corretto.aws/downloads/resources/25.0.4.7.1/amazon-corretto-25.0.4.7.1-macosx-aarch64.tar.gz",
+                        CN = "https://gitcode.com/xlings-res/jdk-corretto/releases/download/25.0.4.7.1/amazon-corretto-25.0.4.7.1-macosx-aarch64.tar.gz",
+                    },
+                    sha256 = "41e185be6b230cff4e9c85d33f9b092274a32e42113087f26d3b2e4f7909ab78",
+                },
+            },
+            ["21.0.12.8.1"] = {
+                x86_64 = {
+                    url = {
+                        GLOBAL = "https://corretto.aws/downloads/resources/21.0.12.8.1/amazon-corretto-21.0.12.8.1-macosx-x64.tar.gz",
+                        CN = "https://gitcode.com/xlings-res/jdk-corretto/releases/download/21.0.12.8.1/amazon-corretto-21.0.12.8.1-macosx-x64.tar.gz",
+                    },
+                    sha256 = "a018ae6221babf065f770479b1bf0ab0d23bea78ed18f236c40bb5d4736612ff",
+                },
+                aarch64 = {
+                    url = {
+                        GLOBAL = "https://corretto.aws/downloads/resources/21.0.12.8.1/amazon-corretto-21.0.12.8.1-macosx-aarch64.tar.gz",
+                        CN = "https://gitcode.com/xlings-res/jdk-corretto/releases/download/21.0.12.8.1/amazon-corretto-21.0.12.8.1-macosx-aarch64.tar.gz",
+                    },
+                    sha256 = "cb230d7ac82784a4438663cdaf91d0d04037a9b4fb99ea41e138d88ce1224ab7",
+                },
+            },
+        },
+        windows = {
+            ["latest"] = { ref = "25.0.4.7.1" },
+            ["25.0.4"] = { ref = "25.0.4.7.1" },
+            ["21.0.12"] = { ref = "21.0.12.8.1" },
+            ["25.0.4.7.1"] = {
+                x86_64 = {
+                    url = {
+                        GLOBAL = "https://corretto.aws/downloads/resources/25.0.4.7.1/amazon-corretto-25.0.4.7.1-windows-x64-jdk.zip",
+                        CN = "https://gitcode.com/xlings-res/jdk-corretto/releases/download/25.0.4.7.1/amazon-corretto-25.0.4.7.1-windows-x64-jdk.zip",
+                    },
+                    sha256 = "3e9126f1af6ecdcae0104e5adfe21b15de0b406319c9b5bba4dacd6bfc0bfc9d",
+                },
+            },
+            ["21.0.12.8.1"] = {
+                x86_64 = {
+                    url = {
+                        GLOBAL = "https://corretto.aws/downloads/resources/21.0.12.8.1/amazon-corretto-21.0.12.8.1-windows-x64-jdk.zip",
+                        CN = "https://gitcode.com/xlings-res/jdk-corretto/releases/download/21.0.12.8.1/amazon-corretto-21.0.12.8.1-windows-x64-jdk.zip",
+                    },
+                    sha256 = "de9ad88fb2575a1aff4715b192014ba31edd6e411d243371f377cff0560e34bc",
+                },
+            },
+        },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+import("xim.libxpkg.log")
+
+local PROGRAMS = { "java", "javac", "jar", "javadoc", "jshell" }
+local FLAVOR = "corretto"
+
+local function flavor_version()
+    return pkginfo.version() .. "-" .. FLAVOR
+end
+
+-- The downloaded archive's own name minus its extension. `pkginfo.install_file()`
+-- is the archive path (verified on the current C++ xim runtime), and for
+-- Corretto's linux tarballs that stem IS the extracted top-level directory --
+-- including the arch token this hook cannot otherwise learn, since os.arch() is
+-- not bound in hooks and _RUNTIME.arch is empty (see node.lua).
+local function archive_stem()
+    local file = pkginfo.install_file() or ""
+    local base = file:match("[^/\\]+$") or ""
+    base = base:gsub("%.tar%.gz$", "")
+    base = base:gsub("%.zip$", "")
+    return base
+end
+
+-- Every platform names its payload directory from a different slice of the
+-- five-part version, and none of them is the version key itself:
+--
+--   linux    amazon-corretto-25.0.4.7.1-linux-x64/bin/java   (full version + arch)
+--   macosx   amazon-corretto-25.jdk/Contents/Home/bin/java   (feature only, .jdk bundle)
+--   windows  jdk25.0.4_7/bin/java.exe                        (java version + build)
+--
+-- macOS is the same signed-bundle shape as Temurin, so the payload is again the
+-- inner Contents/Home and install_dir() ends up being JAVA_HOME everywhere.
+local function payload_candidates()
+    local version = pkginfo.version()
+    local host = os.host()
+
+    if host == "macosx" then
+        local feature = version:match("^(%d+)")
+        return { path.join("amazon-corretto-" .. (feature or version) .. ".jdk",
+                           "Contents", "Home") }
+    end
+
+    if host == "windows" then
+        local java_version, build = version:match("^(%d+%.%d+%.%d+)%.(%d+)")
+        if java_version then
+            return { "jdk" .. java_version .. "_" .. build }
+        end
+        return { "jdk" .. version }
+    end
+
+    -- linux: the archive stem is exact; the arch spellings are a fallback for an
+    -- engine that hands the hook no archive path.
+    local candidates = {}
+    local stem = archive_stem()
+    if stem ~= "" then table.insert(candidates, stem) end
+    for _, token in ipairs({ "x64", "aarch64" }) do
+        table.insert(candidates, "amazon-corretto-" .. version .. "-linux-" .. token)
+    end
+    return candidates
+end
+
+function install()
+    -- Idempotent across xim engines, and never report success without a real
+    -- launcher in place -- see jdk-temurin.lua for the full rationale.
+    local exe = os.host() == "windows" and "java.exe" or "java"
+    local staged = path.join(pkginfo.install_dir(), "bin", exe)
+    if os.isfile(staged) then return true end
+
+    local candidates = payload_candidates()
+    for _, payload in ipairs(candidates) do
+        if os.isdir(payload) then
+            os.tryrm(pkginfo.install_dir())
+            os.mv(payload, pkginfo.install_dir())
+            break
+        end
+    end
+
+    if not os.isfile(staged) then
+        log.error("jdk-corretto: no java launcher at %s (tried: %s)",
+                  staged, table.concat(candidates, ", "))
+        return false
+    end
+    return true
+end
+
+function config()
+    -- install_dir() is the JDK home on every platform (see payload_candidates).
+    local java_home = pkginfo.install_dir()
+    local bindir = path.join(java_home, "bin")
+
+    -- Binding-group root: `type = "group"` because the node names no artifact,
+    -- so it never becomes an orphan shim (openxlings/xlings#452).
+    local binding = "jdk-corretto@" .. pkginfo.version()
+    xvm.add("jdk-corretto", { type = "group" })
+
+    -- `java`/`javac`/... are shared with every other JDK distribution, and xvm
+    -- refuses a second package claiming an exact (name, version) pair -- with
+    -- the plain version, installing this package would make jdk-temurin
+    -- uninstallable and vice versa. Flavor-scope them, as musl-gcc.lua does for
+    -- `gcc`. JAVA_HOME rides on the shims because maven/gradle/IDEs locate a JDK
+    -- through it rather than PATH; it does not leak into the user's shell.
+    local env = { JAVA_HOME = java_home }
+    for _, prog in ipairs(PROGRAMS) do
+        xvm.add(prog, {
+            bindir = bindir,
+            version = flavor_version(),
+            binding = binding,
+            envs = env,
+        })
+    end
+
+    log.info("jdk-corretto: JAVA_HOME = %s", java_home)
+    log.info("jdk-corretto: java/javac/jar/javadoc/jshell registered as %s; other JDK tools live in %s",
+             flavor_version(), bindir)
+
+    return true
+end
+
+function uninstall()
+    -- Version-scoped: another installed version, or another JDK distribution
+    -- sharing these names, must keep its own nodes.
+    for _, prog in ipairs(PROGRAMS) do
+        xvm.remove(prog, flavor_version())
+    end
+    xvm.remove("jdk-corretto", pkginfo.version())
+    return true
+end

--- a/pkgs/j/jdk-zulu.lua
+++ b/pkgs/j/jdk-zulu.lua
@@ -1,0 +1,250 @@
+package = {
+    spec = "2",
+
+    -- base info
+    name = "jdk-zulu",
+    description = "Azul Zulu Community — a TCK-certified, no-cost build of OpenJDK (LTS)",
+
+    homepage = "https://www.azul.com/downloads/?package=jdk",
+    repo = "https://github.com/zulu-openjdk/zulu-openjdk",
+    docs = "https://docs.azul.com/core/",
+    authors = {"Azul Systems"},
+    licenses = {"GPL-2.0-with-classpath-exception"},
+
+    -- xim pkg info
+    type = "package",
+    archs = {"x86_64", "aarch64"},
+    status = "stable",
+    categories = {"language", "jvm", "runtime", "toolchain"},
+    keywords = {"java", "jdk", "openjdk", "zulu", "azul", "jvm", "hotspot"},
+
+    programs = {"java", "javac", "jar", "javadoc", "jshell"},
+    xvm_enable = true,
+
+    -- Third JDK distribution in the index, same shape as jdk-temurin.lua; only
+    -- the parts that genuinely differ from it are spelled out below.
+    --
+    -- VERSION STRING — Zulu carries TWO version numbers: its own distro version
+    -- (zulu25.36.15) and the OpenJDK version it builds (jdk25.0.4). The version
+    -- key here is the OpenJDK one, because that is what `java --version` prints
+    -- and what a user asking for "JDK 25.0.4" means; the distro version stays
+    -- visible in the archive names and in the mirror assets. Consequence worth
+    -- knowing: if Azul ever re-releases the same OpenJDK version under a newer
+    -- distro version, that is a new archive under an existing key -- add it as a
+    -- fresh key rather than rewriting this one's sha256, so an existing install
+    -- keeps resolving to the bytes it was pinned to.
+    --
+    -- SELECTION — packages come from api.azul.com/metadata/v1/zulu/packages with
+    -- `java_package_type=jdk`, `javafx_bundled=false`, `release_status=ga`,
+    -- `certifications=tck`, `availability_type=CA` (Community, the freely
+    -- redistributable line). CRaC and musl builds are filtered out; they are
+    -- different products, not architectures.
+    --
+    -- PROVENANCE — sha256 comes from that same API's per-package detail
+    -- endpoint (`sha256_hash`), which is version-pinned, and was re-verified
+    -- against the downloaded archives while publishing the CN mirror.
+    --
+    -- PAYLOAD LAYOUT — uniform and self-describing: the top-level directory is
+    -- always the archive name minus its extension (macOS then nests the usual
+    -- Contents/Home bundle inside it), so the hook derives it from the archive
+    -- instead of hard-coding distro versions.
+    --
+    -- ARCH / PLATFORM COVERAGE — linux and macosx ship x86_64 + aarch64,
+    -- windows ships x86_64 only.
+    --
+    -- RUNTIME DEPS — none, for the reason recorded in jdk-temurin.lua.
+    xpm = {
+        linux = {
+            ["latest"] = { ref = "25.0.4" },
+            ["25.0.4"] = {
+                x86_64 = {
+                    url = {
+                        GLOBAL = "https://cdn.azul.com/zulu/bin/zulu25.36.15-ca-jdk25.0.4-linux_x64.tar.gz",
+                        CN = "https://gitcode.com/xlings-res/jdk-zulu/releases/download/25.0.4/zulu25.36.15-ca-jdk25.0.4-linux_x64.tar.gz",
+                    },
+                    sha256 = "e476f5c98952cb365ca77a814dbe3c74341e71ae76d1a87d1c0a69c7d2b1b2d0",
+                },
+                aarch64 = {
+                    url = {
+                        GLOBAL = "https://cdn.azul.com/zulu/bin/zulu25.36.15-ca-jdk25.0.4-linux_aarch64.tar.gz",
+                        CN = "https://gitcode.com/xlings-res/jdk-zulu/releases/download/25.0.4/zulu25.36.15-ca-jdk25.0.4-linux_aarch64.tar.gz",
+                    },
+                    sha256 = "ae04e25b16116ddd0f72cb387742d5122bb29c4b94f0fed08ff2bccc395f9daa",
+                },
+            },
+            ["21.0.12"] = {
+                x86_64 = {
+                    url = {
+                        GLOBAL = "https://cdn.azul.com/zulu/bin/zulu21.52.15-ca-jdk21.0.12-linux_x64.tar.gz",
+                        CN = "https://gitcode.com/xlings-res/jdk-zulu/releases/download/21.0.12/zulu21.52.15-ca-jdk21.0.12-linux_x64.tar.gz",
+                    },
+                    sha256 = "b1a9df12e798770d1b2db43b402a80f1e6080cff6d5d1d1fbe5c768fb4225f6a",
+                },
+                aarch64 = {
+                    url = {
+                        GLOBAL = "https://cdn.azul.com/zulu/bin/zulu21.52.15-ca-jdk21.0.12-linux_aarch64.tar.gz",
+                        CN = "https://gitcode.com/xlings-res/jdk-zulu/releases/download/21.0.12/zulu21.52.15-ca-jdk21.0.12-linux_aarch64.tar.gz",
+                    },
+                    sha256 = "dc7ed9ab7dfd33f2ddb1cd8311d3b00738497961a420533d81088051eac3f195",
+                },
+            },
+        },
+        macosx = {
+            ["latest"] = { ref = "25.0.4" },
+            ["25.0.4"] = {
+                x86_64 = {
+                    url = {
+                        GLOBAL = "https://cdn.azul.com/zulu/bin/zulu25.36.15-ca-jdk25.0.4-macosx_x64.tar.gz",
+                        CN = "https://gitcode.com/xlings-res/jdk-zulu/releases/download/25.0.4/zulu25.36.15-ca-jdk25.0.4-macosx_x64.tar.gz",
+                    },
+                    sha256 = "63273c6b9e2d9b250a0009ffdaa6d9f27af6ba98772516c391276106fb9f2820",
+                },
+                aarch64 = {
+                    url = {
+                        GLOBAL = "https://cdn.azul.com/zulu/bin/zulu25.36.15-ca-jdk25.0.4-macosx_aarch64.tar.gz",
+                        CN = "https://gitcode.com/xlings-res/jdk-zulu/releases/download/25.0.4/zulu25.36.15-ca-jdk25.0.4-macosx_aarch64.tar.gz",
+                    },
+                    sha256 = "c422f22713510992c764a7d577ae4f5add223529ab356993f38f8df2d4b247bd",
+                },
+            },
+            ["21.0.12"] = {
+                x86_64 = {
+                    url = {
+                        GLOBAL = "https://cdn.azul.com/zulu/bin/zulu21.52.15-ca-jdk21.0.12-macosx_x64.tar.gz",
+                        CN = "https://gitcode.com/xlings-res/jdk-zulu/releases/download/21.0.12/zulu21.52.15-ca-jdk21.0.12-macosx_x64.tar.gz",
+                    },
+                    sha256 = "14e05cb1299c27cd26d3c5c6815723f63018df548dc7278c810767607902b4f4",
+                },
+                aarch64 = {
+                    url = {
+                        GLOBAL = "https://cdn.azul.com/zulu/bin/zulu21.52.15-ca-jdk21.0.12-macosx_aarch64.tar.gz",
+                        CN = "https://gitcode.com/xlings-res/jdk-zulu/releases/download/21.0.12/zulu21.52.15-ca-jdk21.0.12-macosx_aarch64.tar.gz",
+                    },
+                    sha256 = "84d38c4bf04f73d585bd319b949758d00abde50149a9522c2d9deef46b9a3ec6",
+                },
+            },
+        },
+        windows = {
+            ["latest"] = { ref = "25.0.4" },
+            ["25.0.4"] = {
+                x86_64 = {
+                    url = {
+                        GLOBAL = "https://cdn.azul.com/zulu/bin/zulu25.36.15-ca-jdk25.0.4-win_x64.zip",
+                        CN = "https://gitcode.com/xlings-res/jdk-zulu/releases/download/25.0.4/zulu25.36.15-ca-jdk25.0.4-win_x64.zip",
+                    },
+                    sha256 = "a91265f0f0fb40155befe8f1cae7d1a0ae2ab4b7760f52733160d206637b50d1",
+                },
+            },
+            ["21.0.12"] = {
+                x86_64 = {
+                    url = {
+                        GLOBAL = "https://cdn.azul.com/zulu/bin/zulu21.52.15-ca-jdk21.0.12-win_x64.zip",
+                        CN = "https://gitcode.com/xlings-res/jdk-zulu/releases/download/21.0.12/zulu21.52.15-ca-jdk21.0.12-win_x64.zip",
+                    },
+                    sha256 = "3c06e6693fd6fa725b985e66798a6a8293c75f52b793490754ad3c54d3d8b5a6",
+                },
+            },
+        },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+import("xim.libxpkg.log")
+
+local PROGRAMS = { "java", "javac", "jar", "javadoc", "jshell" }
+local FLAVOR = "zulu"
+
+local function flavor_version()
+    return pkginfo.version() .. "-" .. FLAVOR
+end
+
+-- Zulu's payload directory is always the archive name minus its extension:
+--
+--   linux    zulu25.36.15-ca-jdk25.0.4-linux_x64/bin/java
+--   macosx   zulu25.36.15-ca-jdk25.0.4-macosx_x64/Contents/Home/bin/java
+--   windows  zulu25.36.15-ca-jdk25.0.4-win_x64/bin/java.exe
+--
+-- That name carries the distro version (25.36.15) and the arch, neither of which
+-- this hook can derive from the version key -- and os.arch() is not bound in
+-- hooks anyway (see node.lua). So take it from the archive itself:
+-- `pkginfo.install_file()` is the downloaded archive path (verified on the
+-- current C++ xim runtime), which keeps this hook correct across future Zulu
+-- builds without a hard-coded distro-version table.
+local function payload_dir()
+    local file = pkginfo.install_file() or ""
+    local base = file:match("[^/\\]+$") or ""
+    base = base:gsub("%.tar%.gz$", "")
+    base = base:gsub("%.zip$", "")
+    if base == "" then return nil end
+    if os.host() == "macosx" then
+        -- Same signed .jdk bundle shape as Temurin/Corretto: take the inner
+        -- Contents/Home so install_dir() is JAVA_HOME on every platform.
+        return path.join(base, "Contents", "Home")
+    end
+    return base
+end
+
+function install()
+    -- Idempotent across xim engines, and never report success without a real
+    -- launcher in place -- see jdk-temurin.lua for the full rationale.
+    local exe = os.host() == "windows" and "java.exe" or "java"
+    local staged = path.join(pkginfo.install_dir(), "bin", exe)
+    if os.isfile(staged) then return true end
+
+    local payload = payload_dir()
+    if payload and os.isdir(payload) then
+        os.tryrm(pkginfo.install_dir())
+        os.mv(payload, pkginfo.install_dir())
+    end
+
+    if not os.isfile(staged) then
+        log.error("jdk-zulu: no java launcher at %s (payload dir: %s)",
+                  staged, tostring(payload))
+        return false
+    end
+    return true
+end
+
+function config()
+    -- install_dir() is the JDK home on every platform (see payload_dir).
+    local java_home = pkginfo.install_dir()
+    local bindir = path.join(java_home, "bin")
+
+    -- Binding-group root: `type = "group"` because the node names no artifact,
+    -- so it never becomes an orphan shim (openxlings/xlings#452).
+    local binding = "jdk-zulu@" .. pkginfo.version()
+    xvm.add("jdk-zulu", { type = "group" })
+
+    -- `java`/`javac`/... are shared with every other JDK distribution, and xvm
+    -- refuses a second package claiming an exact (name, version) pair -- with
+    -- the plain version, installing this package would make jdk-temurin
+    -- uninstallable and vice versa. Flavor-scope them, as musl-gcc.lua does for
+    -- `gcc`. JAVA_HOME rides on the shims because maven/gradle/IDEs locate a JDK
+    -- through it rather than PATH; it does not leak into the user's shell.
+    local env = { JAVA_HOME = java_home }
+    for _, prog in ipairs(PROGRAMS) do
+        xvm.add(prog, {
+            bindir = bindir,
+            version = flavor_version(),
+            binding = binding,
+            envs = env,
+        })
+    end
+
+    log.info("jdk-zulu: JAVA_HOME = %s", java_home)
+    log.info("jdk-zulu: java/javac/jar/javadoc/jshell registered as %s; other JDK tools live in %s",
+             flavor_version(), bindir)
+
+    return true
+end
+
+function uninstall()
+    -- Version-scoped: another installed version, or another JDK distribution
+    -- sharing these names, must keep its own nodes.
+    for _, prog in ipairs(PROGRAMS) do
+        xvm.remove(prog, flavor_version())
+    end
+    xvm.remove("jdk-zulu", pkginfo.version())
+    return true
+end

--- a/tests/j/test_jdk_corretto.py
+++ b/tests/j/test_jdk_corretto.py
@@ -1,0 +1,184 @@
+"""测试 jdk-corretto 包"""
+import re
+
+import pytest
+from tests.lib.xpkg_parser import parse_xpkg
+from tests.lib.assertions import (
+    assert_required_fields, assert_valid_spec, assert_valid_type,
+    assert_no_typos, assert_no_exec_xvm, assert_no_bashrc_modification,
+    assert_no_direct_path_modification, assert_uses_new_api,
+    assert_xim_add_succeeds, assert_install_succeeds,
+    assert_command_output, assert_xvm_registered,
+)
+from tests.lib.platform_utils import skip_if_not
+
+PKG = "jdk-corretto"
+PKG_FILE = "pkgs/j/jdk-corretto.lua"
+
+PLATFORMS = ("linux", "macosx", "windows")
+# 2 个版本 (25 / 21 LTS) x 每平台的架构数: linux 2 + macosx 2 + windows 1 = 5
+RESOURCE_COUNT = 10
+VERSIONS = {"25.0.4.7.1": "25.0.4", "21.0.12.8.1": "21.0.12"}
+
+
+def _code(content: str) -> str:
+    """去掉 lua 行注释, 让下面的静态断言只看真实声明 (注释里也写了这些字面量)"""
+    return "\n".join(
+        line for line in content.splitlines() if not line.lstrip().startswith("--")
+    )
+
+
+@pytest.fixture(scope='module')
+def meta():
+    return parse_xpkg(PKG_FILE)
+
+
+class TestStatic:
+    @pytest.mark.static
+    def test_required_fields(self, meta):
+        assert_required_fields(meta)
+
+    @pytest.mark.static
+    def test_valid_spec(self, meta):
+        assert_valid_spec(meta)
+
+    @pytest.mark.static
+    def test_valid_type(self, meta):
+        assert_valid_type(meta)
+
+    @pytest.mark.static
+    def test_no_typos(self):
+        assert_no_typos(PKG_FILE)
+
+    @pytest.mark.static
+    def test_plain_version_alias(self, meta):
+        """Corretto 版本是五段式, `java --version` 只显示前三段, 两种拼法都要能装"""
+        code = _code(meta.raw_content)
+        for full, plain in VERSIONS.items():
+            aliases = re.findall(
+                rf'\["{re.escape(plain)}"\]\s*=\s*\{{\s*ref\s*=\s*"{re.escape(full)}"\s*\}}',
+                code,
+            )
+            assert len(aliases) == len(PLATFORMS), \
+                f"{plain} -> {full} 别名应覆盖 {PLATFORMS}, 实际 {len(aliases)} 个"
+
+    @pytest.mark.static
+    def test_every_resource_has_cn_mirror(self, meta):
+        """每个资源都要有 GLOBAL(upstream) + CN(gitcode) 两个源, 且 sha256 齐全"""
+        code = _code(meta.raw_content)
+        global_urls = re.findall(r'GLOBAL = "https://corretto\.aws/[^"]+"', code)
+        cn_urls = re.findall(
+            r'CN = "https://gitcode\.com/xlings-res/jdk-corretto/[^"]+"', code)
+        shas = re.findall(r'sha256 = "[0-9a-f]{64}"', code)
+        assert len(global_urls) == RESOURCE_COUNT, f"GLOBAL 源数量: {len(global_urls)}"
+        assert len(cn_urls) == RESOURCE_COUNT, f"CN 源数量: {len(cn_urls)}"
+        assert len(shas) == RESOURCE_COUNT, f"sha256 数量: {len(shas)}"
+
+    @pytest.mark.static
+    def test_payload_layout_per_platform(self, meta):
+        """三个平台的解包目录名各不相同, 缺任何一支都会装成空目录"""
+        code = _code(meta.raw_content)
+        assert '"amazon-corretto-" .. (feature or version) .. ".jdk"' in code, \
+            "macOS 是 .jdk bundle, 目录名只带 feature 版本"
+        assert re.search(r'"Contents"\s*,\s*"Home"', code), \
+            "macOS payload 必须取内层 Contents/Home"
+        assert '"jdk" .. java_version .. "_" .. build' in code, \
+            "windows 目录名是 jdk<java version>_<build>"
+        assert "archive_stem()" in code, \
+            "linux 目录名带 arch, 只能从归档名推导 (hook 里没有 os.arch)"
+
+    @pytest.mark.static
+    def test_shared_names_are_flavor_scoped(self, meta):
+        """java/javac 等是所有 JDK 发行版共享的名字, 必须带 flavor 版本
+
+        用裸的数字版本注册的话, 另一个 JDK 发行版想注册同名同版本会被 xvm 直接
+        拒绝 (another package already owns this exact name and version), 整个
+        config 批次失败 —— 等于两个发行版互斥。
+        """
+        code = _code(meta.raw_content)
+        assert re.search(r'version\s*=\s*flavor_version\(\)', code), \
+            "共享程序名必须用 flavor_version() 注册"
+        assert re.search(r'pkginfo\.version\(\)\s*\.\.\s*"-"\s*\.\.\s*FLAVOR', code), \
+            "flavor_version 必须是 <version>-<flavor>"
+        assert 'type = "group"' in code, \
+            "binding root 应为 group 节点, 否则会留下永远失败的孤儿 shim"
+
+    @pytest.mark.static
+    def test_java_home_registered(self, meta):
+        """JDK 只注册 shim 不给 JAVA_HOME 的话, maven/gradle 之类工具找不到它"""
+        assert "JAVA_HOME" in _code(meta.raw_content), "config 应通过 xvm envs 提供 JAVA_HOME"
+
+
+class TestIndex:
+    @pytest.mark.index
+    def test_xim_add(self):
+        assert_xim_add_succeeds(PKG_FILE)
+
+
+class TestIsolation:
+    @pytest.mark.isolation
+    def test_no_exec_xvm(self):
+        assert_no_exec_xvm(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_no_bashrc(self):
+        assert_no_bashrc_modification(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_no_path_modification(self):
+        assert_no_direct_path_modification(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_new_api(self):
+        assert_uses_new_api(PKG_FILE)
+
+
+class TestLifecycle:
+    @pytest.mark.lifecycle
+    @skip_if_not('linux')
+    def test_install(self):
+        # The Corretto 25 tarball is ~220MB; the default 180s can be tight on a
+        # cold cache.
+        assert_install_succeeds(PKG, timeout=420)
+
+
+class TestVerify:
+    @pytest.mark.verify
+    @skip_if_not('linux')
+    def test_java_version(self):
+        # java prints its version banner on stderr. Assert the vendor string too:
+        # "25" alone would also match a pre-existing system JDK.
+        assert_command_output("java -version 2>&1", contains="Corretto-25.0.4")
+
+    @pytest.mark.verify
+    @skip_if_not('linux')
+    def test_javac_version(self):
+        assert_command_output("javac -version", contains="25.0.4")
+
+    @pytest.mark.verify
+    @skip_if_not('linux')
+    def test_java_home_points_at_xpkg(self):
+        assert_command_output(
+            "java -XshowSettings:properties -version 2>&1",
+            regex=r"java\.home = .*jdk-corretto",
+        )
+
+    @pytest.mark.verify
+    @skip_if_not('linux')
+    def test_java_home_env_reaches_jvm(self):
+        """config 注册的 JAVA_HOME 必须真的进到 java 进程的环境里 (maven/gradle 靠它)"""
+        assert_command_output(
+            '''echo 'System.out.println("JH=[" + System.getenv("JAVA_HOME") + "]");' '''
+            '''| jshell -s - 2>&1''',
+            regex=r"JH=\[.*jdk-corretto.*\]",
+        )
+
+    @pytest.mark.verify
+    @skip_if_not('linux')
+    def test_xvm_java(self):
+        assert_xvm_registered("java")
+
+    @pytest.mark.verify
+    @skip_if_not('linux')
+    def test_xvm_javac(self):
+        assert_xvm_registered("javac")

--- a/tests/j/test_jdk_zulu.py
+++ b/tests/j/test_jdk_zulu.py
@@ -1,0 +1,183 @@
+"""测试 jdk-zulu 包"""
+import re
+
+import pytest
+from tests.lib.xpkg_parser import parse_xpkg
+from tests.lib.assertions import (
+    assert_required_fields, assert_valid_spec, assert_valid_type,
+    assert_no_typos, assert_no_exec_xvm, assert_no_bashrc_modification,
+    assert_no_direct_path_modification, assert_uses_new_api,
+    assert_xim_add_succeeds, assert_install_succeeds,
+    assert_command_output, assert_xvm_registered,
+)
+from tests.lib.platform_utils import skip_if_not
+
+PKG = "jdk-zulu"
+PKG_FILE = "pkgs/j/jdk-zulu.lua"
+
+PLATFORMS = ("linux", "macosx", "windows")
+# 2 个版本 (25 / 21 LTS) x 每平台的架构数: linux 2 + macosx 2 + windows 1 = 5
+RESOURCE_COUNT = 10
+VERSIONS = ("25.0.4", "21.0.12")
+
+
+def _code(content: str) -> str:
+    """去掉 lua 行注释, 让下面的静态断言只看真实声明 (注释里也写了这些字面量)"""
+    return "\n".join(
+        line for line in content.splitlines() if not line.lstrip().startswith("--")
+    )
+
+
+@pytest.fixture(scope='module')
+def meta():
+    return parse_xpkg(PKG_FILE)
+
+
+class TestStatic:
+    @pytest.mark.static
+    def test_required_fields(self, meta):
+        assert_required_fields(meta)
+
+    @pytest.mark.static
+    def test_valid_spec(self, meta):
+        assert_valid_spec(meta)
+
+    @pytest.mark.static
+    def test_valid_type(self, meta):
+        assert_valid_type(meta)
+
+    @pytest.mark.static
+    def test_no_typos(self):
+        assert_no_typos(PKG_FILE)
+
+    @pytest.mark.static
+    def test_version_keys_are_openjdk_versions(self, meta):
+        """版本键必须是 OpenJDK 版本 (java --version 显示的那个), 不是 Zulu 自己的 distro 版本"""
+        code = _code(meta.raw_content)
+        for version in VERSIONS:
+            blocks = re.findall(rf'\["{re.escape(version)}"\]\s*=\s*\{{', code)
+            assert len(blocks) == len(PLATFORMS), \
+                f"{version} 版本块应覆盖 {PLATFORMS}, 实际 {len(blocks)} 个"
+        # distro 版本 (zulu25.36.15) 只应出现在归档名里, 不能变成版本键
+        assert '["25.36.15"]' not in code and '["21.52.15"]' not in code, \
+            "distro 版本不应作为版本键"
+
+    @pytest.mark.static
+    def test_every_resource_has_cn_mirror(self, meta):
+        """每个资源都要有 GLOBAL(upstream) + CN(gitcode) 两个源, 且 sha256 齐全"""
+        code = _code(meta.raw_content)
+        global_urls = re.findall(r'GLOBAL = "https://cdn\.azul\.com/zulu/bin/[^"]+"', code)
+        cn_urls = re.findall(
+            r'CN = "https://gitcode\.com/xlings-res/jdk-zulu/[^"]+"', code)
+        shas = re.findall(r'sha256 = "[0-9a-f]{64}"', code)
+        assert len(global_urls) == RESOURCE_COUNT, f"GLOBAL 源数量: {len(global_urls)}"
+        assert len(cn_urls) == RESOURCE_COUNT, f"CN 源数量: {len(cn_urls)}"
+        assert len(shas) == RESOURCE_COUNT, f"sha256 数量: {len(shas)}"
+
+    @pytest.mark.static
+    def test_no_crac_or_musl_builds(self, meta):
+        """CRaC / musl 是不同产品, 不是架构, 不能混进来"""
+        code = _code(meta.raw_content)
+        assert "-crac-" not in code, "CRaC 构建不应出现在资源里"
+        assert "_musl" not in code, "musl 构建不应出现在资源里"
+
+    @pytest.mark.static
+    def test_payload_derived_from_archive(self, meta):
+        """解包目录带 distro 版本和 arch, 只能从归档名推导 (hook 里没有 os.arch)"""
+        code = _code(meta.raw_content)
+        assert "pkginfo.install_file()" in code, "payload 目录应从归档名推导"
+        assert re.search(r'os\.host\(\)\s*==\s*"macosx"', code), \
+            "install 必须区分 macosx 布局"
+        assert re.search(r'"Contents"\s*,\s*"Home"', code), \
+            "macOS payload 必须取内层 Contents/Home"
+
+    @pytest.mark.static
+    def test_shared_names_are_flavor_scoped(self, meta):
+        """java/javac 等是所有 JDK 发行版共享的名字, 必须带 flavor 版本"""
+        code = _code(meta.raw_content)
+        assert re.search(r'version\s*=\s*flavor_version\(\)', code), \
+            "共享程序名必须用 flavor_version() 注册"
+        assert re.search(r'pkginfo\.version\(\)\s*\.\.\s*"-"\s*\.\.\s*FLAVOR', code), \
+            "flavor_version 必须是 <version>-<flavor>"
+        assert 'type = "group"' in code, \
+            "binding root 应为 group 节点, 否则会留下永远失败的孤儿 shim"
+
+    @pytest.mark.static
+    def test_java_home_registered(self, meta):
+        """JDK 只注册 shim 不给 JAVA_HOME 的话, maven/gradle 之类工具找不到它"""
+        assert "JAVA_HOME" in _code(meta.raw_content), "config 应通过 xvm envs 提供 JAVA_HOME"
+
+
+class TestIndex:
+    @pytest.mark.index
+    def test_xim_add(self):
+        assert_xim_add_succeeds(PKG_FILE)
+
+
+class TestIsolation:
+    @pytest.mark.isolation
+    def test_no_exec_xvm(self):
+        assert_no_exec_xvm(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_no_bashrc(self):
+        assert_no_bashrc_modification(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_no_path_modification(self):
+        assert_no_direct_path_modification(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_new_api(self):
+        assert_uses_new_api(PKG_FILE)
+
+
+class TestLifecycle:
+    @pytest.mark.lifecycle
+    @skip_if_not('linux')
+    def test_install(self):
+        # The Zulu 25 tarball is ~230MB; the default 180s can be tight on a
+        # cold cache.
+        assert_install_succeeds(PKG, timeout=420)
+
+
+class TestVerify:
+    @pytest.mark.verify
+    @skip_if_not('linux')
+    def test_java_version(self):
+        # java prints its version banner on stderr. Assert the vendor string too:
+        # "25" alone would also match a pre-existing system JDK.
+        assert_command_output("java -version 2>&1", contains="Zulu")
+
+    @pytest.mark.verify
+    @skip_if_not('linux')
+    def test_javac_version(self):
+        assert_command_output("javac -version", contains="25.0.4")
+
+    @pytest.mark.verify
+    @skip_if_not('linux')
+    def test_java_home_points_at_xpkg(self):
+        assert_command_output(
+            "java -XshowSettings:properties -version 2>&1",
+            regex=r"java\.home = .*jdk-zulu",
+        )
+
+    @pytest.mark.verify
+    @skip_if_not('linux')
+    def test_java_home_env_reaches_jvm(self):
+        """config 注册的 JAVA_HOME 必须真的进到 java 进程的环境里 (maven/gradle 靠它)"""
+        assert_command_output(
+            '''echo 'System.out.println("JH=[" + System.getenv("JAVA_HOME") + "]");' '''
+            '''| jshell -s - 2>&1''',
+            regex=r"JH=\[.*jdk-zulu.*\]",
+        )
+
+    @pytest.mark.verify
+    @skip_if_not('linux')
+    def test_xvm_java(self):
+        assert_xvm_registered("java")
+
+    @pytest.mark.verify
+    @skip_if_not('linux')
+    def test_xvm_javac(self):
+        assert_xvm_registered("javac")


### PR DESCRIPTION
## 用途

按 `jdk-temurin` (#473) 的范式再补两个最流行的、可自由再分发的 JDK 发行版：

| 包 | 发行版 | 版本 |
|---|---|---|
| `jdk-corretto` | Amazon Corretto | `25.0.4.7.1`、`21.0.12.8.1` |
| `jdk-zulu` | Azul Zulu Community (CA) | `25.0.4`、`21.0.12` |

```bash
xlings install jdk-corretto@25.0.4     # 也可以写 @25.0.4.7.1
xlings install jdk-zulu@21.0.12
xlings use jdk-zulu 25.0.4
```

选型：Temurin 之后按使用率排下来是 Oracle JDK、Corretto、Zulu。**Oracle JDK 没选**，它是 NFTC 许可，再分发受限，跟本仓库的 xlings-res 镜像范式冲突；Corretto / Zulu 都是 GPLv2+CPE，镜像没有障碍。GraalVM 作为候选也评估过，它缺 macos-x64、文件名带 `25i2` 这类 interim 标记、单包 330MB，而且是 JDK+native-image 的另一类产品，留待单独一个 PR。

## 平台与架构

两个包都是：linux / macosx 各 x86_64 + aarch64，windows 仅 x86_64（跟 Temurin 一致），每个包 **10 个资源**，每个资源都有独立的 per-arch sha256。

## 资源来源与校验

两家的 checksum 来源不一样，都取的是**版本级钉死**的那份：

- **Corretto** 官方在归档旁边没有可用的 sidecar（`.sha256` URL 直接 403）。但 `corretto/corretto-<feature>` 每个 GitHub release 的正文里有一张 per-artifact 的 MD5/SHA256 表，本包的哈希取自 `25.0.4.7.1` 和 `21.0.12.8.1` 两张表。
- **Zulu** 取自 `api.azul.com/metadata/v1/zulu/packages/<uuid>` 的 `sha256_hash`。筛选条件：`java_package_type=jdk`、`javafx_bundled=false`、`release_status=ga`、`certifications=tck`、`availability_type=CA`；CRaC 和 musl 构建显式排除（它们是不同产品，不是架构）。

20 个归档做了完整的**三方核对：索引声明的 sha256 == 上游实际字节 == GitCode 实际服务的字节**，20/20 全部一致。上传前每个文件在本地哈希比对，不一致就中止而不是发布一个坏镜像；发布后再从 GitCode 逐个流式读回重算 sha256。

## CN 镜像

- `https://gitcode.com/xlings-res/jdk-corretto` — tag `25.0.4.7.1` / `21.0.12.8.1`
- `https://gitcode.com/xlings-res/jdk-zulu` — tag `25.0.4` / `21.0.12`

每个 tag 下 5 个归档 + 5 个 `.sha256` sidecar，均为上游字节副本。GLOBAL 仍指向上游（corretto.aws / cdn.azul.com），没必要为全球路径再存一份。这次的 tag 都不含 `+`，没有踩 #473 那个 GitCode 把路径里 `+` 解成空格的坑。

## 版本键：两家不一样，因为两家本来就不一样

- **Corretto 是五段式**（`25.0.4.7.1` = OpenJDK 25.0.4+7 的 Corretto 第 1 次修订），而 `java --version` 只印 `openjdk 25.0.4`。所以三个平台都声明了 `["25.0.4"] = { ref = "25.0.4.7.1" }`（21 同理），两种拼法都能装 —— 跟 Temurin 那个 `25.0.4` 别名同一个理由。
- **Zulu 有两个版本号**：自己的 distro 版本（`zulu25.36.15`）和它构建的 OpenJDK 版本（`25.0.4`）。版本键取后者，因为那才是用户说「JDK 25.0.4」时指的东西，也是 `java --version` 显示的。配方注释里记了一条：如果 Azul 用新的 distro 版本重新发布同一个 OpenJDK 版本，应该新增版本键而不是改写现有键的 sha256，免得已装的用户脚下的字节被换掉。

## 解包布局：这次真正麻烦的地方

三个平台的顶层目录名各不相同，而且都不是版本键本身。全部对着真实归档验证过，不是猜的：

```
Corretto  linux    amazon-corretto-25.0.4.7.1-linux-x64/bin/java     ← 完整版本 + arch
          macosx   amazon-corretto-25.jdk/Contents/Home/bin/java     ← 只有 feature 版本, .jdk bundle
          windows  jdk25.0.4_7/bin/java.exe                          ← java 版本 + build

Zulu      linux    zulu25.36.15-ca-jdk25.0.4-linux_x64/bin/java
          macosx   zulu25.36.15-ca-jdk25.0.4-macosx_x64/Contents/Home/bin/java
          windows  zulu25.36.15-ca-jdk25.0.4-win_x64/bin/java.exe
```

Zulu 的目录名永远等于「归档名去掉扩展名」，但里面带着 distro 版本和 arch，两样都没法从版本键推出来 —— 而 hook 里 `os.arch()` 没有绑定、`_RUNTIME.arch` 是空的（node.lua 记过）。

解法是 **`pkginfo.install_file()` 返回的是下载下来的归档路径**（在当前 C++ xim runtime 上实测确认），所以直接从归档名推导目录：

```
PROBE install_file = [/home/speak/.xlings/data/runtimedir/ninja-linux.zip]
PROBE install_dir  = [/home/speak/.xlings/data/xpkgs/local-x-hookprobe/1.12.1]
```

Zulu 因此不需要任何硬编码的 distro-version 表，将来 Azul 换构建号也不用动 hook。Corretto 的 linux 分支同样靠它拿到 arch token，mac/windows 两支则从版本串显式推导。两个 hook 都保留了「装完必须真有 launcher，否则 `return false`」的约束。

## 对用户环境的改动

跟 `jdk-temurin` 完全一致：`install()` 只把解包目录搬进 install dir；`config()` 只 `xvm.add`；`uninstall()` 只 `xvm.remove`。不写 rc 文件、不改 PATH、不调系统包管理器。

注册 `jdk-corretto` / `jdk-zulu` 作为 `type = "group"` 的 binding root（不产生孤儿 shim），以及 `java`/`javac`/`jar`/`javadoc`/`jshell` 五个 shim，带 `JAVA_HOME`。JDK 里另外约 90 个工具（`jlink`/`jpackage`/`keytool`…）不注册，避免遮蔽宿主工具，仍可通过 `<install>/bin` 访问。

共享名注册为 **flavor 版本**（`25.0.4.7.1-corretto` / `25.0.4-zulu`）。这是 #473 里探针实测出来的硬约束：xvm 拒绝两个包占用同一个 `(名字, 版本)`，用裸版本号的话两个发行版会互斥。

## 验证结果

**真机跑通（linux x86_64），四个版本块全部用「不带发行版后缀的版本」安装：**

```
$ xlings install local:jdk-corretto@25.0.4   → 解析到 25.0.4.7.1
  OpenJDK Runtime Environment Corretto-25.0.4.7.1 (build 25.0.4+7-LTS)
$ xlings install local:jdk-corretto@21.0.12  → 解析到 21.0.12.8.1
  OpenJDK Runtime Environment Corretto-21.0.12.8.1 (build 21.0.12+8-LTS)
$ xlings install local:jdk-zulu@25.0.4
  OpenJDK Runtime Environment Zulu25.36+15-CA (build 25.0.4+7-LTS)
$ xlings install local:jdk-zulu@21.0.12
  OpenJDK Runtime Environment Zulu21.52+15-CA (build 21.0.12+8-LTS)
```

**三个发行版、五个 JDK 同时共存**（含已合并的 `xim:jdk-temurin`），这也是 flavor 版本方案的实证：

```
java installed = [25.0.4+7-temurin,
                  local:25.0.4.7.1-corretto, local:21.0.12.8.1-corretto,
                  local:25.0.4-zulu,         local:21.0.12-zulu]

$ xlings use jdk-corretto 21.0.12.8.1 → Corretto-21.0.12.8.1
$ xlings use jdk-zulu     25.0.4      → Zulu25.36+15-CA
```

**JAVA_HOME 真的进到 JVM 环境里，且不污染用户 shell：**

```
$ echo 'System.out.println("JH=["+System.getenv("JAVA_HOME")+"]");' | jshell -s -
JH=[.../xpkgs/local-x-jdk-zulu/25.0.4]
$ echo "shell: [$JAVA_HOME]"
shell: []
```

**版本级卸载不误伤兄弟节点**（移除 zulu 21，另外四个和 shim 全部保留）：

```
$ xlings remove local:jdk-zulu@21.0.12
java installed = [25.0.4+7-temurin, local:21.0.12.8.1-corretto,
                  local:25.0.4-zulu, local:25.0.4.7.1-corretto]
shims: jar java javac javadoc jshell   (完好)
```

**CN 镜像端到端**（`xlings config --mirror CN` 后重装，走的是 GitCode，sha256 由 xlings 自己校验）：

```
$ xlings install local:jdk-zulu@25.0.4 -v
[debug] downloading local:jdk-zulu@25.0.4 from
        https://gitcode.com/xlings-res/jdk-zulu/releases/download/25.0.4/zulu25.36.15-ca-jdk25.0.4-linux_x64.tar.gz
Install complete: 1 succeeded
```

**CI（本仓库分支 push，三平台装卸全绿）：**

```
linux-install-test    PASS  jdk-corretto + jdk-zulu 各 5 shim, 卸载后 all shims cleaned
macos-install-test    PASS  macos-26-arm64, 真机验证两个包的 Contents/Home 分支
windows-test          PASS  java.exe/... 5 shim, 验证 jdk25.0.4_7 / *-win_x64 目录名推导
static-and-isolation / index-registration / linux-test    PASS
```

**测试集：**

```
pytest tests/j/test_jdk_corretto.py -m "static or isolation or index or verify" → 18 passed, 2 failed*
pytest tests/j/test_jdk_zulu.py     -m "static or isolation or index or verify" → 19 passed, 2 failed*
pytest tests/ -m "static or isolation"                                          → 全绿
python3 .github/scripts/version-check.py --workspace .                          → exit 0
```

\* 那 2 个都是 `assert_xvm_registered`，维护者本机 `xvm info` 坏了，对**所有**包都失败（拿 ninja/cmake/git 对照确认过），CI 上正常。

两个测试文件各自把关键决定钉成了静态断言：版本别名覆盖三平台、每个资源都有 GLOBAL+CN+sha256、解包布局分支齐全、共享名必须 flavor 化 + group 根、`JAVA_HOME` 必须注册；Zulu 额外断言不能混进 CRaC/musl 构建、distro 版本不能变成版本键。

## 一个留给 review 的选择

`jdk-corretto` 的 URL 其实足够规整，可以改写成 platform 级 `source` 模板 + per-arch sha256（配合 `arch_alias`），比现在的 Shape B 紧凑，也能接 `ci.update`。这里**没有这么做**，两个原因：一是跟 `jdk-temurin` 保持同一种可逐条 grep 核对的写法；二是本包有 `["25.0.4"] = { ref = ... }` 这样的别名，而自动升级只会追加版本块并推进 `latest`，别名会被落在旧构建上 —— 那是个静默的坑。如果维护者更倾向模板写法，我可以另开一个 PR 改。Zulu 无论如何都不能用模板（文件名里带 distro 版本）。
