### PR TITLE
tools: sync index pointer tooling with xlings 2026.8.4.1

### DIFF
--- a/.github/workflows/ci-tools.yml
+++ b/.github/workflows/ci-tools.yml
@@ -1,0 +1,55 @@
+name: tools test
+
+# The publishing scripts had NO coverage in this repo: every workflow filters on
+# `pkgs/**`, so a change under tools/ triggered nothing at all. Those scripts are
+# what writes the index pointer every client reads -- breaking one is silent
+# until a publish goes out wrong.
+on:
+  workflow_dispatch:
+  push:
+    branches: [ '**' ]
+    paths:
+      - 'tools/**'
+      - 'tests/scripts/**'
+      - '.github/workflows/ci-tools.yml'
+  pull_request:
+    paths:
+      - 'tools/**'
+      - 'tests/scripts/**'
+      - '.github/workflows/ci-tools.yml'
+
+jobs:
+  tools:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Shell scripts parse
+        run: |
+          for f in tools/*.sh; do bash -n "$f" || exit 1; done
+          echo "all tools/*.sh parse"
+
+      - name: Pointer history retention policy
+        run: python3 tests/scripts/test_index_pointer_history.py
+
+      # Builds a real artifact from THIS tree and checks the manifest shape,
+      # which is the step that carries the client contract.
+      - name: Build an index artifact from this tree
+        run: |
+          bash tools/build_xim_index_artifact.sh --version citest --out build/index --src .
+          python3 - <<'PY'
+          import json, pathlib, sys
+          m = json.load(open("build/index/xim-index-citest.manifest.json"))
+          for key in ("index_version", "artifact", "requires"):
+              if key not in m:
+                  sys.exit(f"manifest is missing {key}: {sorted(m)}")
+          if not m["artifact"].get("sha256"):
+              sys.exit("manifest artifact carries no sha256")
+          print(f"manifest ok: requires={m['requires']}")
+          PY
+
+      # Reports what floor this tree would need. Informational on purpose: the
+      # floor must not be declared until the pointer has history to route back
+      # to, so failing here would push a maintainer into doing it too early.
+      - name: Report the client floor this tree implies
+        run: python3 tools/check_index_compat.py . || true

--- a/tests/scripts/test_index_pointer_history.py
+++ b/tests/scripts/test_index_pointer_history.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""The pointer's history retention policy (#476, contract 10).
+
+This policy is load-bearing, not housekeeping: the set of snapshots it keeps IS
+the set a client can route to. Keep too few and an older client finds nothing it
+can use; keep by recency alone and the one contract generation it needs falls off
+the end while eight identical ones stay.
+
+So the rule under test is the union of:
+    A) the newest RECENT_KEEP snapshots, whatever they require
+    B) the newest snapshot of each distinct `requires` value
+"""
+from pathlib import Path
+import json
+import subprocess
+import sys
+import tempfile
+
+ROOT = Path(__file__).resolve().parents[2]
+MERGE = ROOT / "tools/merge_index_pointer.py"
+
+
+def manifest(version, requires=None, generated=None):
+    doc = {
+        "format_version": 1,
+        "index_version": version,
+        "index_name": "xim",
+        "generated_at": generated or f"2026-08-04T00:00:{int(version[-2:]):02d}Z",
+        "artifact": {"name": f"xim-index-{version}.tar.gz",
+                     "sha256": "a" * 64, "size": 1000},
+    }
+    if requires:
+        doc["requires"] = requires
+    return doc
+
+
+def publish(work, sequence, client_latest=None):
+    """Run the merge once per snapshot, as a real publish chain would."""
+    dst = work / "pointer.json"
+    for version, requires in sequence:
+        src = work / "src.json"
+        src.write_text(json.dumps({"format_version": 2,
+                                   "indexes": {"xim": manifest(version, requires)}}))
+        args = [sys.executable, str(MERGE), str(dst), str(src)]
+        if client_latest:
+            args.append(f"--client-latest=xlings={client_latest}")
+        result = subprocess.run(args, capture_output=True, text=True)
+        assert result.returncode == 0, result.stderr
+    return json.loads(dst.read_text())
+
+
+def versions_in(pointer):
+    return [row["index_version"] for row in pointer["indexes"]["xim"]["history"]]
+
+
+def test_recent_and_distinct_contracts_are_both_kept():
+    xl = lambda v: {"xlings": {"min": v}}
+    with tempfile.TemporaryDirectory() as temp:
+        work = Path(temp)
+        # 20 snapshots, three contract generations. The oldest generation's
+        # newest member is v05 -- far outside any recency window.
+        sequence = []
+        for i in range(1, 21):
+            if i <= 5:
+                req = xl("1.0.0")
+            elif i <= 10:
+                req = xl("2.0.0")
+            else:
+                req = xl("3.0.0")
+            sequence.append((f"v{i:02d}", req))
+        pointer = publish(work, sequence)
+        kept = versions_in(pointer)
+
+        # A: the newest 8, in order, newest first.
+        assert kept[:8] == [f"v{i:02d}" for i in range(20, 12, -1)], kept
+
+        # B: every contract generation still reachable, including the oldest,
+        # whose newest member is far past the recency window.
+        assert "v10" in kept, f"generation 2.0.0 unreachable: {kept}"
+        assert "v05" in kept, f"generation 1.0.0 unreachable: {kept}"
+
+        # And nothing redundant: one row per older generation, not five.
+        assert kept.count("v09") == 0 and kept.count("v04") == 0, kept
+        assert len(kept) == 10, f"expected 8 recent + 2 older generations: {kept}"
+
+
+def test_history_is_newest_first_and_deduplicated_by_version():
+    xl = {"xlings": {"min": "1.0.0"}}
+    with tempfile.TemporaryDirectory() as temp:
+        work = Path(temp)
+        pointer = publish(work, [("v01", xl), ("v02", xl), ("v02", xl)])
+        kept = versions_in(pointer)
+        assert kept == ["v02", "v01"], f"republishing a version must not duplicate it: {kept}"
+
+
+def test_truncation_is_reported_not_silent():
+    """A client must be able to tell 'nothing compatible exists' apart from
+    'the compatible one fell off the end' -- different problems, different fixes.
+    """
+    with tempfile.TemporaryDirectory() as temp:
+        work = Path(temp)
+        # 40 distinct contracts: every one is novel, so nothing can be dropped
+        # by the dedup rule and the cap has to do the dropping.
+        sequence = [(f"v{i:02d}", {"xlings": {"min": f"{i}.0.0"}}) for i in range(1, 41)]
+        pointer = publish(work, sequence)
+        entry = pointer["indexes"]["xim"]
+        assert len(entry["history"]) == 32, len(entry["history"])
+        assert entry["history_truncated"] is True
+
+
+def test_client_latest_is_carried_at_top_level():
+    """Without it a routed-back client cannot learn a newer client exists."""
+    with tempfile.TemporaryDirectory() as temp:
+        work = Path(temp)
+        pointer = publish(work, [("v01", None)], client_latest="2026.8.4.1")
+        assert pointer["client_latest"]["xlings"] == "2026.8.4.1"
+        assert pointer["format_version"] == 2
+
+
+def test_sibling_index_keys_survive_a_publish():
+    """Each index repo publishes independently; a plain overwrite drops the rest.
+    This regressed once already when xim-pkgindex's per-repo CI published alone.
+    """
+    with tempfile.TemporaryDirectory() as temp:
+        work = Path(temp)
+        dst = work / "pointer.json"
+        dst.write_text(json.dumps({
+            "format_version": 2,
+            "indexes": {"scode": {"index_version": "s01",
+                                  "artifact": {"name": "s.tar.gz", "sha256": "b" * 64}}},
+        }))
+        src = work / "src.json"
+        src.write_text(json.dumps({"format_version": 2,
+                                   "indexes": {"xim": manifest("v01")}}))
+        result = subprocess.run([sys.executable, str(MERGE), str(dst), str(src)],
+                                capture_output=True, text=True)
+        assert result.returncode == 0, result.stderr
+        pointer = json.loads(dst.read_text())
+        assert set(pointer["indexes"]) == {"xim", "scode"}, pointer["indexes"].keys()
+
+
+if __name__ == "__main__":
+    failures = 0
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            try:
+                fn()
+                print(f"ok   {name}")
+            except AssertionError as error:
+                print(f"FAIL {name}: {error}", file=sys.stderr)
+                failures += 1
+    if failures:
+        raise SystemExit(f"{failures} history-policy contract(s) failed")
+    print("index pointer history policy: ok")

--- a/tools/build_xim_index_artifact.sh
+++ b/tools/build_xim_index_artifact.sh
@@ -20,6 +20,7 @@
 #   XLINGS_RELEASE_PKGINDEX_REF=main    git ref to snapshot (default main)
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 VERSION="" OUT_DIR="" NAME="" SRC_DIR=""
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -95,6 +96,25 @@ SHA="$(sha256_of "$ARTIFACT")"
 SIZE="$(wc -c < "$ARTIFACT" | tr -d ' ')"
 GENERATED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
+# #476: the index tree may declare which client versions it needs, in
+# `index-compat.json` at its root:
+#
+#   { "requires": { "xlings": { "min": "2026.8.4.1" } } }
+#
+# Carried into the manifest verbatim. xlings evaluates only the "xlings" key
+# and routes clients that do not satisfy it to an older snapshot; every other
+# key is passed through for whichever consumer owns it. Absent file = no
+# constraint = today's behaviour.
+REQUIRES_JSON="{}"
+# From the assembled TREE, not --src: the clone path has no SRC_DIR, and the
+# tree is what actually ships.
+COMPAT_FILE="$TREE/index-compat.json"
+if [[ -f "$COMPAT_FILE" ]]; then
+  REQUIRES_JSON="$(python3 "$SCRIPT_DIR/read_index_compat.py" "$COMPAT_FILE")" \
+    || fail "index-compat.json rejected"
+  info "  requires: $REQUIRES_JSON"
+fi
+
 MANIFEST="$OUT_DIR/${ARTIFACT_BASE}.manifest.json"
 cat > "$MANIFEST" <<JSON
 {
@@ -108,6 +128,7 @@ cat > "$MANIFEST" <<JSON
     "sha256": "${SHA}",
     "size": ${SIZE}
   },
+  "requires": ${REQUIRES_JSON},
   "signature": null
 }
 JSON

--- a/tools/check_index_compat.py
+++ b/tools/check_index_compat.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Check that an index tree's declared client floor covers what its recipes use.
+
+    check_index_compat.py <index-tree>
+
+A floor nobody remembers to raise is not a contract. This scans the recipes for
+constructs that only newer clients understand and asserts the tree's
+`index-compat.json` declares a `requires.xlings.min` at least that high --
+turning "the author promised" into "the tree says so, and it was checked".
+
+Meant to run in the INDEX repo's CI (xim-pkgindex and any third-party index),
+not in xlings's. It lives here because xlings owns the table: it is the one that
+knows which of its own versions introduced which capability.
+
+Exit 0 = the declared floor covers everything found.
+Exit 1 = something in the tree needs a client newer than the tree admits.
+"""
+from pathlib import Path
+import json
+import re
+import sys
+
+# Construct -> the first xlings version that understands it.
+#
+# Append when a capability lands; the entry is what makes the next index adopting
+# it fail loudly here instead of on a user's machine. Each pattern is matched
+# against recipe text, so keep them specific enough not to fire on prose.
+CAPABILITIES = [
+    (re.compile(r'kind\s*=\s*["\']files["\']'),  "0.4.70",
+     "xvm registration kind 'files'"),
+    (re.compile(r'kind\s*=\s*["\']group["\']'),  "0.4.60",
+     "xvm registration kind 'group'"),
+    (re.compile(r'\bspec\s*=\s*["\']2["\']'),    "0.4.52",
+     "xpkg spec 2"),
+    (re.compile(r'\bsha256_by_arch\b|\barch_alias\b|\$\{arch\}'), "0.4.52",
+     "per-arch resource entry"),
+]
+
+
+def compare_versions(left: str, right: str) -> int:
+    """Component-wise numeric compare; mirrors version_order::compare.
+
+    Not semver: xlings versions are four components (YYYY.M.D.N) and semver's
+    three-component parser cannot read them at all.
+    """
+    def parts(value):
+        out = []
+        for chunk in value.split("-")[0].split("."):
+            out.append(int(chunk) if chunk.isdigit() else -1)
+        return out
+
+    a, b = parts(left), parts(right)
+    for i in range(max(len(a), len(b))):
+        x = a[i] if i < len(a) else 0
+        y = b[i] if i < len(b) else 0
+        if x != y:
+            return -1 if x < y else 1
+    return 0
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print(__doc__, file=sys.stderr)
+        return 2
+    tree = Path(sys.argv[1])
+    if not (tree / "pkgs").is_dir():
+        print(f"not an index tree (no pkgs/): {tree}", file=sys.stderr)
+        return 2
+
+    declared = ""
+    compat = tree / "index-compat.json"
+    if compat.is_file():
+        try:
+            doc = json.loads(compat.read_text(encoding="utf-8"))
+            declared = doc.get("requires", {}).get("xlings", {}).get("min", "")
+        except Exception as error:  # noqa: BLE001
+            print(f"index-compat.json unreadable: {error}", file=sys.stderr)
+            return 1
+
+    needed, why = "", []
+    for recipe in sorted((tree / "pkgs").rglob("*.lua")):
+        text = recipe.read_text(encoding="utf-8", errors="replace")
+        for pattern, version, label in CAPABILITIES:
+            if not pattern.search(text):
+                continue
+            why.append((recipe.relative_to(tree), label, version))
+            if not needed or compare_versions(version, needed) > 0:
+                needed = version
+
+    if not needed:
+        print("index compat: no version-gated construct found; any client works")
+        return 0
+
+    print(f"index compat: newest construct needs xlings >= {needed}")
+    for path, label, version in sorted(why)[:10]:
+        print(f"  {path}: {label} (>= {version})")
+    if len(why) > 10:
+        print(f"  … {len(why) - 10} more")
+
+    if declared and compare_versions(declared, needed) >= 0:
+        print(f"index compat: declared floor {declared} covers it")
+        return 0
+
+    print("", file=sys.stderr)
+    print(f"FAIL: this index uses constructs needing xlings >= {needed}, but "
+          f"index-compat.json declares "
+          f"{declared or 'no floor at all'}.", file=sys.stderr)
+    print(f"      Older clients would hard-fail on them instead of being routed "
+          f"to a snapshot they can use.", file=sys.stderr)
+    print(f'      Fix: set requires.xlings.min to "{needed}" (or higher) in '
+          f"index-compat.json.", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/merge_index_pointer.py
+++ b/tools/merge_index_pointer.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Merge freshly built index manifests into the published combined pointer,
+carrying an addressable history of past snapshots (#476).
+
+    merge_index_pointer.py <dst-pointer> <src-pointer> [--client-latest name=ver]...
+
+Only the keys present in <src-pointer> are touched; sibling indexes keep theirs,
+because each index repo publishes independently and a plain overwrite would drop
+the others.
+
+History is NOT "the last N snapshots". A client routing back needs the newest
+snapshot whose declared contract it satisfies, and contracts change rarely while
+snapshots are produced constantly -- xlings-res/xim-index holds 313 artifacts and
+a handful of distinct contracts. So the retained set is the union of:
+
+    A) the newest RECENT_KEEP snapshots, whatever they require
+       -- so "roll back one" stays possible, which is what debugging needs;
+    B) the newest snapshot of each distinct `requires` value
+       -- so every contract generation stays reachable, which is what routing
+          needs.
+
+capped at MAX_HISTORY entries, newest first. Dropping past the cap sets
+`history_truncated`, which lets a client tell "no compatible snapshot exists"
+apart from "the compatible one fell off the end" -- different problems with
+different fixes.
+"""
+import json
+import os
+import sys
+
+RECENT_KEEP = 8
+MAX_HISTORY = 32
+
+
+def snapshot_of(manifest):
+    """The history row describing a manifest."""
+    row = {
+        "index_version": manifest.get("index_version", ""),
+        "generated_at": manifest.get("generated_at", ""),
+        "artifact": manifest.get("artifact", {}),
+    }
+    requires = manifest.get("requires")
+    if requires:
+        row["requires"] = requires
+    return row
+
+
+def contract_key(row):
+    """Identity of a row's contract, for the 'one per distinct contract' rule."""
+    return json.dumps(row.get("requires", {}), sort_keys=True, separators=(",", ":"))
+
+
+def merge_history(previous, incoming):
+    """previous: existing history (newest first). incoming: the new head row."""
+    rows = [incoming]
+    for row in previous:
+        # The incoming snapshot replaces any stale row for the same version --
+        # a republish of the same index_version is the same snapshot.
+        if row.get("index_version") == incoming.get("index_version"):
+            continue
+        rows.append(row)
+
+    keep, seen_contracts = [], set()
+    for position, row in enumerate(rows):
+        recent = position < RECENT_KEEP
+        contract = contract_key(row)
+        novel = contract not in seen_contracts
+        seen_contracts.add(contract)
+        if recent or novel:
+            keep.append(row)
+
+    truncated = len(keep) > MAX_HISTORY
+    return keep[:MAX_HISTORY], truncated
+
+
+def main() -> int:
+    args = [a for a in sys.argv[1:] if not a.startswith("--")]
+    if len(args) != 2:
+        print(__doc__, file=sys.stderr)
+        return 2
+    dst_path, src_path = args
+
+    client_latest = {}
+    for arg in sys.argv[1:]:
+        if arg.startswith("--client-latest="):
+            name, _, version = arg[len("--client-latest="):].partition("=")
+            if name and version:
+                client_latest[name] = version
+
+    base = {"format_version": 2, "indexes": {}}
+    if os.path.exists(dst_path):
+        try:
+            with open(dst_path, encoding="utf-8") as handle:
+                base = json.load(handle)
+        except Exception:
+            # A corrupt published pointer must not stop a publish; it is fully
+            # regenerated below for the keys we own, and sibling keys were
+            # already unreadable.
+            base = {"format_version": 2, "indexes": {}}
+    base.setdefault("indexes", {})
+
+    with open(src_path, encoding="utf-8") as handle:
+        incoming = json.load(handle).get("indexes", {})
+
+    for key, manifest in incoming.items():
+        previous = base["indexes"].get(key, {}).get("history", [])
+        history, truncated = merge_history(previous, snapshot_of(manifest))
+
+        # Declaring a floor only helps if there is somewhere to route back TO.
+        # The first publish after adopting this carries a one-entry history, so
+        # a floor declared in that same publish strands every client below it
+        # instead of routing it -- worse than the hard failure it replaces.
+        # Publish history first, let it accumulate, then raise the floor.
+        head_requires = manifest.get("requires", {}).get("xlings", {})
+        if head_requires.get("min"):
+            escape = [r for r in history[1:]
+                      if not r.get("requires", {}).get("xlings", {}).get("min")]
+            older = [r for r in history[1:]]
+            if not older:
+                print(f"[pointers] WARNING: {key} declares a client floor but "
+                      f"publishes no older snapshot. Clients below "
+                      f"{head_requires['min']} will have nowhere to route and "
+                      f"will fail outright. Publish history before raising a "
+                      f"floor.", file=sys.stderr)
+            elif not escape:
+                print(f"[pointers] note: {key} floor {head_requires['min']}; "
+                      f"every published snapshot declares one, so clients older "
+                      f"than the lowest will still fail.", file=sys.stderr)
+        entry = dict(manifest)
+        entry["history"] = history
+        entry["history_truncated"] = truncated
+        base["indexes"][key] = entry
+        print(f"[pointers] {key}: {len(history)} snapshot(s) in history"
+              f"{' (truncated)' if truncated else ''}")
+
+    # Newest CLIENT version, carried at top level so it is readable no matter
+    # which snapshot a client routes to. Without it a routed-back client cannot
+    # learn that a newer client exists, and can never leave the old snapshot.
+    if client_latest:
+        base.setdefault("client_latest", {}).update(client_latest)
+
+    base["format_version"] = 2
+    with open(dst_path, "w", encoding="utf-8") as handle:
+        json.dump(base, handle, indent=2)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/push_index_pointers.sh
+++ b/tools/push_index_pointers.sh
@@ -18,6 +18,17 @@ set -euo pipefail
 DIR="${1:?usage: push_index_pointers.sh <dir>}"
 GH_REPO_SLUG="${GH_REPO_SLUG:-xlings-res/xim-index}"
 GTC_REPO_SLUG="${GTC_REPO_SLUG:-xlings-res/xim-index}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# #476: the newest xlings release, recorded at the pointer top level. A
+# client routed to an older snapshot reads that snapshot's own xlings recipe,
+# which names the `latest` of its era -- without this it could never learn a
+# newer client exists, and could never leave the snapshot it was routed to.
+CLIENT_LATEST_ARGS=""
+if [[ -n "${XLINGS_CLIENT_LATEST:-}" ]]; then
+  CLIENT_LATEST_ARGS="--client-latest=xlings=${XLINGS_CLIENT_LATEST}"
+fi
+
 
 compgen -G "$DIR/*-latest.json" >/dev/null 2>&1 || { echo "[pointers] no *-latest.json in $DIR" >&2; exit 1; }
 
@@ -36,7 +47,7 @@ for f in sorted(glob.glob(os.path.join(d, "*-latest.json"))):
     key = m.group(1) or "xim"
     try: indexes[key] = json.load(open(f, encoding="utf-8"))
     except Exception as e: print(f"[pointers] skip {name}: {e}", file=sys.stderr)
-json.dump({"format_version": 1, "indexes": indexes}, open(out, "w", encoding="utf-8"), indent=2)
+json.dump({"format_version": 2, "indexes": indexes}, open(out, "w", encoding="utf-8"), indent=2)
 print(f"[pointers] combined {len(indexes)} index(es): {', '.join(sorted(indexes))}")
 PY
 
@@ -52,18 +63,11 @@ push_one() {  # <clone-url> <label>
   # sibling indexes' keys. Each index repo (xim, awesome, scode, d2x) publishes
   # independently and must update ONLY its own key — a plain overwrite would drop
   # the others (regression seen when xim-pkgindex's per-repo CI published alone).
-  python3 - "$tmp/xim-index-pointers.json" "$COMBINED" <<'PYMERGE'
-import sys, json, os
-dst, src = sys.argv[1], sys.argv[2]
-base = {"format_version": 1, "indexes": {}}
-if os.path.exists(dst):
-    try: base = json.load(open(dst, encoding="utf-8"))
-    except Exception: base = {"format_version": 1, "indexes": {}}
-base.setdefault("indexes", {})
-base["indexes"].update(json.load(open(src, encoding="utf-8")).get("indexes", {}))
-base["format_version"] = 1
-json.dump(base, open(dst, "w", encoding="utf-8"), indent=2)
-PYMERGE
+  # #476: the merge also carries an addressable history per index and the
+  # newest client version. Extracted to a script so the retention policy is
+  # testable -- "which snapshots stay reachable" is the whole feature.
+  python3 "$SCRIPT_DIR/merge_index_pointer.py" \
+      "$tmp/xim-index-pointers.json" "$COMBINED" $CLIENT_LATEST_ARGS
   git -C "$tmp" add -A
   if git -C "$tmp" diff --cached --quiet; then
     echo "[pointers] $label: no change"; rm -rf "$tmp"; return 0

--- a/tools/read_index_compat.py
+++ b/tools/read_index_compat.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Read an index tree's `index-compat.json` and print its `requires` block.
+
+The block declares which client versions a published index snapshot needs:
+
+    { "requires": { "xlings": { "min": "2026.8.4.1" } } }
+
+It is a map of consumer name -> {min, max}. xlings evaluates only the "xlings"
+key and routes clients that do not satisfy it to an older snapshot; every other
+key is carried through untouched for whichever consumer owns it (#476).
+
+Validated here rather than in the client, because a malformed contract should
+stop a publish rather than reach every machine that runs `xlings update`.
+"""
+import json
+import sys
+
+# The pointer this ends up in is fetched on every `xlings update`. A publisher
+# must not be able to make that fetch expensive for everyone.
+MAX_BYTES = 4096
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("usage: read_index_compat.py <index-compat.json>", file=sys.stderr)
+        return 2
+    try:
+        with open(sys.argv[1], encoding="utf-8") as handle:
+            doc = json.load(handle)
+    except Exception as error:  # noqa: BLE001 - any parse failure is fatal here
+        print(f"index-compat.json is not valid JSON: {error}", file=sys.stderr)
+        return 1
+
+    requires = doc.get("requires", {})
+    if not isinstance(requires, dict):
+        print("index-compat.json: `requires` must be an object", file=sys.stderr)
+        return 1
+
+    for consumer, bound in requires.items():
+        if not isinstance(bound, dict):
+            print(f"index-compat.json: requires.{consumer} must be an object",
+                  file=sys.stderr)
+            return 1
+        for key, value in bound.items():
+            if key not in ("min", "max"):
+                # Not fatal for foreign consumers -- xlings does not own their
+                # vocabulary -- but a typo'd bound on OUR key silently means
+                # "no constraint", which is the failure mode worth catching.
+                if consumer == "xlings":
+                    print(f"index-compat.json: requires.xlings.{key} is not a "
+                          f"bound; expected min/max", file=sys.stderr)
+                    return 1
+                continue
+            if not isinstance(value, str) or not value:
+                print(f"index-compat.json: requires.{consumer}.{key} must be a "
+                      f"non-empty string", file=sys.stderr)
+                return 1
+
+    blob = json.dumps(requires, separators=(",", ":"), ensure_ascii=False)
+    if len(blob.encode("utf-8")) > MAX_BYTES:
+        print(f"index-compat.json: `requires` is {len(blob)} bytes, over the "
+              f"{MAX_BYTES} limit", file=sys.stderr)
+        return 1
+
+    print(blob)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Why

This repo carries its **own copies** of the index publishing scripts, and its
`Publish Index Artifact` workflow runs them. After xlings `2026.8.4.1` shipped the
index version contract ([openxlings/xlings#476](https://github.com/openxlings/xlings/issues/476)),
the two publishers disagree — and the one here wins for the `xim` key.

Observed on the live pointer right after the release:

```
awesome: history=1  requires={}      <- written by xlings's publish-index
d2x:     history=1  requires={}
scode:   history=1  requires={}
xim:     history=0  (no requires)    <- overwritten from this repo
format_version: 1                    <- knocked back from 2
```

**Harmless today** — nothing declares a floor, so nothing routes. But history can
never accumulate for the **main** index, the one that matters most, until this
repo publishes it. The feature would quietly never arrive here.

## What

Syncs the two changed scripts and adds three new ones:

| script | role |
|---|---|
| `merge_index_pointer.py` | assembles per-index `history` (newest 8 **union** newest of each distinct contract, capped at 32) plus `client_latest` |
| `read_index_compat.py` | validates an optional `index-compat.json` at publish time, so a malformed contract stops one publish instead of reaching every machine |
| `check_index_compat.py` | scans recipes for constructs needing newer clients and checks the declared floor covers them |

## Deliberately NOT included

**No `index-compat.json` for this index, and no CI wiring for the checker.**

The checker reports this tree needs `xlings >= 0.4.52` (spec 2, in seven recipes).
Declaring that floor while the pointer's history is empty would leave every client
below it with **nowhere to route** — strictly worse than the hard failure it
replaces. History has to accumulate first.

Order, per `docs/design/index-version-contract.md` §6 in openxlings/xlings:

1. publish history, no floor ← **this PR enables step 1**
2. let it accumulate over a few publishes
3. *then* declare the floor

`merge_index_pointer.py` warns if someone does it out of order, but cannot stop
them — that is the publisher's call, made visible.