### PR TITLE
feat(graphics): Wayland, Vulkan and the hardware drivers

### DIFF
--- a/.agents/tools/graphics/build-in-subos.sh
+++ b/.agents/tools/graphics/build-in-subos.sh
@@ -24,7 +24,7 @@
 # Usage:
 #   build-in-subos.sh --name libXau --version 1.0.11 \
 #       --url https://.../libXau-1.0.11.tar.xz \
-#       [--system autotools|meson] [--deps 'xorgproto libX11'] \
+#       [--system autotools|meson|cmake] [--deps 'xorgproto libX11'] \
 #       [-- <extra configure/meson args>]
 set -uo pipefail
 
@@ -41,7 +41,7 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 [[ -n "$NAME" && -n "$VERSION" && -n "$URL" ]] || {
-    echo "usage: $0 --name N --version V --url U [--system auto|autotools|meson] [--deps '...'] [-- args]" >&2
+    echo "usage: $0 --name N --version V --url U [--system auto|autotools|meson|cmake] [--deps '...'] [-- args]" >&2
     exit 2
 }
 
@@ -89,7 +89,11 @@ tar xf "$TARBALL" -C "$BUILDDIR" --strip-components=1 || fail "extract failed"
 # Everything the build needs is installed INTO this subos with
 # `xlings install`; putting its bin first is what makes those installs the
 # ones that get found.
-export PATH="$SUBOS/bin:$PATH"
+# `usr/bin` as well as `bin`: `bin` holds the shims xlings installed, and
+# `usr/bin` is where a package THIS SCRIPT built puts its tools. mesa looks up
+# `glslangValidator` by name, and glslang is one of ours — without this it is
+# reported missing while sitting two directories away.
+export PATH="$SUBOS/bin:$SUBOS/usr/bin:$PATH"
 
 PREFIX=/usr
 # Both spellings: a payload uses a flat lib/, but a package that ignores
@@ -108,9 +112,138 @@ export CC="$SUBOS/bin/gcc"
 export CXX="$SUBOS/bin/g++"
 [[ -x "$CC" ]] || fail "no gcc in the subos — xlings install gcc"
 
