### PR TITLE
feat(graphics): nvidia-gl-host-link — the one host dependency, wired properly

### DIFF
--- a/.agents/tools/graphics/nvprobe.c
+++ b/.agents/tools/graphics/nvprobe.c
@@ -1,0 +1,108 @@
+// nvprobe — the same proof as glprobe, for the NVIDIA proprietary vendor.
+//
+// glprobe reaches a display through EGL_PLATFORM_SURFACELESS_MESA, which is a
+// mesa extension: NVIDIA does not advertise it, so glprobe on an NVIDIA-only
+// stack fails at the first step and says nothing about whether the vendor
+// works. NVIDIA's headless path is EGL_EXT_platform_device — enumerate the
+// EGL devices, take one, render into a pbuffer.
+//
+// Prints one KEY=VALUE per line, same contract as glprobe:
+//   EGL_DEVICE_COUNT / GL_VENDOR / GL_RENDERER / GL_VERSION
+//   PIXEL=RRGGBB
+//   RESULT=ok|fail:<why>
+//
+// A pass here means the host's NVIDIA userspace was reached THROUGH the
+// sentinel's symlinks and our libglvnd, with no host library search path — the
+// one dependency §6 of the design keeps, wired the way the design says.
+#include <EGL/egl.h>
+#include <EGL/eglext.h>
+#include <GL/gl.h>
+#include <stdio.h>
+#include <string.h>
+
+#define W 64
+#define H 64
+#define MAX_DEVICES 16
+
+static int fail(const char *why) {
+    printf("RESULT=fail:%s\n", why);
+    return 1;
+}
+
+int main(void) {
+    PFNEGLQUERYDEVICESEXTPROC queryDevices =
+        (PFNEGLQUERYDEVICESEXTPROC)eglGetProcAddress("eglQueryDevicesEXT");
+    PFNEGLGETPLATFORMDISPLAYEXTPROC getPlatformDisplay =
+        (PFNEGLGETPLATFORMDISPLAYEXTPROC)eglGetProcAddress("eglGetPlatformDisplayEXT");
+    if (!queryDevices || !getPlatformDisplay)
+        return fail("no-EGL_EXT_platform_device");
+
+    EGLDeviceEXT devices[MAX_DEVICES];
+    EGLint numDevices = 0;
+    if (!queryDevices(MAX_DEVICES, devices, &numDevices) || numDevices < 1)
+        return fail("no-egl-devices");
+    printf("EGL_DEVICE_COUNT=%d\n", numDevices);
+
+    // Every device, not just the first: on a machine with both an NVIDIA GPU
+    // and mesa's software device, the order is not ours to choose, and taking
+    // devices[0] would make the result depend on it. We want the NVIDIA one if
+    // it is there at all, so keep going until a device gives a renderer.
+    EGLDisplay dpy = EGL_NO_DISPLAY;
+    EGLint major = 0, minor = 0;
+    int chosen = -1;
+    for (EGLint i = 0; i < numDevices; i++) {
+        EGLDisplay d = getPlatformDisplay(EGL_PLATFORM_DEVICE_EXT, devices[i], NULL);
+        if (d == EGL_NO_DISPLAY) continue;
+        if (!eglInitialize(d, &major, &minor)) continue;
+        const char *vendor = eglQueryString(d, EGL_VENDOR);
+        if (vendor && strstr(vendor, "NVIDIA")) { dpy = d; chosen = i; break; }
+        if (dpy == EGL_NO_DISPLAY) { dpy = d; chosen = i; }  // keep as fallback
+    }
+    if (dpy == EGL_NO_DISPLAY) return fail("no-device-initialized");
+    printf("EGL_DEVICE_INDEX=%d\n", chosen);
+    printf("EGL_VERSION=%d.%d\n", major, minor);
+    printf("EGL_VENDOR=%s\n", eglQueryString(dpy, EGL_VENDOR));
+
+    if (!eglBindAPI(EGL_OPENGL_API)) return fail("eglBindAPI");
+
+    const EGLint cfgAttr[] = {
+        EGL_SURFACE_TYPE,    EGL_PBUFFER_BIT,
+        EGL_RENDERABLE_TYPE, EGL_OPENGL_BIT,
+        EGL_RED_SIZE, 8, EGL_GREEN_SIZE, 8, EGL_BLUE_SIZE, 8,
+        EGL_NONE
+    };
+    EGLConfig cfg; EGLint n = 0;
+    if (!eglChooseConfig(dpy, cfgAttr, &cfg, 1, &n) || n < 1)
+        return fail("eglChooseConfig");
+
+    EGLContext ctx = eglCreateContext(dpy, cfg, EGL_NO_CONTEXT, NULL);
+    if (ctx == EGL_NO_CONTEXT) return fail("eglCreateContext");
+
+    const EGLint pbAttr[] = { EGL_WIDTH, W, EGL_HEIGHT, H, EGL_NONE };
+    EGLSurface surf = eglCreatePbufferSurface(dpy, cfg, pbAttr);
+    if (surf == EGL_NO_SURFACE) return fail("eglCreatePbufferSurface");
+
+    if (!eglMakeCurrent(dpy, surf, surf, ctx)) return fail("eglMakeCurrent");
+
+    const char *vendor   = (const char *)glGetString(GL_VENDOR);
+    const char *renderer = (const char *)glGetString(GL_RENDERER);
+    const char *version  = (const char *)glGetString(GL_VERSION);
+    printf("GL_VENDOR=%s\n",   vendor   ? vendor   : "?");
+    printf("GL_RENDERER=%s\n", renderer ? renderer : "?");
+    printf("GL_VERSION=%s\n",  version  ? version  : "?");
+
+    glClearColor(0.2f, 0.4f, 0.6f, 1.0f);
+    glClear(GL_COLOR_BUFFER_BIT);
+    glFinish();
+
+    unsigned char px[4] = {0, 0, 0, 0};
+    glReadPixels(W / 2, H / 2, 1, 1, GL_RGBA, GL_UNSIGNED_BYTE, px);
+    printf("PIXEL=%02X%02X%02X\n", px[0], px[1], px[2]);
+
+    if (px[0] < 49 || px[0] > 53 || px[1] < 100 || px[1] > 104 ||
+        px[2] < 151 || px[2] > 155) {
+        return fail("pixel-mismatch");
+    }
+    printf("RESULT=ok\n");
+    return 0;
+}

