### PR TITLE
feat(7zip): add 7-Zip 26.02 for all platforms

### DIFF
--- a/pkgs/7/7zip.lua
+++ b/pkgs/7/7zip.lua
@@ -75,13 +75,13 @@ function install()
     if os.host() == "windows" then
         -- The windows asset is a 7z self-extracting archive holding 7z.exe /
         -- 7zG.exe / 7zFM.exe directly. `/S /D=` is its documented silent
-        -- extract form. Run it through PowerShell's `&` call operator: a bare
-        -- os.exec string trips cmd.exe's `/c` quote-stripping and the command
-        -- dies before the SFX runs ("filename, directory name, or volume label
-        -- syntax is incorrect").
+        -- extract form. Two gotchas: a bare os.exec string trips cmd.exe's
+        -- `/c` quote-stripping, and PowerShell's `&` operator does NOT wait
+        -- for a GUI-subsystem process — the hook would check for 7z.exe before
+        -- the SFX finished. `Start-Process -Wait` fixes both.
         fs.mkdir_p(install_dir)
         os.exec(string.format([[
-powershell -NoProfile -ExecutionPolicy Bypass -Command "& '%s' '/S' '/D=%s'"]], archive, install_dir))
+powershell -NoProfile -ExecutionPolicy Bypass -Command "Start-Process -FilePath '%s' -ArgumentList '/S','/D=%s' -Wait | Out-Null"]], archive, install_dir))
         return os.isfile(path.join(install_dir, "7z.exe"))
     end
 

--- a/pkgs/7/7zip.lua
+++ b/pkgs/7/7zip.lua
@@ -73,10 +73,15 @@ function install()
     local archive = pkginfo.install_file()
 
     if os.host() == "windows" then
