### PR TITLE
feat(godot): add Godot Engine editor xpkg with CN mirror

### DIFF
--- a/pkgs/g/godot.lua
+++ b/pkgs/g/godot.lua
@@ -1,0 +1,220 @@
+-- Godot Engine editor — official upstream prebuilt binaries.
+--
+-- Only the *standard* (non-Mono) builds are packaged. They are the
+-- portable ones: the Mono/C# flavour additionally needs a matching .NET
+-- SDK on the host, while the standard editor is a single self-contained
+-- executable. Upstream ships no arch-suffixed variants of a given
+-- platform beyond the ones mapped below.
+--
+-- URL shapes are irregular across platforms and arches
+-- (`linux.x86_64` / `linux.arm64` / `win64` / `windows_arm64` /
+-- `macos.universal`), so this recipe uses the V2 per-arch resource map
+-- (Shape B) with an explicit `{GLOBAL, CN}` mirror table per asset
+-- rather than a `${arch_alias}` template. The helper builders below keep
+-- that from turning into 30 copy-pasted URLs.
+--
+-- GLOBAL = the authoritative upstream GitHub release.
+-- CN     = gitcode.com/xlings-res/godot, a byte-identical copy of those
+--          same assets (same filenames; tag drops the `-stable` suffix),
+--          published so mainland-China installs don't go through
+--          github.com. Both sides were verified against upstream
+--          `SHA512-SUMS.txt` before the sha256 values here were recorded.
+--
+-- No `package.ci`: `version-check.py`'s `normalize_version()` only strips
+-- a leading `v`, so godot's `4.7.1-stable` tags would be proposed as a
+-- literal `4.7.1-stable` version key and never match the `4.7.1` keys
+-- used here. The CN mirror is therefore refreshed by hand per release.
+
+local _GODOT_GH = "https://github.com/godotengine/godot/releases/download"
+local _GODOT_CN = "https://gitcode.com/xlings-res/godot/releases/download"
+
+-- One asset -> its GLOBAL/CN mirror pair. Upstream tags are
+-- `<ver>-stable`; the CN mirror tags are plain `<ver>`.
+local function _res(ver, asset, sha256)
+    return {
+        url = {
+            GLOBAL = string.format("%s/%s-stable/%s", _GODOT_GH, ver, asset),
+            CN = string.format("%s/%s/%s", _GODOT_CN, ver, asset),
+        },
+        sha256 = sha256,
+    }
+end
+
+local function _linux(ver, sha_x86_64, sha_aarch64)
+    return {
+        x86_64 = _res(ver, string.format("Godot_v%s-stable_linux.x86_64.zip", ver), sha_x86_64),
+        aarch64 = _res(ver, string.format("Godot_v%s-stable_linux.arm64.zip", ver), sha_aarch64),
+    }
+end
+
+local function _windows(ver, sha_x86_64, sha_aarch64)
+    return {
+        x86_64 = _res(ver, string.format("Godot_v%s-stable_win64.exe.zip", ver), sha_x86_64),
+        aarch64 = _res(ver, string.format("Godot_v%s-stable_windows_arm64.exe.zip", ver), sha_aarch64),
+    }
+end
+
+-- macOS ships a single universal (x86_64 + arm64) bundle, so both arch
+-- keys intentionally resolve to the same asset and the same sha256.
+local function _macosx(ver, sha)
+    local asset = string.format("Godot_v%s-stable_macos.universal.zip", ver)
+    return {
+        x86_64 = _res(ver, asset, sha),
+        aarch64 = _res(ver, asset, sha),
+    }
+end
+
+package = {
+    spec = "2",
+
+    name = "godot",
+    description = "Godot Engine - multi-platform 2D and 3D game engine (editor + headless export runner)",
+
+    homepage = "https://godotengine.org",
+    maintainers = {"Godot Engine contributors"},
+    licenses = {"MIT"},
+    repo = "https://github.com/godotengine/godot",
+    docs = "https://docs.godotengine.org",
+
+    -- xim pkg info
+    type = "package",
+    archs = {"x86_64", "aarch64"},
+    status = "stable",
+    categories = {"gamedev", "engine", "editor"},
+    keywords = {"godot", "game-engine", "gdscript", "gdextension", "2d", "3d", "gamedev"},
+
+    programs = {"godot"},
+    xvm_enable = true,
+
+    xpm = {
+        linux = {
+            -- Runtime deps. The official editor binary is dynamically
+            -- linked (INTERP=/lib64/ld-linux-x86-64.so.2) against glibc
+            -- only: NEEDED librt/libpthread/libdl/libm/libc, highest
+            -- referenced symbol version GLIBC_2.28. Godot statically
+            -- links its C++ runtime, so libstdc++/libgcc_s are NOT in
+            -- NEEDED (same as griddycode.lua, itself a Godot build).
+            -- GUI libraries (libGL/libX11/libwayland/libXi) are dlopen'd
+            -- by Godot at runtime rather than via DT_NEEDED and are not
+            -- shipped by xim; `godot --headless` works without them,
+            -- opening the editor still needs a real X11/Wayland session.
+            deps = {
+                runtime = { "xim:glibc@2.39" },
+            },
+            ["latest"] = { ref = "4.7.1" },
+            ["4.7.1"] = _linux("4.7.1",
+                "c7ff14fd28472c8d4f193043de30278dcf7e5241a1dcf7566b02e27addaa33ba",
+                "8f527179cd4ae58b402fa265fe817dc505e5b6b14574f309efe57113be562ac1"),
+            -- 4.6.x is kept alongside latest because Godot project files
+            -- record a `config_version` and a 4.6 project opened by a 4.7
+            -- editor is silently migrated. GDExtension consumers that
+            -- pin a 4.6 API (e.g. github.com/FarnaHerry/mcpp-kaki) need
+            -- `xvm use godot@4.6.3` to stay on the matching editor.
+            ["4.6.3"] = _linux("4.6.3",
+                "d0bc2113065e481c9c2c2b2c37daa4e8be3fe9e27f0ab9ab0b6096e9a37907f3",
+                "90c70382eee1542904bf507b9bdc6e62a230ac73fd214bf3887a9e0a4d85aeed"),
+        },
+        windows = {
+            ["latest"] = { ref = "4.7.1" },
+            ["4.7.1"] = _windows("4.7.1",
+                "c7a289051eaefb460b0106b60e9cd5bee0ef55fd102dcb2bed1eb356cf3d90a1",
+                "d9cdf49102092a2b6db4c5929002628d16eca3d7226afca2b1d03431a0a1e64b"),
+            ["4.6.3"] = _windows("4.6.3",
+                "e39986a178d585ce7ac198fb8de6ea436366dc0cc00e594810c2e3e104c04b90",
+                "d53b5b4c1d1e4f242d490a98a0da1b3579628e4d6f98a052542599862a96b10f"),
+        },
+        macosx = {
+            ["latest"] = { ref = "4.7.1" },
+            ["4.7.1"] = _macosx("4.7.1",
+                "897cb7f9799796c717ae75f31446aed883dc92b1d6c3b33d893cc7843fff2fa9"),
+            ["4.6.3"] = _macosx("4.6.3",
+                "30630f3e9b11e10b35c1f90ba8814185dcec43fae1a48345159be7552c64bfe8"),
+        },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+import("xim.libxpkg.system")
+
+-- Every asset is a .zip that expands into the hook cwd (the download
+-- dir) with no wrapper directory:
+--   linux   -> one ELF named exactly like the archive minus `.zip`,
+--              e.g. `Godot_v4.7.1-stable_linux.x86_64`
+--   windows -> `Godot_v4.7.1-stable_win64.exe` plus a `_console.exe`
+--              sibling (the console subsystem build, the one that can
+--              print to a terminal)
+--   macosx  -> a signed `Godot.app/` bundle whose name carries neither
+--              version nor arch
+--
+-- The linux/windows payload name embeds the arch token, and the hook
+-- cannot ask for the host arch: `os.arch` is not bound in the xim hook
+-- runtime and `_RUNTIME.arch` is empty for install hooks. Deriving the
+-- name from `pkginfo.install_file()` (the archive we actually
+-- downloaded) keeps the hook arch-agnostic.
+local function _payload_stem()
+    local file = pkginfo.install_file() or ""
+    local base = file:match("[^/\\]+$") or ""
+    return (base:gsub("%.zip$", ""))
+end
+
+local function _installed_exe()
+    return path.join(pkginfo.install_dir(), os.host() == "windows" and "godot.exe" or "godot")
+end
+
+function install()
+    -- Idempotent across xim engines: some stage the extracted payload
+    -- into install_dir() before the hook runs, others leave it in the
+    -- hook cwd. Never wipe install_dir before a replacement payload is
+    -- confirmed, and never report success unless the binary landed --
+    -- a bare `return true` gets stamped as installed and leaves
+    -- dangling xvm shims over an empty directory.
+    local exe = _installed_exe()
+    if os.isfile(exe) then
+        return true
+    end
+
+    os.tryrm(pkginfo.install_dir())
+    os.mkdir(pkginfo.install_dir())
+
+    if os.host() == "macosx" then
+        -- Keep the bundle intact: Contents/Resources holds the editor
+        -- icons/localisation and Contents/Info.plist drives the code
+        -- signature. Expose the Mach-O through a symlink so xvm's
+        -- bindir model finds a lowercase `godot`; macOS resolves the
+        -- symlink before deriving the bundle path, so resources still
+        -- load. (`symlink = true` on os.cp is the same idiom
+        -- cc-switch.lua uses for its .app bundle.)
+        os.mv("Godot.app", path.join(pkginfo.install_dir(), "Godot.app"))
+        os.cp(path.join(pkginfo.install_dir(), "Godot.app", "Contents", "MacOS", "Godot"),
+              exe, { force = true, symlink = true })
+        return os.isfile(exe)
+    end
+
+    local stem = _payload_stem()
+
+    if os.host() == "windows" then
+        os.mv(stem, exe)
+        local console = stem:gsub("%.exe$", "_console.exe")
+        if os.isfile(console) then
+            os.mv(console, path.join(pkginfo.install_dir(), "godot_console.exe"))
+        end
+        return os.isfile(exe)
+    end
+
+    os.mv(stem, exe)
+    -- The zip stores the executable bit, but restoring it explicitly
+    -- keeps the recipe correct on extractors that drop unix modes.
+    system.exec("chmod +x " .. exe)
+    return os.isfile(exe)
+end
+
+function config()
+    xvm.add("godot", { bindir = pkginfo.install_dir() })
+    return true
+end
+
+function uninstall()
+    xvm.remove("godot")
+    return true
+end

--- a/tests/g/test_godot.py
+++ b/tests/g/test_godot.py
@@ -1,0 +1,94 @@
+"""测试 godot 包"""
+import pytest
+from tests.lib.xpkg_parser import parse_xpkg
+from tests.lib.assertions import (
+    assert_required_fields, assert_valid_spec, assert_valid_type,
+    assert_no_typos, assert_no_exec_xvm, assert_no_bashrc_modification,
+    assert_no_direct_path_modification, assert_uses_new_api,
+    assert_xim_add_succeeds, assert_install_succeeds,
+    assert_command_output, assert_xvm_registered,
+)
+from tests.lib.platform_utils import skip_if_not
+
+PKG = "godot"
+PKG_FILE = "pkgs/g/godot.lua"
+
+
+@pytest.fixture(scope='module')
+def meta():
+    return parse_xpkg(PKG_FILE)
+
+
+class TestStatic:
+    @pytest.mark.static
+    def test_required_fields(self, meta):
+        assert_required_fields(meta)
+
+    @pytest.mark.static
+    def test_valid_spec(self, meta):
+        assert_valid_spec(meta)
+
+    @pytest.mark.static
+    def test_valid_type(self, meta):
+        assert_valid_type(meta)
+
+    @pytest.mark.static
+    def test_no_typos(self):
+        assert_no_typos(PKG_FILE)
+
+    @pytest.mark.static
+    def test_all_platforms_declared(self, meta):
+        """三平台都要在 xpm 中声明 — godot 上游对每个平台都发预构建二进制"""
+        for plat in ("linux", "windows", "macosx"):
+            assert meta.platforms.get(plat), f"xpm 缺少 {plat} 平台"
+
+
+class TestIndex:
+    @pytest.mark.index
+    def test_xim_add(self):
+        assert_xim_add_succeeds(PKG_FILE)
+
+
+class TestIsolation:
+    @pytest.mark.isolation
+    def test_no_exec_xvm(self):
+        assert_no_exec_xvm(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_no_bashrc(self):
+        assert_no_bashrc_modification(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_no_path_modification(self):
+        assert_no_direct_path_modification(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_new_api(self):
+        assert_uses_new_api(PKG_FILE)
+
+
+class TestLifecycle:
+    @pytest.mark.lifecycle
+    @skip_if_not('linux')
+    def test_install(self):
+        assert_install_succeeds(PKG)
+
+
+class TestVerify:
+    @pytest.mark.verify
+    @skip_if_not('linux')
+    def test_godot_version(self):
+        # `--version` needs no display; the editor only requires an
+        # X11/Wayland session when it actually opens a window.
+        assert_command_output("godot --version")
+
+    @pytest.mark.verify
+    @skip_if_not('linux')
+    def test_godot_headless(self):
+        # The export/CI path users actually script against.
+        assert_command_output("godot --headless --version")
+
+    @pytest.mark.verify
+    @skip_if_not('linux')
+    def test_xvm_godot(self):
+        assert_xvm_registered("godot")


### PR DESCRIPTION
## Summary

Adds `godot` — the Godot Engine editor — as an xpkg, using the **official upstream
prebuilt binaries** for all three platforms on both arches, with a CN mirror.

Motivation: a Godot *game* ships standalone (the export template runtime is baked into
the exported executable, players never install Godot), but a Godot **project** cannot be
built or run without the editor binary. GDExtension projects need it twice over — the
`.so`/`.dll` they produce is a plugin whose host process *is* `godot`, and generating the
godot-cpp bindings requires `godot --dump-extension-api`. Such projects state the
dependency as "Godot 4.x, `godot` on PATH" (e.g.
[FarnaHerry/mcpp-kaki](https://github.com/FarnaHerry/mcpp-kaki)), which is exactly what
an xvm shim provides.

### What is packaged

Only the **standard (non-Mono) builds**. They are the portable choice: the Mono/C#
flavour additionally requires a matching .NET SDK on the host, while the standard editor
is a single self-contained executable.

| platform | x86_64 | aarch64 |
|---|---|---|
| linux | `Godot_v<ver>-stable_linux.x86_64.zip` | `Godot_v<ver>-stable_linux.arm64.zip` |
| windows | `Godot_v<ver>-stable_win64.exe.zip` | `Godot_v<ver>-stable_windows_arm64.exe.zip` |
| macosx | `Godot_v<ver>-stable_macos.universal.zip` | *(same universal bundle)* |

Versions: **4.7.1** (`latest`) and **4.6.3**. 4.6.x is kept because Godot project files
record a `config_version` — a 4.6 project opened by a 4.7 editor is silently migrated —
so GDExtension consumers pinned to the 4.6 API can `xvm use godot@4.6.3`.

### CN acceleration

Every asset carries a `{GLOBAL, CN}` mirror pair (V2 Shape B per-arch resource map):

- `GLOBAL` → `github.com/godotengine/godot` (the authoritative upstream release)
- `CN` → `gitcode.com/xlings-res/godot` (new repo, seeded for this PR)

The CN assets are **byte-identical copies** of the upstream ones, same filenames; only
the tag drops the `-stable` suffix (`4.7.1` mirrors `4.7.1-stable`). Provenance chain:
downloaded from upstream → verified against upstream `SHA512-SUMS.txt` → uploaded to
GitCode → re-downloaded from GitCode and compared by sha256 against the local copy. The
sha256 values recorded in the recipe are from those verified bytes.

A `${arch_alias}` template does not fit here — upstream asset names are irregular across
platforms *and* arches (`linux.x86_64` vs `win64` vs `windows_arm64` vs `macos.universal`)
— so the recipe uses the per-arch resource map, generated by three small Lua builders so
the 20 URL pairs aren't copy-pasted.

**No `package.ci`.** `version-check.py`'s `normalize_version()` only strips a leading
`v`, so godot's `4.7.1-stable` tags would be proposed as a literal `4.7.1-stable` version
key that never matches the `4.7.1` keys used here. Enabling `ci.update` would open a
broken bump PR every scan cycle. The CN mirror is refreshed by hand per release instead.

## Behaviour

**Install** — downloads one zip and moves the editor into `install_dir()`:

- linux: the archive holds a single ELF named exactly like the archive minus `.zip`;
  it is renamed to `godot` and `chmod +x`'d.
- windows: `Godot_v<ver>-stable_<win>.exe` → `godot.exe`, and the `_console.exe`
  sibling (the console-subsystem build that can print to a terminal) →
  `godot_console.exe`.
- macosx: the signed `Godot.app/` bundle is moved in whole (its `Contents/Resources`
  holds the editor data and `Info.plist` drives the signature), and
  `Contents/MacOS/Godot` is exposed as a lowercase `godot` symlink so xvm's bindir
  model works — the same idiom `cc-switch.lua` uses.

The payload name is derived from `pkginfo.install_file()` rather than hard-coded per
arch, because `os.arch` is not bound in the xim hook runtime and `_RUNTIME.arch` is
empty for install hooks. `install()` early-returns if the binary is already staged in
`install_dir()`, and returns the result of an `os.isfile` check rather than a bare
`true`, so a failed move cannot be stamped as installed.

**Config** — `xvm.add("godot", { bindir = install_dir() })`. Nothing else.

**Uninstall** — `xvm.remove("godot")`; the payload directory is removed by xim.

**System changes** — none. No PATH edits, no shell profile edits, no system package
manager, no files outside the xpkg dir and the xvm registration.

**Runtime deps (linux)** — `xim:glibc@2.39`. The official binary is dynamically linked
against glibc only (`NEEDED` = librt/libpthread/libdl/libm/libc, highest referenced
symbol version `GLIBC_2.28`); Godot statically links its C++ runtime, so no
libstdc++/libgcc_s — same shape as `griddycode.lua`, itself a Godot build. GUI libraries
(libGL/libX11/libwayland/libXi) are `dlopen`'d by Godot at runtime rather than via
`DT_NEEDED` and are not shipped by xim: `godot --headless` works without them, opening
the editor window still needs a real X11/Wayland session.

## Test plan

Local (linux x86_64, xlings 2026.8.2.1, mirror=CN):

```
xlings config --add-xpkg pkgs/g/godot.lua      → registered
xlings search godot                            → local:godot listed
xlings install local:godot@4.7.1 --yes         → Install complete: 2 succeeded
ls ~/.xlings/data/xpkgs/local-x-godot/4.7.1/   → godot (144583504 bytes, -rwxr-xr-x)
which godot                                    → ~/.xlings/subos/current/bin/godot
godot --version                                → 4.7.1.stable.official.a13da4feb
godot --headless --version                     → 4.7.1.stable.official.a13da4feb
xlings remove local:godot@4.7.1 --yes          → Removed; shim and payload dir both gone
```

pytest:

```
pytest tests/g/test_godot.py -m "static or isolation"  → 9 passed
pytest tests/g/test_godot.py -m index                  → 1 passed
pytest tests/ -m static                                → 623 passed
pytest tests/ -m isolation                             → 342 passed, 4 xpassed
python3 tools/xpkg_ci.py inspect --only godot          → mirror=false, update=false,
                                                         platforms=[linux, macosx, windows]
```

Not run locally, deferred to CI: windows and macOS install/uninstall. `assert_xvm_registered`
also can't be verified on this machine — `xvm info` prints only "[Runtime Tips]" here for
every package, including known-good controls, so that check is left to CI.

### CI (already green on this SHA)

`.github/workflows/ci-test.yml` ("pkgindex test") has no `pull_request` trigger, but it
does fire on push to `'**'`, so it ran on `feat/godot` and covered all three platforms
with a real install + uninstall of `4.7.1`:

| job | result |
|---|---|
| `linux-install-test` | install dir present, `[PASS] new shim: godot`, `[PASS] all shims cleaned` — tested: 1, failures: 0 |
| `macos-install-test` | install dir present, `[PASS] new shim: godot` (the `.app` bundle + symlink path), clean uninstall — tested: 1, failures: 0 |
| `windows-test` | install dir present, `[PASS] new shim: godot.exe`, clean uninstall — tested: 1, failures: 0 |
| `xpkg test` (L0/L1/L2) | success |

Run: https://github.com/openxlings/xim-pkgindex/actions/runs/30846407100

### CN mirror verification

Every asset was downloaded back from `gitcode.com/xlings-res/godot` and compared by
sha256 against the upstream-verified local copy:

```
OK   4.7.1/Godot_v4.7.1-stable_linux.x86_64.zip        c7ff14fd28472c8d4f193043de30278dcf7e5241a1dcf7566b02e27addaa33ba
OK   4.7.1/Godot_v4.7.1-stable_linux.arm64.zip         8f527179cd4ae58b402fa265fe817dc505e5b6b14574f309efe57113be562ac1
OK   4.7.1/Godot_v4.7.1-stable_win64.exe.zip           c7a289051eaefb460b0106b60e9cd5bee0ef55fd102dcb2bed1eb356cf3d90a1
OK   4.7.1/Godot_v4.7.1-stable_windows_arm64.exe.zip   d9cdf49102092a2b6db4c5929002628d16eca3d7226afca2b1d03431a0a1e64b
OK   4.7.1/Godot_v4.7.1-stable_macos.universal.zip     897cb7f9799796c717ae75f31446aed883dc92b1d6c3b33d893cc7843fff2fa9
OK   4.6.3/Godot_v4.6.3-stable_linux.x86_64.zip        d0bc2113065e481c9c2c2b2c37daa4e8be3fe9e27f0ab9ab0b6096e9a37907f3
OK   4.6.3/Godot_v4.6.3-stable_linux.arm64.zip         90c70382eee1542904bf507b9bdc6e62a230ac73fd214bf3887a9e0a4d85aeed
OK   4.6.3/Godot_v4.6.3-stable_win64.exe.zip           e39986a178d585ce7ac198fb8de6ea436366dc0cc00e594810c2e3e104c04b90
OK   4.6.3/Godot_v4.6.3-stable_windows_arm64.exe.zip   d53b5b4c1d1e4f242d490a98a0da1b3579628e4d6f98a052542599862a96b10f
OK   4.6.3/Godot_v4.6.3-stable_macos.universal.zip     30630f3e9b11e10b35c1f90ba8814185dcec43fae1a48345159be7552c64bfe8
```

One operational note for whoever refreshes this mirror next: `gtc release upload` reads
the whole file into memory and does a single urllib `PUT`, which dies with an SSL EOF on
the ~167 MB macOS bundle *after* OBS has already stored a partial object — and the
GitCode release record then keeps pointing at that truncated object, so re-uploading
does not fix it (the download URL still serves the short file). Streaming the same
presigned `PUT` with `curl -T` succeeds at that size. If an asset does end up truncated,
the release has to be dropped (`DELETE /api/v5/repos/<o>/<r>/tags/<tag>`) and recreated.