--- a/.github/scripts/posix-test.sh
+++ b/.github/scripts/posix-test.sh
@@ -119,6 +119,26 @@ skipped=0
 # with "package 'scode:linux-headers@<ver>' not found". Best-effort.
 "$XLINGS_CMD" config --index-repo "scode:https://github.com/openxlings/xim-pkgindex-scode.git" 2>/dev/null || true
 
+# Put this repo's libs/ where a locally-registered recipe can import it.
+#
+# `config --add-xpkg` copies the recipe into the LOCAL index, and
+# `import("xim.pkgindex.sysroot")` resolves against the index the recipe came
+# from. The local index has no libs/, so the import falls through to the
+# unknown-module stub — whose every field is a truthy callable that returns
+# another stub. So every sysroot call in a recipe under test succeeded and did
+# nothing, and the branch guarded by `if not sysroot.declare_headers_tree(...)`
+# never took its fallback either.
+#
+# This is why a change that replaced the whole subos sysroot with a symlink
+# into one package's payload passed install-test green: the code that would
+# have done it was inert here, and only ran once published. A test that cannot
+# execute the thing it is testing reports on nothing.
+if [[ -d "$WORKSPACE_ROOT/libs" ]]; then
+    mkdir -p "$XLINGS_HOME_DIR/data/xim-pkgindex-local/libs"
+    cp "$WORKSPACE_ROOT/libs/"*.lua \
+       "$XLINGS_HOME_DIR/data/xim-pkgindex-local/libs/" 2>/dev/null || true
+fi
+
 # Register every changed descriptor BEFORE testing any of them.
 #
 # The loop below registers each package immediately before installing it, which