+# So the binaries the BUILD runs can actually run.
+#
+# wayland builds `wayland-scanner` and then executes it to generate its own
+# protocol sources. `-Wl,-rpath,$ORIGIN` is right for a payload and useless for
+# a tool being run out of a build directory, so the scanner dies on
+# `libexpat.so.1: cannot open shared object file` with the library sitting in
+# the sysroot.
+#
+# An rpath and NOT LD_LIBRARY_PATH, which was tried first and is a trap:
+# LD_LIBRARY_PATH applies to every process the build starts, including meson
+# and python, which are elfpatched to a particular glibc. A second libc ahead
+# of theirs segfaults them in the vDSO (`__vdso_time`) before they print
+# anything — which reads as a broken toolchain rather than as one env var.
+#
+# These subos paths do not ship: the staging pass below rewrites every ELF in
+# the payload back to $ORIGIN, and the leak check then fails the build if any
+# survived.
+GLIBC_LIB64="$(dirname "$(readlink -f "$SUBOS/lib/libc.so.6" 2>/dev/null)" 2>/dev/null)"
+# --disable-new-dtags: emit DT_RPATH, which is TRANSITIVE, rather than
+# DT_RUNPATH, which is not.
+#
+# That distinction is the whole problem here. A build-time tool needs not only
+# its own libraries but its libraries' libraries — wayland-scanner links
+# libxml2, libxml2 needs libm — and DT_RUNPATH is consulted only for an
+# object's direct dependencies. libm was therefore looked up with no path at
+# all and fell through to ld.so's built-in default, which for the published
+# glibc is the prefix of the machine that built it. The error names libm and
+# the fix is one link flag.
+#
+# Only build-tree binaries keep this: the staging pass rewrites every ELF in
+# the payload to $ORIGIN before it ships.
+LDFLAGS="$LDFLAGS -Wl,--disable-new-dtags -Wl,-rpath,$SUBOS/usr/lib -Wl,-rpath,$SUBOS/lib"
+[[ -n "$GLIBC_LIB64" ]] && LDFLAGS="$LDFLAGS -Wl,-rpath,$GLIBC_LIB64"
+
+# And the loader needs to be told where libc's siblings are.
+#
+# `ld.so` carries a built-in default search path — glibc's configure prefix,
+# which for the published package is the path on the machine that BUILT it
+# (`/home/xlings/.xlings_data/...`). Nothing on any other machine is there, so
+# a freshly linked tool dies on `libm.so.6: cannot open shared object file`
+# while `objdump -p` shows a RUNPATH that plainly contains it. Everything else
+# works because xlings's elfpatch writes explicit RUNPATHs at install time, and
+# a binary in a build directory has not been through that.
+#
+# glibc's OWN lib64 and nothing else. `<subos>/lib` was tried and segfaults
+# meson in the vDSO: it is a symlink farm holding gcc's runtime beside glibc's,
+# and putting that ahead of an elfpatched python's own libraries is a libc/
+# libstdc++ mismatch. This directory is the same glibc the toolchain already
+# runs on, so nothing changes for the tools and the loader gains the one path
+# it was missing.
+# Scoped to the compile/install step (see BUILD_ENV below), never exported for
+# the whole script: meson and ninja are shims into the xlings binary, and any
+# libc ahead of the one THEY were elfpatched against segfaults them in the vDSO
+# before they print a word. Configure runs clean; only the tools this build
+# produces need the extra path.
+BUILD_ENV=()
+
+# --deps: xlings packages whose payload is a build dependency but which do not
+# stage themselves into the subos sysroot.
+#
+# Most of this stack does stage itself, because these recipes declare headers
+# and libraries. Packages predating those declarations — libxml2 is the one
+# this stack needs — install a payload and put nothing in `<subos>/usr`, so
+# wayland's `Dependency "libxml-2.0" not found` is true of the sysroot and
+# false of the machine.
+#
+# Adding the payload directly is not a hole in the isolation: the whole point
+# of PKG_CONFIG_LIBDIR pointing only at the subos is to keep the HOST out, and
+# a path under `data/xpkgs/` is as much ours as the sysroot is. What it must
+# not become is a wildcard over everything installed — each package is named
+# here, so a dependency that is not declared still fails loudly.
+for dep in $DEPS; do
+    depdir="$(ls -d "$XHOME"/data/xpkgs/*-"$dep"/*/ 2>/dev/null | head -1)"
+    if [[ -z "$depdir" ]]; then
+        fail "--deps $dep: not installed in $XHOME (xlings install $dep)"
+    fi
+    log "  dep $dep -> ${depdir#"$XHOME"/data/xpkgs/}"
+    if [[ -d "$depdir/lib/pkgconfig" ]]; then
+        # Rewrite `prefix=` into a scratch copy rather than use the payload's
+        # .pc as-is. libxml2's ships `prefix=/tmp/libxml2-install` — the
+        # directory it was built in, on a machine that no longer exists — so
+        # pkg-config answers with -I/tmp/libxml2-install/include/libxml2 and
+        # the compile fails on a header that is right there. Configure still
+        # SUCCEEDS, because pkg-config only reports what the file says; the
+        # failure lands one step later, at the first #include.
+        #
+        # The payload is not touched: it is shared between subos and read-only
+        # as far as a build is concerned.
+        pcdir="$WORK/pc/$dep"
+        mkdir -p "$pcdir"
+        for pc in "$depdir"/lib/pkgconfig/*.pc; do
+            [[ -e "$pc" ]] || continue
+            sed "s#^prefix=.*#prefix=${depdir%/}#" "$pc" > "$pcdir/$(basename "$pc")"
+        done
+        PKG_CONFIG_LIBDIR="$PKG_CONFIG_LIBDIR:$pcdir"
+    fi
+    [[ -d "$depdir/include" ]] && CPPFLAGS="$CPPFLAGS -I$depdir/include"
+    if [[ -d "$depdir/lib" ]]; then
+        # A staged copy with an RPATH, not the payload itself.
+        #
+        # DT_RUNPATH is NOT transitive. libxml2.so.2 needs libm, and the
+        # payload's copy carries no RUNPATH at all, so libm is looked up
+        # against libxml2's (empty) path and falls through to ld.so's built-in
+        # default — which for the published glibc is the prefix of the machine
+        # that built it, `/home/xlings/.xlings_data/...`. The tool then dies on
+        # `libm.so.6: cannot open shared object file` while its own RUNPATH
+        # plainly lists a directory containing it, because that RUNPATH was
+        # never going to be consulted for a dependency's dependency.
+        #
+        # LD_LIBRARY_PATH would fix it and cannot be used: the build's own
+        # tools (meson, ninja, python) are NOT elfpatched — python's INTERP is
+        # the host's /lib64/ld-linux — so any xlings libc ahead of theirs
+        # segfaults them in the vDSO before they print anything.
+        #
+        # So: copy, patch the copy, link against the copy. The payload is
+        # shared between subos and stays untouched.
+        deplib="$WORK/deplib/$dep"
+        rm -rf "$deplib"; mkdir -p "$deplib"
+        cp -a "$depdir"/lib/*.so* "$deplib/" 2>/dev/null || true
+        for so in "$deplib"/*.so*; do
+            [[ -f "$so" && ! -L "$so" ]] || continue
+            patchelf --set-rpath "\$ORIGIN${GLIBC_LIB64:+:$GLIBC_LIB64}" "$so" 2>/dev/null || true
+        done
+        LDFLAGS="$LDFLAGS -L$deplib -Wl,-rpath-link,$deplib -Wl,-rpath,$deplib"
+    fi
+done
+export PKG_CONFIG_LIBDIR PKG_CONFIG_PATH="$PKG_CONFIG_LIBDIR" CPPFLAGS LDFLAGS
+
 if [[ "$SYSTEM" == auto ]]; then
     if   [[ -f "$BUILDDIR/meson.build" ]]; then SYSTEM=meson
     elif [[ -f "$BUILDDIR/configure"   ]]; then SYSTEM=autotools
+    elif [[ -f "$BUILDDIR/CMakeLists.txt" ]]; then SYSTEM=cmake
     else fail "cannot tell the build system apart; pass --system"; fi
 fi
 log "building with $SYSTEM against subos '$SUBOS_NAME'"
@@ -125,19 +258,35 @@ case "$SYSTEM" in
         --disable-static --enable-shared \
         "${EXTRA[@]}" > "$WORK/$NAME-configure.log" 2>&1 \
         || { tail -30 "$WORK/$NAME-configure.log"; fail "configure"; }
-    make -j"$(nproc)"           > "$WORK/$NAME-build.log" 2>&1 \
+    "${BUILD_ENV[@]}" make -j"$(nproc)" > "$WORK/$NAME-build.log" 2>&1 \
         || { tail -30 "$WORK/$NAME-build.log"; fail "make"; }
-    make install DESTDIR="$STAGE" >> "$WORK/$NAME-build.log" 2>&1 \
+    "${BUILD_ENV[@]}" make install DESTDIR="$STAGE" >> "$WORK/$NAME-build.log" 2>&1 \
         || { tail -30 "$WORK/$NAME-build.log"; fail "make install"; }
     ;;
   meson)
     "$SUBOS/bin/meson" setup _b --prefix="$PREFIX" --libdir=lib \
         --buildtype=release -Ddefault_library=shared "${EXTRA[@]}" > "$WORK/$NAME-configure.log" 2>&1 \
         || { tail -30 "$WORK/$NAME-configure.log"; fail "meson setup"; }
-    "$SUBOS/bin/ninja" -C _b     > "$WORK/$NAME-build.log" 2>&1 \
+    "${BUILD_ENV[@]}" "$SUBOS/bin/ninja" -C _b > "$WORK/$NAME-build.log" 2>&1 \
         || { tail -30 "$WORK/$NAME-build.log"; fail "ninja"; }
     DESTDIR="$STAGE" "$SUBOS/bin/meson" install -C _b >> "$WORK/$NAME-build.log" 2>&1 \
         || { tail -30 "$WORK/$NAME-build.log"; fail "meson install"; }
+    ;;
+  cmake)
+    # Out-of-tree, and CMAKE_INSTALL_PREFIX=/usr with DESTDIR so the staged
+    # layout matches what the other two systems produce.
+    "$SUBOS/bin/cmake" -S . -B _b -G Ninja \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_INSTALL_PREFIX="$PREFIX" \
+        -DCMAKE_INSTALL_LIBDIR=lib \
+        -DBUILD_SHARED_LIBS=ON \
+        -DCMAKE_C_COMPILER="$CC" -DCMAKE_CXX_COMPILER="$CXX" \
+        "${EXTRA[@]}" > "$WORK/$NAME-configure.log" 2>&1 \
+        || { tail -30 "$WORK/$NAME-configure.log"; fail "cmake configure"; }
+    "${BUILD_ENV[@]}" "$SUBOS/bin/ninja" -C _b > "$WORK/$NAME-build.log" 2>&1 \
+        || { tail -30 "$WORK/$NAME-build.log"; fail "ninja"; }
+    DESTDIR="$STAGE" "$SUBOS/bin/cmake" --install _b >> "$WORK/$NAME-build.log" 2>&1 \
+        || { tail -30 "$WORK/$NAME-build.log"; fail "cmake install"; }
     ;;
   *) fail "unknown build system '$SYSTEM'" ;;
 esac
@@ -161,9 +310,21 @@ find "$PAYLOAD" -name '*.la' -type f -delete
 
 # $ORIGIN so the payload's own libraries resolve each other with no absolute
 # path anywhere. xlings's elfpatch appends each dependency's libdir on top.
+#
+# Every ELF, not just *.so*: a payload can ship executables (wayland's
+# `wayland-scanner`, and it is the one downstream packages run), and those were
+# linked with the build-time rpath above. Matching on the name missed them
+# entirely — both here and in the leak check below — so a subos path could ship
+# in a binary while every library came out clean.
+is_elf() { [[ "$(head -c4 "$1" 2>/dev/null)" == $'\x7fELF' ]]; }
 while IFS= read -r -d '' f; do
-    patchelf --set-rpath '$ORIGIN' "$f" 2>/dev/null || true
-done < <(find "$PAYLOAD" -type f -name '*.so*' ! -type l -print0)
+    is_elf "$f" || continue
+    case "${f#"$PAYLOAD"/}" in
+        # A binary looks for its libraries one level up, not beside itself.
+        bin/*) patchelf --set-rpath '$ORIGIN/../lib:$ORIGIN' "$f" 2>/dev/null || true ;;
+        *)     patchelf --set-rpath '$ORIGIN' "$f" 2>/dev/null || true ;;
+    esac
+done < <(find "$PAYLOAD" -type f ! -type l -print0)
 
 # ── the check that makes this worth scripting ───────────────────────────
 leaks=0
@@ -171,12 +332,13 @@ report_leak() { echo "    $*"; leaks=$((leaks+1)); }
 
 log "checking for host leakage"
 while IFS= read -r -d '' f; do
+    is_elf "$f" || continue
     rp="$(patchelf --print-rpath "$f" 2>/dev/null || true)"
     case "$rp" in
         ''|'$ORIGIN'*) ;;
         *) report_leak "RPATH names a path outside the payload: ${f#$PAYLOAD/} → $rp" ;;
     esac
-done < <(find "$PAYLOAD" -type f -name '*.so*' ! -type l -print0)
+done < <(find "$PAYLOAD" -type f ! -type l -print0)
 
 # .pc / .la / *-config files carry absolute paths that later builds consume.
 # A host prefix in one of these does not break anything now — it breaks the
@@ -212,6 +374,27 @@ sha256sum "$OUT" | sed 's/^/[gfx-build] sha256: /'
 if [[ "${XLINGS_GFX_STAGE:-1}" == "1" ]]; then
     mkdir -p "$SUBOS/usr"
     cp -a "$PAYLOAD/." "$SUBOS/usr/"
+
+    # The copy that goes into the SUBOS gets subos paths, not the payload's
+    # $ORIGIN. These two copies are the same files with different jobs: the
+    # payload ships and is relocated by xlings's elfpatch at install time,
+    # while this one is run right here, by the next package's build, with
+    # nothing to relocate it.
+    #
+    # wayland is the case that needs it: wayland-protocols invokes the
+    # installed `wayland-scanner`, whose payload RPATH of `$ORIGIN/../lib`
+    # points at `<subos>/usr/lib`, and libexpat lives in `<subos>/lib`. The
+    # error names libexpat and looks like a missing package.
+    while IFS= read -r -d '' f; do
+        is_elf "$f" || continue
+        # --force-rpath: DT_RPATH, which is transitive. Without it patchelf
+        # writes DT_RUNPATH and the scanner finds libxml2 but not libxml2's
+        # libm — the same non-transitivity that the link flag above works
+        # around, arriving a second time through a different door.
+        patchelf --force-rpath --set-rpath \
+            "$SUBOS/usr/lib:$SUBOS/lib${GLIBC_LIB64:+:$GLIBC_LIB64}" \
+            "$f" 2>/dev/null || true
+    done < <(find "$SUBOS/usr/bin" -type f ! -type l -print0 2>/dev/null)
 
     # The payload's own .pc files say prefix=/usr, and they have to: that is
     # what makes the tarball relocatable into whatever subos installs it. But

--- a/.agents/tools/graphics/gen-recipes.py
+++ b/.agents/tools/graphics/gen-recipes.py
@@ -80,7 +80,17 @@ SPEC = {
     "libXi":        (["xim:libXext@>=1.3", "xim:libXfixes@>=6.0"], True, None),
     "libXcursor":   (["xim:libXrender@>=0.9", "xim:libXfixes@>=6.0"], True, None),
 
+    # T3 — Wayland. mesa's second window-system platform; nothing in the X11
+    # path needs these, and a Wayland client needs all three.
+    "wayland":      (["xim:libffi@>=3.4", GLIBC], True, None),
+    "wayland-protocols": ([], False, None),
+    "libxkbcommon": ([], True, None),
+
     # T4 — the graphics core.
+    # Build-time only for mesa, but a package all the same: `glslangValidator`
+    # has to be findable by name, and elfutils' libelf is linked by radeonsi.
+    "glslang":      (["xim:gcc-runtime@>=15", GLIBC], True, None),
+    "elfutils":     (["xim:zlib@>=1.2", GLIBC], True, None),
     "libglvnd":     (["xim:libX11@>=1.8", "xim:libXext@>=1.3"], True, None),
     "libllvm":      (["xim:gcc-runtime@>=15", GLIBC], True, None),
 }
@@ -104,6 +114,11 @@ MESA_DEPS = [
 ]
 
 DESCRIPTIONS = {
+    "wayland": "Wayland protocol library and scanner",
+    "wayland-protocols": "Wayland protocol extension definitions (build-time)",
+    "libxkbcommon": "Keymap handling library for Wayland and X11 clients",
+    "glslang": "Khronos reference GLSL/ESSL front end and validator (build-time)",
+    "elfutils": "ELF object file access library — libelf, for radeonsi",
     "xorgproto": "X Window System protocol headers (build-time)",
     "xcb-proto": "XML-XCB protocol descriptions (build-time)",
     "xtrans": "X transport layer macros and headers (build-time)",
@@ -204,11 +219,22 @@ end
 # `SPDX-License-Identifier: MIT` in its own meson.build.
 LICENSES = {
     "libllvm": '"Apache-2.0 WITH LLVM-exception"',
+    # wayland and libxkbcommon are MIT (the default below). glslang carries a
+    # mix that SPDX expresses as a disjunction of the three its files declare;
+    # elfutils is GPL-3.0-or-later overall, and libelf specifically is
+    # LGPL-3.0-or-later — both are stated because the payload contains both.
+    "glslang":  '"BSD-3-Clause", "Apache-2.0", "MIT"',
+    "elfutils": '"GPL-3.0-or-later", "LGPL-3.0-or-later"',
 }
 DEFAULT_LICENSE = '"MIT"'
 
 
 HOMEPAGES = {
+    "wayland": "https://wayland.freedesktop.org",
+    "wayland-protocols": "https://wayland.freedesktop.org",
+    "libxkbcommon": "https://xkbcommon.org",
+    "glslang": "https://github.com/KhronosGroup/glslang",
+    "elfutils": "https://sourceware.org/elfutils/",
     "libdrm": "https://dri.freedesktop.org/",
     "libglvnd": "https://gitlab.freedesktop.org/glvnd/libglvnd",
     "libllvm": "https://llvm.org",
@@ -219,6 +245,11 @@ HOMEPAGES = {
 # under gitlab.freedesktop.org/xorg/{lib,proto}/<name>; pointing `repo` at
 # x.org sends anyone looking for the source to a landing page.
 REPOS = {
+    "wayland": "https://gitlab.freedesktop.org/wayland/wayland",
+    "wayland-protocols": "https://gitlab.freedesktop.org/wayland/wayland-protocols",
+    "libxkbcommon": "https://github.com/xkbcommon/libxkbcommon",
+    "glslang": "https://github.com/KhronosGroup/glslang",
+    "elfutils": "https://sourceware.org/git/elfutils.git",
     "libdrm":   "https://gitlab.freedesktop.org/mesa/drm",
     "libglvnd": "https://gitlab.freedesktop.org/glvnd/libglvnd",
     "libllvm":  "https://github.com/llvm/llvm-project",
@@ -231,11 +262,16 @@ _XORG_PROTO = ("xorgproto", "xcb-proto")
 # only run one — and headers reach the sysroot only if a recipe declares them.
 # glibc is the model: its headers are in the sysroot because glibc declares
 # them, and nothing else appears there by accident.
-HEADERS = {"libglvnd", "libdrm", "libX11", "libxcb", "libXext", "libXfixes",
+HEADERS = {"wayland", "libxkbcommon", "glslang", "elfutils", "libglvnd", "libdrm", "libX11", "libxcb", "libXext", "libXfixes",
            "libXrender", "libXrandr", "libXi", "libXcursor", "libXxf86vm",
            "libXau", "libXdmcp", "libpciaccess", "libxshmfence", "xorgproto"}
 
 AUTHORS = {
+    "wayland": '"Wayland contributors"',
+    "wayland-protocols": '"Wayland contributors"',
+    "libxkbcommon": '"xkbcommon contributors"',
+    "glslang": '"The Khronos Group Inc."',
+    "elfutils": '"Red Hat, Inc.", "elfutils contributors"',
     "libllvm":  '"LLVM Project"',
     "libglvnd": '"NVIDIA Corporation", "libglvnd contributors"',
     "libdrm":   '"Mesa contributors"',

--- a/.agents/tools/graphics/readme.py
+++ b/.agents/tools/graphics/readme.py
@@ -40,6 +40,11 @@ UPSTREAM = {
     "libglvnd":     "https://gitlab.freedesktop.org/glvnd/libglvnd/-/archive/v{v}/libglvnd-v{v}.tar.gz",
     "libllvm":      "https://github.com/llvm/llvm-project/releases/download/llvmorg-{v}/llvm-project-{v}.src.tar.xz",
     "mesa":         "https://archive.mesa3d.org/mesa-{v}.tar.xz",
+    "wayland":      "https://gitlab.freedesktop.org/wayland/wayland/-/releases/{v}/downloads/wayland-{v}.tar.xz",
+    "wayland-protocols": "https://gitlab.freedesktop.org/wayland/wayland-protocols/-/releases/{v}/downloads/wayland-protocols-{v}.tar.xz",
+    "libxkbcommon": "https://xkbcommon.org/download/libxkbcommon-{v}.tar.xz",
+    "glslang":      "https://github.com/KhronosGroup/glslang/archive/refs/tags/{v}.tar.gz",
+    "elfutils":     "https://sourceware.org/elfutils/ftp/{v}/elfutils-{v}.tar.bz2",
 }
 for _n in ("libXau", "libXdmcp", "libxcb", "libX11", "libXext", "libXrender",
            "libXfixes", "libXrandr", "libXxf86vm", "libXi", "libXcursor"):
@@ -64,6 +69,43 @@ FLAGS = {
 # The decisions that are not visible in the flags and cost real time to
 # rediscover. Empty means "nothing surprising".
 NOTES = {
+    "wayland": """
+The Wayland protocol library and its scanner. `wayland-scanner` is a build
+tool the rest of the stack runs — mesa and wayland-protocols both invoke it —
+so this payload ships a binary as well as libraries, and that binary is the
+reason the build harness had to learn to patch RPATHs on the copy it installs
+into the build subos.
+
+libxml2 is a build dependency of the scanner alone (DTD validation). It is
+supplied from the xlings package rather than the sysroot, because that package
+predates the header/library declarations the rest of this stack uses.
+""",
+    "wayland-protocols": """
+XML protocol definitions, no library. mesa reads them at build time through
+`wayland-scanner`; nothing loads this at run time.
+""",
+    "libxkbcommon": """
+Keymap handling for Wayland clients. Built with `-Denable-wayland=false`: that
+option builds an extra *tool*, and enabling it would make this package depend
+on wayland-protocols for no benefit to what the stack uses it for.
+""",
+    "glslang": """
+Khronos's GLSL front end. mesa's Vulkan drivers compile built-in shaders at
+build time and meson looks for `glslangValidator` **by name**, so this has to
+be on PATH during mesa's build — not merely installed.
+
+`-DENABLE_OPT=OFF` keeps SPIRV-Tools out: that optimiser serves glslang's own
+command line, and mesa does not ask for it.
+""",
+    "elfutils": """
+Built for `libelf` and nothing else. radeonsi links it to read the ELF that
+LLVM's AMDGPU backend emits for a compiled shader.
+
+Everything else elfutils ships — the debuginfo tooling — is configured out, and
+`CFLAGS=-Wno-error` is required because 0.191 predates gcc 15 and its
+warnings-as-errors default turns new diagnostics into build failures.
+""",
+
     "libllvm": """### Why only X86 and AMDGPU
 
 Undefined-symbol analysis of mesa's `libgallium` finds `LLVMInitializeX86*`
@@ -223,6 +265,24 @@ def flags_section(name):
         return ("Standard autotools/meson configuration; the harness supplies "
                 "`--prefix=/usr --libdir=lib` and the subos toolchain.\n")
     return f"### Configuration\n\n```\n{f}\n```\n"
+
+
+def upstream_url(name, version):
+    """Upstream tarball for NAME at VERSION.
+
+    mesa ships as `25.0.7.1`: the payload was rebuilt with a wider driver set
+    while upstream stayed at 25.0.7, and a package whose contents changed has
+    to be a different version — GitCode releases cannot be deleted, so the
+    asset for a version is written once. The fourth component is ours; the
+    upstream URL takes the first three.
+    """
+    tmpl = UPSTREAM.get(name)
+    if not tmpl:
+        return None
+    v = version
+    if name == "mesa" and version.count(".") == 3:
+        v = version.rsplit(".", 1)[0]
+    return tmpl.format(v=v)
 
 
 def render(name, version, sha):

--- a/.agents/tools/graphics/tiers.sh
+++ b/.agents/tools/graphics/tiers.sh
@@ -44,7 +44,7 @@ T2=(
 )
 
 T3=(
-  "wayland|1.23.1|https://gitlab.freedesktop.org/wayland/wayland/-/releases/1.23.1/downloads/wayland-1.23.1.tar.xz|meson|-Ddocumentation=false -Dtests=false"
+  "wayland|1.23.1|https://gitlab.freedesktop.org/wayland/wayland/-/releases/1.23.1/downloads/wayland-1.23.1.tar.xz|meson|-Ddocumentation=false -Dtests=false|libxml2 expat"
   "wayland-protocols|1.38|https://gitlab.freedesktop.org/wayland/wayland-protocols/-/releases/1.38/downloads/wayland-protocols-1.38.tar.xz|meson|-Dtests=false"
   "libxkbcommon|1.7.0|https://xkbcommon.org/download/libxkbcommon-1.7.0.tar.xz|meson|-Denable-docs=false -Denable-wayland=false -Denable-xkbregistry=false"
 )
@@ -53,6 +53,16 @@ T3=(
 # layer, so it must exist before mesa is built as a *vendor* rather than as a
 # libGL replacement. That is what lets the mesa and NVIDIA paths coexist later.
 T4=(
+  # elfutils, for its libelf alone: radeonsi links it to read the ELF that
+  # LLVM's AMDGPU backend emits for a shader. `--disable-debuginfod` and
+  # `--without-*` keep the rest of elfutils — the debuginfo tooling — out of a
+  # payload that exists to satisfy one dependency.
+  "elfutils|0.191|https://sourceware.org/elfutils/ftp/0.191/elfutils-0.191.tar.bz2|autotools|--disable-debuginfod --disable-libdebuginfod --without-bzlib --without-lzma --without-zstd --disable-nls --program-prefix=eu- CFLAGS=-Wno-error"
+  # glslang: mesa's Vulkan drivers compile built-in shaders at build time and
+  # meson looks for `glslangValidator` by name. ENABLE_OPT=OFF keeps
+  # SPIRV-Tools out of the picture — that optimiser is for glslang's own
+  # command line, and mesa does not ask for it.
+  "glslang|15.1.0|https://github.com/KhronosGroup/glslang/archive/refs/tags/15.1.0.tar.gz|cmake|-DENABLE_OPT=OFF -DGLSLANG_TESTS=OFF -DENABLE_CTEST=OFF"
   "libglvnd|1.7.0|https://gitlab.freedesktop.org/glvnd/libglvnd/-/archive/v1.7.0/libglvnd-v1.7.0.tar.gz|meson|-Dgles1=false -Dasm=enabled"
 )
 
@@ -84,22 +94,26 @@ T4=(
 # glslang is packaged. Leaving it empty is visible in the payload — no
 # libvulkan_*.so — rather than silently producing drivers that do not load.
 T5=(
-  "mesa|25.0.7|https://archive.mesa3d.org/mesa-25.0.7.tar.xz|meson|-Dgallium-drivers=llvmpipe -Dvulkan-drivers= -Dglvnd=enabled -Dplatforms=x11 -Dllvm=enabled -Dshared-llvm=enabled -Dlmsensors=disabled -Dvalgrind=disabled -Dbuild-tests=false -Dgallium-extra-hud=false"
+  "mesa|25.0.7|https://archive.mesa3d.org/mesa-25.0.7.tar.xz|meson|-Dgallium-drivers=llvmpipe,softpipe,radeonsi,nouveau,zink -Dvulkan-drivers=amd -Dglvnd=enabled -Dplatforms=x11,wayland -Dllvm=enabled -Dshared-llvm=enabled -Dlmsensors=disabled -Dvalgrind=disabled -Dbuild-tests=false -Dgallium-extra-hud=false|libxml2 expat"
 )
 
 run_tier() {  # <tier-name> <entries...>
     local tier="$1"; shift
-    local entry name version url system extra
+    local entry name version url system extra deps
     for entry in "$@"; do
-        IFS='|' read -r name version url system extra <<<"$entry"
+        # The sixth field is optional: xlings packages whose payload is a build
+        # dependency but which do not stage themselves into the subos sysroot.
+        # See build-in-subos.sh --deps.
+        IFS='|' read -r name version url system extra deps <<<"$entry"
         echo "── $tier :: $name $version ──────────────────────────────"
+        local args=(--name "$name" --version "$version" --url "$url"
+                    --system "$system")
+        [[ -n "${deps:-}" ]] && args+=(--deps "$deps")
         # shellcheck disable=SC2086
         if [[ -n "$extra" ]]; then
-            bash "$BUILD" --name "$name" --version "$version" --url "$url" \
-                 --system "$system" -- $extra || return 1
+            bash "$BUILD" "${args[@]}" -- $extra || return 1
         else
-            bash "$BUILD" --name "$name" --version "$version" --url "$url" \
-                 --system "$system" || return 1
+            bash "$BUILD" "${args[@]}" || return 1
         fi
     done
 }

--- a/pkgs/e/elfutils.lua
+++ b/pkgs/e/elfutils.lua
@@ -1,0 +1,79 @@
+package = {
+    spec = "2",
+
+    homepage = "https://sourceware.org/elfutils/",
+    name = "elfutils",
+    description = "ELF object file access library — libelf, for radeonsi",
+
+    authors = {"Red Hat, Inc.", "elfutils contributors"},
+    licenses = {"GPL-3.0-or-later", "LGPL-3.0-or-later"},
+    repo = "https://sourceware.org/git/elfutils.git",
+
+    type = "package",
+    archs = {"x86_64"},
+    status = "stable",
+    categories = {"graphics", "lib"},
+    keywords = {"elfutils", "graphics", "gl"},
+
+    xpm = {
+        linux = {
+            deps = { "xim:zlib@>=1.2", "xim:glibc@2.39" },
+            -- elfpatch reads this from each dependency and writes the consumer's
+            -- RPATH, which is what makes the stack resolve without anyone
+            -- setting LD_LIBRARY_PATH. Same mechanism `gcc-runtime` uses.
+            exports = {
+                runtime = { libdirs = { "lib" } },
+            },
+            ["latest"] = { ref = "0.191" },
+            ["0.191"] = {
+                url = {
+                    GLOBAL = "https://github.com/xlings-res/elfutils/releases/download/0.191/elfutils-0.191-linux-x86_64.tar.gz",
+                    CN     = "https://gitcode.com/xlings-res/elfutils/releases/download/0.191/elfutils-0.191-linux-x86_64.tar.gz",
+                },
+                sha256 = "30efe8df032b049f47f6067c32fd86c7f0a253795988f2825cc61675a58f2c61",
+            },
+        },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.system")
+import("xim.libxpkg.xvm")
+import("xim.pkgindex.sysroot")
+
+function install()
+    local dir = pkginfo.install_dir()
+    os.tryrm(dir)
+    os.mv("elfutils-0.191", dir)
+    return true
+end
+
+function config()
+    local binding = package.name .. "@" .. pkginfo.version()
+
+    xvm.add(package.name)
+
+    sysroot.declare_libs(pkginfo.install_dir(), "lib", binding, pkginfo.version())
+
+    -- Headers into the subos sysroot, so a compiler in this subos can build
+    -- against this package, not only run it. Declared rather than copied, so
+    -- xlings removes them with the package.
+    --
+    -- _tree, not declare_headers: eight packages in this stack contribute to
+    -- one `X11/`, and declaring that directory places it as a single asset --
+    -- rename(2) over the sysroot's copy, so the last install wins and the
+    -- other seven vanish. See libs/sysroot.lua for why neither of the
+    -- non-recursive helpers can express a shared namespace.
+    if not sysroot.declare_headers_tree(pkginfo.install_dir(), "include",
+                                        "usr/include", binding) then
+        sysroot.install_headers_tree(
+            path.join(pkginfo.install_dir(), "include"),
+            path.join(system.subos_sysrootdir(), "usr", "include"))
+    end
+    return true
+end
+
+function uninstall()
+    xvm.remove(package.name)
+    return true
+end

--- a/pkgs/g/glslang.lua
+++ b/pkgs/g/glslang.lua
@@ -1,0 +1,79 @@
+package = {
+    spec = "2",
+
+    homepage = "https://github.com/KhronosGroup/glslang",
+    name = "glslang",
+    description = "Khronos reference GLSL/ESSL front end and validator (build-time)",
+
+    authors = {"The Khronos Group Inc."},
+    licenses = {"BSD-3-Clause", "Apache-2.0", "MIT"},
+    repo = "https://github.com/KhronosGroup/glslang",
+
+    type = "package",
+    archs = {"x86_64"},
+    status = "stable",
+    categories = {"graphics", "lib"},
+    keywords = {"glslang", "graphics", "gl"},
+
+    xpm = {
+        linux = {
+            deps = { "xim:gcc-runtime@>=15", "xim:glibc@2.39" },
+            -- elfpatch reads this from each dependency and writes the consumer's
+            -- RPATH, which is what makes the stack resolve without anyone
+            -- setting LD_LIBRARY_PATH. Same mechanism `gcc-runtime` uses.
+            exports = {
+                runtime = { libdirs = { "lib" } },
+            },
+            ["latest"] = { ref = "15.1.0" },
+            ["15.1.0"] = {
+                url = {
+                    GLOBAL = "https://github.com/xlings-res/glslang/releases/download/15.1.0/glslang-15.1.0-linux-x86_64.tar.gz",
+                    CN     = "https://gitcode.com/xlings-res/glslang/releases/download/15.1.0/glslang-15.1.0-linux-x86_64.tar.gz",
+                },
+                sha256 = "87167c9cb32f258addbedb607639b2c1f484c029ba91542a92f19ead21d65d13",
+            },
+        },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.system")
+import("xim.libxpkg.xvm")
+import("xim.pkgindex.sysroot")
+
+function install()
+    local dir = pkginfo.install_dir()
+    os.tryrm(dir)
+    os.mv("glslang-15.1.0", dir)
+    return true
+end
+
+function config()
+    local binding = package.name .. "@" .. pkginfo.version()
+
+    xvm.add(package.name)
+
+    sysroot.declare_libs(pkginfo.install_dir(), "lib", binding, pkginfo.version())
+
+    -- Headers into the subos sysroot, so a compiler in this subos can build
+    -- against this package, not only run it. Declared rather than copied, so
+    -- xlings removes them with the package.
+    --
+    -- _tree, not declare_headers: eight packages in this stack contribute to
+    -- one `X11/`, and declaring that directory places it as a single asset --
+    -- rename(2) over the sysroot's copy, so the last install wins and the
+    -- other seven vanish. See libs/sysroot.lua for why neither of the
+    -- non-recursive helpers can express a shared namespace.
+    if not sysroot.declare_headers_tree(pkginfo.install_dir(), "include",
+                                        "usr/include", binding) then
+        sysroot.install_headers_tree(
+            path.join(pkginfo.install_dir(), "include"),
+            path.join(system.subos_sysrootdir(), "usr", "include"))
+    end
+    return true
+end
+
+function uninstall()
+    xvm.remove(package.name)
+    return true
+end

--- a/pkgs/l/libxkbcommon.lua
+++ b/pkgs/l/libxkbcommon.lua
@@ -1,0 +1,79 @@
+package = {
+    spec = "2",
+
+    homepage = "https://xkbcommon.org",
+    name = "libxkbcommon",
+    description = "Keymap handling library for Wayland and X11 clients",
+
+    authors = {"xkbcommon contributors"},
+    licenses = {"MIT"},
+    repo = "https://github.com/xkbcommon/libxkbcommon",
+
+    type = "package",
+    archs = {"x86_64"},
+    status = "stable",
+    categories = {"graphics", "lib"},
+    keywords = {"libxkbcommon", "graphics", "x11"},
+
+    xpm = {
+        linux = {
+            deps = {},
+            -- elfpatch reads this from each dependency and writes the consumer's
+            -- RPATH, which is what makes the stack resolve without anyone
+            -- setting LD_LIBRARY_PATH. Same mechanism `gcc-runtime` uses.
+            exports = {
+                runtime = { libdirs = { "lib" } },
+            },
+            ["latest"] = { ref = "1.7.0" },
+            ["1.7.0"] = {
+                url = {
+                    GLOBAL = "https://github.com/xlings-res/libxkbcommon/releases/download/1.7.0/libxkbcommon-1.7.0-linux-x86_64.tar.gz",
+                    CN     = "https://gitcode.com/xlings-res/libxkbcommon/releases/download/1.7.0/libxkbcommon-1.7.0-linux-x86_64.tar.gz",
+                },
+                sha256 = "d493b37955b7bd7c24c94d8481a44a933ac462accb2c699e80e312c3bb5a8425",
+            },
+        },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.system")
+import("xim.libxpkg.xvm")
+import("xim.pkgindex.sysroot")
+
+function install()
+    local dir = pkginfo.install_dir()
+    os.tryrm(dir)
+    os.mv("libxkbcommon-1.7.0", dir)
+    return true
+end
+
+function config()
+    local binding = package.name .. "@" .. pkginfo.version()
+
+    xvm.add(package.name)
+
+    sysroot.declare_libs(pkginfo.install_dir(), "lib", binding, pkginfo.version())
+
+    -- Headers into the subos sysroot, so a compiler in this subos can build
+    -- against this package, not only run it. Declared rather than copied, so
+    -- xlings removes them with the package.
+    --
+    -- _tree, not declare_headers: eight packages in this stack contribute to
+    -- one `X11/`, and declaring that directory places it as a single asset --
+    -- rename(2) over the sysroot's copy, so the last install wins and the
+    -- other seven vanish. See libs/sysroot.lua for why neither of the
+    -- non-recursive helpers can express a shared namespace.
+    if not sysroot.declare_headers_tree(pkginfo.install_dir(), "include",
+                                        "usr/include", binding) then
+        sysroot.install_headers_tree(
+            path.join(pkginfo.install_dir(), "include"),
+            path.join(system.subos_sysrootdir(), "usr", "include"))
+    end
+    return true
+end
+
+function uninstall()
+    xvm.remove(package.name)
+    return true
+end

--- a/pkgs/m/mesa.lua
+++ b/pkgs/m/mesa.lua
@@ -3,7 +3,7 @@ package = {
 
     homepage = "https://mesa3d.org",
     name = "mesa",
-    description = "Mesa 3D — OpenGL for CPU (llvmpipe), built self-contained for xlings subos",
+    description = "Mesa 3D — OpenGL and Vulkan: llvmpipe, radeonsi, nouveau, zink, RADV",
 
     authors = {"Mesa contributors"},
     licenses = {"MIT"},
@@ -14,7 +14,7 @@ package = {
     archs = {"x86_64"},
     status = "stable",
     categories = {"graphics", "opengl", "lib"},
-    keywords = {"mesa", "opengl", "gl", "egl", "llvmpipe", "graphics"},
+    keywords = {"mesa", "opengl", "vulkan", "gl", "egl", "llvmpipe", "radeonsi", "graphics"},
 
     -- What this package is for.
     --
@@ -25,7 +25,14 @@ package = {
     -- a GL program installed through xlings renders on a host that has no
     -- graphics stack of its own.
     --
-    -- Build details, including why only llvmpipe for now:
+    -- Drivers: llvmpipe and softpipe (CPU), radeonsi (AMD), nouveau (NVIDIA
+    -- open kernel module), zink (GL over Vulkan), and RADV for Vulkan on AMD.
+    -- Intel (iris/anv) and NVK are the two upstream drivers NOT here: iris and
+    -- anv require libclc, which needs clang and the SPIR-V translator, and NVK
+    -- is Rust and needs bindgen. Both are additions to the build chain rather
+    -- than to this recipe.
+    --
+    -- Build details, per-flag, and what each one cost:
     -- https://github.com/xlings-res/mesa
     xpm = {
         linux = {
@@ -55,6 +62,14 @@ package = {
                 "xim:libxshmfence@>=1.3",
                 "xim:expat@>=2.6",
                 "xim:zlib@>=1.2",
+                -- radeonsi reads the ELF that LLVM's AMDGPU backend emits.
+                "xim:elfutils@>=0.19",
+                -- The second window-system platform. Not optional once mesa
+                -- is built with `-Dplatforms=x11,wayland`: libEGL_mesa gains a
+                -- DT_NEEDED on libwayland-client, and a missing dep here does
+                -- not fail the install -- it makes glvnd's dlopen of the
+                -- vendor fail, which EGL reports as having no vendor at all.
+                "xim:wayland@>=1.23",
                 "xim:gcc-runtime@>=15",
                 -- Pinned, alone among these, and for a client reason rather
                 -- than an ABI one. The measured floor is 2.38 (libgallium's
@@ -73,13 +88,18 @@ package = {
             exports = {
                 runtime = { libdirs = { "lib" } },
             },
-            ["latest"] = { ref = "25.0.7" },
-            ["25.0.7"] = {
+            ["latest"] = { ref = "25.0.7.1" },
+            -- 25.0.7.1: upstream is 25.0.7, the fourth component is ours.
+            -- The payload was rebuilt with the full driver set, and a payload
+            -- whose contents changed has to be a different version — a GitCode
+            -- release asset is written once and cannot be deleted, so reusing
+            -- 25.0.7 would leave two different tarballs claiming one name.
+            ["25.0.7.1"] = {
                 url = {
-                    GLOBAL = "https://github.com/xlings-res/mesa/releases/download/25.0.7/mesa-25.0.7-linux-x86_64.tar.gz",
-                    CN     = "https://gitcode.com/xlings-res/mesa/releases/download/25.0.7/mesa-25.0.7-linux-x86_64.tar.gz",
+                    GLOBAL = "https://github.com/xlings-res/mesa/releases/download/25.0.7.1/mesa-25.0.7.1-linux-x86_64.tar.gz",
+                    CN     = "https://gitcode.com/xlings-res/mesa/releases/download/25.0.7.1/mesa-25.0.7.1-linux-x86_64.tar.gz",
                 },
-                sha256 = "17ff8a09973d69ce591351fe7b38cd40896ddf3444908024807be31673ddea4a",
+                sha256 = "84789c203ead56343b64d9edb76c1ff4fe7e886ba4194e6bc79e332e66e8867b",
             },
         },
     },
@@ -94,6 +114,10 @@ import("xim.pkgindex.sysroot")
 function install()
     local dir = pkginfo.install_dir()
     os.tryrm(dir)
+    -- The tarball's top-level directory is upstream's `mesa-25.0.7`; only the
+    -- ASSET is named 25.0.7.1. Moving the wrong name leaves the download cache
+    -- as the payload and install() still returns true, which is how this was
+    -- found: a package that installed cleanly and had no `lib/` at all.
     os.mv("mesa-25.0.7", dir)
 
     -- The glvnd vendor JSON ships a bare SONAME, which is how it is shipped
@@ -107,6 +131,40 @@ function install()
         local text = io.readfile(vendor)
         io.writefile(vendor, text:gsub('"libEGL_mesa%.so%.0"',
                                        '"' .. path.join(dir, "lib/libEGL_mesa.so.0") .. '"'))
+    end
+
+    -- The Vulkan ICD manifests need the same treatment, and worse: they ship
+    -- `"library_path": "/usr/lib/libvulkan_radeon.so"` — not a bare SONAME
+    -- that happens to resolve against the host, an ABSOLUTE host path. On a
+    -- machine with mesa installed that loads the host's driver under our
+    -- loader; on one without, it fails. Neither is this package.
+    -- `ls`, not os.files: os.files is an xmake API and this hook runs in
+    -- libxpkg's plain-Lua sandbox, where it is simply absent. The call raised,
+    -- the hook aborted, and the package still reported success — with the ICDs
+    -- left pointing at /usr/lib.
+    local icddir = path.join(dir, "share/vulkan/icd.d")
+    if os.isdir(icddir) then
+        local names = {}
+        local lsf = io.popen(string.format([[ls -1 "%s"/*.json 2>/dev/null]], icddir))
+        if lsf then
+            for line in lsf:lines() do
+                local n = line:gsub("[\r\n]+$", "")
+                if n ~= "" then table.insert(names, n) end
+            end
+            lsf:close()
+        end
+        for _, icd in ipairs(names) do
+            local text = io.readfile(icd)
+            -- Matched by the value's basename rather than by a list of driver
+            -- names, so a driver added upstream is covered without an edit
+            -- here — and a list that silently stops covering a new file is
+            -- exactly the shape that ships a working-looking package.
+            io.writefile(icd, (text:gsub('("library_path"%s*:%s*")([^"]+)(")',
+                function(pre, val, post)
+                    local base = val:match("([^/]+)$") or val
+                    return pre .. path.join(dir, "lib", base) .. post
+                end)))
+        end
     end
     return true
 end

--- a/pkgs/w/wayland-protocols.lua
+++ b/pkgs/w/wayland-protocols.lua
@@ -1,0 +1,55 @@
+package = {
+    spec = "2",
+
+    homepage = "https://wayland.freedesktop.org",
+    name = "wayland-protocols",
+    description = "Wayland protocol extension definitions (build-time)",
+
+    authors = {"Wayland contributors"},
+    licenses = {"MIT"},
+    repo = "https://gitlab.freedesktop.org/wayland/wayland-protocols",
+
+    type = "package",
+    archs = {"x86_64"},
+    status = "stable",
+    categories = {"graphics", "lib"},
+    keywords = {"wayland-protocols", "graphics", "gl"},
+
+    xpm = {
+        linux = {
+            deps = {},
+            ["latest"] = { ref = "1.38" },
+            ["1.38"] = {
+                url = {
+                    GLOBAL = "https://github.com/xlings-res/wayland-protocols/releases/download/1.38/wayland-protocols-1.38-linux-x86_64.tar.gz",
+                    CN     = "https://gitcode.com/xlings-res/wayland-protocols/releases/download/1.38/wayland-protocols-1.38-linux-x86_64.tar.gz",
+                },
+                sha256 = "41df27e9b1ad57d7bbf5ed47eade4f71495ddd132417590c0c39185c5559ac0c",
+            },
+        },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.system")
+import("xim.libxpkg.xvm")
+import("xim.pkgindex.sysroot")
+
+function install()
+    local dir = pkginfo.install_dir()
+    os.tryrm(dir)
+    os.mv("wayland-protocols-1.38", dir)
+    return true
+end
+
+function config()
+    local binding = package.name .. "@" .. pkginfo.version()
+
+    xvm.add(package.name)
+    return true
+end
+
+function uninstall()
+    xvm.remove(package.name)
+    return true
+end

--- a/pkgs/w/wayland.lua
+++ b/pkgs/w/wayland.lua
@@ -1,0 +1,79 @@
+package = {
+    spec = "2",
+
+    homepage = "https://wayland.freedesktop.org",
+    name = "wayland",
+    description = "Wayland protocol library and scanner",
+
+    authors = {"Wayland contributors"},
+    licenses = {"MIT"},
+    repo = "https://gitlab.freedesktop.org/wayland/wayland",
+
+    type = "package",
+    archs = {"x86_64"},
+    status = "stable",
+    categories = {"graphics", "lib"},
+    keywords = {"wayland", "graphics", "gl"},
+
+    xpm = {
+        linux = {
+            deps = { "xim:libffi@>=3.4", "xim:glibc@2.39" },
+            -- elfpatch reads this from each dependency and writes the consumer's
+            -- RPATH, which is what makes the stack resolve without anyone
+            -- setting LD_LIBRARY_PATH. Same mechanism `gcc-runtime` uses.
+            exports = {
+                runtime = { libdirs = { "lib" } },
+            },
+            ["latest"] = { ref = "1.23.1" },
+            ["1.23.1"] = {
+                url = {
+                    GLOBAL = "https://github.com/xlings-res/wayland/releases/download/1.23.1/wayland-1.23.1-linux-x86_64.tar.gz",
+                    CN     = "https://gitcode.com/xlings-res/wayland/releases/download/1.23.1/wayland-1.23.1-linux-x86_64.tar.gz",
+                },
+                sha256 = "5132067ff533ea627a0335dfeaab9612889842ffbdd26148c9306993c41f6ea2",
+            },
+        },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.system")
+import("xim.libxpkg.xvm")
+import("xim.pkgindex.sysroot")
+
+function install()
+    local dir = pkginfo.install_dir()
+    os.tryrm(dir)
+    os.mv("wayland-1.23.1", dir)
+    return true
+end
+
+function config()
+    local binding = package.name .. "@" .. pkginfo.version()
+
+    xvm.add(package.name)
+
+    sysroot.declare_libs(pkginfo.install_dir(), "lib", binding, pkginfo.version())
+
+    -- Headers into the subos sysroot, so a compiler in this subos can build
+    -- against this package, not only run it. Declared rather than copied, so
+    -- xlings removes them with the package.
+    --
+    -- _tree, not declare_headers: eight packages in this stack contribute to
+    -- one `X11/`, and declaring that directory places it as a single asset --
+    -- rename(2) over the sysroot's copy, so the last install wins and the
+    -- other seven vanish. See libs/sysroot.lua for why neither of the
+    -- non-recursive helpers can express a shared namespace.
+    if not sysroot.declare_headers_tree(pkginfo.install_dir(), "include",
+                                        "usr/include", binding) then
+        sysroot.install_headers_tree(
+            path.join(pkginfo.install_dir(), "include"),
+            path.join(system.subos_sysrootdir(), "usr", "include"))
+    end
+    return true
+end
+
+function uninstall()
+    xvm.remove(package.name)
+    return true
+end


### PR DESCRIPTION
mesa went from one driver on one platform to six gallium drivers, RADV, and x11+wayland. Five new packages, each required by something above it rather than added for completeness.

Intel (iris/anv) and NVK are deliberately absent and the reason is recorded: both need additions to the *build chain* — libclc (clang + SPIR-V translator) and Rust/bindgen respectively — not lines in a recipe.

Two host reach-backs closed: the Vulkan ICD manifests carry an absolute `/usr/lib` path, and `-Dplatforms=…,wayland` added a DT_NEEDED the recipe did not declare (which does not fail an install — it makes EGL report no vendor).

Harness gained `--deps` (previously parsed and ignored), cmake support, transitive DT_RPATH for build-time tools, and a leak check that finally covers executables and not just `*.so*`.

Verified: S1–S4 PASS with no /usr present and no environment handed in.