### PR TITLE
fix(godot): ship libfreetype dep; fix(ci): arch-independent URL + platforms opt-in

### DIFF
--- a/pkgs/g/godot.lua
+++ b/pkgs/g/godot.lua
@@ -94,12 +94,20 @@ package = {
             -- referenced symbol version GLIBC_2.28. Godot statically
             -- links its C++ runtime, so libstdc++/libgcc_s are NOT in
             -- NEEDED (same as griddycode.lua, itself a Godot build).
-            -- GUI libraries (libGL/libX11/libwayland/libXi) are dlopen'd
-            -- by Godot at runtime rather than via DT_NEEDED and are not
-            -- shipped by xim; `godot --headless` works without them,
-            -- opening the editor still needs a real X11/Wayland session.
+            --
+            -- libfreetype.so.6 is dlopen'd unconditionally at startup
+            -- for the editor's text rendering (fires before even
+            -- `--version` prints), so it ships as a hard runtime dep.
+            -- The remaining GUI libraries -- libGL, libX11, libwayland,
+            -- libXi -- are also dlopen'd but only after a real display
+            -- server is required; `godot --headless` works without them
+            -- and they're left to the host so we don't ship an entire
+            -- X11/mesa stack.
             deps = {
-                runtime = { "xim:glibc@2.39" },
+                runtime = {
+                    "xim:glibc@2.39",
+                    "xim:freetype@2.13.2",
+                },
             },
             ["latest"] = { ref = "4.7.1" },
             ["4.7.1"] = _linux("4.7.1",

--- a/pkgs/n/nvm.lua
+++ b/pkgs/n/nvm.lua
@@ -43,7 +43,11 @@ package = {
     programs = {"nvm"},
     xvm_enable = true,
 
-    ci = { mirror = true, update = true },
+    -- Windows tracks a different repo (coreybutler/nvm-windows) on a different
+    -- version line, so both the version checker and the mirror stay on the
+    -- linux/macosx pair -- opting windows in would trip "per-platform 'latest'
+    -- refs disagree" the moment the two upstreams released independently.
+    ci = { mirror = true, update = true, platforms = {"linux", "macosx"} },
 
     xpm = {
         linux = {

--- a/tests/test_xpkg_ci.py
+++ b/tests/test_xpkg_ci.py
@@ -198,9 +198,12 @@ def test_resolve_platform_arches():
     # jq-linux-amd64 / jq-macos-arm64, archs = {x86_64, aarch64}, aliases = {})
     assert r(["x86_64", "aarch64"], "u/jq-linux-amd64", {}) == (["x86_64"], None)
     assert r(["x86_64", "aarch64"], "u/jq-macos-arm64", {}) == (["aarch64"], None)
-    # non-parameterized URL with no matchable arch -> error, fail closed
-    arches, err = r(["x86_64", "aarch64"], "u/foo-universal.tar.gz", {})
-    assert arches is None and err and "cannot infer arch" in err, (arches, err)
+    # non-parameterized URL with no arch spelling at all -> arch-independent:
+    # mirror once, expose to every declared arch (nvm's pure-shell tar shape).
+    assert r(["x86_64", "aarch64"], "u/nvm-v0.40.6.tar.gz", {}) == (["x86_64", "aarch64"], None)
+    # multiple declared arches both matched -> genuinely ambiguous, fail closed
+    arches, err = r(["x86_64", "aarch64"], "u/foo-x86_64-aarch64.tar.gz", {})
+    assert arches is None and err and "ambiguous arch" in err, (arches, err)
 
 
 def test_archive_suffix_gate():

--- a/tools/xpkg_ci.py
+++ b/tools/xpkg_ci.py
@@ -75,6 +75,13 @@ def bool_field(body: str, name: str) -> bool:
     return re.search(rf"\b{re.escape(name)}\s*=\s*true\b", body) is not None
 
 
+def string_list_field(body: str, name: str) -> list[str] | None:
+    match = re.search(rf"\b{re.escape(name)}\s*=\s*\{{([^{{}}]*)\}}", body)
+    if not match:
+        return None
+    return re.findall(r'"([^"]+)"', match.group(1))
+
+
 def source_value(text: str) -> str | dict[str, str] | None:
     m = re.search(r"\bsource\s*=\s*\"([^\"]+)\"", text)
     if m:
@@ -233,15 +240,20 @@ def resolve_platform_arches(arches: list[str], template: str,
                             aliases: dict[str, str]) -> tuple[list[str] | None, str | None]:
     """Decide which arches to materialize for one platform's URL template.
 
-    An arch-parameterized template (``${arch}``/``{arch}``) covers every declared
-    arch.  A non-parameterized URL bakes in exactly one arch, so infer which
-    declared arch it is (by the arch name or its alias appearing in the URL) and
-    record only that one — otherwise a package like bat, which declares
-    ``{x86_64, aarch64}`` globally but ships x86_64 on linux/windows and aarch64
-    on macOS, would be mislabelled as ``arches[0]`` or rejected outright.
+    Three shapes to distinguish:
+
+    * arch-parameterized template (``${arch}``/``{arch}``) — one URL per arch,
+      covers every declared arch.
+    * arch-baked URL — no template but the URL string contains one arch's name
+      or alias (e.g. bat ships x86_64 on linux and aarch64 on macOS, so each
+      platform pins to exactly one declared arch).
+    * arch-independent URL — no template and no arch spelling appears at all
+      (e.g. nvm's pure-shell tag archive, whose bytes serve every arch). One
+      mirror asset is recorded per declared arch, all pointing at the same
+      upstream URL and sharing the same sha256.
 
     Returns ``(arches, None)`` on success or ``(None, error)`` when a
-    non-parameterized URL cannot be pinned to exactly one declared arch.
+    non-parameterized URL matches more than one declared arch (ambiguous).
     """
     if "${arch}" in template or "{arch}" in template:
         return arches, None
@@ -257,8 +269,10 @@ def resolve_platform_arches(arches: list[str], template: str,
         return False
 
     matched = [a for a in arches if present(a)]
-    if len(matched) != 1:
-        return None, (f"cannot infer arch from non-arch-templated URL "
+    if not matched:
+        return arches, None
+    if len(matched) > 1:
+        return None, (f"ambiguous arch in non-arch-templated URL "
                       f"(declared {arches}, matched {matched})")
     return matched, None
 
@@ -301,9 +315,23 @@ def materialize(args: argparse.Namespace) -> int:
         i += 1
     xpm_body = text[start:i - 1]
     arches = declared_arches(text) or ["x86_64"]
+    # `ci.platforms`, when present, narrows the mirror to a subset of the
+    # (linux, macosx, windows) blocks declared in xpm. Some packages share a
+    # recipe file across unrelated upstreams — nvm-sh/nvm on linux/macosx and
+    # coreybutler/nvm-windows on a different version line — where the "one
+    # version per package" contract can't cover every platform. Absent the
+    # field, all declared platforms mirror as before.
+    ci_platforms = string_list_field(ci_block(text), "platforms")
     assets = []
     chosen_version = args.version
+    # An arch-independent URL is materialized once per platform: the second
+    # arch reuses the file downloaded for the first. Keyed by URL, not by
+    # filename, so two versions with the same tag name across platforms would
+    # still each fetch their own bytes.
+    fetched: dict[str, dict[str, Any]] = {}
     for platform in ("linux", "macosx", "windows"):
+        if ci_platforms is not None and platform not in ci_platforms:
+            continue
         platform_match = re.search(rf'\b{platform}\s*=\s*\{{', xpm_body)
         if not platform_match:
             continue
@@ -342,6 +370,10 @@ def materialize(args: argparse.Namespace) -> int:
             final_url = expand_template(template, args.package, version, platform, arch, aliases)
             if not final_url.startswith("https://"):
                 return fail(f"{platform}/{arch}: source URL must use https")
+            cached = fetched.get(final_url)
+            if cached is not None:
+                assets.append({"os": platform, "arch": arch, **cached})
+                continue
             filename = final_url.rsplit("/", 1)[-1]
             output = Path(args.output) / filename
             output.parent.mkdir(parents=True, exist_ok=True)
@@ -365,10 +397,11 @@ def materialize(args: argparse.Namespace) -> int:
                     return fail(f"invalid archive {filename}: {archive_error}")
             sidecar = output.with_name(output.name + ".sha256")
             sidecar.write_text(f"{digest.hexdigest()}  {output.name}\n", encoding="utf-8")
-            assets.append({"os": platform, "arch": arch, "filename": filename,
-                           "size": size, "sha256": digest.hexdigest(),
-                           "source_url": final_url, "path": str(output),
-                           "sidecar_path": str(sidecar)})
+            fetched[final_url] = {"filename": filename, "size": size,
+                                  "sha256": digest.hexdigest(),
+                                  "source_url": final_url, "path": str(output),
+                                  "sidecar_path": str(sidecar)}
+            assets.append({"os": platform, "arch": arch, **fetched[final_url]})
     manifest = {"format": 1, "package": args.package, "version": chosen_version,
                 "source_repo": lua_string(text, "repo"), "assets": assets}
     errors = validate_manifest(manifest)
@@ -534,12 +567,16 @@ def cmd_mirror(args: argparse.Namespace) -> int:
     tag = str(manifest["version"])
     repo = f"xlings-res/{package}"
     gitcode_repo = f"xlings-res/{package}"
-    files = [str(path)]
+    # dict-of-None preserves order and keeps a single copy per path — an
+    # arch-independent asset (nvm's shell tar) shows up under multiple arches
+    # in the manifest but must be attached to the release only once.
+    files_index: dict[str, None] = {str(path): None}
     for asset in manifest["assets"]:
         if asset.get("path"):
-            files.append(str(asset["path"]))
+            files_index[str(asset["path"])] = None
         if asset.get("sidecar_path"):
-            files.append(str(asset["sidecar_path"]))
+            files_index[str(asset["sidecar_path"])] = None
+    files = list(files_index)
     gh_command = ["gh", "release", "create", tag, "--repo", repo, *files]
     gtc_command = ["tools/gtc", "release", "create", gitcode_repo, "--tag", tag]
     if not args.execute:


### PR DESCRIPTION
## Summary

Two fixes on the godot branch:

- **fix(ci):** `xpkg-mirror-release` failed on main for nvm with `cannot infer arch from non-arch-templated URL (declared ['x86_64', 'aarch64'], matched [])` ([job](https://github.com/openxlings/xim-pkgindex/actions/runs/30838323909/job/91768952171)). Two blockers: (1) `resolve_platform_arches` rejected truly arch-agnostic URLs like nvm's pure-shell tag archive — now `matched=[]` means "mirror once, expose to every declared arch"; ambiguous (`>1`) still errors. (2) `materialize` demanded one version across all platforms, but nvm's windows track (`coreybutler/nvm-windows` at `1.2.2`) is a different upstream from linux/macosx (`0.40.6`). Added `ci.platforms`, an optional list narrowing the mirror to a subset of `xpm` platforms; nvm.lua opts in on linux/macosx only, matching the recipe's own comment that windows stays manual. Download loop dedupes by URL and `cmd_mirror` dedupes attached files, so a shared asset is fetched and uploaded exactly once.

- **fix(godot):** Reproduced `libfreetype.so.6: cannot open shared object file` locally on `godot --version`. `readelf -d` confirms freetype isn't in DT_NEEDED (only glibc), so godot dlopens it at startup for text rendering. The prior comment covered the other dlopen'd GUI libs but missed freetype. Added `xim:freetype@2.13.2` (in-repo package) to linux runtime deps. Remaining GUI libs (libGL/libX11/libwayland/libXi) stay host-provided — they only fire once a real display is required.

## Test plan

- [x] Local: `python3 tools/xpkg_ci.py materialize nvm --output /tmp/x` succeeds (4 assets, one file, matching sha256s)
- [x] Local: `verify` and `mirror` (dry-run) pass on the manifest
- [x] Local: bat / jq / ripgrep / fd / zoxide materialize still resolve unchanged
- [ ] CI: `xpkg test` matrix green on this branch
- [ ] After merge: `xpkg-mirror-release` for nvm publishes to `xlings-res/nvm`
- [ ] Manual: reinstall godot after merge and confirm no more freetype warning on `godot --version`