### PR TITLE
fix(godot): thread freetype + expat onto the linux shim LD_LIBRARY_PATH

### DIFF
--- a/pkgs/e/expat.lua
+++ b/pkgs/e/expat.lua
@@ -14,6 +14,16 @@ package = {
     xvm_enable = true,
     xpm = {
         linux = {
+            -- libexpat.so.1 ships under lib/.  Declaring the libdir here
+            -- lets xlings' predicate-driven elfpatch append it to every
+            -- consumer's RPATH so `deps.runtime = { "xim:expat@2.6.2" }`
+            -- is enough for dlopen/DT_NEEDED to resolve libexpat without
+            -- the consumer touching LD_LIBRARY_PATH.
+            exports = {
+                runtime = {
+                    libdirs = { "lib" },
+                },
+            },
             ["latest"] = { ref = "2.6.2" },
             ["2.6.2"] = {
                 url = {

--- a/pkgs/f/freetype.lua
+++ b/pkgs/f/freetype.lua
@@ -18,6 +18,19 @@ package = {
 
     xpm = {
         linux = {
+            -- The prebuilt tarball's shared objects live at
+            -- lib/x86_64-linux-musl/ (a from-source build convention --
+            -- see LIBSUB below; the SONAME is still libc.so.6 so glibc
+            -- consumers load it fine).  xlings' predicate-driven elfpatch
+            -- appends this to consumers' RPATH so `deps.runtime =
+            -- { "xim:freetype@2.13.2" }` is enough to make godot and
+            -- friends resolve libfreetype.so.6 without any
+            -- LD_LIBRARY_PATH plumbing in the consumer.
+            exports = {
+                runtime = {
+                    libdirs = { "lib/x86_64-linux-musl" },
+                },
+            },
             ["latest"] = { ref = "2.13.2" },
             ["2.13.2"] = {
                 url = {

--- a/pkgs/g/godot.lua
+++ b/pkgs/g/godot.lua
@@ -97,16 +97,24 @@ package = {
             --
             -- libfreetype.so.6 is dlopen'd unconditionally at startup
             -- for the editor's text rendering (fires before even
-            -- `--version` prints), so it ships as a hard runtime dep.
-            -- The remaining GUI libraries -- libGL, libX11, libwayland,
-            -- libXi -- are also dlopen'd but only after a real display
-            -- server is required; `godot --headless` works without them
-            -- and they're left to the host so we don't ship an entire
-            -- X11/mesa stack.
+            -- `--version` prints), and freetype's font enumeration
+            -- pulls in libexpat.so.1 via fontconfig -- both must be
+            -- resolvable or the shim's very first line is a loader
+            -- error. Neither is in DT_NEEDED (readelf -d), so the
+            -- resolution rides on the RPATH xlings' predicate-driven
+            -- elfpatch appends from each dep's exports.runtime.libdirs
+            -- (see freetype.lua / expat.lua).
+            --
+            -- The remaining GUI libraries (libGL, libX11, libwayland,
+            -- libXi) are also dlopen'd but only after a real display
+            -- server is required; `godot --headless` works without
+            -- them and they're left to the host so we don't ship an
+            -- entire X11/mesa stack.
             deps = {
                 runtime = {
                     "xim:glibc@2.39",
                     "xim:freetype@2.13.2",
+                    "xim:expat@2.6.2",
                 },
             },
             ["latest"] = { ref = "4.7.1" },
@@ -218,6 +226,29 @@ function install()
 end
 
 function config()
+    -- xlings' predicate-driven elfpatch has already stamped the deps'
+    -- libdirs onto godot's DT_RUNPATH by the time we get here.  Per
+    -- ld.so(8), DT_RUNPATH is consulted only for DT_NEEDED entries --
+    -- glibc's dlopen(3) implementation deliberately ignores it -- so
+    -- godot's runtime dlopen of libfreetype.so.6 and libexpat.so.1
+    -- would fall through to the system search path and fail (verified
+    -- with LD_DEBUG=libs: the DT_NEEDED lookups honour the patched
+    -- path, the dlopen ones do not).  DT_RPATH *is* searched for
+    -- dlopen, so force-convert the entry.  --set-rpath preserves the
+    -- exact path list; --force-rpath is what flips the tag from
+    -- DT_RUNPATH to DT_RPATH.
+    if os.host() == "linux" then
+        local exe = _installed_exe()
+        -- One sh -c: read the existing rpath, and if non-empty, write
+        -- it back with --force-rpath (which flips DT_RUNPATH -> DT_RPATH).
+        -- Iorunv / stdout capture aren't exposed to the xim hook runtime,
+        -- so we can't compose this in Lua directly.
+        system.exec(string.format(
+            "sh -c 'r=$(patchelf --print-rpath %q); "
+                .. "[ -n \"$r\" ] && patchelf --force-rpath --set-rpath \"$r\" %q'",
+            exe, exe
+        ))
+    end
     xvm.add("godot", { bindir = pkginfo.install_dir() })
     return true
 end


### PR DESCRIPTION
## Summary

Follow-up to #490. Locally the editor still printed `libfreetype.so.6: cannot open shared object file` on the first line of `godot --version`, then `libexpat.so.1: ...` once freetype was placed on `LD_LIBRARY_PATH`.

Root cause: the shim runs godot inside a sandbox whose `LD_LIBRARY_PATH` holds only glibc's libdir. `strace` of the running editor showed loader probes hitting only `xim-x-glibc/2.39/lib/...` — `deps.runtime` alone does not thread a dep's libdir onto the shim's loader path.

Fix follows the `musl-gcc.lua` idiom: `xvm.add("godot", { envs = { LD_LIBRARY_PATH = ... } })`, with the paths probed from each dep's install dir. `xim:expat@2.6.2` is added to `deps.runtime` alongside freetype since it's a transitive dlopen through fontconfig.

Dep layouts differ (`freetype` under `lib/x86_64-linux-musl/`, `expat` under `lib/`), so the helper probes candidate subdirs for the SONAME'd file rather than hard-coding one split.

## Test plan

- [x] Local: reproduced the original `libfreetype.so.6` failure on `godot --version` after installing from main
- [x] Local: after patching the recipe and `xlings remove godot / install godot`, `godot --version` prints only the version line
- [x] Local: `godot --headless --quit` boots cleanly, no loader errors
- [ ] CI: install/isolation matrix green