### PR TITLE
feat(graphics): a self-contained OpenGL stack — 20 packages

### DIFF
--- a/.agents/tools/graphics/build-in-subos.sh
+++ b/.agents/tools/graphics/build-in-subos.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+# Build one graphics-stack package from source, inside a subos, and check that
+# nothing from the host leaked into the result.
+#
+# Design: xlings/.agents/docs/2026-08-05-graphics-stack-ecosystem-closure.md §5
+#
+# The stack has ~30 packages to build and they are mostly ordinary autotools or
+# meson projects. What is NOT ordinary is where they are built: on the host,
+# `./configure && make` links against the host's glibc and finds the host's
+# headers, and the result then needs whatever glibc that host had. That is
+# issue #352, manufactured deliberately.
+#
+# So every build runs with the subos supplying the compiler, the sysroot and
+# the libraries, and the result is checked before it is allowed to ship:
+#
+#   * no DT_NEEDED that resolves outside the subos or the package itself
+#   * no RPATH/RUNPATH naming a host path
+#   * no absolute host path baked into a .pc, .la or config script
+#
+# That check is the reason this script exists rather than a README saying
+# "build it in the subos". A leaked host path does not fail the build; it fails
+# months later on someone else's machine.
+#
+# Usage:
+#   build-in-subos.sh --name libXau --version 1.0.11 \
+#       --url https://.../libXau-1.0.11.tar.xz \
+#       [--system autotools|meson] [--deps 'xorgproto libX11'] \
+#       [-- <extra configure/meson args>]
+set -uo pipefail
+
+NAME= VERSION= URL= SYSTEM=auto DEPS= EXTRA=()
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --name)    NAME="$2"; shift 2 ;;
+        --version) VERSION="$2"; shift 2 ;;
+        --url)     URL="$2"; shift 2 ;;
+        --system)  SYSTEM="$2"; shift 2 ;;
+        --deps)    DEPS="$2"; shift 2 ;;
+        --)        shift; EXTRA=("$@"); break ;;
+        *) echo "unknown argument: $1" >&2; exit 2 ;;
+    esac
+done
+[[ -n "$NAME" && -n "$VERSION" && -n "$URL" ]] || {
+    echo "usage: $0 --name N --version V --url U [--system auto|autotools|meson] [--deps '...'] [-- args]" >&2
+    exit 2
+}
+
+SUBOS_NAME="${XLINGS_GFX_SUBOS:-gfxbuild}"
+XHOME="${XLINGS_HOME:-$HOME/.xlings}"
+SUBOS="$XHOME/subos/$SUBOS_NAME"
+WORK="${XLINGS_GFX_WORK:-${TMPDIR:-/tmp}/xlings-gfx}"
+STAGE="$WORK/stage/$NAME-$VERSION"
+SRC="$WORK/src"
+
+log()  { echo "[gfx-build:$NAME] $*"; }
+fail() { echo "[gfx-build:$NAME] FAIL: $*" >&2; exit 1; }
+
+[[ -d "$SUBOS" ]] || fail "subos '$SUBOS_NAME' not found — xlings subos new $SUBOS_NAME"
+# STAGE is wiped, not just created: a previous run with a different --libdir
+# leaves its own tree here, and `make install DESTDIR=` only adds. The stale
+# copy then rides into the payload and ships two layouts of the same library.
+rm -rf "$STAGE"
+mkdir -p "$SRC" "$STAGE"
+
+# ── fetch ───────────────────────────────────────────────────────────────
+TARBALL="$SRC/$(basename "$URL")"
+[[ -f "$TARBALL" ]] || {
+    log "fetching $(basename "$URL")"
+    curl -fsSL --retry 3 -o "$TARBALL" "$URL" || fail "download failed"
+}
+BUILDDIR="$SRC/$NAME-$VERSION"
+rm -rf "$BUILDDIR"; mkdir -p "$BUILDDIR"
+tar xf "$TARBALL" -C "$BUILDDIR" --strip-components=1 || fail "extract failed"
+
+# ── the subos as the build environment ──────────────────────────────────
+# PKG_CONFIG_PATH and the include/lib paths point ONLY at the subos, so a
+# dependency that is not packaged yet fails the configure step loudly instead
+# of being silently satisfied by the host copy.
+PREFIX=/usr
+# Both spellings: a payload uses a flat lib/, but a package that ignores
+# --libdir still lands in the distro multiarch path and its .pc would then be
+# invisible to the next package — which surfaces as "dependency not found" for
+# something that was just built successfully.
+export PKG_CONFIG_LIBDIR="$SUBOS/usr/lib/pkgconfig:$SUBOS/usr/share/pkgconfig:$SUBOS/usr/lib/x86_64-linux-gnu/pkgconfig"
+export PKG_CONFIG_PATH="$PKG_CONFIG_LIBDIR"
+export CPPFLAGS="-I$SUBOS/usr/include"
+# -rpath-link, not just -L: `-L` resolves what this link line names directly,
+# but a NEEDED entry of one of those libraries (libdrm_intel needing
+# libpciaccess) is only searched along -rpath-link. Without it the link fails
+# on transitive symbols with the library sitting right there.
+export LDFLAGS="-L$SUBOS/lib -L$SUBOS/usr/lib -Wl,-rpath-link,$SUBOS/usr/lib -Wl,-rpath-link,$SUBOS/lib -Wl,-rpath,\$ORIGIN"
+export CC="$SUBOS/bin/gcc"
+export CXX="$SUBOS/bin/g++"
+[[ -x "$CC" ]] || fail "no gcc in the subos — xlings install gcc"
+
+if [[ "$SYSTEM" == auto ]]; then
+    if   [[ -f "$BUILDDIR/meson.build" ]]; then SYSTEM=meson
+    elif [[ -f "$BUILDDIR/configure"   ]]; then SYSTEM=autotools
+    else fail "cannot tell the build system apart; pass --system"; fi
+fi
+log "building with $SYSTEM against subos '$SUBOS_NAME'"
+
+cd "$BUILDDIR" || fail "cd"
+case "$SYSTEM" in
+  autotools)
+    # --libdir=lib: the multiarch layout is a distro convention. A payload has
+    # one architecture by construction, and the extra level only makes RPATH
+    # and exports.runtime.libdirs harder to get right.
+    ./configure --prefix="$PREFIX" --libdir="$PREFIX/lib" \
+        --disable-static --enable-shared \
+        "${EXTRA[@]}" > "$WORK/$NAME-configure.log" 2>&1 \
+        || { tail -30 "$WORK/$NAME-configure.log"; fail "configure"; }
+    make -j"$(nproc)"           > "$WORK/$NAME-build.log" 2>&1 \
+        || { tail -30 "$WORK/$NAME-build.log"; fail "make"; }
+    make install DESTDIR="$STAGE" >> "$WORK/$NAME-build.log" 2>&1 \
+        || { tail -30 "$WORK/$NAME-build.log"; fail "make install"; }
+    ;;
+  meson)
+    "$SUBOS/bin/meson" setup _b --prefix="$PREFIX" --libdir=lib \
+        --buildtype=release -Ddefault_library=shared "${EXTRA[@]}" > "$WORK/$NAME-configure.log" 2>&1 \
+        || { tail -30 "$WORK/$NAME-configure.log"; fail "meson setup"; }
+    "$SUBOS/bin/ninja" -C _b     > "$WORK/$NAME-build.log" 2>&1 \
+        || { tail -30 "$WORK/$NAME-build.log"; fail "ninja"; }
+    DESTDIR="$STAGE" "$SUBOS/bin/meson" install -C _b >> "$WORK/$NAME-build.log" 2>&1 \
+        || { tail -30 "$WORK/$NAME-build.log"; fail "meson install"; }
+    ;;
+  *) fail "unknown build system '$SYSTEM'" ;;
+esac
+
+# ── flatten DESTDIR/usr into the payload root ───────────────────────────
+PAYLOAD="$WORK/payload/$NAME-$VERSION"
+rm -rf "$PAYLOAD"; mkdir -p "$PAYLOAD"
+if [[ -d "$STAGE$PREFIX" ]]; then
+    cp -a "$STAGE$PREFIX/." "$PAYLOAD/"
+else
+    cp -a "$STAGE/." "$PAYLOAD/"
+fi
+
+# $ORIGIN so the payload's own libraries resolve each other with no absolute
+# path anywhere. xlings's elfpatch appends each dependency's libdir on top.
+while IFS= read -r -d '' f; do
+    patchelf --set-rpath '$ORIGIN' "$f" 2>/dev/null || true
+done < <(find "$PAYLOAD" -type f -name '*.so*' ! -type l -print0)
+
+# ── the check that makes this worth scripting ───────────────────────────
+leaks=0
+report_leak() { echo "    $*"; leaks=$((leaks+1)); }
+
+log "checking for host leakage"
+while IFS= read -r -d '' f; do
+    rp="$(patchelf --print-rpath "$f" 2>/dev/null || true)"
+    case "$rp" in
+        ''|'$ORIGIN'*) ;;
+        *) report_leak "RPATH names a path outside the payload: ${f#$PAYLOAD/} → $rp" ;;
+    esac
+done < <(find "$PAYLOAD" -type f -name '*.so*' ! -type l -print0)
+
+# .pc / .la / *-config files carry absolute paths that later builds consume.
+# A host prefix in one of these does not break anything now — it breaks the
+# NEXT package, by pointing its configure at /usr.
+while IFS= read -r -d '' f; do
+    if grep -qE '(^|[=" ])/usr/(lib|include|share)/' "$f" 2>/dev/null; then
+        grep -nE '(^|[=" ])/usr/(lib|include|share)/' "$f" | head -2 \
+          | sed "s|^|    ${f#$PAYLOAD/}: |" | while read -r l; do report_leak "$l"; done
+    fi
+done < <(find "$PAYLOAD" \( -name '*.pc' -o -name '*.la' -o -name '*-config' \) -type f -print0)
+
+if [[ $leaks -gt 0 ]]; then
+    fail "$leaks host reference(s) in the payload — this would work here and fail elsewhere"
+fi
+log "  no host references"
+
+# ── package ─────────────────────────────────────────────────────────────
+OUT="$WORK/dist/$NAME-$VERSION-linux-x86_64.tar.gz"
+mkdir -p "$(dirname "$OUT")"
+tar czf "$OUT" -C "$WORK/payload" "$NAME-$VERSION"
+log "→ $OUT  ($(du -h "$OUT" | cut -f1))"
+sha256sum "$OUT" | sed 's/^/[gfx-build] sha256: /'
+
+# ── stage into the build subos ──────────────────────────────────────────
+# The tiers depend on each other: libXau needs xorgproto's headers, libxcb
+# needs libXau's .pc, mesa needs all of it. Until every recipe is published
+# there is nothing to `xlings install`, so the freshly built payload is placed
+# into the subos sysroot the same way an installed package would appear.
+#
+# This is staging, not installing: no xvm registration, no manifest entry. It
+# exists so tier N+1 can be built and is replaced by a real `xlings install`
+# once the recipes are published.
+if [[ "${XLINGS_GFX_STAGE:-1}" == "1" ]]; then
+    mkdir -p "$SUBOS/usr"
+    cp -a "$PAYLOAD/." "$SUBOS/usr/"
+    log "  staged into $SUBOS_NAME's sysroot for the next tier"
+fi

--- a/.agents/tools/graphics/build-in-subos.sh
+++ b/.agents/tools/graphics/build-in-subos.sh
@@ -136,6 +136,14 @@ else
     cp -a "$STAGE/." "$PAYLOAD/"
 fi
 
+# Drop libtool archives. A .la records the absolute libdir it was built with,
+# and the next package's libtool reads that path literally — libX11 fails with
+# "'/usr/lib/libXau.la' is not a valid libtool archive" because it went looking
+# on the host root. Rewriting them is possible; deleting them is what most
+# distributions settled on, since anything still consuming a .la in 2026 is
+# also consuming the .pc that says the same thing correctly.
+find "$PAYLOAD" -name '*.la' -type f -delete
+
 # $ORIGIN so the payload's own libraries resolve each other with no absolute
 # path anywhere. xlings's elfpatch appends each dependency's libdir on top.
 while IFS= read -r -d '' f; do
@@ -189,5 +197,18 @@ sha256sum "$OUT" | sed 's/^/[gfx-build] sha256: /'
 if [[ "${XLINGS_GFX_STAGE:-1}" == "1" ]]; then
     mkdir -p "$SUBOS/usr"
     cp -a "$PAYLOAD/." "$SUBOS/usr/"
+
+    # The payload's own .pc files say prefix=/usr, and they have to: that is
+    # what makes the tarball relocatable into whatever subos installs it. But
+    # the STAGED copy is consumed right now, from $SUBOS/usr, so a consumer
+    # reading prefix=/usr resolves against the host root instead — libxcb fails
+    # with "No rule to make target '//usr/share/xcb/'", pointing at a directory
+    # that belongs to the host.
+    #
+    # Only the staged copy is rewritten. The tarball keeps /usr.
+    while IFS= read -r -d '' pc; do
+        sed -i "s|^prefix=/usr$|prefix=$SUBOS/usr|; s|=/usr/|=$SUBOS/usr/|g" "$pc"
+    done < <(find "$SUBOS/usr" -name '*.pc' -type f -print0)
+
     log "  staged into $SUBOS_NAME's sysroot for the next tier"
 fi

--- a/.agents/tools/graphics/build-in-subos.sh
+++ b/.agents/tools/graphics/build-in-subos.sh
@@ -76,6 +76,21 @@ tar xf "$TARBALL" -C "$BUILDDIR" --strip-components=1 || fail "extract failed"
 # PKG_CONFIG_PATH and the include/lib paths point ONLY at the subos, so a
 # dependency that is not packaged yet fails the configure step loudly instead
 # of being silently satisfied by the host copy.
+
+# Enter the subos the way `xlings subos use` does: its bin/ first on PATH.
+#
+# This is not a workaround for the subos mechanism — it IS the mechanism. A
+# tool invoked by absolute path (as this script does for meson and gcc) never
+# enters the subos context, so anything those tools then look up by NAME
+# resolves against the ambient PATH instead. meson's find_program('python3')
+# picked the developer's global `subos/current` python, and mesa reported its
+# mako module missing from an interpreter nobody installed it into.
+#
+# Everything the build needs is installed INTO this subos with
+# `xlings install`; putting its bin first is what makes those installs the
+# ones that get found.
+export PATH="$SUBOS/bin:$PATH"
+
 PREFIX=/usr
 # Both spellings: a payload uses a flat lib/, but a package that ignores
 # --libdir still lands in the distro multiarch path and its .pc would then be

--- a/.agents/tools/graphics/build-libllvm.sh
+++ b/.agents/tools/graphics/build-libllvm.sh
@@ -59,16 +59,29 @@ rm -rf "$BUILD"; mkdir -p "$BUILD"
 CMAKE="$SUBOS/bin/cmake"; [[ -x "$CMAKE" ]] || CMAKE="$(command -v cmake)" || fail "no cmake"
 NINJA="$SUBOS/bin/ninja";  [[ -x "$NINJA" ]] || NINJA="$(command -v ninja)"  || fail "no ninja"
 
-# clang, not gcc. gcc 16.1.0 — the subos default — ICEs with a segfault on
-# AMDGPUAsmParser.cpp, and AMDGPU is not optional here (radeonsi needs it, see
-# the target list above). LLVM is also the compiler upstream builds LLVM with,
-# so this is the better-tested path rather than a workaround.
-BUILD_CC="$SUBOS/bin/clang"
-BUILD_CXX="$SUBOS/bin/clang++"
-if [[ ! -x "$BUILD_CC" ]]; then
-    log "clang not in the subos, falling back to gcc (expect an ICE on AMDGPU)"
-    BUILD_CC="$SUBOS/bin/gcc"; BUILD_CXX="$SUBOS/bin/g++"
-fi
+# gcc 15.1.0, explicitly — not the subos default and not clang.
+#
+# The subos default is gcc 16.1.0, which ICEs with a segfault on
+# AMDGPUAsmParser.cpp at 2212/2218. AMDGPU is not droppable: it is half of why
+# libllvm exists, since radeonsi's shader compiler needs it.
+#
+# clang was the obvious alternative and is wrong for a subtler reason. The
+# xlings `llvm` package's clang defaults to libc++, and libgallium references
+# 97 mangled llvm:: symbols while mesa is built against libstdc++. Two C++
+# runtimes in one process produce symbol names that match and object layouts
+# that do not. Forcing -stdlib=libstdc++ then fails to link.
+#
+# So: build with the compiler whose runtime the ecosystem actually ships.
+# `gcc-runtime` is 15.1.0, so gcc 15.1.0 makes the C++ ABI consistent by
+# construction rather than by a flag.
+# Through the subos's shim, not the payload's bin/ directly. The shim is what
+# carries the elfpatch'd interpreter and RPATH; invoking the payload binary by
+# absolute path bypasses that and cmake's compiler probe fails to link.
+# Select the version with `xlings use gcc 15.1.0` first.
+BUILD_CC="$SUBOS/bin/gcc"
+BUILD_CXX="$SUBOS/bin/g++"
+[[ -x "$BUILD_CC" ]] || fail "no gcc shim in the subos"
+log "compiler: $("$BUILD_CC" --version | head -1)"
 
 log "configuring (X86;AMDGPU, shared libLLVM)"
 "$CMAKE" -S "$SRC/llvm" -B "$BUILD" -G Ninja \

--- a/.agents/tools/graphics/build-libllvm.sh
+++ b/.agents/tools/graphics/build-libllvm.sh
@@ -86,7 +86,7 @@ log "compiler: $("$BUILD_CC" --version | head -1)"
 log "configuring (X86;AMDGPU, shared libLLVM)"
 "$CMAKE" -S "$SRC/llvm" -B "$BUILD" -G Ninja \
   -DCMAKE_BUILD_TYPE=Release \
-  -DCMAKE_INSTALL_PREFIX=/usr \
+  -DCMAKE_INSTALL_PREFIX="$SUBOS/usr" \
   -DCMAKE_C_COMPILER="$BUILD_CC" \
   -DCMAKE_CXX_COMPILER="$BUILD_CXX" \
   -DCMAKE_MAKE_PROGRAM="$NINJA" \
@@ -115,7 +115,11 @@ log "configuring (X86;AMDGPU, shared libLLVM)"
 # that would otherwise have to be packaged and shipped for nobody.
 
 log "building (this is the long one)"
-"$NINJA" -C "$BUILD" LLVM > "$WORK/libllvm-build.log" 2>&1 \
+# llvm-config alongside the library: mesa's meson resolves LLVM through
+# `dependency('llvm')`, which shells out to llvm-config for the include path,
+# the library name and the component list. Without it meson falls through to
+# looking for an llvm.wrap subproject and stops.
+"$NINJA" -C "$BUILD" LLVM llvm-config > "$WORK/libllvm-build.log" 2>&1 \
   || { tail -25 "$WORK/libllvm-build.log"; fail "ninja"; }
 
 SO="$(find "$BUILD/lib" -maxdepth 1 -name 'libLLVM.so.*' ! -type l | head -1)"
@@ -136,7 +140,22 @@ log "→ $OUT  ($(du -h "$OUT" | cut -f1), unpacked $(du -sh "$PAYLOAD" | cut -f
 sha256sum "$OUT" | sed 's/^/[libllvm] sha256: /'
 
 if [[ "${XLINGS_GFX_STAGE:-1}" == "1" ]]; then
-    mkdir -p "$SUBOS/usr/lib"
+    mkdir -p "$SUBOS/usr/lib" "$SUBOS/usr/bin"
     cp -a "$PAYLOAD/lib/." "$SUBOS/usr/lib/"
-    log "  staged into $SUBOS_NAME"
+
+    # A full LLVM install is staged for the BUILD, separately from the payload.
+    #
+    # Copying llvm-config and the headers by hand is not enough: llvm-config
+    # answers `--shared-mode` by checking that the component archives it knows
+    # about are present, so against a lib/ holding only libLLVM.so it errors
+    # out per component and mesa's `dependency('llvm', method: 'config-tool')`
+    # reports LLVM missing. A runtime-only tree cannot serve as a build
+    # dependency; the tool needs a coherent installation to describe.
+    #
+    # So the subos gets the whole install and the tarball keeps only lib/ —
+    # the line distributions draw between libllvm20 and llvm-dev.
+    log "staging a full LLVM install for the build (payload stays lib-only)"
+    "$NINJA" -C "$BUILD" install >> "$WORK/libllvm-build.log" 2>&1 \
+      || { tail -15 "$WORK/libllvm-build.log"; fail "llvm install"; }
+    ln -sf ../usr/bin/llvm-config "$SUBOS/bin/llvm-config" 2>/dev/null || true
 fi

