### PR TITLE
fix(python): the interpreter ran on the HOST's glibc

### DIFF
--- a/pkgs/p/python.lua
+++ b/pkgs/p/python.lua
@@ -19,6 +19,11 @@ package = {
 
     xpm = {
         linux = {
+            -- glibc, so elfpatch has a loader provider to key off. Without a
+            -- dep declaring exports.runtime.loader the predicate never fires
+            -- and the payload keeps python-build-standalone's INTERP, which is
+            -- the HOST's /lib64/ld-linux-x86-64.so.2.
+            deps = { "xim:glibc@2.39" },
             ["latest"] = { ref = "3.13.12" },
             ["3.13.12"] = {
                 url = "https://gitcode.com/xlings-res/mirror-cn/releases/download/python/cpython-3.13.12%2B20260310-x86_64-unknown-linux-gnu-install_only.tar.gz",


### PR DESCRIPTION
`xim:python` kept python-build-standalone's INTERP — `/lib64/ld-linux-x86-64.so.2`. It works on most machines and is not ours: too old a host glibc and it fails; inside a subos with no host it does not start at all, reporting `execvp: No such file or directory` for a binary that is plainly there (the ENOENT is the loader's).

python is what meson runs on, so the tool that builds the graphics stack was the one part of the build still requiring the host to be right.

The cause is a missing declaration, not a missing feature: elfpatch's predicate fires only when a runtime dep exports `runtime.loader`, and this recipe had no deps at all. One line fixes it.

**Verified** in a container with no /usr and no /lib: `import ssl, sqlite3, zlib, ctypes, hashlib` all succeed; host behaviour unchanged.

Wider picture: 94 of 106 linux payload recipes declare no glibc and cannot trigger the predicate. Most are static Go/Rust and unaffected — the at-risk set is the dynamically-linked remainder, testable with `readelf -p .interp`.