### PR TITLE
fix(graphics): merge the sysroot instead of replacing it, and register libs for linking

### DIFF
--- a/.agents/tools/graphics/gen-recipes.py
+++ b/.agents/tools/graphics/gen-recipes.py
@@ -42,6 +42,22 @@ import sys
 # refuses to guess. Namespacing is right in both directions — it is unambiguous
 # by construction, and the unpublished-sibling case it loses is handled where it
 # belongs, by the pre-registration pass in .github/scripts/posix-test.sh.
+
+# glibc is pinned where every other dep is a range, and the reason is a client
+# bug rather than an ABI one. Before 2026.8.5.2, xlings matched a dep's version
+# half by string equality, so `xim:glibc@>=2.38` matched no plan node, glibc's
+# exports were dropped, and elfpatch concluded "no loader provider in deps" and
+# patched nothing -- the package installed reporting success and its libraries
+# kept a build-time RPATH, so anything dlopen'd out of them failed to find its
+# siblings. glibc is the only dep that carries `exports.runtime.loader`, so it
+# is the only one where the miss is fatal: for the rest, closure_lib_paths
+# falls back to the {lib64, lib} convention and the RPATH still comes out
+# right. Pinning this one keeps the stack usable on clients already released.
+#
+# The measured floor is 2.38 (libgallium's highest required symbol version).
+# Widen this to a range once the fixed client is the floor worth assuming.
+GLIBC = "xim:glibc@2.39"
+
 SPEC = {
     # T1 — protocol descriptions and the kernel interface.
     "xorgproto":    ([], False, None),
@@ -66,7 +82,7 @@ SPEC = {
 
     # T4 — the graphics core.
     "libglvnd":     (["xim:libX11@>=1.8", "xim:libXext@>=1.3"], True, None),
-    "libllvm":      (["xim:gcc-runtime@>=15", "xim:glibc@>=2.38"], True, None),
+    "libllvm":      (["xim:gcc-runtime@>=15", GLIBC], True, None),
 }
 
 # mesa is written separately: it is the only recipe with an exact pin, and the
@@ -84,7 +100,7 @@ MESA_DEPS = [
     "xim:expat@>=2.6",
     "xim:zlib@>=1.2",
     "xim:gcc-runtime@>=15",
-    "xim:glibc@>=2.38",
+    GLIBC,
 ]
 
 DESCRIPTIONS = {
@@ -143,7 +159,9 @@ HEADER = '''package = {{
 }}
 
 import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.system")
 import("xim.libxpkg.xvm")
+import("xim.pkgindex.sysroot")
 '''
 
 EXPORTS = """            -- elfpatch reads this from each dependency and writes the consumer's
@@ -165,8 +183,10 @@ end
 
 CONFIG_LIB = '''
 function config()
+    local binding = package.name .. "@" .. pkginfo.version()
+
     xvm.add(package.name)
-{headers}    return true
+{libs}{headers}    return true
 end
 
 function uninstall()
@@ -257,14 +277,29 @@ def render(name, version, sha, global_url, cn_url):
         # and simply does not get the headers, rather than aborting the whole
         # registration on an unknown node kind.
         hdr = ("""
-    -- Headers into the subos sysroot, so a compiler in this subos can find
-    -- them. Declared rather than copied: xlings removes them with the package.
-    if xvm.files then
-        xvm.files{ src = "include", dst = "usr/include",
-                   binding = package.name .. "@" .. pkginfo.version() }
+    -- Headers into the subos sysroot, so a compiler in this subos can build
+    -- against this package, not only run it. Declared rather than copied, so
+    -- xlings removes them with the package.
+    --
+    -- _tree, not declare_headers: eight packages in this stack contribute to
+    -- one `X11/`, and declaring that directory places it as a single asset --
+    -- rename(2) over the sysroot's copy, so the last install wins and the
+    -- other seven vanish. See libs/sysroot.lua for why neither of the
+    -- non-recursive helpers can express a shared namespace.
+    if not sysroot.declare_headers_tree(pkginfo.install_dir(), "include",
+                                        "usr/include", binding) then
+        sysroot.install_headers_tree(
+            path.join(pkginfo.install_dir(), "include"),
+            path.join(system.subos_sysrootdir(), "usr", "include"))
     end
 """)
-    out += CONFIG_LIB.format(headers=hdr)
+    libs = ""
+    if has_libs:
+        # So a program in this subos can be LINKED against the stack, not only
+        # run against it. See sysroot.declare_libs.
+        libs = ("\n    sysroot.declare_libs(pkginfo.install_dir(), \"lib\", "
+                "binding, pkginfo.version())\n")
+    out += CONFIG_LIB.format(headers=hdr, libs=libs)
     return out
 
 

--- a/.agents/tools/graphics/glprobe.c
+++ b/.agents/tools/graphics/glprobe.c
@@ -29,12 +29,28 @@ int main(void) {
     // with no display server reachable, which is what an empty host looks like.
     EGLDisplay dpy = EGL_NO_DISPLAY;
 
+    // Three ways to reach a display, reported separately. Collapsing them into
+    // one "no-display" hides which layer refused: a missing client extension
+    // (the loader never advertised surfaceless), a vendor that declined the
+    // platform, and no vendor at all are three different bugs, and the first
+    // two are indistinguishable from "the stack is not there" without this.
+    const char *clientExts = eglQueryString(EGL_NO_DISPLAY, EGL_EXTENSIONS);
+    printf("EGL_CLIENT_EXTENSIONS=%s\n", clientExts ? clientExts : "(none)");
+
     PFNEGLGETPLATFORMDISPLAYEXTPROC getPlatformDisplay =
         (PFNEGLGETPLATFORMDISPLAYEXTPROC)eglGetProcAddress("eglGetPlatformDisplayEXT");
-    if (getPlatformDisplay)
+    if (getPlatformDisplay) {
         dpy = getPlatformDisplay(EGL_PLATFORM_SURFACELESS_MESA, EGL_DEFAULT_DISPLAY, NULL);
-    if (dpy == EGL_NO_DISPLAY)
+        if (dpy == EGL_NO_DISPLAY)
+            printf("EGL_NOTE=surfaceless refused, egl error 0x%x\n", eglGetError());
+    } else {
+        printf("EGL_NOTE=no eglGetPlatformDisplayEXT\n");
+    }
+    if (dpy == EGL_NO_DISPLAY) {
         dpy = eglGetDisplay(EGL_DEFAULT_DISPLAY);
+        if (dpy == EGL_NO_DISPLAY)
+            printf("EGL_NOTE=default display refused, egl error 0x%x\n", eglGetError());
+    }
     if (dpy == EGL_NO_DISPLAY) return fail("no-display");
 
     EGLint major = 0, minor = 0;

--- a/.agents/tools/graphics/selfcontained-check.sh
+++ b/.agents/tools/graphics/selfcontained-check.sh
@@ -51,8 +51,14 @@ SUBOS_DIR="$XHOME/subos/$SUBOS_NAME"
 PROBE="$SUBOS_DIR/bin/glprobe"
 if [[ ! -x "$PROBE" || "$HERE/glprobe.c" -nt "$PROBE" ]]; then
     log "building glprobe against the subos"
+    # The subos's compiler, or nothing. Falling back to whatever `gcc` is on
+    # PATH does not degrade the test, it invalidates it: on this machine that
+    # is the real home's musl-gcc shim, which pairs musl's <stdarg.h> with the
+    # subos's glibc <stdio.h> and fails on `va_list` -- a libc mismatch that
+    # reads as a broken graphics stack. A compiler outside the subos also
+    # cannot prove anything about a subos that is meant to be self-contained.
     CC="$SUBOS_DIR/bin/gcc"
-    [[ -x "$CC" ]] || CC="$(command -v gcc)" || fail "no compiler"
+    [[ -x "$CC" ]] || fail "no gcc in subos '$SUBOS_NAME' (xlings install gcc)"
     # No pipe into head here: the exit status would be head's, and a failed
     # compile would sail past `|| fail` to be reported later as a missing
     # binary inside the container — which reads as an incomplete closure
@@ -75,6 +81,42 @@ fi
 # surfacing as "execvp: No such file or directory" for a binary that is plainly
 # there. The ENOENT is the loader's, not the binary's, which sends you looking
 # in the wrong place.
+
+# The environment the container gets is not written here. It is read back out
+# of the subos, where `mesa`'s config() put it through subos.env{} — the same
+# `--shell` code path that sets it for a user who enters the subos, evaluated
+# for a container instead of a login shell.
+#
+# This is the assertion, not the setup. An earlier revision of this script
+# hand-wrote --setenv LIBGL_DRIVERS_PATH and passed, which proved only that
+# mesa renders when told where its drivers are. Taking the values from the
+# package's own declaration is what makes a pass mean the user gets this for
+# free; if the declaration is dropped, S0 below fails instead of the script
+# quietly supplying it.
+SUBOS_ENV="$("$XLINGS_BIN" subos use "$SUBOS_NAME" --shell sh 2>/dev/null)"
+# `set` emits `: "${VAR:=value}"; export VAR;`, `prepend` emits
+# `export VAR="value${VAR:+:$VAR}";` — both shapes, names only.
+DECLARED="$(printf '%s\n' "$SUBOS_ENV" \
+    | sed -n -e 's/^export \([A-Za-z_][A-Za-z0-9_]*\)=.*/\1/p' \
+             -e 's/^: "${\([A-Za-z_][A-Za-z0-9_]*\):=.*/\1/p' \
+    | sort -u | grep -vxE 'PATH|XLINGS_[A-Z_]*')"
+
+grep -qx "LIBGL_DRIVERS_PATH" <<<"$DECLARED" \
+  || fail "S0: subos '$SUBOS_NAME' declares no LIBGL_DRIVERS_PATH — mesa's subos.env{} did not reach the manifest"
+log "  S0 ok — the subos declares: $(tr '\n' ' ' <<<"$DECLARED")"
+
+ENVARGS=()
+while IFS= read -r name; do
+    [[ -n "$name" ]] || continue
+    # Evaluated in an empty shell so the value is the declaration's, not this
+    # shell's variable of the same name leaking in.
+    value="$(env -i sh -c "$SUBOS_ENV"$'\n'"printf '%s' \"\${$name}\"")"
+    ENVARGS+=(--setenv "$name" "$value")
+done <<<"$DECLARED"
+
+# No LD_LIBRARY_PATH either: the probe was linked with -rpath into the subos,
+# which is how any program xlings installs finds its libraries. Handing one in
+# would hide a stack that only resolves when someone sets a search path.
 OUT="$(
   bwrap \
     --unshare-all --die-with-parent \
@@ -84,18 +126,10 @@ OUT="$(
     --ro-bind /sys /sys \
     --setenv XLINGS_HOME "$XHOME" \
     --setenv HOME /tmp \
-    --setenv LIBGL_DRIVERS_PATH "$SUBOS_DIR/usr/lib/dri" \
-    --setenv __EGL_VENDOR_LIBRARY_DIRS "$SUBOS_DIR/usr/share/glvnd/egl_vendor.d" \
-    --setenv LD_LIBRARY_PATH "$SUBOS_DIR/usr/lib:$SUBOS_DIR/lib" \
+    "${ENVARGS[@]}" \
     -- "$PROBE" 2>&1
 )"
 RC=$?
-# The three --setenv above are TEMPORARY, and their removal is the next
-# milestone rather than a cleanup. They are exactly what `mesa`'s config() will
-# declare through subos.env{} once the recipe is published — at which point
-# entering the subos sets them and this script should still pass with these
-# lines deleted. Until then they stand in for the recipe, so the stack itself
-# can be judged separately from the packaging around it.
 
 echo "$OUT" | sed 's/^/    /'
 

--- a/libs/sysroot.lua
+++ b/libs/sysroot.lua
@@ -95,6 +95,57 @@ function sysroot.declare_headers(install_dir, src_rel, dst_rel, binding)
     return true
 end
 
+-- declare_headers, but for a directory whose names are NOT yours.
+--
+-- declare_headers stops at the immediate children, which is right when the
+-- package owns those names (`openssl/`, `python3.13/`, glibc's 130). The X11
+-- stack is the case it cannot express: eight packages -- xorgproto, libX11,
+-- libXau, libXdmcp, libXext, libXfixes, libXxf86vm, libxshmfence -- each ship
+-- part of one `X11/` directory. Declaring that child places the whole
+-- directory as a single asset, and a file asset is placed by rename(2), so
+-- the eighth package to install REPLACES the other seven. install_headers
+-- fails the same case from the other side: it skips a name that already
+-- exists, so the first package wins and the other seven are dropped.
+--
+-- Neither is a merge, and `usr/include` shared by eight packages needs one.
+--
+-- So: recurse, and declare at the leaves. Directories are never declared,
+-- which is the whole point -- xlings creates the parent of each asset, so
+-- `usr/include/X11/` becomes a real directory holding symlinks contributed by
+-- all eight, exactly as a distribution's /usr/include is assembled. Only two
+-- packages shipping the same *file* now collide, and that collision is
+-- recorded per file rather than swallowing a directory.
+--
+-- Cost is one node per header: 270 for the whole graphics stack. Use
+-- declare_headers when the names are yours -- it is one node per directory --
+-- and this when they are not.
+function sysroot.declare_headers_tree(install_dir, src_rel, dst_rel, binding)
+    if not xvm.files then return false end
+    if not os.isdir(path.join(install_dir, src_rel)) then return true end
+    sysroot.__declare_tree(install_dir, src_rel, dst_rel, binding, 0)
+    return true
+end
+
+function sysroot.__declare_tree(install_dir, src_rel, dst_rel, binding, depth)
+    -- Header trees are three or four deep (`X11/extensions/`, `libdrm/`).
+    -- The cap is a stop for a payload that symlinks a directory back to an
+    -- ancestor, which would otherwise walk until Lua runs out of stack.
+    if depth > 8 then return end
+    for _, name in ipairs(sysroot.entries(path.join(install_dir, src_rel))) do
+        local child = path.join(src_rel, name)
+        if os.isdir(path.join(install_dir, child)) then
+            sysroot.__declare_tree(install_dir, child,
+                                   path.join(dst_rel, name), binding, depth + 1)
+        else
+            xvm.files{
+                src = child,
+                dst = path.join(dst_rel, name),
+                binding = binding,
+            }
+        end
+    end
+end
+
 -- Install headers from SRC_DIR into DST_DIR — strictly non-recursive.
 --
 -- Only the immediate children of SRC_DIR are processed. Each entry
@@ -144,6 +195,65 @@ function sysroot.install_headers(src_dir, dst_dir)
         else
             local src = path.join(src_dir, name)
             fs.symlink(src, dst)
+        end
+    end
+end
+
+-- The legacy fallback for declare_headers_tree: same recursive merge, done
+-- by hand for a client with no `xvm.files`.
+--
+-- Where install_headers skips a name that already exists, this descends into
+-- it. A directory present on both sides is made a real directory in the
+-- sysroot and both contents land in it; only at a *file* that already exists
+-- does the first claimant still win. Without that descent an existing `X11/`
+-- -- from the host bind-mount or from whichever package installed first --
+-- hides every other package's X11 headers.
+function sysroot.install_headers_tree(src_dir, dst_dir, depth)
+    if not os.isdir(src_dir) then return end
+    if (depth or 0) > 8 then return end
+    fs.mkdir_p(dst_dir)
+    for _, name in ipairs(sysroot.entries(src_dir)) do
+        local src = path.join(src_dir, name)
+        local dst = path.join(dst_dir, name)
+        if os.isdir(src) then
+            sysroot.install_headers_tree(src, dst, (depth or 0) + 1)
+        elseif not (os.isdir(dst) or os.isfile(dst)) then
+            fs.symlink(src, dst)
+        end
+    end
+end
+
+-- Register a payload's shared libraries so they appear in `<subos>/lib`.
+--
+-- Headers alone do not make a sysroot. A package installed through xlings
+-- RUNS without this -- elfpatch writes the consumer's RPATH from
+-- exports.runtime.libdirs, straight into the payload -- but nothing can be
+-- LINKED against it: `gcc -lEGL` searches the subos's lib directory, and the
+-- payload is not on that path. The stack was in the odd position of shipping
+-- headers a compiler could find and libraries it could not.
+--
+-- Same mechanism zlib and glibc use, enumerated instead of hand-listed: at
+-- eighteen packages a per-package list is a place for a name to go missing,
+-- and the failure (one undefined symbol at link time) does not name the list.
+--
+-- Immediate children only, which is what keeps mesa's `lib/dri/*.so` out --
+-- those are driver modules loaded by path through LIBGL_DRIVERS_PATH, not
+-- link targets, and registering them would put twelve drivers in `<subos>/lib`
+-- for anything to link against by accident.
+function sysroot.declare_libs(install_dir, src_rel, binding, version)
+    local libdir = path.join(install_dir, src_rel)
+    if not os.isdir(libdir) then return end
+    for _, name in ipairs(sysroot.entries(libdir)) do
+        if (name:find("%.so$") or name:find("%.so%."))
+           and os.isfile(path.join(libdir, name)) then
+            xvm.add(name, {
+                version = version,
+                type = "lib",
+                bindir = libdir,
+                filename = name,
+                alias = name,
+                binding = binding,
+            })
         end
     end
 end

--- a/pkgs/l/libX11.lua
+++ b/pkgs/l/libX11.lua
@@ -37,7 +37,9 @@ package = {
 }
 
 import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.system")
 import("xim.libxpkg.xvm")
+import("xim.pkgindex.sysroot")
 
 function install()
     local dir = pkginfo.install_dir()
@@ -47,13 +49,26 @@ function install()
 end
 
 function config()
+    local binding = package.name .. "@" .. pkginfo.version()
+
     xvm.add(package.name)
 
-    -- Headers into the subos sysroot, so a compiler in this subos can find
-    -- them. Declared rather than copied: xlings removes them with the package.
-    if xvm.files then
-        xvm.files{ src = "include", dst = "usr/include",
-                   binding = package.name .. "@" .. pkginfo.version() }
+    sysroot.declare_libs(pkginfo.install_dir(), "lib", binding, pkginfo.version())
+
+    -- Headers into the subos sysroot, so a compiler in this subos can build
+    -- against this package, not only run it. Declared rather than copied, so
+    -- xlings removes them with the package.
+    --
+    -- _tree, not declare_headers: eight packages in this stack contribute to
+    -- one `X11/`, and declaring that directory places it as a single asset --
+    -- rename(2) over the sysroot's copy, so the last install wins and the
+    -- other seven vanish. See libs/sysroot.lua for why neither of the
+    -- non-recursive helpers can express a shared namespace.
+    if not sysroot.declare_headers_tree(pkginfo.install_dir(), "include",
+                                        "usr/include", binding) then
+        sysroot.install_headers_tree(
+            path.join(pkginfo.install_dir(), "include"),
+            path.join(system.subos_sysrootdir(), "usr", "include"))
     end
     return true
 end

--- a/pkgs/l/libXau.lua
+++ b/pkgs/l/libXau.lua
@@ -37,7 +37,9 @@ package = {
 }
 
 import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.system")
 import("xim.libxpkg.xvm")
+import("xim.pkgindex.sysroot")
 
 function install()
     local dir = pkginfo.install_dir()
@@ -47,13 +49,26 @@ function install()
 end
 
 function config()
+    local binding = package.name .. "@" .. pkginfo.version()
+
     xvm.add(package.name)
 
-    -- Headers into the subos sysroot, so a compiler in this subos can find
-    -- them. Declared rather than copied: xlings removes them with the package.
-    if xvm.files then
-        xvm.files{ src = "include", dst = "usr/include",
-                   binding = package.name .. "@" .. pkginfo.version() }
+    sysroot.declare_libs(pkginfo.install_dir(), "lib", binding, pkginfo.version())
+
+    -- Headers into the subos sysroot, so a compiler in this subos can build
+    -- against this package, not only run it. Declared rather than copied, so
+    -- xlings removes them with the package.
+    --
+    -- _tree, not declare_headers: eight packages in this stack contribute to
+    -- one `X11/`, and declaring that directory places it as a single asset --
+    -- rename(2) over the sysroot's copy, so the last install wins and the
+    -- other seven vanish. See libs/sysroot.lua for why neither of the
+    -- non-recursive helpers can express a shared namespace.
+    if not sysroot.declare_headers_tree(pkginfo.install_dir(), "include",
+                                        "usr/include", binding) then
+        sysroot.install_headers_tree(
+            path.join(pkginfo.install_dir(), "include"),
+            path.join(system.subos_sysrootdir(), "usr", "include"))
     end
     return true
 end

--- a/pkgs/l/libXcursor.lua
+++ b/pkgs/l/libXcursor.lua
@@ -37,7 +37,9 @@ package = {
 }
 
 import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.system")
 import("xim.libxpkg.xvm")
+import("xim.pkgindex.sysroot")
 
 function install()
     local dir = pkginfo.install_dir()
@@ -47,13 +49,26 @@ function install()
 end
 
 function config()
+    local binding = package.name .. "@" .. pkginfo.version()
+
     xvm.add(package.name)
 
-    -- Headers into the subos sysroot, so a compiler in this subos can find
-    -- them. Declared rather than copied: xlings removes them with the package.
-    if xvm.files then
-        xvm.files{ src = "include", dst = "usr/include",
-                   binding = package.name .. "@" .. pkginfo.version() }
+    sysroot.declare_libs(pkginfo.install_dir(), "lib", binding, pkginfo.version())
+
+    -- Headers into the subos sysroot, so a compiler in this subos can build
+    -- against this package, not only run it. Declared rather than copied, so
+    -- xlings removes them with the package.
+    --
+    -- _tree, not declare_headers: eight packages in this stack contribute to
+    -- one `X11/`, and declaring that directory places it as a single asset --
+    -- rename(2) over the sysroot's copy, so the last install wins and the
+    -- other seven vanish. See libs/sysroot.lua for why neither of the
+    -- non-recursive helpers can express a shared namespace.
+    if not sysroot.declare_headers_tree(pkginfo.install_dir(), "include",
+                                        "usr/include", binding) then
+        sysroot.install_headers_tree(
+            path.join(pkginfo.install_dir(), "include"),
+            path.join(system.subos_sysrootdir(), "usr", "include"))
     end
     return true
 end

--- a/pkgs/l/libXdmcp.lua
+++ b/pkgs/l/libXdmcp.lua
@@ -37,7 +37,9 @@ package = {
 }
 
 import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.system")
 import("xim.libxpkg.xvm")
+import("xim.pkgindex.sysroot")
 
 function install()
     local dir = pkginfo.install_dir()
@@ -47,13 +49,26 @@ function install()
 end
 
 function config()
+    local binding = package.name .. "@" .. pkginfo.version()
+
     xvm.add(package.name)
 
-    -- Headers into the subos sysroot, so a compiler in this subos can find
-    -- them. Declared rather than copied: xlings removes them with the package.
-    if xvm.files then
-        xvm.files{ src = "include", dst = "usr/include",
-                   binding = package.name .. "@" .. pkginfo.version() }
+    sysroot.declare_libs(pkginfo.install_dir(), "lib", binding, pkginfo.version())
+
+    -- Headers into the subos sysroot, so a compiler in this subos can build
+    -- against this package, not only run it. Declared rather than copied, so
+    -- xlings removes them with the package.
+    --
+    -- _tree, not declare_headers: eight packages in this stack contribute to
+    -- one `X11/`, and declaring that directory places it as a single asset --
+    -- rename(2) over the sysroot's copy, so the last install wins and the
+    -- other seven vanish. See libs/sysroot.lua for why neither of the
+    -- non-recursive helpers can express a shared namespace.
+    if not sysroot.declare_headers_tree(pkginfo.install_dir(), "include",
+                                        "usr/include", binding) then
+        sysroot.install_headers_tree(
+            path.join(pkginfo.install_dir(), "include"),
+            path.join(system.subos_sysrootdir(), "usr", "include"))
     end
     return true
 end

--- a/pkgs/l/libXext.lua
+++ b/pkgs/l/libXext.lua
@@ -37,7 +37,9 @@ package = {
 }
 
 import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.system")
 import("xim.libxpkg.xvm")
+import("xim.pkgindex.sysroot")
 
 function install()
     local dir = pkginfo.install_dir()
@@ -47,13 +49,26 @@ function install()
 end
 
 function config()
+    local binding = package.name .. "@" .. pkginfo.version()
+
     xvm.add(package.name)
 
-    -- Headers into the subos sysroot, so a compiler in this subos can find
-    -- them. Declared rather than copied: xlings removes them with the package.
-    if xvm.files then
-        xvm.files{ src = "include", dst = "usr/include",
-                   binding = package.name .. "@" .. pkginfo.version() }
+    sysroot.declare_libs(pkginfo.install_dir(), "lib", binding, pkginfo.version())
+
+    -- Headers into the subos sysroot, so a compiler in this subos can build
+    -- against this package, not only run it. Declared rather than copied, so
+    -- xlings removes them with the package.
+    --
+    -- _tree, not declare_headers: eight packages in this stack contribute to
+    -- one `X11/`, and declaring that directory places it as a single asset --
+    -- rename(2) over the sysroot's copy, so the last install wins and the
+    -- other seven vanish. See libs/sysroot.lua for why neither of the
+    -- non-recursive helpers can express a shared namespace.
+    if not sysroot.declare_headers_tree(pkginfo.install_dir(), "include",
+                                        "usr/include", binding) then
+        sysroot.install_headers_tree(
+            path.join(pkginfo.install_dir(), "include"),
+            path.join(system.subos_sysrootdir(), "usr", "include"))
     end
     return true
 end

--- a/pkgs/l/libXfixes.lua
+++ b/pkgs/l/libXfixes.lua
@@ -37,7 +37,9 @@ package = {
 }
 
 import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.system")
 import("xim.libxpkg.xvm")
+import("xim.pkgindex.sysroot")
 
 function install()
     local dir = pkginfo.install_dir()
@@ -47,13 +49,26 @@ function install()
 end
 
 function config()
+    local binding = package.name .. "@" .. pkginfo.version()
+
     xvm.add(package.name)
 
-    -- Headers into the subos sysroot, so a compiler in this subos can find
-    -- them. Declared rather than copied: xlings removes them with the package.
-    if xvm.files then
-        xvm.files{ src = "include", dst = "usr/include",
-                   binding = package.name .. "@" .. pkginfo.version() }
+    sysroot.declare_libs(pkginfo.install_dir(), "lib", binding, pkginfo.version())
+
+    -- Headers into the subos sysroot, so a compiler in this subos can build
+    -- against this package, not only run it. Declared rather than copied, so
+    -- xlings removes them with the package.
+    --
+    -- _tree, not declare_headers: eight packages in this stack contribute to
+    -- one `X11/`, and declaring that directory places it as a single asset --
+    -- rename(2) over the sysroot's copy, so the last install wins and the
+    -- other seven vanish. See libs/sysroot.lua for why neither of the
+    -- non-recursive helpers can express a shared namespace.
+    if not sysroot.declare_headers_tree(pkginfo.install_dir(), "include",
+                                        "usr/include", binding) then
+        sysroot.install_headers_tree(
+            path.join(pkginfo.install_dir(), "include"),
+            path.join(system.subos_sysrootdir(), "usr", "include"))
     end
     return true
 end

--- a/pkgs/l/libXi.lua
+++ b/pkgs/l/libXi.lua
@@ -37,7 +37,9 @@ package = {
 }
 
 import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.system")
 import("xim.libxpkg.xvm")
+import("xim.pkgindex.sysroot")
 
 function install()
     local dir = pkginfo.install_dir()
@@ -47,13 +49,26 @@ function install()
 end
 
 function config()
+    local binding = package.name .. "@" .. pkginfo.version()
+
     xvm.add(package.name)
 
-    -- Headers into the subos sysroot, so a compiler in this subos can find
-    -- them. Declared rather than copied: xlings removes them with the package.
-    if xvm.files then
-        xvm.files{ src = "include", dst = "usr/include",
-                   binding = package.name .. "@" .. pkginfo.version() }
+    sysroot.declare_libs(pkginfo.install_dir(), "lib", binding, pkginfo.version())
+
+    -- Headers into the subos sysroot, so a compiler in this subos can build
+    -- against this package, not only run it. Declared rather than copied, so
+    -- xlings removes them with the package.
+    --
+    -- _tree, not declare_headers: eight packages in this stack contribute to
+    -- one `X11/`, and declaring that directory places it as a single asset --
+    -- rename(2) over the sysroot's copy, so the last install wins and the
+    -- other seven vanish. See libs/sysroot.lua for why neither of the
+    -- non-recursive helpers can express a shared namespace.
+    if not sysroot.declare_headers_tree(pkginfo.install_dir(), "include",
+                                        "usr/include", binding) then
+        sysroot.install_headers_tree(
+            path.join(pkginfo.install_dir(), "include"),
+            path.join(system.subos_sysrootdir(), "usr", "include"))
     end
     return true
 end

--- a/pkgs/l/libXrandr.lua
+++ b/pkgs/l/libXrandr.lua
@@ -37,7 +37,9 @@ package = {
 }
 
 import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.system")
 import("xim.libxpkg.xvm")
+import("xim.pkgindex.sysroot")
 
 function install()
     local dir = pkginfo.install_dir()
@@ -47,13 +49,26 @@ function install()
 end
 
 function config()
+    local binding = package.name .. "@" .. pkginfo.version()
+
     xvm.add(package.name)
 
-    -- Headers into the subos sysroot, so a compiler in this subos can find
-    -- them. Declared rather than copied: xlings removes them with the package.
-    if xvm.files then
-        xvm.files{ src = "include", dst = "usr/include",
-                   binding = package.name .. "@" .. pkginfo.version() }
+    sysroot.declare_libs(pkginfo.install_dir(), "lib", binding, pkginfo.version())
+
+    -- Headers into the subos sysroot, so a compiler in this subos can build
+    -- against this package, not only run it. Declared rather than copied, so
+    -- xlings removes them with the package.
+    --
+    -- _tree, not declare_headers: eight packages in this stack contribute to
+    -- one `X11/`, and declaring that directory places it as a single asset --
+    -- rename(2) over the sysroot's copy, so the last install wins and the
+    -- other seven vanish. See libs/sysroot.lua for why neither of the
+    -- non-recursive helpers can express a shared namespace.
+    if not sysroot.declare_headers_tree(pkginfo.install_dir(), "include",
+                                        "usr/include", binding) then
+        sysroot.install_headers_tree(
+            path.join(pkginfo.install_dir(), "include"),
+            path.join(system.subos_sysrootdir(), "usr", "include"))
     end
     return true
 end

--- a/pkgs/l/libXrender.lua
+++ b/pkgs/l/libXrender.lua
@@ -37,7 +37,9 @@ package = {
 }
 
 import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.system")
 import("xim.libxpkg.xvm")
+import("xim.pkgindex.sysroot")
 
 function install()
     local dir = pkginfo.install_dir()
@@ -47,13 +49,26 @@ function install()
 end
 
 function config()
+    local binding = package.name .. "@" .. pkginfo.version()
+
     xvm.add(package.name)
 
-    -- Headers into the subos sysroot, so a compiler in this subos can find
-    -- them. Declared rather than copied: xlings removes them with the package.
-    if xvm.files then
-        xvm.files{ src = "include", dst = "usr/include",
-                   binding = package.name .. "@" .. pkginfo.version() }
+    sysroot.declare_libs(pkginfo.install_dir(), "lib", binding, pkginfo.version())
+
+    -- Headers into the subos sysroot, so a compiler in this subos can build
+    -- against this package, not only run it. Declared rather than copied, so
+    -- xlings removes them with the package.
+    --
+    -- _tree, not declare_headers: eight packages in this stack contribute to
+    -- one `X11/`, and declaring that directory places it as a single asset --
+    -- rename(2) over the sysroot's copy, so the last install wins and the
+    -- other seven vanish. See libs/sysroot.lua for why neither of the
+    -- non-recursive helpers can express a shared namespace.
+    if not sysroot.declare_headers_tree(pkginfo.install_dir(), "include",
+                                        "usr/include", binding) then
+        sysroot.install_headers_tree(
+            path.join(pkginfo.install_dir(), "include"),
+            path.join(system.subos_sysrootdir(), "usr", "include"))
     end
     return true
 end

--- a/pkgs/l/libXxf86vm.lua
+++ b/pkgs/l/libXxf86vm.lua
@@ -37,7 +37,9 @@ package = {
 }
 
 import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.system")
 import("xim.libxpkg.xvm")
+import("xim.pkgindex.sysroot")
 
 function install()
     local dir = pkginfo.install_dir()
@@ -47,13 +49,26 @@ function install()
 end
 
 function config()
+    local binding = package.name .. "@" .. pkginfo.version()
+
     xvm.add(package.name)
 
-    -- Headers into the subos sysroot, so a compiler in this subos can find
-    -- them. Declared rather than copied: xlings removes them with the package.
-    if xvm.files then
-        xvm.files{ src = "include", dst = "usr/include",
-                   binding = package.name .. "@" .. pkginfo.version() }
+    sysroot.declare_libs(pkginfo.install_dir(), "lib", binding, pkginfo.version())
+
+    -- Headers into the subos sysroot, so a compiler in this subos can build
+    -- against this package, not only run it. Declared rather than copied, so
+    -- xlings removes them with the package.
+    --
+    -- _tree, not declare_headers: eight packages in this stack contribute to
+    -- one `X11/`, and declaring that directory places it as a single asset --
+    -- rename(2) over the sysroot's copy, so the last install wins and the
+    -- other seven vanish. See libs/sysroot.lua for why neither of the
+    -- non-recursive helpers can express a shared namespace.
+    if not sysroot.declare_headers_tree(pkginfo.install_dir(), "include",
+                                        "usr/include", binding) then
+        sysroot.install_headers_tree(
+            path.join(pkginfo.install_dir(), "include"),
+            path.join(system.subos_sysrootdir(), "usr", "include"))
     end
     return true
 end

--- a/pkgs/l/libdrm.lua
+++ b/pkgs/l/libdrm.lua
@@ -37,7 +37,9 @@ package = {
 }
 
 import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.system")
 import("xim.libxpkg.xvm")
+import("xim.pkgindex.sysroot")
 
 function install()
     local dir = pkginfo.install_dir()
@@ -47,13 +49,26 @@ function install()
 end
 
 function config()
+    local binding = package.name .. "@" .. pkginfo.version()
+
     xvm.add(package.name)
 
-    -- Headers into the subos sysroot, so a compiler in this subos can find
-    -- them. Declared rather than copied: xlings removes them with the package.
-    if xvm.files then
-        xvm.files{ src = "include", dst = "usr/include",
-                   binding = package.name .. "@" .. pkginfo.version() }
+    sysroot.declare_libs(pkginfo.install_dir(), "lib", binding, pkginfo.version())
+
+    -- Headers into the subos sysroot, so a compiler in this subos can build
+    -- against this package, not only run it. Declared rather than copied, so
+    -- xlings removes them with the package.
+    --
+    -- _tree, not declare_headers: eight packages in this stack contribute to
+    -- one `X11/`, and declaring that directory places it as a single asset --
+    -- rename(2) over the sysroot's copy, so the last install wins and the
+    -- other seven vanish. See libs/sysroot.lua for why neither of the
+    -- non-recursive helpers can express a shared namespace.
+    if not sysroot.declare_headers_tree(pkginfo.install_dir(), "include",
+                                        "usr/include", binding) then
+        sysroot.install_headers_tree(
+            path.join(pkginfo.install_dir(), "include"),
+            path.join(system.subos_sysrootdir(), "usr", "include"))
     end
     return true
 end

--- a/pkgs/l/libglvnd.lua
+++ b/pkgs/l/libglvnd.lua
@@ -37,7 +37,9 @@ package = {
 }
 
 import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.system")
 import("xim.libxpkg.xvm")
+import("xim.pkgindex.sysroot")
 
 function install()
     local dir = pkginfo.install_dir()
@@ -47,13 +49,26 @@ function install()
 end
 
 function config()
+    local binding = package.name .. "@" .. pkginfo.version()
+
     xvm.add(package.name)
 
-    -- Headers into the subos sysroot, so a compiler in this subos can find
-    -- them. Declared rather than copied: xlings removes them with the package.
-    if xvm.files then
-        xvm.files{ src = "include", dst = "usr/include",
-                   binding = package.name .. "@" .. pkginfo.version() }
+    sysroot.declare_libs(pkginfo.install_dir(), "lib", binding, pkginfo.version())
+
+    -- Headers into the subos sysroot, so a compiler in this subos can build
+    -- against this package, not only run it. Declared rather than copied, so
+    -- xlings removes them with the package.
+    --
+    -- _tree, not declare_headers: eight packages in this stack contribute to
+    -- one `X11/`, and declaring that directory places it as a single asset --
+    -- rename(2) over the sysroot's copy, so the last install wins and the
+    -- other seven vanish. See libs/sysroot.lua for why neither of the
+    -- non-recursive helpers can express a shared namespace.
+    if not sysroot.declare_headers_tree(pkginfo.install_dir(), "include",
+                                        "usr/include", binding) then
+        sysroot.install_headers_tree(
+            path.join(pkginfo.install_dir(), "include"),
+            path.join(system.subos_sysrootdir(), "usr", "include"))
     end
     return true
 end

--- a/pkgs/l/libllvm.lua
+++ b/pkgs/l/libllvm.lua
@@ -17,7 +17,7 @@ package = {
 
     xpm = {
         linux = {
-            deps = { "xim:gcc-runtime@>=15", "xim:glibc@>=2.38" },
+            deps = { "xim:gcc-runtime@>=15", "xim:glibc@2.39" },
             -- elfpatch reads this from each dependency and writes the consumer's
             -- RPATH, which is what makes the stack resolve without anyone
             -- setting LD_LIBRARY_PATH. Same mechanism `gcc-runtime` uses.
@@ -37,7 +37,9 @@ package = {
 }
 
 import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.system")
 import("xim.libxpkg.xvm")
+import("xim.pkgindex.sysroot")
 
 function install()
     local dir = pkginfo.install_dir()
@@ -47,7 +49,11 @@ function install()
 end
 
 function config()
+    local binding = package.name .. "@" .. pkginfo.version()
+
     xvm.add(package.name)
+
+    sysroot.declare_libs(pkginfo.install_dir(), "lib", binding, pkginfo.version())
     return true
 end
 

--- a/pkgs/l/libpciaccess.lua
+++ b/pkgs/l/libpciaccess.lua
@@ -37,7 +37,9 @@ package = {
 }
 
 import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.system")
 import("xim.libxpkg.xvm")
+import("xim.pkgindex.sysroot")
 
 function install()
     local dir = pkginfo.install_dir()
@@ -47,13 +49,26 @@ function install()
 end
 
 function config()
+    local binding = package.name .. "@" .. pkginfo.version()
+
     xvm.add(package.name)
 
-    -- Headers into the subos sysroot, so a compiler in this subos can find
-    -- them. Declared rather than copied: xlings removes them with the package.
-    if xvm.files then
-        xvm.files{ src = "include", dst = "usr/include",
-                   binding = package.name .. "@" .. pkginfo.version() }
+    sysroot.declare_libs(pkginfo.install_dir(), "lib", binding, pkginfo.version())
+
+    -- Headers into the subos sysroot, so a compiler in this subos can build
+    -- against this package, not only run it. Declared rather than copied, so
+    -- xlings removes them with the package.
+    --
+    -- _tree, not declare_headers: eight packages in this stack contribute to
+    -- one `X11/`, and declaring that directory places it as a single asset --
+    -- rename(2) over the sysroot's copy, so the last install wins and the
+    -- other seven vanish. See libs/sysroot.lua for why neither of the
+    -- non-recursive helpers can express a shared namespace.
+    if not sysroot.declare_headers_tree(pkginfo.install_dir(), "include",
+                                        "usr/include", binding) then
+        sysroot.install_headers_tree(
+            path.join(pkginfo.install_dir(), "include"),
+            path.join(system.subos_sysrootdir(), "usr", "include"))
     end
     return true
 end

--- a/pkgs/l/libxcb.lua
+++ b/pkgs/l/libxcb.lua
@@ -37,7 +37,9 @@ package = {
 }
 
 import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.system")
 import("xim.libxpkg.xvm")
+import("xim.pkgindex.sysroot")
 
 function install()
     local dir = pkginfo.install_dir()
@@ -47,13 +49,26 @@ function install()
 end
 
 function config()
+    local binding = package.name .. "@" .. pkginfo.version()
+
     xvm.add(package.name)
 
-    -- Headers into the subos sysroot, so a compiler in this subos can find
-    -- them. Declared rather than copied: xlings removes them with the package.
-    if xvm.files then
-        xvm.files{ src = "include", dst = "usr/include",
-                   binding = package.name .. "@" .. pkginfo.version() }
+    sysroot.declare_libs(pkginfo.install_dir(), "lib", binding, pkginfo.version())
+
+    -- Headers into the subos sysroot, so a compiler in this subos can build
+    -- against this package, not only run it. Declared rather than copied, so
+    -- xlings removes them with the package.
+    --
+    -- _tree, not declare_headers: eight packages in this stack contribute to
+    -- one `X11/`, and declaring that directory places it as a single asset --
+    -- rename(2) over the sysroot's copy, so the last install wins and the
+    -- other seven vanish. See libs/sysroot.lua for why neither of the
+    -- non-recursive helpers can express a shared namespace.
+    if not sysroot.declare_headers_tree(pkginfo.install_dir(), "include",
+                                        "usr/include", binding) then
+        sysroot.install_headers_tree(
+            path.join(pkginfo.install_dir(), "include"),
+            path.join(system.subos_sysrootdir(), "usr", "include"))
     end
     return true
 end

--- a/pkgs/l/libxshmfence.lua
+++ b/pkgs/l/libxshmfence.lua
@@ -37,7 +37,9 @@ package = {
 }
 
 import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.system")
 import("xim.libxpkg.xvm")
+import("xim.pkgindex.sysroot")
 
 function install()
     local dir = pkginfo.install_dir()
@@ -47,13 +49,26 @@ function install()
 end
 
 function config()
+    local binding = package.name .. "@" .. pkginfo.version()
+
     xvm.add(package.name)
 
-    -- Headers into the subos sysroot, so a compiler in this subos can find
-    -- them. Declared rather than copied: xlings removes them with the package.
-    if xvm.files then
-        xvm.files{ src = "include", dst = "usr/include",
-                   binding = package.name .. "@" .. pkginfo.version() }
+    sysroot.declare_libs(pkginfo.install_dir(), "lib", binding, pkginfo.version())
+
+    -- Headers into the subos sysroot, so a compiler in this subos can build
+    -- against this package, not only run it. Declared rather than copied, so
+    -- xlings removes them with the package.
+    --
+    -- _tree, not declare_headers: eight packages in this stack contribute to
+    -- one `X11/`, and declaring that directory places it as a single asset --
+    -- rename(2) over the sysroot's copy, so the last install wins and the
+    -- other seven vanish. See libs/sysroot.lua for why neither of the
+    -- non-recursive helpers can express a shared namespace.
+    if not sysroot.declare_headers_tree(pkginfo.install_dir(), "include",
+                                        "usr/include", binding) then
+        sysroot.install_headers_tree(
+            path.join(pkginfo.install_dir(), "include"),
+            path.join(system.subos_sysrootdir(), "usr", "include"))
     end
     return true
 end

--- a/pkgs/m/mesa.lua
+++ b/pkgs/m/mesa.lua
@@ -56,10 +56,19 @@ package = {
                 "xim:expat@>=2.6",
                 "xim:zlib@>=1.2",
                 "xim:gcc-runtime@>=15",
-                -- >=2.38 is the measured floor: libgallium's highest required
-                -- symbol version is GLIBC_2.38. Writing @2.39 would state a
-                -- requirement the payload does not have.
-                "xim:glibc@>=2.38",
+                -- Pinned, alone among these, and for a client reason rather
+                -- than an ABI one. The measured floor is 2.38 (libgallium's
+                -- highest required symbol version), but before 2026.8.5.2
+                -- xlings compared a dep's version half by string equality:
+                -- `@>=2.38` matched no plan node, glibc's exports were
+                -- dropped, elfpatch found "no loader provider in deps" and
+                -- patched nothing. mesa then installed reporting success with
+                -- its libraries still on a build-time RPATH, and glvnd's
+                -- dlopen of libEGL_mesa failed to find libexpat -- surfacing
+                -- as EGL having no vendor at all. glibc is the only dep that
+                -- exports a loader, so it is the only one where the miss is
+                -- fatal. Pinning keeps this usable on clients already out.
+                "xim:glibc@2.39",
             },
             exports = {
                 runtime = { libdirs = { "lib" } },
@@ -77,8 +86,10 @@ package = {
 }
 
 import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.system")
 import("xim.libxpkg.xvm")
 import("xim.libxpkg.subos")
+import("xim.pkgindex.sysroot")
 
 function install()
     local dir = pkginfo.install_dir()
@@ -106,10 +117,22 @@ function config()
 
     xvm.add(package.name)
 
+    -- Only `lib/*.so*`, so the twelve driver modules under `lib/dri/` stay
+    -- out of `<subos>/lib`: those are loaded by path through
+    -- LIBGL_DRIVERS_PATH below, and are not link targets.
+    sysroot.declare_libs(dir, "lib", tag, pkginfo.version())
+
     -- Headers into the subos sysroot, so a compiler in this subos can build
     -- against the stack rather than only run it.
-    if xvm.files then
-        xvm.files{ src = "include", dst = "usr/include", binding = tag }
+    --
+    -- _tree because `EGL/`, `GL/` and `KHR/` are libglvnd's directories that
+    -- mesa adds files to. Declaring the directory would place it whole, and a
+    -- file asset is placed by rename(2) -- mesa's four headers would replace
+    -- libglvnd's twenty rather than join them.
+    if not sysroot.declare_headers_tree(dir, "include", "usr/include", tag) then
+        sysroot.install_headers_tree(
+            path.join(dir, "include"),
+            path.join(system.subos_sysrootdir(), "usr", "include"))
     end
 
     -- The configuration layer. Neither PATH nor RPATH can carry these: the

--- a/pkgs/x/xcb-proto.lua
+++ b/pkgs/x/xcb-proto.lua
@@ -31,7 +31,9 @@ package = {
 }
 
 import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.system")
 import("xim.libxpkg.xvm")
+import("xim.pkgindex.sysroot")
 
 function install()
     local dir = pkginfo.install_dir()
@@ -41,6 +43,8 @@ function install()
 end
 
 function config()
+    local binding = package.name .. "@" .. pkginfo.version()
+
     xvm.add(package.name)
     return true
 end

--- a/pkgs/x/xorgproto.lua
+++ b/pkgs/x/xorgproto.lua
@@ -31,7 +31,9 @@ package = {
 }
 
 import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.system")
 import("xim.libxpkg.xvm")
+import("xim.pkgindex.sysroot")
 
 function install()
     local dir = pkginfo.install_dir()
@@ -41,13 +43,24 @@ function install()
 end
 
 function config()
+    local binding = package.name .. "@" .. pkginfo.version()
+
     xvm.add(package.name)
 
-    -- Headers into the subos sysroot, so a compiler in this subos can find
-    -- them. Declared rather than copied: xlings removes them with the package.
-    if xvm.files then
-        xvm.files{ src = "include", dst = "usr/include",
-                   binding = package.name .. "@" .. pkginfo.version() }
+    -- Headers into the subos sysroot, so a compiler in this subos can build
+    -- against this package, not only run it. Declared rather than copied, so
+    -- xlings removes them with the package.
+    --
+    -- _tree, not declare_headers: eight packages in this stack contribute to
+    -- one `X11/`, and declaring that directory places it as a single asset --
+    -- rename(2) over the sysroot's copy, so the last install wins and the
+    -- other seven vanish. See libs/sysroot.lua for why neither of the
+    -- non-recursive helpers can express a shared namespace.
+    if not sysroot.declare_headers_tree(pkginfo.install_dir(), "include",
+                                        "usr/include", binding) then
+        sysroot.install_headers_tree(
+            path.join(pkginfo.install_dir(), "include"),
+            path.join(system.subos_sysrootdir(), "usr", "include"))
     end
     return true
 end

--- a/pkgs/x/xtrans.lua
+++ b/pkgs/x/xtrans.lua
@@ -31,7 +31,9 @@ package = {
 }
 
 import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.system")
 import("xim.libxpkg.xvm")
+import("xim.pkgindex.sysroot")
 
 function install()
     local dir = pkginfo.install_dir()
@@ -41,6 +43,8 @@ function install()
 end
 
 function config()
+    local binding = package.name .. "@" .. pkginfo.version()
+
     xvm.add(package.name)
     return true
 end


### PR DESCRIPTION
The graphics stack shipped in #498/#499 made `usr/include` a symlink into one package's payload — the last install won and took glibc's headers with it. Neither non-recursive sysroot helper can express a namespace eight packages contribute to, so this adds a recursive, leaf-level declaration, plus `declare_libs` so a subos can *link* against the stack and not only run it.

`glibc` returns to an exact pin: released clients compare a dep's version half by string equality, so a range silently dropped glibc's exports and elfpatch patched nothing — the failure surfaced as EGL having no vendor. Fixed properly in xlings 2026.8.5.2; the pin keeps this working on clients already out.

Verified on a fresh home with no environment handed in — S0 asserts the container's variables came from mesa's own `subos.env{}` — S1–S4 PASS with no /usr present, `GL_RENDERER=llvmpipe (LLVM 20.1.7)`. Also verified against the released 2026.8.5.1 binary.