--- a/.agents/tools/graphics/build-libllvm.sh
+++ b/.agents/tools/graphics/build-libllvm.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# Build `libllvm` — LLVM as a shared library, for mesa and nothing else.
+#
+# Design: xlings/.agents/docs/2026-08-05-graphics-stack-ecosystem-closure.md §3
+#
+# This is NOT the `llvm` package. That one is a self-contained clang/lld
+# toolchain whose acceptance gate explicitly forbids a shared libLLVM
+# (.agents/skills/llvm-subpackaging: "Linux: ldd 只能是系统库(不应出现
+# libLLVM.so)"). Different consumer, different axis, different package — the
+# same split the index already makes between `gcc` and `gcc-runtime`.
+#
+# Two build choices, both measured rather than assumed:
+#
+#   LLVM_TARGETS_TO_BUILD=X86;AMDGPU
+#       Undefined-symbol analysis of libgallium finds LLVMInitializeX86* (the
+#       llvmpipe/lavapipe JIT) and 27 AMDGPU symbols (radeonsi's shader
+#       compiler). Intel and NVIDIA-open go through NIR backends and never
+#       reach LLVM, so the other dozen-plus targets are dead weight — the
+#       distro build ships them and costs 137 MB.
+#
+#   LLVM_LINK_LLVM_DYLIB=ON
+#       Produces the single libLLVM.so mesa links against. Without it LLVM
+#       builds a hundred static archives and there is nothing to package.
+#
+# The result is ABI-locked to its major.minor: libgallium references 97 C++
+# mangled llvm:: symbols carrying an @LLVM_<ver> version tag, so consumers pin
+# exactly and a mismatch fails at load rather than misbehaving.
+set -uo pipefail
+
+VERSION="${1:-20.1.7}"
+SUBOS_NAME="${XLINGS_GFX_SUBOS:-gfxbuild}"
+XHOME="${XLINGS_HOME:-$HOME/.xlings}"
+SUBOS="$XHOME/subos/$SUBOS_NAME"
+WORK="${XLINGS_GFX_WORK:-${TMPDIR:-/tmp}/xlings-gfx}"
+
+log()  { echo "[libllvm] $*"; }
+fail() { echo "[libllvm] FAIL: $*" >&2; exit 1; }
+
+[[ -d "$SUBOS" ]] || fail "subos '$SUBOS_NAME' not found"
+mkdir -p "$WORK/src" "$WORK/dist"
+
+SRC="$WORK/src/llvm-$VERSION"
+TARBALL="$WORK/src/llvm-project-$VERSION.src.tar.xz"
+if [[ ! -d "$SRC" ]]; then
+    [[ -f "$TARBALL" ]] || {
+        log "fetching llvm-project $VERSION (~130 MB)"
+        curl -fsSL --retry 3 -o "$TARBALL" \
+          "https://github.com/llvm/llvm-project/releases/download/llvmorg-$VERSION/llvm-project-$VERSION.src.tar.xz" \
+          || fail "download failed"
+    }
+    log "extracting"
+    mkdir -p "$SRC"
+    tar xf "$TARBALL" -C "$SRC" --strip-components=1 || fail "extract failed"
+fi
+
+BUILD="$WORK/src/llvm-$VERSION-build"
+rm -rf "$BUILD"; mkdir -p "$BUILD"
+
+CMAKE="$SUBOS/bin/cmake"; [[ -x "$CMAKE" ]] || CMAKE="$(command -v cmake)" || fail "no cmake"
+NINJA="$SUBOS/bin/ninja";  [[ -x "$NINJA" ]] || NINJA="$(command -v ninja)"  || fail "no ninja"
+
+# clang, not gcc. gcc 16.1.0 — the subos default — ICEs with a segfault on
+# AMDGPUAsmParser.cpp, and AMDGPU is not optional here (radeonsi needs it, see
+# the target list above). LLVM is also the compiler upstream builds LLVM with,
+# so this is the better-tested path rather than a workaround.
+BUILD_CC="$SUBOS/bin/clang"
+BUILD_CXX="$SUBOS/bin/clang++"
+if [[ ! -x "$BUILD_CC" ]]; then
+    log "clang not in the subos, falling back to gcc (expect an ICE on AMDGPU)"
+    BUILD_CC="$SUBOS/bin/gcc"; BUILD_CXX="$SUBOS/bin/g++"
+fi
+
+log "configuring (X86;AMDGPU, shared libLLVM)"
+"$CMAKE" -S "$SRC/llvm" -B "$BUILD" -G Ninja \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_INSTALL_PREFIX=/usr \
+  -DCMAKE_C_COMPILER="$BUILD_CC" \
+  -DCMAKE_CXX_COMPILER="$BUILD_CXX" \
+  -DCMAKE_MAKE_PROGRAM="$NINJA" \
+  -DLLVM_TARGETS_TO_BUILD="X86;AMDGPU" \
+  -DLLVM_BUILD_LLVM_DYLIB=ON \
+  -DLLVM_LINK_LLVM_DYLIB=ON \
+  -DLLVM_ENABLE_RTTI=ON \
+  -DLLVM_ENABLE_TERMINFO=OFF \
+  -DLLVM_ENABLE_LIBEDIT=OFF \
+  -DLLVM_ENABLE_LIBXML2=OFF \
+  -DLLVM_ENABLE_ZLIB=OFF \
+  -DLLVM_ENABLE_ZSTD=OFF \
+  -DLLVM_ENABLE_LIBPFM=OFF \
+  -DLLVM_INCLUDE_TESTS=OFF \
+  -DLLVM_INCLUDE_EXAMPLES=OFF \
+  -DLLVM_INCLUDE_BENCHMARKS=OFF \
+  -DLLVM_INCLUDE_DOCS=OFF \
+  -DLLVM_INCLUDE_UTILS=OFF \
+  > "$WORK/libllvm-configure.log" 2>&1 \
+  || { tail -25 "$WORK/libllvm-configure.log"; fail "cmake configure"; }
+
+# terminfo/libedit/xml2/zlib/zstd are all switched OFF above on purpose. The
+# distro build links them and they are pure closure cost here: mesa uses LLVM
+# for code generation, and none of that path touches a terminal, an XML parser
+# or a decompressor. Turning them off removes six libraries from the payload
+# that would otherwise have to be packaged and shipped for nobody.
+
+log "building (this is the long one)"
+"$NINJA" -C "$BUILD" LLVM > "$WORK/libllvm-build.log" 2>&1 \
+  || { tail -25 "$WORK/libllvm-build.log"; fail "ninja"; }
+
+SO="$(find "$BUILD/lib" -maxdepth 1 -name 'libLLVM.so.*' ! -type l | head -1)"
+[[ -n "$SO" ]] || fail "no libLLVM.so was produced"
+
+PAYLOAD="$WORK/payload/libllvm-$VERSION"
+rm -rf "$PAYLOAD"; mkdir -p "$PAYLOAD/lib"
+cp "$SO" "$PAYLOAD/lib/"
+ln -sf "$(basename "$SO")" "$PAYLOAD/lib/libLLVM.so"
+patchelf --set-rpath '$ORIGIN' "$PAYLOAD/lib/$(basename "$SO")" 2>/dev/null || true
+
+log "closure:"
+readelf -d "$PAYLOAD/lib/$(basename "$SO")" | sed -n 's/.*\[\(lib[^]]*\)\].*/    \1/p'
+
+OUT="$WORK/dist/libllvm-$VERSION-linux-x86_64.tar.gz"
+tar czf "$OUT" -C "$WORK/payload" "libllvm-$VERSION"
+log "→ $OUT  ($(du -h "$OUT" | cut -f1), unpacked $(du -sh "$PAYLOAD" | cut -f1))"
+sha256sum "$OUT" | sed 's/^/[libllvm] sha256: /'
+
+if [[ "${XLINGS_GFX_STAGE:-1}" == "1" ]]; then
+    mkdir -p "$SUBOS/usr/lib"
+    cp -a "$PAYLOAD/lib/." "$SUBOS/usr/lib/"
+    log "  staged into $SUBOS_NAME"
+fi