--- a/pkgs/m/mesa.lua
+++ b/pkgs/m/mesa.lua
@@ -143,9 +143,22 @@ function config()
     -- permissive proxy whose every key is truthy, so `if subos.env then` is
     -- true on clients that would accept the call and discard it.
     if type(subos.env) == "function" then
-        subos.env{ var = "LIBGL_DRIVERS_PATH", op = "set",
+        -- prepend, not set, for both of these: they are colon-separated
+        -- LISTS, and mesa is not the only thing entitled to be on them.
+        -- `nvidia-gl-host-link` contributes an EGL vendor directory for the
+        -- host's proprietary driver, and glvnd is built to see several
+        -- vendors at once and pick per display -- that is what
+        -- vendor-neutral dispatch is.
+        --
+        -- A `set` here does not merely lose that, it silently discards it:
+        -- xlings resolves a variable declared `set` by one provider and
+        -- `prepend` by another in favour of the `set`, so mesa would erase
+        -- NVIDIA's entry and the machine with the GPU would quietly render
+        -- through llvmpipe. Both operations still preserve a value the user
+        -- exported themselves, so nothing is given up by using prepend.
+        subos.env{ var = "LIBGL_DRIVERS_PATH", op = "prepend",
                    value = "${pkgdir}/lib/dri", binding = tag }
-        subos.env{ var = "__EGL_VENDOR_LIBRARY_DIRS", op = "set",
+        subos.env{ var = "__EGL_VENDOR_LIBRARY_DIRS", op = "prepend",
                    value = "${pkgdir}/share/glvnd/egl_vendor.d", binding = tag }
         subos.env{ var = "XDG_DATA_DIRS", op = "prepend",
                    value = "${pkgdir}/share", binding = tag }

--- a/pkgs/n/nvidia-gl-host-link.lua
+++ b/pkgs/n/nvidia-gl-host-link.lua
@@ -1,0 +1,293 @@
+package = {
+    spec = "2",
+
+    homepage = "https://www.nvidia.com/en-us/drivers/",
+    name = "nvidia-gl-host-link",
+    description = "Sentinel: stable symlinks to the host's NVIDIA proprietary GL/EGL userspace",
+
+    authors = {"xlings contributors"},
+    -- The recipe. The libraries it links to are NVIDIA's and are neither
+    -- copied nor redistributed by this package — see below.
+    licenses = {"Apache-2.0"},
+    repo = "https://github.com/openxlings/xim-pkgindex",
+
+    type = "package",
+    archs = {"x86_64"},
+    status = "stable",
+    categories = {"graphics", "gpu", "nvidia", "lib"},
+    keywords = {"nvidia", "opengl", "egl", "glx", "host-link", "sentinel"},
+
+    -- ─────────────────────────────────────────────────────────────────────
+    -- The one userspace dependency the graphics stack keeps on the host.
+    --
+    -- Everything else in the stack is ours: mesa, libglvnd, the X11 client
+    -- libraries, LLVM. This is the exception, and it is an exception for two
+    -- reasons that no amount of packaging removes:
+    --
+    --   * The NVIDIA proprietary GL userspace is in lockstep with the kernel
+    --     module. libGLX_nvidia 550.144.03 talks to nvidia.ko 550.144.03 and
+    --     to nothing else. We do not own the kernel module, so we cannot own
+    --     the userspace half either.
+    --   * The NVIDIA driver EULA does not permit redistribution.
+    --
+    -- Design: xlings/.agents/docs/2026-08-05-graphics-stack-ecosystem-closure.md §6
+    --
+    -- WHAT THIS DOES
+    --   Symlinks the host's NVIDIA userspace into <install_dir>/lib, and
+    --   writes a glvnd vendor JSON pointing at that symlink.
+    --
+    -- WHAT IT DOES NOT DO
+    --   Copy or redistribute any NVIDIA library. Every file it creates is a
+    --   symlink to a file the host's own driver package installed.
+    --
+    -- WHY LINK THE WHOLE SET AND NOT JUST THE TWO VENDOR LIBRARIES
+    --   libGLX_nvidia.so.0's DT_NEEDED reads, verbatim:
+    --     libnvidia-glsi.so.550.144.03  libnvidia-tls.so.550.144.03
+    --     libnvidia-glcore.so.550.144.03  libX11.so.6  libXext.so.6
+    --   The private halves carry the driver version IN THE SONAME, so only a
+    --   symlink of exactly that name resolves them. Linking the two vendor
+    --   entry points alone produces a library that loads on the host (ld.so
+    --   cache) and fails in a subos, which is the difference this package
+    --   exists to erase. libX11/libXext are the two it needs from us, and
+    --   they are declared as deps below.
+    --
+    -- WHEN THE HOST HAS NO NVIDIA DRIVER
+    --   install() succeeds and links nothing. That is deliberate: this is a
+    --   sentinel, and "no NVIDIA on this machine" is a normal state, not a
+    --   failure. mesa's llvmpipe still renders, which is what glvnd falls
+    --   back to when no NVIDIA vendor JSON is present.
+    xpm = {
+        linux = {
+            -- What the host's vendor libraries link against and we supply:
+            -- libX11/libXext by DT_NEEDED, glibc for libc/libpthread/libdl,
+            -- and libglvnd because it is what dispatches to a vendor at all.
+            -- install() links each of these into this package's own lib dir,
+            -- so declaring them is not decoration — it is where they come
+            -- from. glibc is pinned for the reason mesa's is; see that recipe.
+            deps = {
+                "xim:libglvnd@>=1.7",
+                "xim:libX11@>=1.8",
+                "xim:libXext@>=1.3",
+                "xim:glibc@2.39",
+            },
+            exports = {
+                runtime = { libdirs = { "lib" } },
+            },
+            ["latest"] = { ref = "0.1.0" },
+            -- No payload: everything this package installs is a symlink it
+            -- creates at install time from what it finds on the host. The
+            -- version is the recipe's, not the driver's — the driver version
+            -- is whatever the host has, and pinning it here would make the
+            -- package wrong on every machine but one.
+            ["0.1.0"] = { },
+        },
+    },
+}
+
+import("xim.libxpkg.log")
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.system")
+import("xim.libxpkg.xvm")
+import("xim.libxpkg.subos")
+import("xim.pkgindex.sysroot")
+
+-- Where the host keeps its NVIDIA userspace.
+--
+-- Located by finding libGLX_nvidia.so.0 rather than by guessing a distro
+-- layout: the two vendor entry points and their private dependencies are
+-- always installed together in one directory, so one hit fixes the rest.
+local function __probe_nvidia_dir()
+    -- ldconfig first — it is the answer on any distro whose driver package
+    -- registered itself, which is all of them when installed normally.
+    local out = try {
+        function() return os.iorun("ldconfig -p 2>/dev/null") end
+    }
+    if out and out ~= "" then
+        for line in out:gmatch("[^\n]+") do
+            if line:find("libGLX_nvidia.so.0", 1, true)
+               and line:find("x86-64", 1, true) then
+                local p = line:match("=>%s*(/%S+)")
+                if p and os.isfile(p) then return path.directory(p) end
+            end
+        end
+    end
+    -- Containers with no populated ld.so.cache, and non-FHS hosts.
+    for _, d in ipairs({
+        "/usr/lib/x86_64-linux-gnu",
+        "/usr/lib64",
+        "/usr/lib",
+    }) do
+        if os.isfile(path.join(d, "libGLX_nvidia.so.0")) then return d end
+    end
+    return nil
+end
+
+-- Every NVIDIA userspace file in DIR, by name.
+--
+-- Enumerated rather than listed: the private libraries are named after the
+-- driver version, so a fixed list would be a list of one driver release. The
+-- prefixes are the stable part.
+local function __nvidia_entries(dir)
+    local names = {}
+    local f = io.popen(string.format([[ls -1 "%s" 2>/dev/null]], dir))
+    if not f then return names end
+    for line in f:lines() do
+        local name = line:gsub("[\r\n]+$", "")
+        if name ~= "" and (name:find("^libnvidia%-")
+                        or name:find("^libGLX_nvidia%.")
+                        or name:find("^libEGL_nvidia%.")
+                        or name:find("^libGLESv1_CM_nvidia%.")
+                        or name:find("^libGLESv2_nvidia%.")) then
+            table.insert(names, name)
+        end
+    end
+    f:close()
+    return names
+end
+
+function install()
+    local dir = pkginfo.install_dir()
+    os.tryrm(dir)
+    os.mkdir(path.join(dir, "lib"))
+
+    local nvdir = __probe_nvidia_dir()
+    if not nvdir then
+        log.warn("no NVIDIA driver userspace on this host.")
+        log.warn("  GL programs will render through mesa (llvmpipe or an")
+        log.warn("  open driver). Install the NVIDIA driver with your distro")
+        log.warn("  package manager and reinstall this package to use it.")
+        return true
+    end
+
+    local linked = 0
+    for _, name in ipairs(__nvidia_entries(nvdir)) do
+        system.exec(string.format([[ln -sf "%s" "%s"]],
+            path.join(nvdir, name), path.join(dir, "lib", name)))
+        linked = linked + 1
+    end
+
+    -- Complete the directory with what the vendor needs from OUR packages.
+    --
+    -- glvnd dlopens libEGL_nvidia by absolute path. Its dependencies are then
+    -- searched against the process's paths — and the vendor is the host's
+    -- file, so we cannot patch an RPATH into it the way every other library
+    -- in this stack gets one. It needs a search path, and the question is
+    -- which directory that path should name.
+    --
+    -- This one, not `<subos>/lib`. Everything else in the stack resolves
+    -- through payload directories, which the dependency graph pins; the subos
+    -- lib directory holds whatever happens to be installed in the subos the
+    -- user is standing in. Installing this package into a subos without
+    -- libX11 would leave `<subos>/lib` quietly short of it, and the failure
+    -- would be the vendor not loading, three layers from the cause.
+    --
+    -- So the payload becomes self-sufficient: the host's NVIDIA userspace
+    -- plus links to the exact libraries it needs from our packages. Names
+    -- already linked above are never overwritten — NVIDIA's own copy of a
+    -- name wins over ours, which is what the driver expects.
+    for _, dep in ipairs({
+        {"glibc",    {"libc.so.6", "libpthread.so.0", "libdl.so.2",
+                      "libm.so.6", "librt.so.1"}},
+        {"libX11",   {"libX11.so.6", "libX11-xcb.so.1"}},
+        {"libXext",  {"libXext.so.6"}},
+        {"libglvnd", {"libGLdispatch.so.0"}},
+        -- libX11's own dependencies, and they have to be here too.
+        -- DT_RUNPATH is not transitive: once libX11 is found through
+        -- LD_LIBRARY_PATH, ITS libxcb is searched against the same path
+        -- rather than against the RUNPATH of whoever loaded it. A directory
+        -- that stops one level short resolves the rest from the host, which
+        -- is the leak this whole stack exists to close — and it does it
+        -- silently, because a host that has libxcb makes it look like it
+        -- worked.
+        {"libxcb",   {"libxcb.so.1"}},
+        {"libXau",   {"libXau.so.6"}},
+        {"libXdmcp", {"libXdmcp.so.6"}},
+    }) do
+        local depdir = pkginfo.dep_install_dir(dep[1])
+        if depdir then
+            for _, name in ipairs(dep[2]) do
+                local link = path.join(dir, "lib", name)
+                if not os.isfile(link) then
+                    -- glibc keeps its shared objects in lib64 on x86_64 and
+                    -- everything else in lib; try both rather than encode a
+                    -- layout that is true of one package.
+                    for _, sub in ipairs({"lib", "lib64"}) do
+                        local src = path.join(depdir, sub, name)
+                        if os.isfile(src) then
+                            system.exec(string.format([[ln -sf "%s" "%s"]],
+                                src, link))
+                            linked = linked + 1
+                            break
+                        end
+                    end
+                end
+            end
+        end
+    end
+
+    -- The glvnd vendor JSON, written rather than linked.
+    --
+    -- The host's own 10_nvidia.json says `"library_path": "libEGL_nvidia.so.0"`
+    -- — a bare SONAME, which is correct on a host with an ld.so cache and
+    -- wrong in a subos, where it would either fail to resolve or resolve
+    -- against something else. Same rewrite mesa does to its 50_mesa.json, and
+    -- for the same reason: a bare name here is a way for the host's stack to
+    -- get back in through the door we closed.
+    local egldir = path.join(dir, "share", "glvnd", "egl_vendor.d")
+    os.mkdir(egldir)
+    io.writefile(path.join(egldir, "10_nvidia.json"), string.format([[{
+    "file_format_version" : "1.0.0",
+    "ICD" : {
+        "library_path" : "%s"
+    }
+}
+]], path.join(dir, "lib", "libEGL_nvidia.so.0")))
+
+    log.info("nvidia-gl-host-link → %s (%d libraries) ✓", nvdir, linked)
+    return true
+end
+
+function config()
+    local dir = pkginfo.install_dir()
+    local tag = package.name .. "@" .. pkginfo.version()
+
+    xvm.add(package.name)
+
+    -- Into `<subos>/lib` like every other library in the stack. Symlinking
+    -- them under the payload is not enough: glvnd dlopens the vendor by
+    -- absolute path, and the vendor's own dependencies are then searched
+    -- against the process's paths, not the payload's. Without this the
+    -- vendor fails to load on `libpthread.so.0` — which our glibc provides
+    -- and the subos lib directory is where it lives.
+    sysroot.declare_libs(dir, "lib", tag, pkginfo.version())
+
+    if type(subos.env) == "function" then
+        -- prepend, where mesa's declaration for the same variable is `set`.
+        -- Both vendors have to be visible at once: glvnd picks per display,
+        -- so a machine with an NVIDIA GPU and a software fallback needs both
+        -- directories on the list. A second `set` would collide with mesa's
+        -- and one of the two would lose.
+        subos.env{ var = "__EGL_VENDOR_LIBRARY_DIRS", op = "prepend",
+                   value = "${pkgdir}/share/glvnd/egl_vendor.d",
+                   binding = tag }
+
+        -- The one place in this stack that needs a library SEARCH PATH
+        -- rather than an RPATH, for the same reason this is a sentinel at
+        -- all: the vendor is the host's file, and a file we do not own is a
+        -- file we cannot patch. install() made this directory sufficient on
+        -- its own, so the path names it and not `<subos>/lib` — a payload
+        -- directory is pinned by the dependency graph, where the subos lib
+        -- directory holds whatever that subos happens to contain.
+        --
+        -- Scoped to this package: uninstalling it takes the declaration
+        -- with it, and a subos with no NVIDIA in it never gets one.
+        subos.env{ var = "LD_LIBRARY_PATH", op = "prepend",
+                   value = "${pkgdir}/lib", binding = tag }
+    end
+    return true
+end
+
+function uninstall()
+    xvm.remove(package.name)
+    return true
+end


### PR DESCRIPTION
The NVIDIA proprietary GL userspace is the single piece of this stack that cannot be ours (kernel-module lockstep, no redistribution). Borrowed the way `libcuda-host-link` borrows libcuda: symlinks, never copies.

What took getting right: the private halves carry the driver version in the SONAME, so the whole set has to be linked; the vendor JSON's bare SONAME is a door back to the host stack and gets rewritten; and because glvnd dlopens the vendor by absolute path and the vendor is a file we cannot patch, it needs a search path — pointed at this package's own lib directory, which `install()` completes with the transitive closure it needs from our packages. DT_RUNPATH is not transitive, so stopping one level short means libX11 quietly resolves its libxcb from the host.

mesa's env declarations become `prepend`: they are lists, and a `set` silently discards NVIDIA's vendor entry.

**CI fix worth reading on its own**: `--add-xpkg` registers into the local index, which had no `libs/`, so `import("xim.pkgindex.sysroot")` fell through to the truthy-callable stub and *every sysroot call in a recipe under test did nothing*. That is why #499 replaced the whole subos sysroot with a symlink and passed green.

Verified on an RTX 4080 / 550.144.03: `GL_RENDERER=NVIDIA GeForce RTX 4080/PCIe/SSE2`, and llvmpipe still passes S1–S4 with no /usr present.