-        -- The windows asset is a 7z self-extracting archive (Type = 7z).
-        -- `/S /D=` makes it extract silently into our own install dir instead
-        -- of running the interactive installer; /D must be the last argument.
-        os.exec(string.format('"%s" /S /D="%s"', archive, install_dir))
+        -- The windows asset is a 7z self-extracting archive holding 7z.exe /
+        -- 7zG.exe / 7zFM.exe directly. `/S /D=` is its documented silent
+        -- extract form. Run it through PowerShell's `&` call operator: a bare
+        -- os.exec string trips cmd.exe's `/c` quote-stripping and the command
+        -- dies before the SFX runs ("filename, directory name, or volume label
+        -- syntax is incorrect").
+        fs.mkdir_p(install_dir)
+        os.exec(string.format([[
+powershell -NoProfile -ExecutionPolicy Bypass -Command "& '%s' '/S' '/D=%s'"]], archive, install_dir))
         return os.isfile(path.join(install_dir, "7z.exe"))
     end
 

--- a/pkgs/7/7zip.lua
+++ b/pkgs/7/7zip.lua
@@ -1,0 +1,128 @@
+package = {
+    spec = "2",
+
+    homepage = "https://www.7-zip.org",
+    name = "7zip",
+    description = "7-Zip — a file archiver with a high compression ratio",
+
+    authors = {"Igor Pavlov"},
+    licenses = {"LGPL-2.1-or-later"},
+    repo = "https://github.com/ip7z/7zip",
+    docs = "https://7-zip.org/documentation.html",
+
+    -- xim pkg info
+    type = "package",
+    archs = {"x86_64", "aarch64"},
+    status = "stable",
+    categories = {"tools", "archiver"},
+    keywords = {"7zip", "7z", "compression", "archive"},
+
+    programs = {"7zz", "7z"},
+
+    xvm_enable = true,
+
+    -- 7-Zip ships third-party binaries on GitHub (ip7z/7zip). Per-arch tar.xz
+    -- on linux, a single universal tar.xz on macosx (one binary for both
+    -- arches), and self-extracting 7z archives (the `.exe` installers) on
+    -- windows. Every sha256 below was verified by downloading the asset and
+    -- hashing it; no xlings-res mirror exists for this upstream.
+    xpm = {
+        linux = {
+            ["latest"] = { ref = "26.02" },
+            ["26.02"] = {
+                x86_64 = {
+                    url = "https://github.com/ip7z/7zip/releases/download/26.02/7z2602-linux-x64.tar.xz",
+                    sha256 = "41aaba7b1235304ab5aa0624530c67ae829496cd29e875925271efdccc28c03e",
+                },
+                aarch64 = {
+                    url = "https://github.com/ip7z/7zip/releases/download/26.02/7z2602-linux-arm64.tar.xz",
+                    sha256 = "70ea6cc737ae1495ea2d7eb20ef3120fe579bd3f1a83a9d2362b62ec5bde2bba",
+                },
+            },
+        },
+        macosx = {
+            ["latest"] = { ref = "26.02" },
+            ["26.02"] = {
+                -- universal binary serves both x86_64 and aarch64
+                url = "https://github.com/ip7z/7zip/releases/download/26.02/7z2602-mac.tar.xz",
+                sha256 = "1cf6760579502f87e591ff5c73a005ec50b3e4d6f507e8b038382d563c3175b9",
+            },
+        },
+        windows = {
+            ["latest"] = { ref = "26.02" },
+            ["26.02"] = {
+                x86_64 = {
+                    url = "https://github.com/ip7z/7zip/releases/download/26.02/7z2602-x64.exe",
+                    sha256 = "6745fa76dc2ea031596d8678f6f6b99c3c1b435b4164a63485adbbc7b8d82ef0",
+                },
+                aarch64 = {
+                    url = "https://github.com/ip7z/7zip/releases/download/26.02/7z2602-arm64.exe",
+                    sha256 = "7c6fde79ed5e11b81c7bb6573b7962d3b6322aa5fce69c33ed19f672b55173ab",
+                },
+            },
+        },
+    },
+}
+
+import("xim.libxpkg.fs")
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+
+function install()
+    local install_dir = pkginfo.install_dir()
+    local archive = pkginfo.install_file()
+
+    if os.host() == "windows" then
+        -- The windows asset is a 7z self-extracting archive (Type = 7z).
+        -- `/S /D=` makes it extract silently into our own install dir instead
+        -- of running the interactive installer; /D must be the last argument.
+        os.exec(string.format('"%s" /S /D="%s"', archive, install_dir))
+        return os.isfile(path.join(install_dir, "7z.exe"))
+    end
+
+    -- linux / macosx: the tar.xz expands flat (7zz, docs, license) into the
+    -- hook cwd. xlings does not create install_dir for us, and os.mv cannot
+    -- create its parent, so mkdir_p first.
+    os.tryrm(install_dir)
+    fs.mkdir_p(install_dir)
+    -- xlings may have auto-extracted the archive; if it is still present, do
+    -- it here.
+    if os.isfile(path.filename(archive)) then
+        os.exec("tar -xf " .. path.filename(archive))
+        os.tryrm(path.filename(archive))
+    end
+    os.mv("7zz", path.join(install_dir, "7zz"))
+    if os.isfile("7zzs") then
+        os.mv("7zzs", path.join(install_dir, "7zzs"))
+    end
+    if os.isfile("License.txt") then
+        os.mv("License.txt", path.join(install_dir, "License.txt"))
+    end
+    return os.isfile(path.join(install_dir, "7zz"))
+end
+
+function config()
+    local install_dir = pkginfo.install_dir()
+
+    -- Binding-group root: the package name names no artifact, so `type =
+    -- "group"` keeps it from becoming an orphan shim (openxlings/xlings#452).
+    xvm.add(package.name, { type = "group" })
+
+    if os.host() == "windows" then
+        -- the real binary is 7z.exe; 7zz is an alias shim
+        xvm.add("7z", { bindir = install_dir })
+        xvm.add("7zz", { bindir = install_dir, alias = "7z" })
+    else
+        -- the real binary is 7zz; 7z is a convenience alias
+        xvm.add("7zz", { bindir = install_dir })
+        xvm.add("7z", { bindir = install_dir, alias = "7zz" })
+    end
+    return true
+end
+
+function uninstall()
+    xvm.remove("7zz")
+    xvm.remove("7z")
+    xvm.remove(package.name)
+    return true
+end

--- a/tests/7/test_7zip.py
+++ b/tests/7/test_7zip.py
@@ -1,0 +1,80 @@
+"""测试 7zip 包"""
+import pytest
+from tests.lib.xpkg_parser import parse_xpkg
+from tests.lib.assertions import (
+    assert_required_fields, assert_valid_spec, assert_valid_type,
+    assert_no_typos, assert_no_exec_xvm, assert_no_bashrc_modification,
+    assert_no_direct_path_modification, assert_uses_new_api,
+    assert_xim_add_succeeds, assert_install_succeeds,
+    assert_command_output, assert_xvm_shim_exists,
+)
+from tests.lib.platform_utils import skip_if_not
+
+PKG = "7zip"
+PKG_FILE = "pkgs/7/7zip.lua"
+
+
+@pytest.fixture(scope='module')
+def meta():
+    return parse_xpkg(PKG_FILE)
+
+
+class TestStatic:
+    @pytest.mark.static
+    def test_required_fields(self, meta):
+        assert_required_fields(meta)
+
+    @pytest.mark.static
+    def test_valid_spec(self, meta):
+        assert_valid_spec(meta)
+
+    @pytest.mark.static
+    def test_valid_type(self, meta):
+        assert_valid_type(meta)
+
+    @pytest.mark.static
+    def test_no_typos(self):
+        assert_no_typos(PKG_FILE)
+
+
+class TestIndex:
+    @pytest.mark.index
+    def test_xim_add(self):
+        assert_xim_add_succeeds(PKG_FILE)
+
+
+class TestIsolation:
+    @pytest.mark.isolation
+    def test_no_exec_xvm(self):
+        assert_no_exec_xvm(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_no_bashrc(self):
+        assert_no_bashrc_modification(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_no_path_modification(self):
+        assert_no_direct_path_modification(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_new_api(self):
+        assert_uses_new_api(PKG_FILE)
+
+
+class TestLifecycle:
+    @pytest.mark.lifecycle
+    @skip_if_not('linux')
+    def test_install(self):
+        assert_install_succeeds(PKG)
+
+
+class TestVerify:
+    @pytest.mark.verify
+    @skip_if_not('linux')
+    def test_7zz(self):
+        assert_command_output("7zz i", contains="7-Zip")
+
+    @pytest.mark.verify
+    @skip_if_not('linux')
+    def test_7zz_shim(self):
+        assert_xvm_shim_exists("7zz")


### PR DESCRIPTION
## Summary
Add a new **7zip** package (`pkgs/7/7zip.lua`) tracking **7-Zip 26.02** (latest release, tag `26.02`) on linux / macosx / windows, with mirror test `tests/7/test_7zip.py`. First digit-bucketed (`pkgs/7/`) package in the index.

## Resources (all verified by downloading and hashing)
- **linux x86_64**: `7z2602-linux-x64.tar.xz` — sha256 `41aaba7b1235304ab5aa0624530c67ae829496cd29e875925271efdccc28c03e`
- **linux aarch64**: `7z2602-linux-arm64.tar.xz` — sha256 `70ea6cc737ae1495ea2d7eb20ef3120fe579bd3f1a83a9d2362b62ec5bde2bba`
- **macosx** (universal, one binary for x86_64 + aarch64): `7z2602-mac.tar.xz` — sha256 `1cf6760579502f87e591ff5c73a005ec50b3e4d6f507e8b038382d563c3175b9`
- **windows x86_64**: `7z2602-x64.exe` — sha256 `6745fa76dc2ea031596d8678f6f6b99c3c1b435b4164a63485adbbc7b8d82ef0`
- **windows aarch64**: `7z2602-arm64.exe` — sha256 `7c6fde79ed5e11b81c7bb6573b7962d3b6322aa5fce69c33ed19f672b55173ab`

No `xlings-res` mirror exists for this upstream, so the recipe uses per-arch resource maps (spec V2, Shape B). `spec = "2"`, `archs = {"x86_64","aarch64"}`.

## Install / uninstall behavior
- **linux/macosx**: tar.xz expands flat → install hook moves `7zz` (+ static `7zzs`, license) into `install_dir`. Creates the install dir first (xlings doesn't; `os.mv` can't make its parent).
- **windows**: the asset is a 7z self-extracting archive (`Type = 7z`, contains `7z.exe`). Runs it with `/S /D=<install_dir>` to extract silently into the package's own dir — nothing touches the host (no Program Files, no registry).
- Registers `7zz` + `7z` shims (real binary on each platform, the other as alias) plus the `package.name` binding-group root. `uninstall()` removes all three.

## Test plan
- `pytest tests/7/test_7zip.py -m "static or isolation"` → 8 passed
- `pytest tests/ -m "static or isolation"` → **1083 passed**, 4 xpassed (pre-existing xfail) — includes the D1 spec test over all packages
- `python3 .github/scripts/parse-xpkg-meta.py pkgs/7/7zip.lua` → name=7zip, programs=[7zz,7z], has_linux/macosx/windows=true
- `version-check.py --workspace .` and `check-no-direct-ld-libpath.sh` → exit 0
- **Isolated install verified locally** (fresh `XLINGS_HOME`): `config --add-xpkg` → `install local:7zip` ✓ → `7zz i` prints `7-Zip (z) 26.02 (x64)` → `remove local:7zip` ✓ payload cleaned
- CI will additionally run install/uninstall on linux, windows, macos runners