--- a/.agents/tools/graphics/gen-recipes.py
+++ b/.agents/tools/graphics/gen-recipes.py
@@ -111,8 +111,9 @@ HEADER = '''package = {{
     name = "{name}",
     description = "{desc}",
 
+    authors = {{{authors}}},
     licenses = {{{licenses}}},
-    repo = "{homepage}",
+    repo = "{repo}",
 
     type = "package",
     archs = {{"x86_64"}},
@@ -188,9 +189,34 @@ HOMEPAGES = {
     "mesa": "https://mesa3d.org",
 }
 
+# The source repository, which is NOT the homepage. Every X.Org library lives
+# under gitlab.freedesktop.org/xorg/{lib,proto}/<name>; pointing `repo` at
+# x.org sends anyone looking for the source to a landing page.
+REPOS = {
+    "libdrm":   "https://gitlab.freedesktop.org/mesa/drm",
+    "libglvnd": "https://gitlab.freedesktop.org/glvnd/libglvnd",
+    "libllvm":  "https://github.com/llvm/llvm-project",
+    "mesa":     "https://gitlab.freedesktop.org/mesa/mesa",
+}
+_XORG_PROTO = ("xorgproto", "xcb-proto")
+
+AUTHORS = {
+    "libllvm":  '"LLVM Project"',
+    "libglvnd": '"NVIDIA Corporation", "libglvnd contributors"',
+    "libdrm":   '"Mesa contributors"',
+}
+DEFAULT_AUTHORS = '"X.Org Foundation"'
+
 
 def homepage(name):
     return HOMEPAGES.get(name, "https://www.x.org")
+
+
+def repo(name):
+    if name in REPOS:
+        return REPOS[name]
+    kind = "proto" if name in _XORG_PROTO else "lib"
+    return f"https://gitlab.freedesktop.org/xorg/{kind}/{name}"
 
 
 def render(name, version, sha, global_url, cn_url):
@@ -201,6 +227,7 @@ def render(name, version, sha, global_url, cn_url):
     kw = ", ".join(f'"{k}"' for k in (name.lower(), "graphics", "x11" if name.startswith(("libX", "libx", "xorg", "xcb", "xtrans")) else "gl"))
     out = HEADER.format(
         homepage=homepage(name), name=name, desc=DESCRIPTIONS[name],
+        repo=repo(name), authors=AUTHORS.get(name, DEFAULT_AUTHORS),
         licenses=LICENSES.get(name, DEFAULT_LICENSE),
         keywords=kw, deps=deps_s, version=version, sha=sha,
         global_url=global_url, cn=cn_url,

--- a/.agents/tools/graphics/gen-recipes.py
+++ b/.agents/tools/graphics/gen-recipes.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""Generate the graphics-stack recipes from the publish manifest.
+
+Design: xlings/.agents/docs/2026-08-05-graphics-stack-ecosystem-closure.md
+
+Twenty-two recipes with the same shape — an xpm block pointing at the two
+mirrors, a deps list, and a config() that registers the payload's libraries so
+consumers resolve them. Hand-writing them would take longer and the errors
+would be the silent kind: a wrong sha256 fails loudly, a missing dep does not.
+
+Two conventions are enforced here rather than left to whoever edits next.
+
+DEPENDENCY RANGES. The index's existing recipes pin exactly, but the resolver
+supports ranges (semver.cppm: `@3`, `@^1.2`, `>=1.0 <2.0`), and pinning makes
+this stack a single block — a libX11 patch bump would touch a dozen recipes
+that only care that the library exists. So the default is a lower bound. The
+one exception is mesa → libllvm, where libgallium references 97 mangled llvm::
+symbols carrying an @LLVM_20.1 version tag: that coupling is exact to
+major.minor and a range would suggest an upgrade path that does not exist.
+
+exports.runtime.libdirs. This is what makes the stack work without the user
+setting anything: xlings's elfpatch reads it from each dependency and writes
+the consumer's RPATH. `gcc-runtime` established the pattern.
+"""
+import pathlib
+import sys
+
+# name -> (deps, has_libs, extra_config)
+#
+# deps use ranges by default; see the module docstring for why, and for the one
+# place that does not.
+SPEC = {
+    # T1 — protocol descriptions and the kernel interface.
+    "xorgproto":    ([], False, None),
+    "xcb-proto":    ([], False, None),
+    "xtrans":       ([], False, None),
+    "libpciaccess": (["xim:zlib@>=1.2"], True, None),
+    "libdrm":       (["xim:libpciaccess@>=0.18"], True, None),
+    "libxshmfence": ([], True, None),
+
+    # T2 — the X11 client stack. Each layer needs the one below it at run time.
+    "libXau":       (["xim:xorgproto@>=2024"], True, None),
+    "libXdmcp":     (["xim:xorgproto@>=2024"], True, None),
+    "libxcb":       (["xim:libXau@>=1.0", "xim:libXdmcp@>=1.1"], True, None),
+    "libX11":       (["xim:libxcb@>=1.17", "xim:xorgproto@>=2024"], True, None),
+    "libXext":      (["xim:libX11@>=1.8"], True, None),
+    "libXrender":   (["xim:libX11@>=1.8"], True, None),
+    "libXfixes":    (["xim:libX11@>=1.8"], True, None),
+    "libXrandr":    (["xim:libXext@>=1.3", "xim:libXrender@>=0.9"], True, None),
+    "libXxf86vm":   (["xim:libXext@>=1.3"], True, None),
+    "libXi":        (["xim:libXext@>=1.3", "xim:libXfixes@>=6.0"], True, None),
+    "libXcursor":   (["xim:libXrender@>=0.9", "xim:libXfixes@>=6.0"], True, None),
+
+    # T4 — the graphics core.
+    "libglvnd":     (["xim:libX11@>=1.8", "xim:libXext@>=1.3"], True, None),
+    "libllvm":      (["xim:gcc-runtime@>=15", "xim:glibc@>=2.38"], True, None),
+}
+
+# mesa is written separately: it is the only recipe with an exact pin, and the
+# only one that declares environment through subos.env.
+MESA_DEPS = [
+    "xim:libllvm@20.1.7",        # exact — see the module docstring
+    "xim:libglvnd@>=1.7",
+    "xim:libdrm@>=2.4",
+    "xim:libX11@>=1.8",
+    "xim:libxcb@>=1.17",
+    "xim:libXext@>=1.3",
+    "xim:libXfixes@>=6.0",
+    "xim:libXxf86vm@>=1.1",
+    "xim:libxshmfence@>=1.3",
+    "xim:expat@>=2.6",
+    "xim:zlib@>=1.2",
+    "xim:gcc-runtime@>=15",
+    "xim:glibc@>=2.38",
+]
+
+DESCRIPTIONS = {
+    "xorgproto": "X Window System protocol headers (build-time)",
+    "xcb-proto": "XML-XCB protocol descriptions (build-time)",
+    "xtrans": "X transport layer macros and headers (build-time)",
+    "libpciaccess": "Generic PCI device access library",
+    "libdrm": "Userspace interface to the kernel DRM services",
+    "libxshmfence": "Shared-memory fences for DRI3",
+    "libXau": "X11 authorisation protocol library",
+    "libXdmcp": "X Display Manager Control Protocol library",
+    "libxcb": "X protocol C-language Binding",
+    "libX11": "Core X11 client library",
+    "libXext": "X11 miscellaneous extensions library",
+    "libXrender": "X Rendering Extension client library",
+    "libXfixes": "X Fixes extension client library",
+    "libXrandr": "X Resize, Rotate and Reflect extension library",
+    "libXxf86vm": "X11 XFree86 video mode extension library",
+    "libXi": "X Input Extension client library",
+    "libXcursor": "X cursor management library",
+    "libglvnd": "The GL Vendor-Neutral Dispatch library",
+    "libllvm": "LLVM as a shared library — the code generator mesa's llvmpipe and radeonsi use",
+    "mesa": "Mesa 3D — OpenGL for CPU (llvmpipe), Intel, AMD and NVIDIA-open",
+}
+
+HEADER = '''package = {{
+    spec = "2",
+
+    homepage = "{homepage}",
+    name = "{name}",
+    description = "{desc}",
+
+    licenses = {{{licenses}}},
+    repo = "{homepage}",
+
+    type = "package",
+    archs = {{"x86_64"}},
+    status = "stable",
+    categories = {{"graphics", "lib"}},
+    keywords = {{{keywords}}},
+
+    xpm = {{
+        linux = {{
+            deps = {{{deps}}},
+{exports}            ["latest"] = {{ ref = "{version}" }},
+            ["{version}"] = {{
+                url = {{
+                    GLOBAL = "{global_url}",
+                    CN     = "{cn}",
+                }},
+                sha256 = "{sha}",
+            }},
+        }},
+    }},
+}}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+'''
+
+EXPORTS = """            -- elfpatch reads this from each dependency and writes the consumer's
+            -- RPATH, which is what makes the stack resolve without anyone
+            -- setting LD_LIBRARY_PATH. Same mechanism `gcc-runtime` uses.
+            exports = {
+                runtime = { libdirs = { "lib" } },
+            },
+"""
+
+INSTALL = '''
+function install()
+    local dir = pkginfo.install_dir()
+    os.tryrm(dir)
+    os.mv("{name}-{version}", dir)
+    return true
+end
+'''
+
+CONFIG_LIB = '''
+function config()
+    xvm.add(package.name)
+    return true
+end
+
+function uninstall()
+    xvm.remove(package.name)
+    return true
+end
+'''
+
+# Licences per package, verified against each upstream's own LICENSE/COPYING.
+#
+# A single default would be wrong and wrong quietly: LLVM is Apache-2.0 WITH
+# LLVM-exception, not MIT, and the index's existing `llvm` recipe already says
+# so. The X.Org libraries use the X11 variant of MIT, which SPDX labels MIT;
+# libglvnd's is the Khronos/NVIDIA "Materials" wording, also MIT; mesa declares
+# `SPDX-License-Identifier: MIT` in its own meson.build.
+LICENSES = {
+    "libllvm": '"Apache-2.0 WITH LLVM-exception"',
+}
+DEFAULT_LICENSE = '"MIT"'
+
+
+HOMEPAGES = {
+    "libdrm": "https://dri.freedesktop.org/",
+    "libglvnd": "https://gitlab.freedesktop.org/glvnd/libglvnd",
+    "libllvm": "https://llvm.org",
+    "mesa": "https://mesa3d.org",
+}
+
+
+def homepage(name):
+    return HOMEPAGES.get(name, "https://www.x.org")
+
+
+def render(name, version, sha, global_url, cn_url):
+    deps, has_libs, _ = SPEC[name]
+    deps_s = ""
+    if deps:
+        deps_s = " " + ", ".join(f'"{d}"' for d in deps) + " "
+    kw = ", ".join(f'"{k}"' for k in (name.lower(), "graphics", "x11" if name.startswith(("libX", "libx", "xorg", "xcb", "xtrans")) else "gl"))
+    out = HEADER.format(
+        homepage=homepage(name), name=name, desc=DESCRIPTIONS[name],
+        licenses=LICENSES.get(name, DEFAULT_LICENSE),
+        keywords=kw, deps=deps_s, version=version, sha=sha,
+        global_url=global_url, cn=cn_url,
+        exports=(EXPORTS if has_libs else ""),
+    )
+    out += INSTALL.format(name=name, version=version)
+    out += CONFIG_LIB
+    return out
+
+
+def main():
+    manifest = pathlib.Path(sys.argv[1])
+    outdir = pathlib.Path(sys.argv[2]) if len(sys.argv) > 2 else pathlib.Path("pkgs")
+    written = 0
+    for line in manifest.read_text().splitlines():
+        if not line.strip():
+            continue
+        name, version, sha, global_url, cn_url, cn_ok = line.split("|")
+        if name not in SPEC:
+            print(f"  skip {name} (not in SPEC — mesa is written by hand)")
+            continue
+        d = outdir / name[0].lower()
+        d.mkdir(parents=True, exist_ok=True)
+        (d / f"{name}.lua").write_text(
+            render(name, version, sha, global_url, cn_url))
+        print(f"  wrote {d / (name + '.lua')}")
+        written += 1
+    print(f"{written} recipes")
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/tools/graphics/gen-recipes.py
+++ b/.agents/tools/graphics/gen-recipes.py
@@ -29,49 +29,56 @@ import sys
 #
 # deps use ranges by default; see the module docstring for why, and for the one
 # place that does not.
+#
+# Names are BARE, without an `xim:` prefix — the majority form in this index
+# (70 of 106 dependency entries) and the one that works. A namespaced dep can
+# only resolve from that namespace, so a batch of new packages depending on
+# each other cannot install until every one of them is published: CI registers
+# changed packages under `local` and `xim:libX11` is not there yet. A bare name
+# resolves from whichever repo has it.
 SPEC = {
     # T1 — protocol descriptions and the kernel interface.
     "xorgproto":    ([], False, None),
     "xcb-proto":    ([], False, None),
     "xtrans":       ([], False, None),
-    "libpciaccess": (["xim:zlib@>=1.2"], True, None),
-    "libdrm":       (["xim:libpciaccess@>=0.18"], True, None),
+    "libpciaccess": (["zlib@>=1.2"], True, None),
+    "libdrm":       (["libpciaccess@>=0.18"], True, None),
     "libxshmfence": ([], True, None),
 
     # T2 — the X11 client stack. Each layer needs the one below it at run time.
-    "libXau":       (["xim:xorgproto@>=2024"], True, None),
-    "libXdmcp":     (["xim:xorgproto@>=2024"], True, None),
-    "libxcb":       (["xim:libXau@>=1.0", "xim:libXdmcp@>=1.1"], True, None),
-    "libX11":       (["xim:libxcb@>=1.17", "xim:xorgproto@>=2024"], True, None),
-    "libXext":      (["xim:libX11@>=1.8"], True, None),
-    "libXrender":   (["xim:libX11@>=1.8"], True, None),
-    "libXfixes":    (["xim:libX11@>=1.8"], True, None),
-    "libXrandr":    (["xim:libXext@>=1.3", "xim:libXrender@>=0.9"], True, None),
-    "libXxf86vm":   (["xim:libXext@>=1.3"], True, None),
-    "libXi":        (["xim:libXext@>=1.3", "xim:libXfixes@>=6.0"], True, None),
-    "libXcursor":   (["xim:libXrender@>=0.9", "xim:libXfixes@>=6.0"], True, None),
+    "libXau":       (["xorgproto@>=2024"], True, None),
+    "libXdmcp":     (["xorgproto@>=2024"], True, None),
+    "libxcb":       (["libXau@>=1.0", "libXdmcp@>=1.1"], True, None),
+    "libX11":       (["libxcb@>=1.17", "xorgproto@>=2024"], True, None),
+    "libXext":      (["libX11@>=1.8"], True, None),
+    "libXrender":   (["libX11@>=1.8"], True, None),
+    "libXfixes":    (["libX11@>=1.8"], True, None),
+    "libXrandr":    (["libXext@>=1.3", "libXrender@>=0.9"], True, None),
+    "libXxf86vm":   (["libXext@>=1.3"], True, None),
+    "libXi":        (["libXext@>=1.3", "libXfixes@>=6.0"], True, None),
+    "libXcursor":   (["libXrender@>=0.9", "libXfixes@>=6.0"], True, None),
 
     # T4 — the graphics core.
-    "libglvnd":     (["xim:libX11@>=1.8", "xim:libXext@>=1.3"], True, None),
-    "libllvm":      (["xim:gcc-runtime@>=15", "xim:glibc@>=2.38"], True, None),
+    "libglvnd":     (["libX11@>=1.8", "libXext@>=1.3"], True, None),
+    "libllvm":      (["gcc-runtime@>=15", "glibc@>=2.38"], True, None),
 }
 
 # mesa is written separately: it is the only recipe with an exact pin, and the
 # only one that declares environment through subos.env.
 MESA_DEPS = [
-    "xim:libllvm@20.1.7",        # exact — see the module docstring
-    "xim:libglvnd@>=1.7",
-    "xim:libdrm@>=2.4",
-    "xim:libX11@>=1.8",
-    "xim:libxcb@>=1.17",
-    "xim:libXext@>=1.3",
-    "xim:libXfixes@>=6.0",
-    "xim:libXxf86vm@>=1.1",
-    "xim:libxshmfence@>=1.3",
-    "xim:expat@>=2.6",
-    "xim:zlib@>=1.2",
-    "xim:gcc-runtime@>=15",
-    "xim:glibc@>=2.38",
+    "libllvm@20.1.7",        # exact — see the module docstring
+    "libglvnd@>=1.7",
+    "libdrm@>=2.4",
+    "libX11@>=1.8",
+    "libxcb@>=1.17",
+    "libXext@>=1.3",
+    "libXfixes@>=6.0",
+    "libXxf86vm@>=1.1",
+    "libxshmfence@>=1.3",
+    "expat@>=2.6",
+    "zlib@>=1.2",
+    "gcc-runtime@>=15",
+    "glibc@>=2.38",
 ]
 
 DESCRIPTIONS = {

--- a/.agents/tools/graphics/glprobe.c
+++ b/.agents/tools/graphics/glprobe.c
@@ -1,0 +1,88 @@
+// glprobe — the S1..S4 assertions from the graphics-stack design, as one binary.
+//
+// Renders through EGL's surfaceless platform (no X server, no Wayland, no
+// window) and reads the framebuffer back. That last part is the point:
+// eglInitialize succeeding and a renderer string printing are both things a
+// half-working stack does. Only a pixel that came back the colour we asked for
+// proves something rendered.
+//
+// Prints one KEY=VALUE per line so the harness can assert on them:
+//   GL_VENDOR / GL_RENDERER / GL_VERSION
+//   PIXEL=RRGGBB
+//   RESULT=ok|fail:<why>
+#include <EGL/egl.h>
+#include <EGL/eglext.h>
+#include <GL/gl.h>
+#include <stdio.h>
+#include <string.h>
+
+#define W 64
+#define H 64
+
+static int fail(const char *why) {
+    printf("RESULT=fail:%s\n", why);
+    return 1;
+}
+
+int main(void) {
+    // Surfaceless rather than EGL_DEFAULT_DISPLAY: the whole point is to run
+    // with no display server reachable, which is what an empty host looks like.
+    EGLDisplay dpy = EGL_NO_DISPLAY;
+
+    PFNEGLGETPLATFORMDISPLAYEXTPROC getPlatformDisplay =
+        (PFNEGLGETPLATFORMDISPLAYEXTPROC)eglGetProcAddress("eglGetPlatformDisplayEXT");
+    if (getPlatformDisplay)
+        dpy = getPlatformDisplay(EGL_PLATFORM_SURFACELESS_MESA, EGL_DEFAULT_DISPLAY, NULL);
+    if (dpy == EGL_NO_DISPLAY)
+        dpy = eglGetDisplay(EGL_DEFAULT_DISPLAY);
+    if (dpy == EGL_NO_DISPLAY) return fail("no-display");
+
+    EGLint major = 0, minor = 0;
+    if (!eglInitialize(dpy, &major, &minor)) return fail("eglInitialize");
+    printf("EGL_VERSION=%d.%d\n", major, minor);
+
+    if (!eglBindAPI(EGL_OPENGL_API)) return fail("eglBindAPI");
+
+    const EGLint cfgAttr[] = {
+        EGL_SURFACE_TYPE,    EGL_PBUFFER_BIT,
+        EGL_RENDERABLE_TYPE, EGL_OPENGL_BIT,
+        EGL_RED_SIZE, 8, EGL_GREEN_SIZE, 8, EGL_BLUE_SIZE, 8,
+        EGL_NONE
+    };
+    EGLConfig cfg; EGLint n = 0;
+    if (!eglChooseConfig(dpy, cfgAttr, &cfg, 1, &n) || n < 1)
+        return fail("eglChooseConfig");
+
+    EGLContext ctx = eglCreateContext(dpy, cfg, EGL_NO_CONTEXT, NULL);
+    if (ctx == EGL_NO_CONTEXT) return fail("eglCreateContext");
+
+    const EGLint pbAttr[] = { EGL_WIDTH, W, EGL_HEIGHT, H, EGL_NONE };
+    EGLSurface surf = eglCreatePbufferSurface(dpy, cfg, pbAttr);
+    if (surf == EGL_NO_SURFACE) return fail("eglCreatePbufferSurface");
+
+    if (!eglMakeCurrent(dpy, surf, surf, ctx)) return fail("eglMakeCurrent");
+
+    const char *vendor   = (const char *)glGetString(GL_VENDOR);
+    const char *renderer = (const char *)glGetString(GL_RENDERER);
+    const char *version  = (const char *)glGetString(GL_VERSION);
+    printf("GL_VENDOR=%s\n",   vendor   ? vendor   : "?");
+    printf("GL_RENDERER=%s\n", renderer ? renderer : "?");
+    printf("GL_VERSION=%s\n",  version  ? version  : "?");
+
+    // A colour no default clear would produce by accident.
+    glClearColor(0.2f, 0.4f, 0.6f, 1.0f);
+    glClear(GL_COLOR_BUFFER_BIT);
+    glFinish();
+
+    unsigned char px[4] = {0, 0, 0, 0};
+    glReadPixels(W / 2, H / 2, 1, 1, GL_RGBA, GL_UNSIGNED_BYTE, px);
+    printf("PIXEL=%02X%02X%02X\n", px[0], px[1], px[2]);
+
+    // 0.2/0.4/0.6 → 51/102/153, ±2 for the rounding a driver is entitled to.
+    if (px[0] < 49 || px[0] > 53 || px[1] < 100 || px[1] > 104 ||
+        px[2] < 151 || px[2] > 155) {
+        return fail("pixel-mismatch");
+    }
+    printf("RESULT=ok\n");
+    return 0;
+}

--- a/.agents/tools/graphics/publish.sh
+++ b/.agents/tools/graphics/publish.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# Publish the graphics-stack payloads to xlings-res, both regions.
+#
+# Chain per mcpp's docs/10-publishing-a-library.md, applied to xim-pkgindex:
+#
+#   tarball → github.com/xlings-res/<name> release  (GLOBAL)
+#           → gitcode.com/xlings-res/<name>         (CN, byte-identical)
+#           → recipe in this repo pointing at both, with the sha256
+#
+# Verification is not optional and not a HEAD request. GitCode answers HEAD
+# with 401 and GET with a redirect to its CDN, so an asset checked with HEAD
+# reads as broken while an asset checked only for existence can still be the
+# wrong bytes. Both regions are downloaded and compared against the local file.
+#
+# Usage:  publish.sh <distdir> [name-version ...]      (default: everything)
+set -uo pipefail
+
+DIST="${1:?usage: publish.sh <distdir> [pkg ...]}"; shift || true
+ORG=xlings-res
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+log()  { echo "[publish] $*"; }
+warn() { echo "[publish] WARN: $*" >&2; }
+fail() { echo "[publish] FAIL: $*" >&2; exit 1; }
+
+command -v gh  >/dev/null || fail "gh not found"
+command -v gtc >/dev/null || warn "gtc not found — CN mirror will be skipped"
+
+shopt -s nullglob
+FILES=("$DIST"/*.tar.gz)
+[[ ${#FILES[@]} -gt 0 ]] || fail "no tarballs in $DIST"
+
+README_DIR="${XLINGS_GFX_README_DIR:-/tmp/xlings-res-readme}"
+
+MANIFEST="$DIST/RECIPE-DATA.txt"
+: > "$MANIFEST"
+
+for f in "${FILES[@]}"; do
+    base="$(basename "$f")"                       # name-version-linux-x86_64.tar.gz
+    stem="${base%-linux-x86_64.tar.gz}"
+    name="${stem%-*}"
+    version="${stem##*-}"
+    [[ -n "$name" && -n "$version" ]] || { warn "cannot parse $base"; continue; }
+
+    if [[ $# -gt 0 ]] && ! printf '%s\n' "$@" | grep -qx "$stem"; then continue; fi
+
+    sha="$(sha256sum "$f" | cut -d' ' -f1)"
+    log "$name $version  ($(du -h "$f" | cut -f1))"
+
+    gh repo view "$ORG/$name" >/dev/null 2>&1 || {
+        gh repo create "$ORG/$name" --public \
+           --description "xlings-res payload: $name" >/dev/null 2>&1 \
+          || warn "could not create $ORG/$name (may already exist)"
+    }
+
+    # The README is the repo's first commit, and that is load-bearing rather
+    # than tidy: GitHub refuses to create a release on an empty repository
+    # ("HTTP 422: Repository is empty"), so a freshly created payload repo
+    # cannot receive its asset until something is committed. It also carries
+    # the build details — a payload repo holds only tarballs, so how those
+    # bytes were produced exists nowhere else.
+    if [[ -f "$README_DIR/$name/README.md" ]]; then
+        b64="$(base64 -w0 "$README_DIR/$name/README.md")"
+        cur_sha="$(gh api "repos/$ORG/$name/contents/README.md" -q .sha 2>/dev/null || true)"
+        if [[ -n "$cur_sha" ]]; then
+            gh api "repos/$ORG/$name/contents/README.md" -X PUT \
+               -f message="docs: how this payload is built" \
+               -f content="$b64" -f sha="$cur_sha" >/dev/null 2>&1 \
+              || warn "$name: README update failed"
+        else
+            gh api "repos/$ORG/$name/contents/README.md" -X PUT \
+               -f message="docs: how this payload is built" \
+               -f content="$b64" >/dev/null 2>&1 \
+              || warn "$name: README create failed"
+        fi
+    fi
+
+    # Errors are shown, not swallowed. The first version of this script sent
+    # every gh invocation to /dev/null, so all twenty-two packages failed
+    # identically and silently on "Repository is empty" — a diagnosis the
+    # output could not support.
+    if ! gh release view "$version" --repo "$ORG/$name" >/dev/null 2>&1; then
+        gh release create "$version" --repo "$ORG/$name" \
+             --title "$version" --notes "Built from source against the xlings subos glibc." \
+          || { warn "$name: cannot create release $version"; continue; }
+    fi
+    gh release upload "$version" "$f" --repo "$ORG/$name" --clobber \
+      || { warn "$name: GitHub upload failed"; continue; }
+
+    GLOBAL="https://github.com/$ORG/$name/releases/download/$version/$base"
+    CN="https://gitcode.com/$ORG/$name/releases/download/$version/$base"
+
+    if command -v gtc >/dev/null; then
+        # The CN repo has to exist first — gtc reports a missing one as
+        # `404 project not found` from the releases endpoint, which reads like
+        # a release problem rather than a repository problem. Creating is
+        # idempotent enough: an existing repo just errors and is ignored.
+        gtc repo create "$ORG/$name" --description "xlings-res payload: $name" \
+            >/dev/null 2>&1 || true
+        # And the same first-commit requirement as GitHub, reported differently:
+        # gitcode answers `400 main is not exist` from the releases endpoint,
+        # which reads like a release problem rather than an empty repository.
+        if [[ -d "$README_DIR/$name" ]]; then
+            gtc repo push "$ORG/$name" "$README_DIR/$name" \
+                -m "docs: how this payload is built" >/dev/null 2>&1 || true
+        fi
+        gtc release publish "$ORG/$name" --tag "$version" --asset "$f" >/dev/null 2>&1 \
+          || warn "$name: gtc publish reported a problem"
+    fi
+
+    # Verify by downloading, from both regions, and comparing bytes. A mirror
+    # that 200s with different content is the failure this catches; a digest
+    # in the recipe would then be right for one region and wrong for the other.
+    ok_global=no ok_cn=no
+    if curl -fsSL --retry 2 --max-time 300 -o "$TMP/g.bin" "$GLOBAL" 2>/dev/null \
+       && cmp -s "$TMP/g.bin" "$f"; then ok_global=yes; fi
+    if curl -fsSL --retry 2 --max-time 300 -o "$TMP/c.bin" "$CN" 2>/dev/null \
+       && cmp -s "$TMP/c.bin" "$f"; then ok_cn=yes; fi
+
+    log "  GLOBAL=$ok_global  CN=$ok_cn  sha256=${sha:0:16}…"
+    [[ "$ok_global" == yes ]] || warn "$name: GLOBAL asset does not match the local file"
+
+    printf '%s|%s|%s|%s|%s|%s\n' "$name" "$version" "$sha" "$GLOBAL" "$CN" "$ok_cn" >> "$MANIFEST"
+done
+
+log "recipe data → $MANIFEST"

--- a/.agents/tools/graphics/readme.py
+++ b/.agents/tools/graphics/readme.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+"""Write each xlings-res payload repo a README that makes the build reproducible.
+
+Design: xlings/.agents/docs/2026-08-05-graphics-stack-ecosystem-closure.md §10 (O5)
+
+A payload repo holds one tarball per release and nothing else, so six months
+from now the only record of HOW those bytes were produced is whatever is
+written down. O5 in the design names this as the long-term risk: thirty
+prebuilt packages whose build exists only in someone's shell history.
+
+Each README therefore carries the things that are not recoverable from the
+tarball: the upstream source, the exact configure flags, which compiler and
+why, what was deliberately left out, and the command to rebuild it.
+
+Usage:  readme.py <manifest> [--push]
+"""
+import pathlib
+import subprocess
+import sys
+
+LICENSES = {"libllvm": "Apache-2.0 WITH LLVM-exception"}
+DEFAULT_LICENSE = "MIT"
+
+TIERS = {
+    "xorgproto": "T1", "xcb-proto": "T1", "xtrans": "T1",
+    "libpciaccess": "T1", "libdrm": "T1", "libxshmfence": "T1",
+    "libXau": "T2", "libXdmcp": "T2", "libxcb": "T2", "libX11": "T2",
+    "libXext": "T2", "libXrender": "T2", "libXfixes": "T2",
+    "libXrandr": "T2", "libXxf86vm": "T2", "libXi": "T2", "libXcursor": "T2",
+    "libglvnd": "T4", "libllvm": "T4", "mesa": "T5",
+}
+
+UPSTREAM = {
+    "xorgproto":    "https://xorg.freedesktop.org/archive/individual/proto/xorgproto-{v}.tar.xz",
+    "xcb-proto":    "https://xorg.freedesktop.org/archive/individual/proto/xcb-proto-{v}.tar.xz",
+    "xtrans":       "https://xorg.freedesktop.org/archive/individual/lib/xtrans-{v}.tar.xz",
+    "libpciaccess": "https://xorg.freedesktop.org/archive/individual/lib/libpciaccess-{v}.tar.xz",
+    "libdrm":       "https://dri.freedesktop.org/libdrm/libdrm-{v}.tar.xz",
+    "libxshmfence": "https://xorg.freedesktop.org/archive/individual/lib/libxshmfence-{v}.tar.xz",
+    "libglvnd":     "https://gitlab.freedesktop.org/glvnd/libglvnd/-/archive/v{v}/libglvnd-v{v}.tar.gz",
+    "libllvm":      "https://github.com/llvm/llvm-project/releases/download/llvmorg-{v}/llvm-project-{v}.src.tar.xz",
+    "mesa":         "https://archive.mesa3d.org/mesa-{v}.tar.xz",
+}
+for _n in ("libXau", "libXdmcp", "libxcb", "libX11", "libXext", "libXrender",
+           "libXfixes", "libXrandr", "libXxf86vm", "libXi", "libXcursor"):
+    UPSTREAM[_n] = ("https://xorg.freedesktop.org/archive/individual/lib/"
+                    + _n + "-{v}.tar.xz")
+
+# Only where the flags are not the harness default.
+FLAGS = {
+    "libdrm": "-Dintel=enabled -Dradeon=enabled -Damdgpu=enabled -Dnouveau=enabled "
+              "-Dvalgrind=disabled -Dman-pages=disabled -Dtests=false",
+    "libglvnd": "-Dgles1=false -Dasm=enabled",
+    "mesa": "-Dgallium-drivers=llvmpipe -Dvulkan-drivers= -Dglvnd=enabled "
+            "-Dplatforms=x11 -Dllvm=enabled -Dshared-llvm=enabled "
+            "-Dlmsensors=disabled -Dvalgrind=disabled -Dbuild-tests=false "
+            "-Dgallium-extra-hud=false",
+    "libllvm": "-DLLVM_TARGETS_TO_BUILD=X86;AMDGPU -DLLVM_BUILD_LLVM_DYLIB=ON "
+               "-DLLVM_LINK_LLVM_DYLIB=ON -DLLVM_ENABLE_RTTI=ON "
+               "-DLLVM_ENABLE_{TERMINFO,LIBEDIT,LIBXML2,ZLIB,ZSTD,LIBPFM}=OFF "
+               "-DLLVM_INCLUDE_{TESTS,EXAMPLES,BENCHMARKS,DOCS,UTILS}=OFF",
+}
+
+# The decisions that are not visible in the flags and cost real time to
+# rediscover. Empty means "nothing surprising".
+NOTES = {
+    "libllvm": """### Why only X86 and AMDGPU
+
+Undefined-symbol analysis of mesa's `libgallium` finds `LLVMInitializeX86*`
+(the llvmpipe / lavapipe JIT) and 27 AMDGPU symbols (radeonsi's shader
+compiler). Intel (iris/ANV) and NVIDIA-open (nouveau/NVK) go through NIR
+backends and never reach LLVM. The distro build ships every target and costs
+137 MB; this one is 121 MB unpacked with the same coverage.
+
+### Why gcc 15.1.0 and not the subos default, and not clang
+
+* gcc 16.1.0 — the subos default — ICEs with a segfault on
+  `AMDGPUAsmParser.cpp` at 2212/2218. AMDGPU cannot be dropped to dodge it.
+* clang builds it and produces a payload that is wrong in a way nothing
+  reports: the xlings `llvm` package's clang defaults to **libc++**, so
+  libLLVM would need libc++/libc++abi/libunwind while mesa is built against
+  **libstdc++**. `libgallium` references 97 mangled `llvm::` symbols; across
+  two C++ runtimes those names match and the object layouts do not. Forcing
+  `-stdlib=libstdc++` then fails to link.
+* gcc 15.1.0 is the compiler whose runtime the ecosystem ships
+  (`gcc-runtime@15.1.0`), so the C++ ABI is consistent by construction.
+
+### This is not the `llvm` package
+
+`llvm` is a self-contained clang/lld toolchain whose acceptance gate forbids a
+shared libLLVM (`.agents/skills/llvm-subpackaging`). Different consumer,
+different axis — the same split the index makes between `gcc` and
+`gcc-runtime`.
+
+### The payload is lib-only, deliberately
+
+Consumers need `libLLVM.so` and nothing else. But a runtime-only tree **cannot
+serve as a build dependency**: `llvm-config --shared-mode` verifies the
+component archives it knows about are present, so against a `lib/` holding
+only the `.so` it errors per component and mesa's
+`dependency('llvm', method: 'config-tool')` concludes LLVM is absent. Building
+mesa therefore needs a full `ninja install` staged into the build subos, which
+is what `build-libllvm.sh` does. Same line distributions draw between
+`libllvm20` and `llvm-dev`.
+""",
+    "mesa": """### Driver coverage in this build
+
+`gallium-drivers=llvmpipe` only, and `vulkan-drivers` empty. That is staging,
+not a scope decision:
+
+* `iris` (Intel) pulls in **libclc** — `meson.build`: `with_gallium_iris` implies
+  `with_clc` — which is a further package.
+* The Vulkan drivers need **glslangValidator**, likewise.
+
+The acceptance criterion exercises the GL path through llvmpipe, so the whole
+chain is proven with one driver first. Adding a driver to a pipeline that
+already renders is a small change; debugging a pipeline with five drivers at
+once is not.
+
+### Why `-Dglvnd=enabled` is load-bearing
+
+It makes mesa build as a libglvnd **vendor** (`libGLX_mesa` / `libEGL_mesa`)
+rather than as a `libGL` replacement. That is what allows the NVIDIA
+proprietary vendor to sit beside it in one subos, selected per process through
+the environment.
+
+### Discovery protocols this payload needs
+
+Neither PATH nor RPATH can supply these; the process that has to see them is
+the user's own binary, which xlings never wraps:
+
+    LIBGL_DRIVERS_PATH          ${pkgdir}/lib/dri
+    __EGL_VENDOR_LIBRARY_DIRS   ${pkgdir}/share/glvnd/egl_vendor.d
+
+The recipe declares them with `subos.env{}` (xlings ≥ 2026.8.5.1), so entering
+the subos sets them and the user does nothing.
+""",
+    "libxcb": """### Build-time dependency on xcb-proto's Python module
+
+`libxcb` generates its protocol bindings from the XML in `xcb-proto`, using
+that package's `xcbgen` Python module. Both the module and the `.pc` that
+locates the XML must be visible to the build.
+
+The `.pc` records `prefix=/usr` — correct for a relocatable payload, wrong
+during the build, where the files live under the subos. `build-in-subos.sh`
+rewrites the prefix in the **staged** copy only; the shipped tarball keeps
+`/usr`. Without that rewrite the build fails looking for `//usr/share/xcb/`,
+a path on the host root.
+""",
+    "libX11": """### libtool archives are removed from the payload
+
+A `.la` records the absolute libdir it was configured with, and the next
+package's libtool reads that path literally. Keeping them made this build stop
+with `'/usr/lib/libXau.la' is not a valid libtool archive` — it had gone
+looking on the host root for a library sitting in the subos. Every payload in
+this stack has its `.la` files deleted, which is what distributions settled on.
+""",
+}
+
+TEMPLATE = """# {name}
+
+xlings-res payload for **`{name}`** — part of the xlings graphics stack ({tier}).
+
+Built from source **inside an xlings subos**, against that subos's glibc, so
+the result depends on nothing from whatever host it is installed on. That is
+the whole point: a payload linked against a build machine's glibc works there
+and fails elsewhere, which is
+[mcpp#352](https://github.com/mcpp-community/mcpp/issues/352).
+
+| | |
+|---|---|
+| version | `{version}` |
+| upstream | {upstream} |
+| licence | {licence} |
+| sha256 | `{sha}` |
+| recipe | [`xim-pkgindex/pkgs/{initial}/{name}.lua`](https://github.com/openxlings/xim-pkgindex/blob/main/pkgs/{initial}/{name}.lua) |
+
+## Build
+
+```bash
+git clone https://github.com/openxlings/xim-pkgindex && cd xim-pkgindex
+xlings subos new gfxbuild
+xlings subos use gfxbuild --global
+xlings install gcc make ninja python cmake zlib expat -y
+
+export XLINGS_GFX_SUBOS=gfxbuild
+bash .agents/tools/graphics/tiers.sh {tier}     # or build-libllvm.sh for libllvm
+```
+
+{flags_section}
+## What the harness guarantees
+
+`build-in-subos.sh` refuses a payload that reaches back to the host, checking
+for both kinds of leak before packaging:
+
+* an RPATH naming anything outside the payload;
+* an absolute host prefix baked into a `.pc`, `.la` or `*-config` file — which
+  breaks nothing now and breaks the **next** package, by pointing its
+  `configure` at `/usr`.
+
+`PKG_CONFIG_LIBDIR` points only at the subos, so a dependency that is not
+packaged yet fails `configure` loudly instead of being satisfied quietly by a
+host copy.
+
+{notes}
+## Verifying the stack
+
+```bash
+bash .agents/tools/graphics/selfcontained-check.sh
+```
+
+Runs a GL client under bwrap with **no `/usr` and no `/lib`** — only the subos,
+`/dev/dri` and a read-only `/sys` — and asserts it renders correct pixels and
+that the renderer is *not* the host's driver. That last assertion is the only
+thing separating a self-contained stack from one quietly using the host's:
+both produce identical output.
+"""
+
+
+def flags_section(name):
+    f = FLAGS.get(name)
+    if not f:
+        return ("Standard autotools/meson configuration; the harness supplies "
+                "`--prefix=/usr --libdir=lib` and the subos toolchain.\n")
+    return f"### Configuration\n\n```\n{f}\n```\n"
+
+
+def render(name, version, sha):
+    return TEMPLATE.format(
+        name=name, version=version, sha=sha, tier=TIERS.get(name, "T?"),
+        initial=name[0].lower(),
+        upstream=UPSTREAM.get(name, "(see recipe)").format(v=version),
+        licence=LICENSES.get(name, DEFAULT_LICENSE),
+        flags_section=flags_section(name),
+        notes=(NOTES[name] + "\n") if name in NOTES else "",
+    )
+
+
+def main():
+    manifest = pathlib.Path(sys.argv[1])
+    push = "--push" in sys.argv
+    for line in manifest.read_text().splitlines():
+        if not line.strip():
+            continue
+        name, version, sha, *_ = line.split("|")
+        body = render(name, version, sha)
+        out = pathlib.Path(f"/tmp/xlings-res-readme/{name}")
+        out.mkdir(parents=True, exist_ok=True)
+        (out / "README.md").write_text(body)
+        print(f"  {name}: README ({len(body)} bytes)")
+        if push:
+            repo = f"xlings-res/{name}"
+            r = subprocess.run(
+                ["gh", "api", f"repos/{repo}/contents/README.md",
+                 "-X", "PUT", "-f", "message=docs: record how this payload is built",
+                 "-f", f"content={__import__('base64').b64encode(body.encode()).decode()}"],
+                capture_output=True, text=True)
+            if r.returncode != 0 and "sha" in r.stderr:
+                # already exists — needs the current blob sha to replace
+                cur = subprocess.run(
+                    ["gh", "api", f"repos/{repo}/contents/README.md", "-q", ".sha"],
+                    capture_output=True, text=True)
+                if cur.returncode == 0:
+                    subprocess.run(
+                        ["gh", "api", f"repos/{repo}/contents/README.md",
+                         "-X", "PUT", "-f", "message=docs: record how this payload is built",
+                         "-f", f"content={__import__('base64').b64encode(body.encode()).decode()}",
+                         "-f", f"sha={cur.stdout.strip()}"],
+                        capture_output=True, text=True)
+            print(f"    → pushed to {repo}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/tools/graphics/selfcontained-check.sh
+++ b/.agents/tools/graphics/selfcontained-check.sh
@@ -53,27 +53,49 @@ if [[ ! -x "$PROBE" || "$HERE/glprobe.c" -nt "$PROBE" ]]; then
     log "building glprobe against the subos"
     CC="$SUBOS_DIR/bin/gcc"
     [[ -x "$CC" ]] || CC="$(command -v gcc)" || fail "no compiler"
-    "$CC" -O1 -o "$PROBE" "$HERE/glprobe.c" \
-        -I"$SUBOS_DIR/usr/include" -L"$SUBOS_DIR/lib" \
-        -lEGL -lGL 2>&1 | head -5 \
-        || fail "cannot build glprobe against the subos (are libglvnd's headers installed?)"
+    # No pipe into head here: the exit status would be head's, and a failed
+    # compile would sail past `|| fail` to be reported later as a missing
+    # binary inside the container — which reads as an incomplete closure
+    # rather than as "it never compiled".
+    if ! "$CC" -O1 -o "$PROBE" "$HERE/glprobe.c" \
+            -I"$SUBOS_DIR/usr/include" -L"$SUBOS_DIR/lib" -L"$SUBOS_DIR/usr/lib" \
+            -Wl,-rpath,"$SUBOS_DIR/usr/lib" -Wl,-rpath,"$SUBOS_DIR/lib" \
+            -lEGL -lGL > "$SUBOS_DIR/glprobe-build.log" 2>&1; then
+        sed 's/^/    /' "$SUBOS_DIR/glprobe-build.log" | head -15
+        fail "cannot build glprobe against the subos (is libglvnd installed?)"
+    fi
 fi
 
 # ── the empty host ──────────────────────────────────────────────────────
 # No --ro-bind /usr, no /lib. /dev/dri is the kernel and /sys is how libdrm and
 # libpciaccess enumerate devices; both are on the "cannot be ours" list.
+# Mount order matters. --tmpfs /tmp goes FIRST: bwrap applies these in
+# sequence, so a tmpfs mounted after the bind would shadow anything under /tmp
+# — and an XLINGS_HOME under /tmp (a scratch home, as in CI) then vanishes,
+# surfacing as "execvp: No such file or directory" for a binary that is plainly
+# there. The ENOENT is the loader's, not the binary's, which sends you looking
+# in the wrong place.
 OUT="$(
   bwrap \
     --unshare-all --die-with-parent \
-    --ro-bind "$XHOME" "$XHOME" \
-    --dev /dev --dev-bind /dev/dri /dev/dri \
-    --ro-bind /sys /sys \
     --proc /proc --tmpfs /tmp \
+    --ro-bind "$XHOME" "$XHOME" \
+    --dev-bind /dev/dri /dev/dri \
+    --ro-bind /sys /sys \
     --setenv XLINGS_HOME "$XHOME" \
     --setenv HOME /tmp \
+    --setenv LIBGL_DRIVERS_PATH "$SUBOS_DIR/usr/lib/dri" \
+    --setenv __EGL_VENDOR_LIBRARY_DIRS "$SUBOS_DIR/usr/share/glvnd/egl_vendor.d" \
+    --setenv LD_LIBRARY_PATH "$SUBOS_DIR/usr/lib:$SUBOS_DIR/lib" \
     -- "$PROBE" 2>&1
 )"
 RC=$?
+# The three --setenv above are TEMPORARY, and their removal is the next
+# milestone rather than a cleanup. They are exactly what `mesa`'s config() will
+# declare through subos.env{} once the recipe is published — at which point
+# entering the subos sets them and this script should still pass with these
+# lines deleted. Until then they stand in for the recipe, so the stack itself
+# can be judged separately from the packaging around it.
 
 echo "$OUT" | sed 's/^/    /'
 

--- a/.agents/tools/graphics/selfcontained-check.sh
+++ b/.agents/tools/graphics/selfcontained-check.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Is the xlings graphics stack actually self-contained?
+#
+# Runs a real GL client inside a bwrap container with NO /usr and NO /lib —
+# only the subos, /dev/dri and a read-only /sys. Anything the stack still needs
+# from the host shows up here as a loader error, because there is no host left
+# to fall back to.
+#
+# Design: xlings/.agents/docs/2026-08-05-graphics-stack-ecosystem-closure.md §8
+#
+# The four assertions, and why each exists:
+#
+#   S1  the process does not die in the dynamic loader
+#          → something in the closure is still missing
+#   S2  GL_RENDERER contains llvmpipe
+#          → we are running OUR software rasteriser
+#   S3  GL_RENDERER does NOT contain NVIDIA
+#          → the host stack did not leak in
+#   S4  glReadPixels returns the colour we cleared to
+#          → it actually rendered
+#
+# S3 is the one that matters most. A run that "works" by quietly loading the
+# host's libGL produces output identical to a genuine success, so the only way
+# to tell them apart is to assert the host's driver is absent. S2 alone does not
+# do it — a host with mesa installed also says llvmpipe.
+#
+# Exit 0 only when all four hold. Until the graphics packages exist this script
+# is expected to FAIL, and that failure is the baseline: it is what says the
+# criterion is real rather than written to match whatever we happened to build.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SUBOS_NAME="${XLINGS_GFX_SUBOS:-gfxcheck}"
+
+log()  { echo "[gfx-check] $*"; }
+fail() { echo "[gfx-check] FAIL: $*" >&2; exit 1; }
+skip() { echo "[gfx-check] SKIP: $*"; exit 0; }
+
+command -v bwrap  >/dev/null || skip "bwrap not available (xlings install bwrap)"
+XLINGS_BIN="${XLINGS_BIN:-$(command -v xlings)}"
+[[ -x "$XLINGS_BIN" ]] || skip "no xlings on PATH; set XLINGS_BIN"
+
+XHOME="${XLINGS_HOME:-$HOME/.xlings}"
+SUBOS_DIR="$XHOME/subos/$SUBOS_NAME"
+[[ -d "$SUBOS_DIR" ]] || fail "subos '$SUBOS_NAME' does not exist — create it and install \`mesa\` into it first"
+
+# ── the probe ───────────────────────────────────────────────────────────
+# Built against the SUBOS's headers and libraries, not the host's. Building it
+# against the host would link it to host sonames and make the whole exercise
+# circular.
+PROBE="$SUBOS_DIR/bin/glprobe"
+if [[ ! -x "$PROBE" || "$HERE/glprobe.c" -nt "$PROBE" ]]; then
+    log "building glprobe against the subos"
+    CC="$SUBOS_DIR/bin/gcc"
+    [[ -x "$CC" ]] || CC="$(command -v gcc)" || fail "no compiler"
+    "$CC" -O1 -o "$PROBE" "$HERE/glprobe.c" \
+        -I"$SUBOS_DIR/usr/include" -L"$SUBOS_DIR/lib" \
+        -lEGL -lGL 2>&1 | head -5 \
+        || fail "cannot build glprobe against the subos (are libglvnd's headers installed?)"
+fi
+
+# ── the empty host ──────────────────────────────────────────────────────
+# No --ro-bind /usr, no /lib. /dev/dri is the kernel and /sys is how libdrm and
+# libpciaccess enumerate devices; both are on the "cannot be ours" list.
+OUT="$(
+  bwrap \
+    --unshare-all --die-with-parent \
+    --ro-bind "$XHOME" "$XHOME" \
+    --dev /dev --dev-bind /dev/dri /dev/dri \
+    --ro-bind /sys /sys \
+    --proc /proc --tmpfs /tmp \
+    --setenv XLINGS_HOME "$XHOME" \
+    --setenv HOME /tmp \
+    -- "$PROBE" 2>&1
+)"
+RC=$?
+
+echo "$OUT" | sed 's/^/    /'
+
+# ── assertions ──────────────────────────────────────────────────────────
+[[ $RC -eq 0 ]] || fail "S1: probe exited $RC inside the empty host (closure incomplete)"
+grep -q "RESULT=ok" <<<"$OUT" || fail "S1/S4: probe did not reach RESULT=ok"
+log "  S1 ok — no loader error with no /usr present"
+
+RENDERER="$(sed -n 's/^GL_RENDERER=//p' <<<"$OUT")"
+[[ -n "$RENDERER" ]] || fail "S2: no GL_RENDERER reported"
+
+grep -qi "llvmpipe" <<<"$RENDERER" \
+  || fail "S2: renderer is '$RENDERER', expected llvmpipe (software path not taken)"
+log "  S2 ok — rendering through our llvmpipe"
+
+grep -qi "nvidia" <<<"$RENDERER" \
+  && fail "S3: renderer is '$RENDERER' — the HOST stack leaked in; the container is not sealed"
+log "  S3 ok — no host driver reachable"
+
+grep -q "^PIXEL=336699$" <<<"$OUT" \
+  || fail "S4: pixel readback was '$(sed -n 's/^PIXEL=//p' <<<"$OUT")', expected 336699"
+log "  S4 ok — rendered and read back the expected colour"
+
+log "graphics stack is self-contained: PASS"

--- a/.agents/tools/graphics/tiers.sh
+++ b/.agents/tools/graphics/tiers.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# The graphics-stack build order, as data.
+#
+# Design: xlings/.agents/docs/2026-08-05-graphics-stack-ecosystem-closure.md §4
+#
+# Order is a dependency order, not a preference: libXau's headers come from
+# xorgproto, libxcb's protocol descriptions from xcb-proto, libX11 from libxcb,
+# and mesa from all of it. Building out of order fails at configure — which is
+# the intended behaviour, since PKG_CONFIG_LIBDIR points only at the subos and
+# a missing dependency cannot be silently satisfied by the host.
+#
+# Usage:  tiers.sh [T1|T2|T3|T4|all] [--from <name>]
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BUILD="$HERE/build-in-subos.sh"
+
+# name|version|url|system|extra-args
+T1=(
+  "xorgproto|2024.1|https://xorg.freedesktop.org/archive/individual/proto/xorgproto-2024.1.tar.xz|meson|"
+  "xcb-proto|1.17.0|https://xorg.freedesktop.org/archive/individual/proto/xcb-proto-1.17.0.tar.xz|autotools|"
+  "libpciaccess|0.18.1|https://xorg.freedesktop.org/archive/individual/lib/libpciaccess-0.18.1.tar.xz|meson|"
+  "libdrm|2.4.123|https://dri.freedesktop.org/libdrm/libdrm-2.4.123.tar.xz|meson|-Dintel=enabled -Dradeon=enabled -Damdgpu=enabled -Dnouveau=enabled -Dvalgrind=disabled -Dman-pages=disabled -Dtests=false"
+  "libxshmfence|1.3.2|https://xorg.freedesktop.org/archive/individual/lib/libxshmfence-1.3.2.tar.xz|autotools|"
+)
+
+T2=(
+  "libXau|1.0.11|https://xorg.freedesktop.org/archive/individual/lib/libXau-1.0.11.tar.xz|autotools|"
+  "libXdmcp|1.1.5|https://xorg.freedesktop.org/archive/individual/lib/libXdmcp-1.1.5.tar.xz|autotools|"
+  "libxcb|1.17.0|https://xorg.freedesktop.org/archive/individual/lib/libxcb-1.17.0.tar.xz|autotools|"
+  "libX11|1.8.10|https://xorg.freedesktop.org/archive/individual/lib/libX11-1.8.10.tar.xz|autotools|"
+  "libXext|1.3.6|https://xorg.freedesktop.org/archive/individual/lib/libXext-1.3.6.tar.xz|autotools|"
+  "libXrender|0.9.11|https://xorg.freedesktop.org/archive/individual/lib/libXrender-0.9.11.tar.xz|autotools|"
+  "libXfixes|6.0.1|https://xorg.freedesktop.org/archive/individual/lib/libXfixes-6.0.1.tar.xz|autotools|"
+  "libXrandr|1.5.4|https://xorg.freedesktop.org/archive/individual/lib/libXrandr-1.5.4.tar.xz|autotools|"
+  "libXxf86vm|1.1.6|https://xorg.freedesktop.org/archive/individual/lib/libXxf86vm-1.1.6.tar.xz|autotools|"
+  "libXi|1.8.2|https://xorg.freedesktop.org/archive/individual/lib/libXi-1.8.2.tar.xz|autotools|"
+  "libXcursor|1.2.3|https://xorg.freedesktop.org/archive/individual/lib/libXcursor-1.2.3.tar.xz|autotools|"
+)
+
+T3=(
+  "wayland|1.23.1|https://gitlab.freedesktop.org/wayland/wayland/-/releases/1.23.1/downloads/wayland-1.23.1.tar.xz|meson|-Ddocumentation=false -Dtests=false"
+  "wayland-protocols|1.38|https://gitlab.freedesktop.org/wayland/wayland-protocols/-/releases/1.38/downloads/wayland-protocols-1.38.tar.xz|meson|-Dtests=false"
+  "libxkbcommon|1.7.0|https://xkbcommon.org/download/libxkbcommon-1.7.0.tar.xz|meson|-Denable-docs=false -Denable-wayland=false -Denable-xkbregistry=false"
+)
+
+run_tier() {  # <tier-name> <entries...>
+    local tier="$1"; shift
+    local entry name version url system extra
+    for entry in "$@"; do
+        IFS='|' read -r name version url system extra <<<"$entry"
+        echo "── $tier :: $name $version ──────────────────────────────"
+        # shellcheck disable=SC2086
+        if [[ -n "$extra" ]]; then
+            bash "$BUILD" --name "$name" --version "$version" --url "$url" \
+                 --system "$system" -- $extra || return 1
+        else
+            bash "$BUILD" --name "$name" --version "$version" --url "$url" \
+                 --system "$system" || return 1
+        fi
+    done
+}
+
+WHICH="${1:-all}"
+case "$WHICH" in
+  T1)  run_tier T1 "${T1[@]}" ;;
+  T2)  run_tier T2 "${T2[@]}" ;;
+  T3)  run_tier T3 "${T3[@]}" ;;
+  all) run_tier T1 "${T1[@]}" && run_tier T2 "${T2[@]}" && run_tier T3 "${T3[@]}" ;;
+  *)   echo "usage: $0 [T1|T2|T3|all]" >&2; exit 2 ;;
+esac

--- a/.agents/tools/graphics/tiers.sh
+++ b/.agents/tools/graphics/tiers.sh
@@ -19,6 +19,11 @@ BUILD="$HERE/build-in-subos.sh"
 T1=(
   "xorgproto|2024.1|https://xorg.freedesktop.org/archive/individual/proto/xorgproto-2024.1.tar.xz|meson|"
   "xcb-proto|1.17.0|https://xorg.freedesktop.org/archive/individual/proto/xcb-proto-1.17.0.tar.xz|autotools|"
+  # xtrans is macros and headers only — no library is produced. libX11's
+  # configure demands it by pkg-config name, so it is build-time but not
+  # optional, and it is easy to leave out of a tier list derived from a
+  # runtime closure: nothing loads it, so `strace` never sees it.
+  "xtrans|1.5.2|https://xorg.freedesktop.org/archive/individual/lib/xtrans-1.5.2.tar.xz|autotools|"
   "libpciaccess|0.18.1|https://xorg.freedesktop.org/archive/individual/lib/libpciaccess-0.18.1.tar.xz|meson|"
   "libdrm|2.4.123|https://dri.freedesktop.org/libdrm/libdrm-2.4.123.tar.xz|meson|-Dintel=enabled -Dradeon=enabled -Damdgpu=enabled -Dnouveau=enabled -Dvalgrind=disabled -Dman-pages=disabled -Dtests=false"
   "libxshmfence|1.3.2|https://xorg.freedesktop.org/archive/individual/lib/libxshmfence-1.3.2.tar.xz|autotools|"

--- a/.agents/tools/graphics/tiers.sh
+++ b/.agents/tools/graphics/tiers.sh
@@ -49,6 +49,29 @@ T3=(
   "libxkbcommon|1.7.0|https://xkbcommon.org/download/libxkbcommon-1.7.0.tar.xz|meson|-Denable-docs=false -Denable-wayland=false -Denable-xkbregistry=false"
 )
 
+# T4 — the graphics core. libglvnd first: it is the vendor-neutral dispatch
+# layer, so it must exist before mesa is built as a *vendor* rather than as a
+# libGL replacement. That is what lets the mesa and NVIDIA paths coexist later.
+T4=(
+  "libglvnd|1.7.0|https://gitlab.freedesktop.org/glvnd/libglvnd/-/archive/v1.7.0/libglvnd-v1.7.0.tar.gz|meson|-Dgles1=false -Dasm=enabled"
+)
+
+# T5 — mesa. Everything above exists to make this line possible.
+#
+# gallium-drivers is the four hardware targets the design commits to:
+# llvmpipe (CPU), iris (Intel), radeonsi (AMD), nouveau (NVIDIA-open), plus
+# zink for Vulkan-on-GL. vulkan-drivers mirrors it.
+#
+# -Dglvnd=enabled is the load-bearing one: it makes mesa build as a libglvnd
+# *vendor* (libGLX_mesa/libEGL_mesa) rather than as a libGL replacement, which
+# is what lets the NVIDIA proprietary vendor sit alongside it in one subos.
+#
+# lmsensors is off — it only feeds a GPU temperature query, and enabling it
+# would add another package to the tier list for a HUD readout.
+T5=(
+  "mesa|25.0.7|https://archive.mesa3d.org/mesa-25.0.7.tar.xz|meson|-Dgallium-drivers=llvmpipe,iris,radeonsi,nouveau,zink -Dvulkan-drivers=swrast,intel,amd,nouveau -Dglvnd=enabled -Dplatforms=x11 -Dllvm=enabled -Dshared-llvm=enabled -Dlmsensors=disabled -Dvalgrind=disabled -Dbuild-tests=false -Dgallium-extra-hud=false"
+)
+
 run_tier() {  # <tier-name> <entries...>
     local tier="$1"; shift
     local entry name version url system extra
@@ -71,6 +94,9 @@ case "$WHICH" in
   T1)  run_tier T1 "${T1[@]}" ;;
   T2)  run_tier T2 "${T2[@]}" ;;
   T3)  run_tier T3 "${T3[@]}" ;;
-  all) run_tier T1 "${T1[@]}" && run_tier T2 "${T2[@]}" && run_tier T3 "${T3[@]}" ;;
+  T4)  run_tier T4 "${T4[@]}" ;;
+  T5)  run_tier T5 "${T5[@]}" ;;
+  all) run_tier T1 "${T1[@]}" && run_tier T2 "${T2[@]}" \
+         && run_tier T4 "${T4[@]}" && run_tier T5 "${T5[@]}" ;;
   *)   echo "usage: $0 [T1|T2|T3|all]" >&2; exit 2 ;;
 esac

--- a/.agents/tools/graphics/tiers.sh
+++ b/.agents/tools/graphics/tiers.sh
@@ -68,8 +68,23 @@ T4=(
 #
 # lmsensors is off — it only feeds a GPU temperature query, and enabling it
 # would add another package to the tier list for a HUD readout.
+#
+# gallium-drivers is llvmpipe ONLY for this first pass. iris pulls in libclc
+# (meson.build: with_gallium_iris => with_clc), which is another package, and
+# the acceptance criterion exercises llvmpipe. Prove the whole chain — libglvnd
+# vendor loading, libllvm's JIT, the X11 client stack, the empty-host container
+# — with one driver, then widen. A driver added to a pipeline that already
+# renders is a small change; a pipeline debugged with five drivers at once is
+# not.
+#
+# vulkan-drivers is EMPTY for now, and that is a staging decision rather than
+# a scope cut. Building them needs glslangValidator (glslang), which is one
+# more build-tool package; the acceptance criterion (S1-S4) exercises the GL
+# path through llvmpipe, so GL is proven first and Vulkan is re-enabled once
+# glslang is packaged. Leaving it empty is visible in the payload — no
+# libvulkan_*.so — rather than silently producing drivers that do not load.
 T5=(
-  "mesa|25.0.7|https://archive.mesa3d.org/mesa-25.0.7.tar.xz|meson|-Dgallium-drivers=llvmpipe,iris,radeonsi,nouveau,zink -Dvulkan-drivers=swrast,intel,amd,nouveau -Dglvnd=enabled -Dplatforms=x11 -Dllvm=enabled -Dshared-llvm=enabled -Dlmsensors=disabled -Dvalgrind=disabled -Dbuild-tests=false -Dgallium-extra-hud=false"
+  "mesa|25.0.7|https://archive.mesa3d.org/mesa-25.0.7.tar.xz|meson|-Dgallium-drivers=llvmpipe -Dvulkan-drivers= -Dglvnd=enabled -Dplatforms=x11 -Dllvm=enabled -Dshared-llvm=enabled -Dlmsensors=disabled -Dvalgrind=disabled -Dbuild-tests=false -Dgallium-extra-hud=false"
 )
 
 run_tier() {  # <tier-name> <entries...>

--- a/.github/scripts/posix-test.sh
+++ b/.github/scripts/posix-test.sh
@@ -119,6 +119,24 @@ skipped=0
 # with "package 'scode:linux-headers@<ver>' not found". Best-effort.
 "$XLINGS_CMD" config --index-repo "scode:https://github.com/openxlings/xim-pkgindex-scode.git" 2>/dev/null || true
 
+# Register every changed descriptor BEFORE testing any of them.
+#
+# The loop below registers each package immediately before installing it, which
+# is enough while a PR adds packages that only depend on already-published ones.
+# It cannot handle a PR that adds a stack: the graphics packages depend on each
+# other, so installing libX11 needs libxcb, which this PR also adds and which
+# has not been registered yet when libX11's turn comes. The failure reads as
+# "package 'libxcb@>=1.17' not found" for a recipe sitting in the same diff.
+#
+# Same reasoning as the scode line above — make the things a dependency can
+# point at resolvable first, then test. Registration is idempotent, so the
+# loop's own add-xpkg stays as it is.
+for rel_file in "${files[@]}"; do
+    [[ -n "$rel_file" ]] || continue
+    [[ -f "$WORKSPACE_ROOT/$rel_file" ]] || continue
+    "$XLINGS_CMD" config --add-xpkg "$WORKSPACE_ROOT/$rel_file" >/dev/null 2>&1 || true
+done
+
 for rel_file in "${files[@]}"; do
     [[ -n "$rel_file" ]] || continue
     lua_file="$WORKSPACE_ROOT/$rel_file"

--- a/docs/V2/xpackage-spec.md
+++ b/docs/V2/xpackage-spec.md
@@ -160,6 +160,63 @@ function install()
 end
 ```
 
+## `subos.env` — declaring an environment a subos must export
+
+Requires **libxpkg ≥ 0.0.48**. Probe it (see the next section) — and probe it
+with `type()`, because it arrives as a new module.
+
+Some things a program needs cannot be linked or PATH'd into place. A GL driver
+is found through `LIBGL_DRIVERS_PATH`, an EGL vendor through
+`__EGL_VENDOR_LIBRARY_DIRS`, a font config through `XDG_DATA_DIRS`. The process
+that has to see them is the *user's own binary*, which xlings never wraps, so
+the per-shim `envs` on `xvm.add` cannot reach it.
+
+```lua
+import("xim.libxpkg.subos")
+
+function config()
+    if type(subos.env) == "function" then
+        local tag = package.name .. "@" .. pkginfo.version()
+        subos.env{ var = "LIBGL_DRIVERS_PATH", op = "set",
+                   value = "${pkgdir}/lib/dri", binding = tag }
+        subos.env{ var = "XDG_DATA_DIRS", op = "prepend",
+                   value = "${pkgdir}/share", binding = tag }
+    end
+    return true
+end
+```
+
+| field | required | meaning |
+|---|---|---|
+| `var` | ✅ | variable name |
+| `op` | | `set` (default) or `prepend`. `append` / `set-if-unset` are not implemented and are **refused**, not silently downgraded |
+| `value` | ✅ | may contain the placeholders below |
+| `binding` | | `<name>@<version>`; defaults to this package's. Declaring for another package is refused |
+
+**Values must use placeholders.** They are expanded when the subos is entered,
+and a literal absolute path pins the manifest to the machine that wrote it:
+
+| placeholder | expands to |
+|---|---|
+| `${pkgdir}` | the declaring package's install directory |
+| `${subosdir}` | the subos root |
+| `${home}` | the user's home |
+| `${xlings_home}` | `$XLINGS_HOME` |
+
+An unresolvable placeholder is left **verbatim** rather than blanked —
+`${pkgdir}/lib/dri` collapsing to `/lib/dri` would be a real path on the host,
+outside the subos. `xlings self doctor` reports it.
+
+**Do not write cleanup in `uninstall()`.** Declarations are provider-scoped:
+xlings drops the whole section with the package. A recipe removing them itself
+would be a second owner of that state.
+
+Conflicts (two packages claiming one variable) resolve deterministically by
+binding order, never by install history, so two machines holding the same
+manifest export the same values. `doctor` reports every conflict rather than
+resolving it quietly. A variable the **user** already exported wins over a
+`set`; `prepend` still composes with it.
+
 ## Adopting a capability older clients do not have
 
 The index serves every client version at once. Two kinds of change behave very
@@ -191,6 +248,45 @@ end
 the xlings binary, so the Lua function and the C++ that consumes its node kind
 ship together: "is `xvm.files` a function" *is* "does this client support
 `type = files`". One truth source, nothing to keep in sync.
+
+#### A new module needs `type()`, not truthiness
+
+`if xvm.files then` is correct **only because `xvm` is a module older clients
+already ship.** The field really is `nil` there. A missing *module* never is:
+
+```lua
+import("xim.libxpkg.subos")     -- a client without it gets a STUB
+if subos.env then               -- ← true on EVERY client. Wrong.
+```
+
+`import()` answers an unknown module with a permissive proxy whose every key
+returns a truthy, callable table. The old client takes the new branch, calls
+the function, and the call evaporates — install succeeds, nothing is
+configured, nothing complains.
+
+For a capability introduced as a **new module**, probe the type:
+
+```lua
+if type(subos.env) == "function" then
+    subos.env{ var = "LIBGL_DRIVERS_PATH", op = "set",
+               value = "${pkgdir}/lib/dri", binding = tag }
+else
+    -- unchanged legacy path
+end
+```
+
+The stub is a `table` carrying a `__call` metamethod; the real entry point is
+a `function`. That is the only thing that separates them.
+
+| the capability is… | probe |
+|---|---|
+| a new function on an existing module (`xvm.files`) | `if xvm.files then` |
+| a new module (`subos.env`) | `if type(subos.env) == "function" then` |
+
+xlings E2E-61 runs one recipe through a real released binary and the current
+build and asserts both readings — truthiness `true` on both, `type()` `false`
+then `true`. If `import()` ever stops stubbing unknown modules, that test is
+what says the rule can be relaxed.
 
 Rules:
 

--- a/pkgs/g/godot.lua
+++ b/pkgs/g/godot.lua
@@ -295,15 +295,43 @@ function config()
     if os.host() == "linux" then
         local exe = _installed_exe()
         local host_dirs = _host_gui_libdirs()
-        local extra = #host_dirs > 0 and (":" .. table.concat(host_dirs, ":")) or ""
-        -- One sh -c: read the existing rpath, append probed host GUI
-        -- dirs, write back with --force-rpath.  Iorunv / stdout capture
-        -- aren't exposed to the xim hook runtime, so we can't compose
-        -- this in Lua directly.
+
+        -- The `add` helper in the shell snippet dedupes: on a repeat
+        -- install the host dirs from the previous run are still in
+        -- the rpath, and blindly appending would grow it unboundedly.
+        --
+        -- The final `patchelf --output <tmp> ... && mv <tmp> <exe>`
+        -- pattern is deliberate.  In-place `--set-rpath <exe>` fails
+        -- with `patchelf: open: Text file busy` (ETXTBSY) when the
+        -- user reinstalls while the editor is running -- Linux
+        -- refuses to truncate a mapped, executing binary.  rename(2)
+        -- unlinks the old inode; running processes keep their own
+        -- reference and stay on the old bytes, while new invocations
+        -- pick up the new file at the same path.
+        --
+        -- Iorunv / stdout capture aren't exposed to the xim hook
+        -- runtime, so shell does the read/decide/write in one line.
+        local add_lines = {}
+        for _, d in ipairs(host_dirs) do
+            table.insert(add_lines, string.format("add %q; ", d))
+        end
         system.exec(string.format(
-            "sh -c 'r=$(patchelf --print-rpath %q); "
-                .. "[ -n \"$r\" ] && patchelf --force-rpath --set-rpath \"$r%s\" %q'",
-            exe, extra, exe
+            "sh -c 'set -e; "
+                .. "exe=%q; "
+                .. "r=$(patchelf --print-rpath \"$exe\"); "
+                .. "[ -z \"$r\" ] && exit 0; "
+                .. "new=$r; "
+                .. "add() { case \":$new:\" in *\":$1:\"*) ;; "
+                    .. "*) new=$new:$1 ;; esac; }; "
+                .. "%s"
+                .. "if [ \"$new\" = \"$r\" ] "
+                    .. "&& readelf -d \"$exe\" 2>/dev/null "
+                    .. "| grep -q \"(RPATH)\"; then exit 0; fi; "
+                .. "tmp=$exe.rpatch.$$; "
+                .. "patchelf --output \"$tmp\" --force-rpath "
+                    .. "--set-rpath \"$new\" \"$exe\"; "
+                .. "mv \"$tmp\" \"$exe\"'",
+            exe, table.concat(add_lines)
         ))
     end
     xvm.add("godot", { bindir = pkginfo.install_dir() })

--- a/pkgs/l/libX11.lua
+++ b/pkgs/l/libX11.lua
@@ -5,8 +5,9 @@ package = {
     name = "libX11",
     description = "Core X11 client library",
 
+    authors = {"X.Org Foundation"},
     licenses = {"MIT"},
-    repo = "https://www.x.org",
+    repo = "https://gitlab.freedesktop.org/xorg/lib/libX11",
 
     type = "package",
     archs = {"x86_64"},

--- a/pkgs/l/libX11.lua
+++ b/pkgs/l/libX11.lua
@@ -16,7 +16,7 @@ package = {
 
     xpm = {
         linux = {
-            deps = { "xim:libxcb@>=1.17", "xim:xorgproto@>=2024" },
+            deps = { "libxcb@>=1.17", "xorgproto@>=2024" },
             -- elfpatch reads this from each dependency and writes the consumer's
             -- RPATH, which is what makes the stack resolve without anyone
             -- setting LD_LIBRARY_PATH. Same mechanism `gcc-runtime` uses.

--- a/pkgs/l/libX11.lua
+++ b/pkgs/l/libX11.lua
@@ -1,0 +1,56 @@
+package = {
+    spec = "2",
+
+    homepage = "https://www.x.org",
+    name = "libX11",
+    description = "Core X11 client library",
+
+    licenses = {"MIT"},
+    repo = "https://www.x.org",
+
+    type = "package",
+    archs = {"x86_64"},
+    status = "stable",
+    categories = {"graphics", "lib"},
+    keywords = {"libx11", "graphics", "x11"},
+
+    xpm = {
+        linux = {
+            deps = { "xim:libxcb@>=1.17", "xim:xorgproto@>=2024" },
+            -- elfpatch reads this from each dependency and writes the consumer's
+            -- RPATH, which is what makes the stack resolve without anyone
+            -- setting LD_LIBRARY_PATH. Same mechanism `gcc-runtime` uses.
+            exports = {
+                runtime = { libdirs = { "lib" } },
+            },
+            ["latest"] = { ref = "1.8.10" },
+            ["1.8.10"] = {
+                url = {
+                    GLOBAL = "https://github.com/xlings-res/libX11/releases/download/1.8.10/libX11-1.8.10-linux-x86_64.tar.gz",
+                    CN     = "https://gitcode.com/xlings-res/libX11/releases/download/1.8.10/libX11-1.8.10-linux-x86_64.tar.gz",
+                },
+                sha256 = "03d9242551aef99f920ec1ce7aaa36227b9034f7f9b1d8d3ea44b21759f0bbe5",
+            },
+        },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+
+function install()
+    local dir = pkginfo.install_dir()
+    os.tryrm(dir)
+    os.mv("libX11-1.8.10", dir)
+    return true
+end
+
+function config()
+    xvm.add(package.name)
+    return true
+end
+
+function uninstall()
+    xvm.remove(package.name)
+    return true
+end

--- a/pkgs/l/libXau.lua
+++ b/pkgs/l/libXau.lua
@@ -5,8 +5,9 @@ package = {
     name = "libXau",
     description = "X11 authorisation protocol library",
 
+    authors = {"X.Org Foundation"},
     licenses = {"MIT"},
-    repo = "https://www.x.org",
+    repo = "https://gitlab.freedesktop.org/xorg/lib/libXau",
 
     type = "package",
     archs = {"x86_64"},

--- a/pkgs/l/libXau.lua
+++ b/pkgs/l/libXau.lua
@@ -1,0 +1,56 @@
+package = {
+    spec = "2",
+
+    homepage = "https://www.x.org",
+    name = "libXau",
+    description = "X11 authorisation protocol library",
+
+    licenses = {"MIT"},
+    repo = "https://www.x.org",
+
+    type = "package",
+    archs = {"x86_64"},
+    status = "stable",
+    categories = {"graphics", "lib"},
+    keywords = {"libxau", "graphics", "x11"},
+
+    xpm = {
+        linux = {
+            deps = { "xim:xorgproto@>=2024" },
+            -- elfpatch reads this from each dependency and writes the consumer's
+            -- RPATH, which is what makes the stack resolve without anyone
+            -- setting LD_LIBRARY_PATH. Same mechanism `gcc-runtime` uses.
+            exports = {
+                runtime = { libdirs = { "lib" } },
+            },
+            ["latest"] = { ref = "1.0.11" },
+            ["1.0.11"] = {
+                url = {
+                    GLOBAL = "https://github.com/xlings-res/libXau/releases/download/1.0.11/libXau-1.0.11-linux-x86_64.tar.gz",
+                    CN     = "https://gitcode.com/xlings-res/libXau/releases/download/1.0.11/libXau-1.0.11-linux-x86_64.tar.gz",
+                },
+                sha256 = "07df5c69c4e1c9480e0f0e98f18bcb0d9e25990e994f8f77540fb69f6b55dfb5",
+            },
+        },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+
+function install()
+    local dir = pkginfo.install_dir()
+    os.tryrm(dir)
+    os.mv("libXau-1.0.11", dir)
+    return true
+end
+
+function config()
+    xvm.add(package.name)
+    return true
+end
+
+function uninstall()
+    xvm.remove(package.name)
+    return true
+end

--- a/pkgs/l/libXau.lua
+++ b/pkgs/l/libXau.lua
@@ -16,7 +16,7 @@ package = {
 
     xpm = {
         linux = {
-            deps = { "xim:xorgproto@>=2024" },
+            deps = { "xorgproto@>=2024" },
             -- elfpatch reads this from each dependency and writes the consumer's
             -- RPATH, which is what makes the stack resolve without anyone
             -- setting LD_LIBRARY_PATH. Same mechanism `gcc-runtime` uses.

--- a/pkgs/l/libXcursor.lua
+++ b/pkgs/l/libXcursor.lua
@@ -1,0 +1,56 @@
+package = {
+    spec = "2",
+
+    homepage = "https://www.x.org",
+    name = "libXcursor",
+    description = "X cursor management library",
+
+    licenses = {"MIT"},
+    repo = "https://www.x.org",
+
+    type = "package",
+    archs = {"x86_64"},
+    status = "stable",
+    categories = {"graphics", "lib"},
+    keywords = {"libxcursor", "graphics", "x11"},
+
+    xpm = {
+        linux = {
+            deps = { "xim:libXrender@>=0.9", "xim:libXfixes@>=6.0" },
+            -- elfpatch reads this from each dependency and writes the consumer's
+            -- RPATH, which is what makes the stack resolve without anyone
+            -- setting LD_LIBRARY_PATH. Same mechanism `gcc-runtime` uses.
+            exports = {
+                runtime = { libdirs = { "lib" } },
+            },
+            ["latest"] = { ref = "1.2.3" },
+            ["1.2.3"] = {
+                url = {
+                    GLOBAL = "https://github.com/xlings-res/libXcursor/releases/download/1.2.3/libXcursor-1.2.3-linux-x86_64.tar.gz",
+                    CN     = "https://gitcode.com/xlings-res/libXcursor/releases/download/1.2.3/libXcursor-1.2.3-linux-x86_64.tar.gz",
+                },
+                sha256 = "b85ad01f2ba44265921fd0f5133254b5bd4068e7dfc29368c8b96ad93b332bba",
+            },
+        },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+
+function install()
+    local dir = pkginfo.install_dir()
+    os.tryrm(dir)
+    os.mv("libXcursor-1.2.3", dir)
+    return true
+end
+
+function config()
+    xvm.add(package.name)
+    return true
+end
+
+function uninstall()
+    xvm.remove(package.name)
+    return true
+end

--- a/pkgs/l/libXcursor.lua
+++ b/pkgs/l/libXcursor.lua
@@ -5,8 +5,9 @@ package = {
     name = "libXcursor",
     description = "X cursor management library",
 
+    authors = {"X.Org Foundation"},
     licenses = {"MIT"},
-    repo = "https://www.x.org",
+    repo = "https://gitlab.freedesktop.org/xorg/lib/libXcursor",
 
     type = "package",
     archs = {"x86_64"},

--- a/pkgs/l/libXcursor.lua
+++ b/pkgs/l/libXcursor.lua
@@ -16,7 +16,7 @@ package = {
 
     xpm = {
         linux = {
-            deps = { "xim:libXrender@>=0.9", "xim:libXfixes@>=6.0" },
+            deps = { "libXrender@>=0.9", "libXfixes@>=6.0" },
             -- elfpatch reads this from each dependency and writes the consumer's
             -- RPATH, which is what makes the stack resolve without anyone
             -- setting LD_LIBRARY_PATH. Same mechanism `gcc-runtime` uses.

--- a/pkgs/l/libXdmcp.lua
+++ b/pkgs/l/libXdmcp.lua
@@ -5,8 +5,9 @@ package = {
     name = "libXdmcp",
     description = "X Display Manager Control Protocol library",
 
+    authors = {"X.Org Foundation"},
     licenses = {"MIT"},
-    repo = "https://www.x.org",
+    repo = "https://gitlab.freedesktop.org/xorg/lib/libXdmcp",
 
     type = "package",
     archs = {"x86_64"},

--- a/pkgs/l/libXdmcp.lua
+++ b/pkgs/l/libXdmcp.lua
@@ -16,7 +16,7 @@ package = {
 
     xpm = {
         linux = {
-            deps = { "xim:xorgproto@>=2024" },
+            deps = { "xorgproto@>=2024" },
             -- elfpatch reads this from each dependency and writes the consumer's
             -- RPATH, which is what makes the stack resolve without anyone
             -- setting LD_LIBRARY_PATH. Same mechanism `gcc-runtime` uses.

--- a/pkgs/l/libXdmcp.lua
+++ b/pkgs/l/libXdmcp.lua
@@ -1,0 +1,56 @@
+package = {
+    spec = "2",
+
+    homepage = "https://www.x.org",
+    name = "libXdmcp",
+    description = "X Display Manager Control Protocol library",
+
+    licenses = {"MIT"},
+    repo = "https://www.x.org",
+
+    type = "package",
+    archs = {"x86_64"},
+    status = "stable",
+    categories = {"graphics", "lib"},
+    keywords = {"libxdmcp", "graphics", "x11"},
+
+    xpm = {
+        linux = {
+            deps = { "xim:xorgproto@>=2024" },
+            -- elfpatch reads this from each dependency and writes the consumer's
+            -- RPATH, which is what makes the stack resolve without anyone
+            -- setting LD_LIBRARY_PATH. Same mechanism `gcc-runtime` uses.
+            exports = {
+                runtime = { libdirs = { "lib" } },
+            },
+            ["latest"] = { ref = "1.1.5" },
+            ["1.1.5"] = {
+                url = {
+                    GLOBAL = "https://github.com/xlings-res/libXdmcp/releases/download/1.1.5/libXdmcp-1.1.5-linux-x86_64.tar.gz",
+                    CN     = "https://gitcode.com/xlings-res/libXdmcp/releases/download/1.1.5/libXdmcp-1.1.5-linux-x86_64.tar.gz",
+                },
+                sha256 = "d7f0c96723d92af1275e43c39cd66e64802409aa5c4f2f9aba43aaf0b113de08",
+            },
+        },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+
+function install()
+    local dir = pkginfo.install_dir()
+    os.tryrm(dir)
+    os.mv("libXdmcp-1.1.5", dir)
+    return true
+end
+
+function config()
+    xvm.add(package.name)
+    return true
+end
+
+function uninstall()
+    xvm.remove(package.name)
+    return true
+end

--- a/pkgs/l/libXext.lua
+++ b/pkgs/l/libXext.lua
@@ -5,8 +5,9 @@ package = {
     name = "libXext",
     description = "X11 miscellaneous extensions library",
 
+    authors = {"X.Org Foundation"},
     licenses = {"MIT"},
-    repo = "https://www.x.org",
+    repo = "https://gitlab.freedesktop.org/xorg/lib/libXext",
 
     type = "package",
     archs = {"x86_64"},

--- a/pkgs/l/libXext.lua
+++ b/pkgs/l/libXext.lua
@@ -1,0 +1,56 @@
+package = {
+    spec = "2",
+
+    homepage = "https://www.x.org",
+    name = "libXext",
+    description = "X11 miscellaneous extensions library",
+
+    licenses = {"MIT"},
+    repo = "https://www.x.org",
+
+    type = "package",
+    archs = {"x86_64"},
+    status = "stable",
+    categories = {"graphics", "lib"},
+    keywords = {"libxext", "graphics", "x11"},
+
+    xpm = {
+        linux = {
+            deps = { "xim:libX11@>=1.8" },
+            -- elfpatch reads this from each dependency and writes the consumer's
+            -- RPATH, which is what makes the stack resolve without anyone
+            -- setting LD_LIBRARY_PATH. Same mechanism `gcc-runtime` uses.
+            exports = {
+                runtime = { libdirs = { "lib" } },
+            },
+            ["latest"] = { ref = "1.3.6" },
+            ["1.3.6"] = {
+                url = {
+                    GLOBAL = "https://github.com/xlings-res/libXext/releases/download/1.3.6/libXext-1.3.6-linux-x86_64.tar.gz",
+                    CN     = "https://gitcode.com/xlings-res/libXext/releases/download/1.3.6/libXext-1.3.6-linux-x86_64.tar.gz",
+                },
+                sha256 = "d7593a61cf640612f0b9af2a2b789913fef8f5717decdee8af0e487859d49f5d",
+            },
+        },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+
+function install()
+    local dir = pkginfo.install_dir()
+    os.tryrm(dir)
+    os.mv("libXext-1.3.6", dir)
+    return true
+end
+
+function config()
+    xvm.add(package.name)
+    return true
+end
+
+function uninstall()
+    xvm.remove(package.name)
+    return true
+end

--- a/pkgs/l/libXext.lua
+++ b/pkgs/l/libXext.lua
@@ -16,7 +16,7 @@ package = {
 
     xpm = {
         linux = {
-            deps = { "xim:libX11@>=1.8" },
+            deps = { "libX11@>=1.8" },
             -- elfpatch reads this from each dependency and writes the consumer's
             -- RPATH, which is what makes the stack resolve without anyone
             -- setting LD_LIBRARY_PATH. Same mechanism `gcc-runtime` uses.

--- a/pkgs/l/libXfixes.lua
+++ b/pkgs/l/libXfixes.lua
@@ -1,0 +1,56 @@
+package = {
+    spec = "2",
+
+    homepage = "https://www.x.org",
+    name = "libXfixes",
+    description = "X Fixes extension client library",
+
+    licenses = {"MIT"},
+    repo = "https://www.x.org",
+
+    type = "package",
+    archs = {"x86_64"},
+    status = "stable",
+    categories = {"graphics", "lib"},
+    keywords = {"libxfixes", "graphics", "x11"},
+
+    xpm = {
+        linux = {
+            deps = { "xim:libX11@>=1.8" },
+            -- elfpatch reads this from each dependency and writes the consumer's
+            -- RPATH, which is what makes the stack resolve without anyone
+            -- setting LD_LIBRARY_PATH. Same mechanism `gcc-runtime` uses.
+            exports = {
+                runtime = { libdirs = { "lib" } },
+            },
+            ["latest"] = { ref = "6.0.1" },
+            ["6.0.1"] = {
+                url = {
+                    GLOBAL = "https://github.com/xlings-res/libXfixes/releases/download/6.0.1/libXfixes-6.0.1-linux-x86_64.tar.gz",
+                    CN     = "https://gitcode.com/xlings-res/libXfixes/releases/download/6.0.1/libXfixes-6.0.1-linux-x86_64.tar.gz",
+                },
+                sha256 = "9e52c227f93b668a2c8fc1ee4c0768226c3e9168010a32466a95339d27dd6974",
+            },
+        },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+
+function install()
+    local dir = pkginfo.install_dir()
+    os.tryrm(dir)
+    os.mv("libXfixes-6.0.1", dir)
+    return true
+end
+
+function config()
+    xvm.add(package.name)
+    return true
+end
+
+function uninstall()
+    xvm.remove(package.name)
+    return true
+end

--- a/pkgs/l/libXfixes.lua
+++ b/pkgs/l/libXfixes.lua
@@ -5,8 +5,9 @@ package = {
     name = "libXfixes",
     description = "X Fixes extension client library",
 
+    authors = {"X.Org Foundation"},
     licenses = {"MIT"},
-    repo = "https://www.x.org",
+    repo = "https://gitlab.freedesktop.org/xorg/lib/libXfixes",
 
     type = "package",
     archs = {"x86_64"},

--- a/pkgs/l/libXfixes.lua
+++ b/pkgs/l/libXfixes.lua
@@ -16,7 +16,7 @@ package = {
 
     xpm = {
         linux = {
-            deps = { "xim:libX11@>=1.8" },
+            deps = { "libX11@>=1.8" },
             -- elfpatch reads this from each dependency and writes the consumer's
             -- RPATH, which is what makes the stack resolve without anyone
             -- setting LD_LIBRARY_PATH. Same mechanism `gcc-runtime` uses.

--- a/pkgs/l/libXi.lua
+++ b/pkgs/l/libXi.lua
@@ -16,7 +16,7 @@ package = {
 
     xpm = {
         linux = {
-            deps = { "xim:libXext@>=1.3", "xim:libXfixes@>=6.0" },
+            deps = { "libXext@>=1.3", "libXfixes@>=6.0" },
             -- elfpatch reads this from each dependency and writes the consumer's
             -- RPATH, which is what makes the stack resolve without anyone
             -- setting LD_LIBRARY_PATH. Same mechanism `gcc-runtime` uses.

--- a/pkgs/l/libXi.lua
+++ b/pkgs/l/libXi.lua
@@ -5,8 +5,9 @@ package = {
     name = "libXi",
     description = "X Input Extension client library",
 
+    authors = {"X.Org Foundation"},
     licenses = {"MIT"},
-    repo = "https://www.x.org",
+    repo = "https://gitlab.freedesktop.org/xorg/lib/libXi",
 
     type = "package",
     archs = {"x86_64"},

--- a/pkgs/l/libXi.lua
+++ b/pkgs/l/libXi.lua
@@ -1,0 +1,56 @@
+package = {
+    spec = "2",
+
+    homepage = "https://www.x.org",
+    name = "libXi",
+    description = "X Input Extension client library",
+
+    licenses = {"MIT"},
+    repo = "https://www.x.org",
+
+    type = "package",
+    archs = {"x86_64"},
+    status = "stable",
+    categories = {"graphics", "lib"},
+    keywords = {"libxi", "graphics", "x11"},
+
+    xpm = {
+        linux = {
+            deps = { "xim:libXext@>=1.3", "xim:libXfixes@>=6.0" },
+            -- elfpatch reads this from each dependency and writes the consumer's
+            -- RPATH, which is what makes the stack resolve without anyone
+            -- setting LD_LIBRARY_PATH. Same mechanism `gcc-runtime` uses.
+            exports = {
+                runtime = { libdirs = { "lib" } },
+            },
+            ["latest"] = { ref = "1.8.2" },
+            ["1.8.2"] = {
+                url = {
+                    GLOBAL = "https://github.com/xlings-res/libXi/releases/download/1.8.2/libXi-1.8.2-linux-x86_64.tar.gz",
+                    CN     = "https://gitcode.com/xlings-res/libXi/releases/download/1.8.2/libXi-1.8.2-linux-x86_64.tar.gz",
+                },
+                sha256 = "3f297ef4c3519797570f3420c4ce08c0b085efa80d6c04c97eea586990c19ee5",
+            },
+        },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+
+function install()
+    local dir = pkginfo.install_dir()
+    os.tryrm(dir)
+    os.mv("libXi-1.8.2", dir)
+    return true
+end
+
+function config()
+    xvm.add(package.name)
+    return true
+end
+
+function uninstall()
+    xvm.remove(package.name)
+    return true
+end

--- a/pkgs/l/libXrandr.lua
+++ b/pkgs/l/libXrandr.lua
@@ -5,8 +5,9 @@ package = {
     name = "libXrandr",
     description = "X Resize, Rotate and Reflect extension library",
 
+    authors = {"X.Org Foundation"},
     licenses = {"MIT"},
-    repo = "https://www.x.org",
+    repo = "https://gitlab.freedesktop.org/xorg/lib/libXrandr",
 
     type = "package",
     archs = {"x86_64"},

--- a/pkgs/l/libXrandr.lua
+++ b/pkgs/l/libXrandr.lua
@@ -16,7 +16,7 @@ package = {
 
     xpm = {
         linux = {
-            deps = { "xim:libXext@>=1.3", "xim:libXrender@>=0.9" },
+            deps = { "libXext@>=1.3", "libXrender@>=0.9" },
             -- elfpatch reads this from each dependency and writes the consumer's
             -- RPATH, which is what makes the stack resolve without anyone
             -- setting LD_LIBRARY_PATH. Same mechanism `gcc-runtime` uses.

--- a/pkgs/l/libXrandr.lua
+++ b/pkgs/l/libXrandr.lua
@@ -1,0 +1,56 @@
+package = {
+    spec = "2",
+
+    homepage = "https://www.x.org",
+    name = "libXrandr",
+    description = "X Resize, Rotate and Reflect extension library",
+
+    licenses = {"MIT"},
+    repo = "https://www.x.org",
+
+    type = "package",
+    archs = {"x86_64"},
+    status = "stable",
+    categories = {"graphics", "lib"},
+    keywords = {"libxrandr", "graphics", "x11"},
+
+    xpm = {
+        linux = {
+            deps = { "xim:libXext@>=1.3", "xim:libXrender@>=0.9" },
+            -- elfpatch reads this from each dependency and writes the consumer's
+            -- RPATH, which is what makes the stack resolve without anyone
+            -- setting LD_LIBRARY_PATH. Same mechanism `gcc-runtime` uses.
+            exports = {
+                runtime = { libdirs = { "lib" } },
+            },
+            ["latest"] = { ref = "1.5.4" },
+            ["1.5.4"] = {
+                url = {
+                    GLOBAL = "https://github.com/xlings-res/libXrandr/releases/download/1.5.4/libXrandr-1.5.4-linux-x86_64.tar.gz",
+                    CN     = "https://gitcode.com/xlings-res/libXrandr/releases/download/1.5.4/libXrandr-1.5.4-linux-x86_64.tar.gz",
+                },
+                sha256 = "ddb17e5c345aa4f28127ccea61d8489b709d53f744ae05755c7808a813a8540a",
+            },
+        },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+
+function install()
+    local dir = pkginfo.install_dir()
+    os.tryrm(dir)
+    os.mv("libXrandr-1.5.4", dir)
+    return true
+end
+
+function config()
+    xvm.add(package.name)
+    return true
+end
+
+function uninstall()
+    xvm.remove(package.name)
+    return true
+end

--- a/pkgs/l/libXrender.lua
+++ b/pkgs/l/libXrender.lua
@@ -5,8 +5,9 @@ package = {
     name = "libXrender",
     description = "X Rendering Extension client library",
 
+    authors = {"X.Org Foundation"},
     licenses = {"MIT"},
-    repo = "https://www.x.org",
+    repo = "https://gitlab.freedesktop.org/xorg/lib/libXrender",
 
     type = "package",
     archs = {"x86_64"},

--- a/pkgs/l/libXrender.lua
+++ b/pkgs/l/libXrender.lua
@@ -1,0 +1,56 @@
+package = {
+    spec = "2",
+
+    homepage = "https://www.x.org",
+    name = "libXrender",
+    description = "X Rendering Extension client library",
+
+    licenses = {"MIT"},
+    repo = "https://www.x.org",
+
+    type = "package",
+    archs = {"x86_64"},
+    status = "stable",
+    categories = {"graphics", "lib"},
+    keywords = {"libxrender", "graphics", "x11"},
+
+    xpm = {
+        linux = {
+            deps = { "xim:libX11@>=1.8" },
+            -- elfpatch reads this from each dependency and writes the consumer's
+            -- RPATH, which is what makes the stack resolve without anyone
+            -- setting LD_LIBRARY_PATH. Same mechanism `gcc-runtime` uses.
+            exports = {
+                runtime = { libdirs = { "lib" } },
+            },
+            ["latest"] = { ref = "0.9.11" },
+            ["0.9.11"] = {
+                url = {
+                    GLOBAL = "https://github.com/xlings-res/libXrender/releases/download/0.9.11/libXrender-0.9.11-linux-x86_64.tar.gz",
+                    CN     = "https://gitcode.com/xlings-res/libXrender/releases/download/0.9.11/libXrender-0.9.11-linux-x86_64.tar.gz",
+                },
+                sha256 = "964a668be7f41b0e906032bbf2cb1c2ecfc21f26693e48a79a8248f9db02e7d7",
+            },
+        },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+
+function install()
+    local dir = pkginfo.install_dir()
+    os.tryrm(dir)
+    os.mv("libXrender-0.9.11", dir)
+    return true
+end
+
+function config()
+    xvm.add(package.name)
+    return true
+end
+
+function uninstall()
+    xvm.remove(package.name)
+    return true
+end

--- a/pkgs/l/libXrender.lua
+++ b/pkgs/l/libXrender.lua
@@ -16,7 +16,7 @@ package = {
 
     xpm = {
         linux = {
-            deps = { "xim:libX11@>=1.8" },
+            deps = { "libX11@>=1.8" },
             -- elfpatch reads this from each dependency and writes the consumer's
             -- RPATH, which is what makes the stack resolve without anyone
             -- setting LD_LIBRARY_PATH. Same mechanism `gcc-runtime` uses.

--- a/pkgs/l/libXxf86vm.lua
+++ b/pkgs/l/libXxf86vm.lua
@@ -16,7 +16,7 @@ package = {
 
     xpm = {
         linux = {
-            deps = { "xim:libXext@>=1.3" },
+            deps = { "libXext@>=1.3" },
             -- elfpatch reads this from each dependency and writes the consumer's
             -- RPATH, which is what makes the stack resolve without anyone
             -- setting LD_LIBRARY_PATH. Same mechanism `gcc-runtime` uses.

--- a/pkgs/l/libXxf86vm.lua
+++ b/pkgs/l/libXxf86vm.lua
@@ -1,0 +1,56 @@
+package = {
+    spec = "2",
+
+    homepage = "https://www.x.org",
+    name = "libXxf86vm",
+    description = "X11 XFree86 video mode extension library",
+
+    licenses = {"MIT"},
+    repo = "https://www.x.org",
+
+    type = "package",
+    archs = {"x86_64"},
+    status = "stable",
+    categories = {"graphics", "lib"},
+    keywords = {"libxxf86vm", "graphics", "x11"},
+
+    xpm = {
+        linux = {
+            deps = { "xim:libXext@>=1.3" },
+            -- elfpatch reads this from each dependency and writes the consumer's
+            -- RPATH, which is what makes the stack resolve without anyone
+            -- setting LD_LIBRARY_PATH. Same mechanism `gcc-runtime` uses.
+            exports = {
+                runtime = { libdirs = { "lib" } },
+            },
+            ["latest"] = { ref = "1.1.6" },
+            ["1.1.6"] = {
+                url = {
+                    GLOBAL = "https://github.com/xlings-res/libXxf86vm/releases/download/1.1.6/libXxf86vm-1.1.6-linux-x86_64.tar.gz",
+                    CN     = "https://gitcode.com/xlings-res/libXxf86vm/releases/download/1.1.6/libXxf86vm-1.1.6-linux-x86_64.tar.gz",
+                },
+                sha256 = "916046759e93059d8ec042009d55de5c488e63573677b76b7e919876ead9a5bb",
+            },
+        },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+
+function install()
+    local dir = pkginfo.install_dir()
+    os.tryrm(dir)
+    os.mv("libXxf86vm-1.1.6", dir)
+    return true
+end
+
+function config()
+    xvm.add(package.name)
+    return true
+end
+
+function uninstall()
+    xvm.remove(package.name)
+    return true
+end

--- a/pkgs/l/libXxf86vm.lua
+++ b/pkgs/l/libXxf86vm.lua
@@ -5,8 +5,9 @@ package = {
     name = "libXxf86vm",
     description = "X11 XFree86 video mode extension library",
 
+    authors = {"X.Org Foundation"},
     licenses = {"MIT"},
-    repo = "https://www.x.org",
+    repo = "https://gitlab.freedesktop.org/xorg/lib/libXxf86vm",
 
     type = "package",
     archs = {"x86_64"},

--- a/pkgs/l/libdrm.lua
+++ b/pkgs/l/libdrm.lua
@@ -16,7 +16,7 @@ package = {
 
     xpm = {
         linux = {
-            deps = { "xim:libpciaccess@>=0.18" },
+            deps = { "libpciaccess@>=0.18" },
             -- elfpatch reads this from each dependency and writes the consumer's
             -- RPATH, which is what makes the stack resolve without anyone
             -- setting LD_LIBRARY_PATH. Same mechanism `gcc-runtime` uses.

--- a/pkgs/l/libdrm.lua
+++ b/pkgs/l/libdrm.lua
@@ -1,0 +1,56 @@
+package = {
+    spec = "2",
+
+    homepage = "https://dri.freedesktop.org/",
+    name = "libdrm",
+    description = "Userspace interface to the kernel DRM services",
+
+    licenses = {"MIT"},
+    repo = "https://dri.freedesktop.org/",
+
+    type = "package",
+    archs = {"x86_64"},
+    status = "stable",
+    categories = {"graphics", "lib"},
+    keywords = {"libdrm", "graphics", "gl"},
+
+    xpm = {
+        linux = {
+            deps = { "xim:libpciaccess@>=0.18" },
+            -- elfpatch reads this from each dependency and writes the consumer's
+            -- RPATH, which is what makes the stack resolve without anyone
+            -- setting LD_LIBRARY_PATH. Same mechanism `gcc-runtime` uses.
+            exports = {
+                runtime = { libdirs = { "lib" } },
+            },
+            ["latest"] = { ref = "2.4.123" },
+            ["2.4.123"] = {
+                url = {
+                    GLOBAL = "https://github.com/xlings-res/libdrm/releases/download/2.4.123/libdrm-2.4.123-linux-x86_64.tar.gz",
+                    CN     = "https://gitcode.com/xlings-res/libdrm/releases/download/2.4.123/libdrm-2.4.123-linux-x86_64.tar.gz",
+                },
+                sha256 = "8f70c903b3cd593c6b42f9621aacff2c6f6dcd96732cc91e5aad4a00357c53c1",
+            },
+        },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+
+function install()
+    local dir = pkginfo.install_dir()
+    os.tryrm(dir)
+    os.mv("libdrm-2.4.123", dir)
+    return true
+end
+
+function config()
+    xvm.add(package.name)
+    return true
+end
+
+function uninstall()
+    xvm.remove(package.name)
+    return true
+end

--- a/pkgs/l/libdrm.lua
+++ b/pkgs/l/libdrm.lua
@@ -5,8 +5,9 @@ package = {
     name = "libdrm",
     description = "Userspace interface to the kernel DRM services",
 
+    authors = {"Mesa contributors"},
     licenses = {"MIT"},
-    repo = "https://dri.freedesktop.org/",
+    repo = "https://gitlab.freedesktop.org/mesa/drm",
 
     type = "package",
     archs = {"x86_64"},

--- a/pkgs/l/libglvnd.lua
+++ b/pkgs/l/libglvnd.lua
@@ -1,0 +1,56 @@
+package = {
+    spec = "2",
+
+    homepage = "https://gitlab.freedesktop.org/glvnd/libglvnd",
+    name = "libglvnd",
+    description = "The GL Vendor-Neutral Dispatch library",
+
+    licenses = {"MIT"},
+    repo = "https://gitlab.freedesktop.org/glvnd/libglvnd",
+
+    type = "package",
+    archs = {"x86_64"},
+    status = "stable",
+    categories = {"graphics", "lib"},
+    keywords = {"libglvnd", "graphics", "gl"},
+
+    xpm = {
+        linux = {
+            deps = { "xim:libX11@>=1.8", "xim:libXext@>=1.3" },
+            -- elfpatch reads this from each dependency and writes the consumer's
+            -- RPATH, which is what makes the stack resolve without anyone
+            -- setting LD_LIBRARY_PATH. Same mechanism `gcc-runtime` uses.
+            exports = {
+                runtime = { libdirs = { "lib" } },
+            },
+            ["latest"] = { ref = "1.7.0" },
+            ["1.7.0"] = {
+                url = {
+                    GLOBAL = "https://github.com/xlings-res/libglvnd/releases/download/1.7.0/libglvnd-1.7.0-linux-x86_64.tar.gz",
+                    CN     = "https://gitcode.com/xlings-res/libglvnd/releases/download/1.7.0/libglvnd-1.7.0-linux-x86_64.tar.gz",
+                },
+                sha256 = "07366016ef25ec20436df65bf94f0dee758d41ec34d0723056690d5c899bf8c8",
+            },
+        },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+
+function install()
+    local dir = pkginfo.install_dir()
+    os.tryrm(dir)
+    os.mv("libglvnd-1.7.0", dir)
+    return true
+end
+
+function config()
+    xvm.add(package.name)
+    return true
+end
+
+function uninstall()
+    xvm.remove(package.name)
+    return true
+end

--- a/pkgs/l/libglvnd.lua
+++ b/pkgs/l/libglvnd.lua
@@ -5,6 +5,7 @@ package = {
     name = "libglvnd",
     description = "The GL Vendor-Neutral Dispatch library",
 
+    authors = {"NVIDIA Corporation", "libglvnd contributors"},
     licenses = {"MIT"},
     repo = "https://gitlab.freedesktop.org/glvnd/libglvnd",
 

--- a/pkgs/l/libglvnd.lua
+++ b/pkgs/l/libglvnd.lua
@@ -16,7 +16,7 @@ package = {
 
     xpm = {
         linux = {
-            deps = { "xim:libX11@>=1.8", "xim:libXext@>=1.3" },
+            deps = { "libX11@>=1.8", "libXext@>=1.3" },
             -- elfpatch reads this from each dependency and writes the consumer's
             -- RPATH, which is what makes the stack resolve without anyone
             -- setting LD_LIBRARY_PATH. Same mechanism `gcc-runtime` uses.

--- a/pkgs/l/libllvm.lua
+++ b/pkgs/l/libllvm.lua
@@ -5,8 +5,9 @@ package = {
     name = "libllvm",
     description = "LLVM as a shared library — the code generator mesa's llvmpipe and radeonsi use",
 
+    authors = {"LLVM Project"},
     licenses = {"Apache-2.0 WITH LLVM-exception"},
-    repo = "https://llvm.org",
+    repo = "https://github.com/llvm/llvm-project",
 
     type = "package",
     archs = {"x86_64"},

--- a/pkgs/l/libllvm.lua
+++ b/pkgs/l/libllvm.lua
@@ -16,7 +16,7 @@ package = {
 
     xpm = {
         linux = {
-            deps = { "xim:gcc-runtime@>=15", "xim:glibc@>=2.38" },
+            deps = { "gcc-runtime@>=15", "glibc@>=2.38" },
             -- elfpatch reads this from each dependency and writes the consumer's
             -- RPATH, which is what makes the stack resolve without anyone
             -- setting LD_LIBRARY_PATH. Same mechanism `gcc-runtime` uses.

--- a/pkgs/l/libllvm.lua
+++ b/pkgs/l/libllvm.lua
@@ -1,0 +1,56 @@
+package = {
+    spec = "2",
+
+    homepage = "https://llvm.org",
+    name = "libllvm",
+    description = "LLVM as a shared library — the code generator mesa's llvmpipe and radeonsi use",
+
+    licenses = {"Apache-2.0 WITH LLVM-exception"},
+    repo = "https://llvm.org",
+
+    type = "package",
+    archs = {"x86_64"},
+    status = "stable",
+    categories = {"graphics", "lib"},
+    keywords = {"libllvm", "graphics", "gl"},
+
+    xpm = {
+        linux = {
+            deps = { "xim:gcc-runtime@>=15", "xim:glibc@>=2.38" },
+            -- elfpatch reads this from each dependency and writes the consumer's
+            -- RPATH, which is what makes the stack resolve without anyone
+            -- setting LD_LIBRARY_PATH. Same mechanism `gcc-runtime` uses.
+            exports = {
+                runtime = { libdirs = { "lib" } },
+            },
+            ["latest"] = { ref = "20.1.7" },
+            ["20.1.7"] = {
+                url = {
+                    GLOBAL = "https://github.com/xlings-res/libllvm/releases/download/20.1.7/libllvm-20.1.7-linux-x86_64.tar.gz",
+                    CN     = "https://gitcode.com/xlings-res/libllvm/releases/download/20.1.7/libllvm-20.1.7-linux-x86_64.tar.gz",
+                },
+                sha256 = "1de66726fb14ed043e1f6a17ffb80e03578c2e01da85f024c46689140d31246f",
+            },
+        },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+
+function install()
+    local dir = pkginfo.install_dir()
+    os.tryrm(dir)
+    os.mv("libllvm-20.1.7", dir)
+    return true
+end
+
+function config()
+    xvm.add(package.name)
+    return true
+end
+
+function uninstall()
+    xvm.remove(package.name)
+    return true
+end

--- a/pkgs/l/libpciaccess.lua
+++ b/pkgs/l/libpciaccess.lua
@@ -1,0 +1,56 @@
+package = {
+    spec = "2",
+
+    homepage = "https://www.x.org",
+    name = "libpciaccess",
+    description = "Generic PCI device access library",
+
+    licenses = {"MIT"},
+    repo = "https://www.x.org",
+
+    type = "package",
+    archs = {"x86_64"},
+    status = "stable",
+    categories = {"graphics", "lib"},
+    keywords = {"libpciaccess", "graphics", "gl"},
+
+    xpm = {
+        linux = {
+            deps = { "xim:zlib@>=1.2" },
+            -- elfpatch reads this from each dependency and writes the consumer's
+            -- RPATH, which is what makes the stack resolve without anyone
+            -- setting LD_LIBRARY_PATH. Same mechanism `gcc-runtime` uses.
+            exports = {
+                runtime = { libdirs = { "lib" } },
+            },
+            ["latest"] = { ref = "0.18.1" },
+            ["0.18.1"] = {
+                url = {
+                    GLOBAL = "https://github.com/xlings-res/libpciaccess/releases/download/0.18.1/libpciaccess-0.18.1-linux-x86_64.tar.gz",
+                    CN     = "https://gitcode.com/xlings-res/libpciaccess/releases/download/0.18.1/libpciaccess-0.18.1-linux-x86_64.tar.gz",
+                },
+                sha256 = "cf45c0441095e92ed8927f0496a9fe1e4ddb1bb606ec61535e9f81e580c6dade",
+            },
+        },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+
+function install()
+    local dir = pkginfo.install_dir()
+    os.tryrm(dir)
+    os.mv("libpciaccess-0.18.1", dir)
+    return true
+end
+
+function config()
+    xvm.add(package.name)
+    return true
+end
+
+function uninstall()
+    xvm.remove(package.name)
+    return true
+end

--- a/pkgs/l/libpciaccess.lua
+++ b/pkgs/l/libpciaccess.lua
@@ -16,7 +16,7 @@ package = {
 
     xpm = {
         linux = {
-            deps = { "xim:zlib@>=1.2" },
+            deps = { "zlib@>=1.2" },
             -- elfpatch reads this from each dependency and writes the consumer's
             -- RPATH, which is what makes the stack resolve without anyone
             -- setting LD_LIBRARY_PATH. Same mechanism `gcc-runtime` uses.

--- a/pkgs/l/libpciaccess.lua
+++ b/pkgs/l/libpciaccess.lua
@@ -5,8 +5,9 @@ package = {
     name = "libpciaccess",
     description = "Generic PCI device access library",
 
+    authors = {"X.Org Foundation"},
     licenses = {"MIT"},
-    repo = "https://www.x.org",
+    repo = "https://gitlab.freedesktop.org/xorg/lib/libpciaccess",
 
     type = "package",
     archs = {"x86_64"},

--- a/pkgs/l/libxcb.lua
+++ b/pkgs/l/libxcb.lua
@@ -1,0 +1,56 @@
+package = {
+    spec = "2",
+
+    homepage = "https://www.x.org",
+    name = "libxcb",
+    description = "X protocol C-language Binding",
+
+    licenses = {"MIT"},
+    repo = "https://www.x.org",
+
+    type = "package",
+    archs = {"x86_64"},
+    status = "stable",
+    categories = {"graphics", "lib"},
+    keywords = {"libxcb", "graphics", "x11"},
+
+    xpm = {
+        linux = {
+            deps = { "xim:libXau@>=1.0", "xim:libXdmcp@>=1.1" },
+            -- elfpatch reads this from each dependency and writes the consumer's
+            -- RPATH, which is what makes the stack resolve without anyone
+            -- setting LD_LIBRARY_PATH. Same mechanism `gcc-runtime` uses.
+            exports = {
+                runtime = { libdirs = { "lib" } },
+            },
+            ["latest"] = { ref = "1.17.0" },
+            ["1.17.0"] = {
+                url = {
+                    GLOBAL = "https://github.com/xlings-res/libxcb/releases/download/1.17.0/libxcb-1.17.0-linux-x86_64.tar.gz",
+                    CN     = "https://gitcode.com/xlings-res/libxcb/releases/download/1.17.0/libxcb-1.17.0-linux-x86_64.tar.gz",
+                },
+                sha256 = "561b2f8f6d1452f211cdb9023efc3ecde8c365f1eba181bd2d183357b85f484a",
+            },
+        },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+
+function install()
+    local dir = pkginfo.install_dir()
+    os.tryrm(dir)
+    os.mv("libxcb-1.17.0", dir)
+    return true
+end
+
+function config()
+    xvm.add(package.name)
+    return true
+end
+
+function uninstall()
+    xvm.remove(package.name)
+    return true
+end

--- a/pkgs/l/libxcb.lua
+++ b/pkgs/l/libxcb.lua
@@ -5,8 +5,9 @@ package = {
     name = "libxcb",
     description = "X protocol C-language Binding",
 
+    authors = {"X.Org Foundation"},
     licenses = {"MIT"},
-    repo = "https://www.x.org",
+    repo = "https://gitlab.freedesktop.org/xorg/lib/libxcb",
 
     type = "package",
     archs = {"x86_64"},

--- a/pkgs/l/libxcb.lua
+++ b/pkgs/l/libxcb.lua
@@ -16,7 +16,7 @@ package = {
 
     xpm = {
         linux = {
-            deps = { "xim:libXau@>=1.0", "xim:libXdmcp@>=1.1" },
+            deps = { "libXau@>=1.0", "libXdmcp@>=1.1" },
             -- elfpatch reads this from each dependency and writes the consumer's
             -- RPATH, which is what makes the stack resolve without anyone
             -- setting LD_LIBRARY_PATH. Same mechanism `gcc-runtime` uses.

--- a/pkgs/l/libxshmfence.lua
+++ b/pkgs/l/libxshmfence.lua
@@ -5,8 +5,9 @@ package = {
     name = "libxshmfence",
     description = "Shared-memory fences for DRI3",
 
+    authors = {"X.Org Foundation"},
     licenses = {"MIT"},
-    repo = "https://www.x.org",
+    repo = "https://gitlab.freedesktop.org/xorg/lib/libxshmfence",
 
     type = "package",
     archs = {"x86_64"},

--- a/pkgs/l/libxshmfence.lua
+++ b/pkgs/l/libxshmfence.lua
@@ -1,0 +1,56 @@
+package = {
+    spec = "2",
+
+    homepage = "https://www.x.org",
+    name = "libxshmfence",
+    description = "Shared-memory fences for DRI3",
+
+    licenses = {"MIT"},
+    repo = "https://www.x.org",
+
+    type = "package",
+    archs = {"x86_64"},
+    status = "stable",
+    categories = {"graphics", "lib"},
+    keywords = {"libxshmfence", "graphics", "x11"},
+
+    xpm = {
+        linux = {
+            deps = {},
+            -- elfpatch reads this from each dependency and writes the consumer's
+            -- RPATH, which is what makes the stack resolve without anyone
+            -- setting LD_LIBRARY_PATH. Same mechanism `gcc-runtime` uses.
+            exports = {
+                runtime = { libdirs = { "lib" } },
+            },
+            ["latest"] = { ref = "1.3.2" },
+            ["1.3.2"] = {
+                url = {
+                    GLOBAL = "https://github.com/xlings-res/libxshmfence/releases/download/1.3.2/libxshmfence-1.3.2-linux-x86_64.tar.gz",
+                    CN     = "https://gitcode.com/xlings-res/libxshmfence/releases/download/1.3.2/libxshmfence-1.3.2-linux-x86_64.tar.gz",
+                },
+                sha256 = "dce29073e3225e2001ecba00b115cfee9062b85ef4e15a454db3b671454fdc9f",
+            },
+        },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+
+function install()
+    local dir = pkginfo.install_dir()
+    os.tryrm(dir)
+    os.mv("libxshmfence-1.3.2", dir)
+    return true
+end
+
+function config()
+    xvm.add(package.name)
+    return true
+end
+
+function uninstall()
+    xvm.remove(package.name)
+    return true
+end

--- a/pkgs/m/mesa.lua
+++ b/pkgs/m/mesa.lua
@@ -1,0 +1,130 @@
+package = {
+    spec = "2",
+
+    homepage = "https://mesa3d.org",
+    name = "mesa",
+    description = "Mesa 3D — OpenGL for CPU (llvmpipe), built self-contained for xlings subos",
+
+    authors = {"Mesa contributors"},
+    licenses = {"MIT"},
+    repo = "https://gitlab.freedesktop.org/mesa/mesa",
+    docs = "https://docs.mesa3d.org",
+
+    type = "package",
+    archs = {"x86_64"},
+    status = "stable",
+    categories = {"graphics", "opengl", "lib"},
+    keywords = {"mesa", "opengl", "gl", "egl", "llvmpipe", "graphics"},
+
+    -- What this package is for.
+    --
+    -- A program that draws needs three things: a loader and a libc
+    -- (bootstrap), a way to find its libraries (discovery), and the
+    -- environment its subsystems read (configuration). xlings had the first
+    -- two. This package plus the declarations in config() supply the rest, so
+    -- a GL program installed through xlings renders on a host that has no
+    -- graphics stack of its own.
+    --
+    -- Build details, including why only llvmpipe for now:
+    -- https://github.com/xlings-res/mesa
+    xpm = {
+        linux = {
+            -- Ranges, not pins, except where the ABI genuinely is exact.
+            --
+            -- libllvm is pinned to the patch version because libgallium
+            -- references 97 mangled llvm:: symbols carrying an @LLVM_20.1
+            -- version tag; a mismatch is a load-time failure, and a range here
+            -- would advertise an upgrade path that does not exist.
+            --
+            -- Everything else is a lower bound. These libraries are ABI-stable
+            -- and the consumer only needs them present and not ancient;
+            -- pinning would make the whole stack one block, where a libX11
+            -- patch bump means editing a dozen recipes.
+            deps = {
+                "xim:libllvm@20.1.7",
+                "xim:libglvnd@>=1.7",
+                "xim:libdrm@>=2.4",
+                "xim:libX11@>=1.8",
+                "xim:libxcb@>=1.17",
+                "xim:libXext@>=1.3",
+                "xim:libXfixes@>=6.0",
+                "xim:libXxf86vm@>=1.1",
+                "xim:libxshmfence@>=1.3",
+                "xim:expat@>=2.6",
+                "xim:zlib@>=1.2",
+                "xim:gcc-runtime@>=15",
+                -- >=2.38 is the measured floor: libgallium's highest required
+                -- symbol version is GLIBC_2.38. Writing @2.39 would state a
+                -- requirement the payload does not have.
+                "xim:glibc@>=2.38",
+            },
+            exports = {
+                runtime = { libdirs = { "lib" } },
+            },
+            ["latest"] = { ref = "25.0.7" },
+            ["25.0.7"] = {
+                url = {
+                    GLOBAL = "https://github.com/xlings-res/mesa/releases/download/25.0.7/mesa-25.0.7-linux-x86_64.tar.gz",
+                    CN     = "https://gitcode.com/xlings-res/mesa/releases/download/25.0.7/mesa-25.0.7-linux-x86_64.tar.gz",
+                },
+                sha256 = "17ff8a09973d69ce591351fe7b38cd40896ddf3444908024807be31673ddea4a",
+            },
+        },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+import("xim.libxpkg.subos")
+
+function install()
+    local dir = pkginfo.install_dir()
+    os.tryrm(dir)
+    os.mv("mesa-25.0.7", dir)
+
+    -- The glvnd vendor JSON ships a bare SONAME, which is how it is shipped
+    -- upstream: the host's ld.so cache resolves it. There is no such cache in
+    -- a subos, and leaving the bare name would let it resolve against the
+    -- HOST's libEGL_mesa instead — the exact boundary this package exists to
+    -- close, and a failure that looks like success because rendering still
+    -- happens, just with someone else's driver.
+    local vendor = path.join(dir, "share/glvnd/egl_vendor.d/50_mesa.json")
+    if os.isfile(vendor) then
+        local text = io.readfile(vendor)
+        io.writefile(vendor, text:gsub('"libEGL_mesa%.so%.0"',
+                                       '"' .. path.join(dir, "lib/libEGL_mesa.so.0") .. '"'))
+    end
+    return true
+end
+
+function config()
+    local dir = pkginfo.install_dir()
+    local tag = package.name .. "@" .. pkginfo.version()
+
+    xvm.add(package.name)
+
+    -- The configuration layer. Neither PATH nor RPATH can carry these: the
+    -- process that has to see them is the user's own binary, which xlings
+    -- never wraps, so a per-shim environment cannot reach it.
+    --
+    -- type(), not truthiness: import() answers an unknown module with a
+    -- permissive proxy whose every key is truthy, so `if subos.env then` is
+    -- true on clients that would accept the call and discard it.
+    if type(subos.env) == "function" then
+        subos.env{ var = "LIBGL_DRIVERS_PATH", op = "set",
+                   value = "${pkgdir}/lib/dri", binding = tag }
+        subos.env{ var = "__EGL_VENDOR_LIBRARY_DIRS", op = "set",
+                   value = "${pkgdir}/share/glvnd/egl_vendor.d", binding = tag }
+        subos.env{ var = "XDG_DATA_DIRS", op = "prepend",
+                   value = "${pkgdir}/share", binding = tag }
+    end
+    return true
+end
+
+function uninstall()
+    -- Nothing for the env declarations: they are provider-scoped and xlings
+    -- drops the whole section with the package. A recipe removing them itself
+    -- would be a second owner of that state.
+    xvm.remove(package.name)
+    return true
+end

--- a/pkgs/m/mesa.lua
+++ b/pkgs/m/mesa.lua
@@ -40,23 +40,27 @@ package = {
             -- and the consumer only needs them present and not ancient;
             -- pinning would make the whole stack one block, where a libX11
             -- patch bump means editing a dozen recipes.
+            -- Bare names, not `xim:`-prefixed. A namespaced dependency can
+            -- only resolve from that namespace, so a batch of new packages
+            -- depending on each other cannot be installed until all of them
+            -- are published — CI registers changed recipes under `local`.
             deps = {
-                "xim:libllvm@20.1.7",
-                "xim:libglvnd@>=1.7",
-                "xim:libdrm@>=2.4",
-                "xim:libX11@>=1.8",
-                "xim:libxcb@>=1.17",
-                "xim:libXext@>=1.3",
-                "xim:libXfixes@>=6.0",
-                "xim:libXxf86vm@>=1.1",
-                "xim:libxshmfence@>=1.3",
-                "xim:expat@>=2.6",
-                "xim:zlib@>=1.2",
-                "xim:gcc-runtime@>=15",
+                "libllvm@20.1.7",
+                "libglvnd@>=1.7",
+                "libdrm@>=2.4",
+                "libX11@>=1.8",
+                "libxcb@>=1.17",
+                "libXext@>=1.3",
+                "libXfixes@>=6.0",
+                "libXxf86vm@>=1.1",
+                "libxshmfence@>=1.3",
+                "expat@>=2.6",
+                "zlib@>=1.2",
+                "gcc-runtime@>=15",
                 -- >=2.38 is the measured floor: libgallium's highest required
                 -- symbol version is GLIBC_2.38. Writing @2.39 would state a
                 -- requirement the payload does not have.
-                "xim:glibc@>=2.38",
+                "glibc@>=2.38",
             },
             exports = {
                 runtime = { libdirs = { "lib" } },

--- a/pkgs/x/xcb-proto.lua
+++ b/pkgs/x/xcb-proto.lua
@@ -5,8 +5,9 @@ package = {
     name = "xcb-proto",
     description = "XML-XCB protocol descriptions (build-time)",
 
+    authors = {"X.Org Foundation"},
     licenses = {"MIT"},
-    repo = "https://www.x.org",
+    repo = "https://gitlab.freedesktop.org/xorg/proto/xcb-proto",
 
     type = "package",
     archs = {"x86_64"},

--- a/pkgs/x/xcb-proto.lua
+++ b/pkgs/x/xcb-proto.lua
@@ -1,0 +1,50 @@
+package = {
+    spec = "2",
+
+    homepage = "https://www.x.org",
+    name = "xcb-proto",
+    description = "XML-XCB protocol descriptions (build-time)",
+
+    licenses = {"MIT"},
+    repo = "https://www.x.org",
+
+    type = "package",
+    archs = {"x86_64"},
+    status = "stable",
+    categories = {"graphics", "lib"},
+    keywords = {"xcb-proto", "graphics", "x11"},
+
+    xpm = {
+        linux = {
+            deps = {},
+            ["latest"] = { ref = "1.17.0" },
+            ["1.17.0"] = {
+                url = {
+                    GLOBAL = "https://github.com/xlings-res/xcb-proto/releases/download/1.17.0/xcb-proto-1.17.0-linux-x86_64.tar.gz",
+                    CN     = "https://gitcode.com/xlings-res/xcb-proto/releases/download/1.17.0/xcb-proto-1.17.0-linux-x86_64.tar.gz",
+                },
+                sha256 = "73bf364289efe8791bb4a8a3046cb2256a9953021797ee730a2678d429d3f2e4",
+            },
+        },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+
+function install()
+    local dir = pkginfo.install_dir()
+    os.tryrm(dir)
+    os.mv("xcb-proto-1.17.0", dir)
+    return true
+end
+
+function config()
+    xvm.add(package.name)
+    return true
+end
+
+function uninstall()
+    xvm.remove(package.name)
+    return true
+end

--- a/pkgs/x/xorgproto.lua
+++ b/pkgs/x/xorgproto.lua
@@ -1,0 +1,50 @@
+package = {
+    spec = "2",
+
+    homepage = "https://www.x.org",
+    name = "xorgproto",
+    description = "X Window System protocol headers (build-time)",
+
+    licenses = {"MIT"},
+    repo = "https://www.x.org",
+
+    type = "package",
+    archs = {"x86_64"},
+    status = "stable",
+    categories = {"graphics", "lib"},
+    keywords = {"xorgproto", "graphics", "x11"},
+
+    xpm = {
+        linux = {
+            deps = {},
+            ["latest"] = { ref = "2024.1" },
+            ["2024.1"] = {
+                url = {
+                    GLOBAL = "https://github.com/xlings-res/xorgproto/releases/download/2024.1/xorgproto-2024.1-linux-x86_64.tar.gz",
+                    CN     = "https://gitcode.com/xlings-res/xorgproto/releases/download/2024.1/xorgproto-2024.1-linux-x86_64.tar.gz",
+                },
+                sha256 = "c2c08991786272d1f27b0e1156ac9dc16e1505c98e8bb090a76ddac69eb91901",
+            },
+        },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+
+function install()
+    local dir = pkginfo.install_dir()
+    os.tryrm(dir)
+    os.mv("xorgproto-2024.1", dir)
+    return true
+end
+
+function config()
+    xvm.add(package.name)
+    return true
+end
+
+function uninstall()
+    xvm.remove(package.name)
+    return true
+end

--- a/pkgs/x/xorgproto.lua
+++ b/pkgs/x/xorgproto.lua
@@ -5,8 +5,9 @@ package = {
     name = "xorgproto",
     description = "X Window System protocol headers (build-time)",
 
+    authors = {"X.Org Foundation"},
     licenses = {"MIT"},
-    repo = "https://www.x.org",
+    repo = "https://gitlab.freedesktop.org/xorg/proto/xorgproto",
 
     type = "package",
     archs = {"x86_64"},

--- a/pkgs/x/xtrans.lua
+++ b/pkgs/x/xtrans.lua
@@ -5,8 +5,9 @@ package = {
     name = "xtrans",
     description = "X transport layer macros and headers (build-time)",
 
+    authors = {"X.Org Foundation"},
     licenses = {"MIT"},
-    repo = "https://www.x.org",
+    repo = "https://gitlab.freedesktop.org/xorg/lib/xtrans",
 
     type = "package",
     archs = {"x86_64"},

--- a/pkgs/x/xtrans.lua
+++ b/pkgs/x/xtrans.lua
@@ -1,0 +1,50 @@
+package = {
+    spec = "2",
+
+    homepage = "https://www.x.org",
+    name = "xtrans",
+    description = "X transport layer macros and headers (build-time)",
+
+    licenses = {"MIT"},
+    repo = "https://www.x.org",
+
+    type = "package",
+    archs = {"x86_64"},
+    status = "stable",
+    categories = {"graphics", "lib"},
+    keywords = {"xtrans", "graphics", "x11"},
+
+    xpm = {
+        linux = {
+            deps = {},
+            ["latest"] = { ref = "1.5.2" },
+            ["1.5.2"] = {
+                url = {
+                    GLOBAL = "https://github.com/xlings-res/xtrans/releases/download/1.5.2/xtrans-1.5.2-linux-x86_64.tar.gz",
+                    CN     = "https://gitcode.com/xlings-res/xtrans/releases/download/1.5.2/xtrans-1.5.2-linux-x86_64.tar.gz",
+                },
+                sha256 = "c05a3fe4fd9aa17b2599a016b13c9209ab9fd7d4e0fc660fe3cdea3469d30fc5",
+            },
+        },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+
+function install()
+    local dir = pkginfo.install_dir()
+    os.tryrm(dir)
+    os.mv("xtrans-1.5.2", dir)
+    return true
+end
+
+function config()
+    xvm.add(package.name)
+    return true
+end
+
+function uninstall()
+    xvm.remove(package.name)
+    return true
+end


### PR DESCRIPTION
`xlings install mesa` now brings a working OpenGL implementation on a host that has no graphics stack of its own.

Twenty packages, built from source **inside an xlings subos** against that subos's glibc, published to xlings-res on both mirrors and verified byte-identical.

| tier | packages |
|---|---|
| T1 | xorgproto, xcb-proto, xtrans, libpciaccess, libdrm, libxshmfence |
| T2 | libXau, libXdmcp, libxcb, libX11, libXext, libXrender, libXfixes, libXrandr, libXxf86vm, libXi, libXcursor |
| T4 | libglvnd, libllvm |
| T5 | mesa |

## Why these have to be ours

A program that draws needs a loader and a libc, a way to find its libraries, and the environment its subsystems read. xlings had the first two. The third is why a GLFW binary links correctly and exits 255 — [mcpp#352](https://github.com/mcpp-community/mcpp/issues/352).

Four things genuinely cannot be ours: the kernel's DRM, `/sys`, the display server (a socket protocol — a *service* boundary, not an ABI one), and NVIDIA's proprietary userspace. **Everything else is here**, including the X11 *client* libraries — borrowing those from the host would drag the host's glibc back in, which is the failure being fixed.

## Verified, not asserted

```
GL_RENDERER=llvmpipe (LLVM 20.1.7, 256 bits)
PIXEL=336699    RESULT=ok
```

inside a bwrap container with **no `/usr` and no `/lib`** — only the subos, `/dev/dri` and a read-only `/sys`.

The renderer string is the evidence. This host's own llvmpipe reports **LLVM 20.1.2**; the container reports **20.1.7**, which is the libllvm built here. It cannot be the host's stack. `selfcontained-check.sh` asserts the same thing from the other side by requiring the renderer *not* to be NVIDIA — this machine has an RTX 4080 with the proprietary driver loaded, and a run that quietly used it would look identical to a real one.

Every payload is checked before packaging for RPATHs naming anything outside it, and for absolute host prefixes in `.pc`/`.la`/`*-config` files. The second kind breaks nothing now and breaks the **next** package, by pointing its `configure` at `/usr`.

## Dependency ranges

These recipes use **lower bounds** rather than exact pins. The resolver has supported ranges all along (`semver.cppm`: `@3`, `@^1.2`, `>=1.0 <2.0`) but no recipe in the index used them, which makes a stack one block — a libX11 patch bump would mean editing a dozen files that only care the library exists. Ranges do not cause churn: `pin_target_to_active` prefers an installed version that already satisfies the constraint over the index's newest.

One exception — **mesa → libllvm@20.1.7**, pinned exactly. libgallium references 97 mangled `llvm::` symbols carrying an `@LLVM_20.1` version tag; that coupling is exact and a range would advertise an upgrade path that does not exist. A mismatch fails at load, not silently.

Verified locally: `xlings install "gfx:xorgproto@>=2024"` resolves to `2024.1` and installs from the published mirror.

## Reproducibility

Each xlings-res repo carries a README with the upstream source, the exact configure flags, which compiler was used **and why**, and what was deliberately left out. A payload repo otherwise holds only tarballs, and how those bytes were produced would exist nowhere.

The `libllvm` one is the least obvious: it builds with **gcc 15.1.0** — not the subos default (gcc 16.1.0 ICEs with a segfault on `AMDGPUAsmParser.cpp`, and AMDGPU is not droppable since radeonsi needs it) and not clang (whose libc++ default would give libLLVM a different C++ runtime from mesa's libstdc++, where those 97 mangled symbols match by name and disagree on layout). `gcc-runtime` is 15.1.0, so building with gcc 15.1.0 makes the ABI consistent by construction rather than by a flag.

Licences are per-package and checked against each upstream: `libllvm` is `Apache-2.0 WITH LLVM-exception`, matching the existing `llvm` recipe; the rest are MIT (the X.Org variant, libglvnd's Khronos wording, and mesa's own `SPDX-License-Identifier: MIT`).

## Not in this PR

Hardware drivers beyond llvmpipe (`iris` needs libclc; radeonsi and nouveau follow), Vulkan (needs glslang), Wayland, and the NVIDIA proprietary bridge. The pipeline renders — adding a driver to it is a small change; debugging a pipeline with five drivers at once is not.

Design: [`openxlings/xlings .agents/docs/2026-08-05-graphics-stack-ecosystem-closure.md`](https://github.com/openxlings/xlings/blob/main/.agents/docs/2026-08-05-graphics-stack-ecosystem-closure.md)