### PR TITLE
feat(glibc): 2.44, and dependencies that can accept it

### DIFF
--- a/.agents/tools/graphics/build-glibc.sh
+++ b/.agents/tools/graphics/build-glibc.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# Build glibc from source into an xlings payload.
+#
+# Separate from build-in-subos.sh because glibc is not an ordinary package:
+#
+#   * it must be configured out-of-tree, and refuses to run in the source dir
+#   * `--prefix` is not only where files go — it is compiled into ld.so as the
+#     DEFAULT LIBRARY SEARCH PATH, consulted whenever an object asks for a
+#     library with no RUNPATH of its own. The published 2.39 carries
+#     `/home/xlings/.xlings_data/xim/xpkgs/fromsource-x-glibc/2.39/lib`, the
+#     path on the machine that built it, and that is why a freshly linked tool
+#     whose dependency's dependency has no RUNPATH dies on `libm.so.6: cannot
+#     open shared object file` while `objdump -p` shows a path containing it.
+#     There is no prefix that is right on every machine — xlings rewrites
+#     INTERP and RPATH at install time, which is what actually resolves this —
+#     so the value here only has to be inert, never accidentally present on a
+#     user's disk, and consistent with what shipped before.
+#   * it is the one package whose payload cannot be patched by elfpatch: it IS
+#     the loader. Its own layout has to be right at build time.
+#
+# Usage:  build-glibc.sh <version>            (e.g. build-glibc.sh 2.44)
+set -uo pipefail
+
+VERSION="${1:?usage: build-glibc.sh <version>}"
+NAME=glibc
+SUBOS_NAME="${XLINGS_GFX_SUBOS:-gfxbuild}"
+XHOME="${XLINGS_HOME:-$HOME/.xlings}"
+SUBOS="$XHOME/subos/$SUBOS_NAME"
+WORK="${XLINGS_GFX_WORK:-${TMPDIR:-/tmp}/xlings-gfx}"
+SRC="$WORK/src"
+STAGE="$WORK/stage/$NAME-$VERSION"
+DIST="$WORK/dist"
+
+log()  { echo "[gfx-build:$NAME] $*"; }
+fail() { echo "[gfx-build:$NAME] FAIL: $*" >&2; exit 1; }
+
+[[ -d "$SUBOS" ]] || fail "subos '$SUBOS_NAME' not found"
+rm -rf "$STAGE"; mkdir -p "$SRC" "$STAGE" "$DIST"
+
+# Same shape as the published 2.39, so a home holding both resolves them the
+# same way. Nothing is expected to exist at this path.
+PREFIX="/home/xlings/.xlings_data/xim/xpkgs/fromsource-x-$NAME/$VERSION"
+
+TARBALL="$SRC/glibc-$VERSION.tar.xz"
+[[ -f "$TARBALL" ]] || {
+    log "fetching glibc-$VERSION.tar.xz"
+    curl -fsSL --retry 3 -o "$TARBALL" \
+        "https://ftp.gnu.org/gnu/glibc/glibc-$VERSION.tar.xz" || fail "download"
+}
+BUILDDIR="$SRC/glibc-$VERSION"
+rm -rf "$BUILDDIR"; mkdir -p "$BUILDDIR"
+tar xf "$TARBALL" -C "$BUILDDIR" --strip-components=1 || fail "extract"
+
+export PATH="$SUBOS/bin:$SUBOS/usr/bin:$PATH"
+export CC="$SUBOS/bin/gcc" CXX="$SUBOS/bin/g++"
+[[ -x "$CC" ]] || fail "no gcc in the subos"
+
+# NO CPPFLAGS/LDFLAGS pointing at the subos.
+#
+# glibc builds against the KERNEL headers and nothing else; handing it the
+# sysroot's include directory puts the OLD glibc's headers ahead of the ones it
+# is building, and the failures read as glibc's own source being broken.
+unset CPPFLAGS LDFLAGS LD_LIBRARY_PATH
+
+mkdir -p "$BUILDDIR/_b" && cd "$BUILDDIR/_b" || fail "cd"
+log "configuring $VERSION (prefix=$PREFIX)"
+# --enable-kernel: the oldest kernel this build supports. 4.19 is the floor
+#   most distributions target; raising it drops compatibility code, lowering it
+#   is pointless for a payload that ships with xlings.
+# --disable-werror: glibc treats new gcc diagnostics as errors, and this is
+#   built with a compiler newer than the release.
+# --with-headers: the subos's kernel headers, which is the one thing it does
+#   take from there.
+../configure \
+    --prefix="$PREFIX" \
+    --libdir="$PREFIX/lib" \
+    --with-headers="$SUBOS/usr/include" \
+    --enable-kernel=4.19 \
+    --disable-werror \
+    --disable-profile \
+    --disable-nscd \
+    --enable-stack-protector=strong \
+    > "$WORK/$NAME-configure.log" 2>&1 \
+    || { tail -30 "$WORK/$NAME-configure.log"; fail "configure"; }
+
+log "building (this takes a while)"
+make -j"$(nproc)" > "$WORK/$NAME-build.log" 2>&1 \
+    || { tail -30 "$WORK/$NAME-build.log"; fail "make"; }
+
+log "staging"
+make install DESTDIR="$STAGE" >> "$WORK/$NAME-build.log" 2>&1 \
+    || { tail -30 "$WORK/$NAME-build.log"; fail "make install"; }
+
+PAYLOAD="$WORK/payload/$NAME-$VERSION"
+rm -rf "$PAYLOAD"; mkdir -p "$PAYLOAD"
+cp -a "$STAGE$PREFIX/." "$PAYLOAD/" || fail "payload copy"
+
+# lib64 beside lib, because that is where the recipe and every elfpatched
+# consumer look for the loader (`exports.runtime.loader = lib64/ld-linux-...`).
+if [[ ! -d "$PAYLOAD/lib64" ]]; then
+    ln -s lib "$PAYLOAD/lib64" || fail "lib64 link"
+fi
+
+# ── the checks ──────────────────────────────────────────────────────────
+log "checking the payload"
+leaks=0
+LOADER="$(find "$PAYLOAD" -maxdepth 2 -name 'ld-linux-*.so.*' ! -type l | head -1)"
+[[ -n "$LOADER" ]] || { echo "    no ld-linux in the payload"; leaks=$((leaks+1)); }
+
+# The one that matters: the loader has to run and report the version we asked
+# for. A glibc that builds and does not run is not detectable from file lists.
+if [[ -n "$LOADER" ]]; then
+    got="$("$LOADER" --version 2>/dev/null | head -1)"
+    case "$got" in
+        *"$VERSION"*) log "  loader reports: $got" ;;
+        *) echo "    loader reports '$got', expected $VERSION"; leaks=$((leaks+1)) ;;
+    esac
+fi
+
+# And libc has to load under it, which is the pairing that actually gets used.
+if [[ -n "$LOADER" && -f "$PAYLOAD/lib/libc.so.6" ]]; then
+    if ! "$LOADER" --library-path "$PAYLOAD/lib" "$PAYLOAD/lib/libc.so.6" \
+            >/dev/null 2>&1; then
+        echo "    libc.so.6 does not run under the built loader"
+        leaks=$((leaks+1))
+    fi
+fi
+
+(( leaks == 0 )) || fail "$leaks problem(s) — payload not packaged"
+
+TAR="$DIST/$NAME-$VERSION-linux-x86_64.tar.gz"
+rm -f "$TAR"
+tar czf "$TAR" -C "$(dirname "$PAYLOAD")" "$(basename "$PAYLOAD")" || fail "tar"
+log "packaged $(basename "$TAR") ($(du -h "$TAR" | cut -f1))"
+log "sha256 $(sha256sum "$TAR" | cut -d' ' -f1)"

--- a/.agents/tools/graphics/gen-recipes.py
+++ b/.agents/tools/graphics/gen-recipes.py
@@ -43,20 +43,22 @@ import sys
 # by construction, and the unpublished-sibling case it loses is handled where it
 # belongs, by the pre-registration pass in .github/scripts/posix-test.sh.
 
-# glibc is pinned where every other dep is a range, and the reason is a client
-# bug rather than an ABI one. Before 2026.8.5.2, xlings matched a dep's version
-# half by string equality, so `xim:glibc@>=2.38` matched no plan node, glibc's
-# exports were dropped, and elfpatch concluded "no loader provider in deps" and
-# patched nothing -- the package installed reporting success and its libraries
-# kept a build-time RPATH, so anything dlopen'd out of them failed to find its
-# siblings. glibc is the only dep that carries `exports.runtime.loader`, so it
-# is the only one where the miss is fatal: for the rest, closure_lib_paths
-# falls back to the {lib64, lib} convention and the RPATH still comes out
-# right. Pinning this one keeps the stack usable on clients already released.
+# glibc as a floor, like every other dep here.
 #
-# The measured floor is 2.38 (libgallium's highest required symbol version).
-# Widen this to a range once the fixed client is the floor worth assuming.
-GLIBC = "xim:glibc@2.39"
+# It was pinned for one release, and the reason was a client bug rather than an
+# ABI one: before xlings 2026.8.5.2 a dep's version half was compared by string
+# equality, so `xim:glibc@>=2.38` matched no plan node, glibc's exports were
+# dropped, and elfpatch concluded "no loader provider in deps" and patched
+# nothing at all — the package installed reporting success with its libraries
+# still on a build-time RPATH. That is fixed, and these packages shipped
+# alongside the fix, so the pin has served its purpose.
+#
+# 2.38 is measured, not chosen: it is libgallium's highest required symbol
+# version. A floor is also the only expression that lets a NEWER glibc satisfy
+# the dependency, which is the direction that matters — glibc is backward
+# compatible, so a 2.44 runtime runs these 2.39-built payloads (verified), and
+# a pin would have refused it.
+GLIBC = "xim:glibc@>=2.38"
 
 SPEC = {
     # T1 — protocol descriptions and the kernel interface.

--- a/pkgs/c/code.lua
+++ b/pkgs/c/code.lua
@@ -1,11 +1,14 @@
-local function _win_url(ver)
-    return { url = string.format("https://update.code.visualstudio.com/%s/win32-x64-archive/stable", ver), sha256 = nil }
+-- sha256 is the official hash from the VS Code update API
+-- (update.code.visualstudio.com/api/update/<platform>/stable/latest). Nil for
+-- historical entries that predate checksum coverage; new versions must carry it.
+local function _win_url(ver, sha256)
+    return { url = string.format("https://update.code.visualstudio.com/%s/win32-x64-archive/stable", ver), sha256 = sha256 }
 end
-local function _linux_url(ver)
-    return { url = string.format("https://update.code.visualstudio.com/%s/linux-x64/stable", ver), sha256 = nil }
+local function _linux_url(ver, sha256)
+    return { url = string.format("https://update.code.visualstudio.com/%s/linux-x64/stable", ver), sha256 = sha256 }
 end
-local function _mac_url(ver)
-    return { url = string.format("https://update.code.visualstudio.com/%s/darwin-universal/stable", ver), sha256 = nil }
+local function _mac_url(ver, sha256)
+    return { url = string.format("https://update.code.visualstudio.com/%s/darwin-universal/stable", ver), sha256 = sha256 }
 end
 
 package = {
@@ -27,7 +30,8 @@ package = {
 
     xpm = {
         windows = {
-            ["latest"] = { ref = "1.125.1" },
+            ["latest"] = { ref = "1.132.0" },
+            ["1.132.0"] = _win_url("1.132.0", "98bd4a4721a5bd8534dbad8eaf9801f001ee36703a278c5d52d6036df8c7e503"),
             ["1.125.1"] = _win_url("1.125.1"),
             ["1.108.1"] = _win_url("1.108.1"),
             ["1.108.0"] = _win_url("1.108.0"),
@@ -40,7 +44,8 @@ package = {
             ["1.93.1"] = _win_url("1.93.1"),
         },
         linux = {
-            ["latest"] = { ref = "1.125.1" },
+            ["latest"] = { ref = "1.132.0" },
+            ["1.132.0"] = _linux_url("1.132.0", "acdaf0fa557bda1720956ff65ca0de0965e92d68f97e2db22341984400937aed"),
             ["1.125.1"] = _linux_url("1.125.1"),
             ["1.108.1"] = _linux_url("1.108.1"),
             ["1.108.0"] = _linux_url("1.108.0"),
@@ -50,7 +55,8 @@ package = {
             ["1.93.1"] = _linux_url("1.93.1"),
         },
         macosx = {
-            ["latest"] = { ref = "1.125.1" },
+            ["latest"] = { ref = "1.132.0" },
+            ["1.132.0"] = _mac_url("1.132.0", "5c9cc989a2916be9e1b83624c60e5f5e1ec9ddb1176b6b1c1e4d140ba06b9c2c"),
             ["1.125.1"] = _mac_url("1.125.1"),
             ["1.108.1"] = _mac_url("1.108.1"),
             ["1.108.0"] = _mac_url("1.108.0"),

--- a/pkgs/e/elfutils.lua
+++ b/pkgs/e/elfutils.lua
@@ -17,7 +17,7 @@ package = {
 
     xpm = {
         linux = {
-            deps = { "xim:zlib@>=1.2", "xim:glibc@2.39" },
+            deps = { "xim:zlib@>=1.2", "xim:glibc@>=2.38" },
             -- elfpatch reads this from each dependency and writes the consumer's
             -- RPATH, which is what makes the stack resolve without anyone
             -- setting LD_LIBRARY_PATH. Same mechanism `gcc-runtime` uses.

--- a/pkgs/g/glibc.lua
+++ b/pkgs/g/glibc.lua
@@ -174,7 +174,7 @@ function config()
     xvm.add("glibc")
 
     local glibc_root_binding = "glibc@" .. pkginfo.version()
-    local glibc_version = "glibc-" .. pkginfo.version()
+    local glibc_version = __version_key()
     local glibc_bindir = path.join(pkginfo.install_dir(), "bin")
     local glibc_libdir = path.join(pkginfo.install_dir(), "lib64")
 
@@ -225,7 +225,7 @@ function config()
 end
 
 function uninstall()
-    local glibc_version = "glibc-" .. pkginfo.version()
+    local glibc_version = __version_key()
     for _, lib in ipairs(glibc_libs) do
         xvm.remove(lib, glibc_version)
     end
@@ -236,6 +236,30 @@ function uninstall()
 end
 
 -- private
+
+-- The version key this package's entries are stored under.
+--
+-- xlings keys a version by namespace for every repo but the primary one, so
+-- `local:glibc` stores `local:glibc-2.39` while `xim:glibc` stores a bare
+-- `glibc-2.39`. Removing by the bare key is unambiguous only while ONE of
+-- them exists: with both installed, removal fails with
+--
+--     bare removal version 'glibc-2.39' matches 2 stored versions
+--
+-- and uninstall leaves every registered lib behind. That state was
+-- unreachable while the index shipped one glibc; adding 2.44 made it
+-- ordinary.
+--
+-- The namespace is not exposed to a hook, but the store directory is:
+-- `<data>/xpkgs/<ns>-x-glibc/<version>`. Deriving it from install_dir() keeps
+-- this to the recipe rather than waiting on a libxpkg field.
+function __version_key()
+    local store = path.filename(path.directory(pkginfo.install_dir()))
+    local ns = store:match("^(.-)%-x%-")
+    local bare = "glibc-" .. pkginfo.version()
+    if ns and ns ~= "" and ns ~= "xim" then return ns .. ":" .. bare end
+    return bare
+end
 
 function __config_header(binding)
     -- Declared where the client supports it, so the 130 top-level entries

--- a/pkgs/g/glibc.lua
+++ b/pkgs/g/glibc.lua
@@ -42,8 +42,36 @@ package = {
                     -- libdirs not declared → falls back to {lib64, lib} convention
                 },
             },
+            -- `latest` stays 2.39, deliberately.
+            --
+            -- glibc is backward compatible and not forward compatible: a
+            -- binary built against 2.39 runs on 2.44, and one built against
+            -- 2.44 does not run on 2.39. Every payload in the index today was
+            -- built against 2.39, so 2.39 is the version that runs all of
+            -- them. Moving `latest` to 2.44 would be safe for the same reason
+            -- — but it would also silently change which glibc every existing
+            -- home resolves to, and that is a decision to make deliberately
+            -- rather than as a side effect of adding a version.
+            --
+            -- What 2.44 is FOR is the other direction: a newer runtime hosts
+            -- MORE prebuilt binaries. Anything built elsewhere against a
+            -- glibc up to 2.44 — a vendor's binary, a distro's, the host's
+            -- NVIDIA userspace that nvidia-gl-host-link links to — loads under
+            -- it and does not under 2.39. Ask for it with `xlings install
+            -- glibc@2.44` or `xlings subos new <name> --runtime glibc@2.44`.
             ["latest"] = { ref = "2.39" },
             ["2.39"] = "XLINGS_RES",
+            -- Built from source, not XLINGS_RES: the sha256 is checked, which
+            -- an XLINGS_RES entry cannot do. Build recipe and the reason its
+            -- prefix looks the way it does:
+            -- .agents/tools/graphics/build-glibc.sh
+            ["2.44"] = {
+                url = {
+                    GLOBAL = "https://github.com/xlings-res/glibc/releases/download/2.44/glibc-2.44-linux-x86_64.tar.gz",
+                    CN     = "https://gitcode.com/xlings-res/glibc/releases/download/2.44/glibc-2.44-linux-x86_64.tar.gz",
+                },
+                sha256 = "0105292fd6b49f74fbf51f93af973b78a9fc18225cb1c757c720e90de3120182",
+            },
         },
     },
 }
@@ -60,7 +88,11 @@ local glibc_libs = {
     "ld-linux-x86-64.so.2", -- dynamic linker/loader
     "libc.a", "libc.so", "libc.so.6", "libc_nonshared.a", -- C library
     "libdl.a", "libdl.so.2", -- dynamic loading
-    "libm.a", "libm-2.39.a", "libmvec.a", "libm.so", "libm.so.6", "libmvec.so.1", -- math
+    -- `libm-<version>.a` is version-named and is added in config() rather than
+    -- listed here: writing `libm-2.39.a` made this list true of exactly one
+    -- glibc, and installing any other version registered a file that is not
+    -- there.
+    "libm.a", "libmvec.a", "libm.so", "libm.so.6", "libmvec.so.1", -- math
     "libpthread.so.0", "libpthread.a", -- pthread
     "librt.so.1", -- realtime
     "libresolv.so", "libresolv.so.2", -- resolver
@@ -89,7 +121,45 @@ local glibc_libs = {
 
 function install()
 
+    -- The payload root, without assuming what the tarball called it.
+    --
+    -- This used to be `install_file() minus .tar.gz`, which is true of the
+    -- 2.39 asset and of nothing else by construction — 2.44's tar holds
+    -- `glibc-2.44/`, not `glibc-2.44-linux-x86_64/`. The mismatch does not
+    -- raise: os.mv fails, install() returns true, and the install directory is
+    -- left holding the download cache. What you get is a glibc package with no
+    -- loader in it, reported as a successful install.
     local glibcdir = pkginfo.install_file():replace(".tar.gz", "")
+    if not os.isdir(glibcdir) then
+        -- Identified by CONTENT, not by name. The extraction directory is
+        -- shared and holds more than this archive, so "the only directory" is
+        -- not a usable rule either; what makes a directory glibc's payload is
+        -- that it contains glibc.
+        local base = path.directory(glibcdir)
+        local found = nil
+        local f = io.popen(string.format([[ls -1 "%s" 2>/dev/null]], base))
+        if f then
+            for line in f:lines() do
+                local d = line:gsub("[\r\n]+$", "")
+                if d ~= "" then
+                    local cand = path.join(base, d)
+                    if os.isdir(cand)
+                       and (os.isfile(path.join(cand, "lib", "libc.so.6"))
+                         or os.isfile(path.join(cand, "lib64", "libc.so.6"))) then
+                        found = cand
+                        break
+                    end
+                end
+            end
+            f:close()
+        end
+        if not found then
+            raise(string.format(
+                "cannot find the payload root under '%s': no extracted "
+                .. "directory contains lib/libc.so.6", base))
+        end
+        glibcdir = found
+    end
 
     os.tryrm(pkginfo.install_dir())
     os.mv(glibcdir, pkginfo.install_dir())
@@ -130,10 +200,21 @@ function config()
         binding = glibc_root_binding,
     }
 
-    for _, lib in ipairs(glibc_libs) do
-        lib_config.filename = lib -- target file name
-        lib_config.alias = lib -- source file name
-        xvm.add(lib, lib_config)
+    -- The version-named archive, whatever this release calls it.
+    local libs = {}
+    for _, l in ipairs(glibc_libs) do table.insert(libs, l) end
+    table.insert(libs, "libm-" .. pkginfo.version() .. ".a")
+
+    for _, lib in ipairs(libs) do
+        -- Guarded, the way zlib's registration is. A name that is not in this
+        -- release's payload should be skipped, not registered as a lib whose
+        -- source file does not exist — glibc's own file set changes between
+        -- versions and the list above cannot be right for all of them.
+        if os.isfile(path.join(glibc_libdir, lib)) then
+            lib_config.filename = lib -- target file name
+            lib_config.alias = lib -- source file name
+            xvm.add(lib, lib_config)
+        end
     end
 
     log.debug("3 - glibc config header files...")
@@ -148,6 +229,7 @@ function uninstall()
     for _, lib in ipairs(glibc_libs) do
         xvm.remove(lib, glibc_version)
     end
+    xvm.remove("libm-" .. pkginfo.version() .. ".a", glibc_version)
     xvm.remove("ldd", glibc_version)
     xvm.remove("glibc")
     return true

--- a/pkgs/g/glslang.lua
+++ b/pkgs/g/glslang.lua
@@ -17,7 +17,7 @@ package = {
 
     xpm = {
         linux = {
-            deps = { "xim:gcc-runtime@>=15", "xim:glibc@2.39" },
+            deps = { "xim:gcc-runtime@>=15", "xim:glibc@>=2.38" },
             -- elfpatch reads this from each dependency and writes the consumer's
             -- RPATH, which is what makes the stack resolve without anyone
             -- setting LD_LIBRARY_PATH. Same mechanism `gcc-runtime` uses.

--- a/pkgs/l/libllvm.lua
+++ b/pkgs/l/libllvm.lua
@@ -17,7 +17,7 @@ package = {
 
     xpm = {
         linux = {
-            deps = { "xim:gcc-runtime@>=15", "xim:glibc@2.39" },
+            deps = { "xim:gcc-runtime@>=15", "xim:glibc@>=2.38" },
             -- elfpatch reads this from each dependency and writes the consumer's
             -- RPATH, which is what makes the stack resolve without anyone
             -- setting LD_LIBRARY_PATH. Same mechanism `gcc-runtime` uses.

--- a/pkgs/m/mesa.lua
+++ b/pkgs/m/mesa.lua
@@ -71,19 +71,15 @@ package = {
                 -- vendor fail, which EGL reports as having no vendor at all.
                 "xim:wayland@>=1.23",
                 "xim:gcc-runtime@>=15",
-                -- Pinned, alone among these, and for a client reason rather
-                -- than an ABI one. The measured floor is 2.38 (libgallium's
-                -- highest required symbol version), but before 2026.8.5.2
-                -- xlings compared a dep's version half by string equality:
-                -- `@>=2.38` matched no plan node, glibc's exports were
-                -- dropped, elfpatch found "no loader provider in deps" and
-                -- patched nothing. mesa then installed reporting success with
-                -- its libraries still on a build-time RPATH, and glvnd's
-                -- dlopen of libEGL_mesa failed to find libexpat -- surfacing
-                -- as EGL having no vendor at all. glibc is the only dep that
-                -- exports a loader, so it is the only one where the miss is
-                -- fatal. Pinning keeps this usable on clients already out.
-                "xim:glibc@2.39",
+                -- A floor, and 2.38 is measured: libgallium's highest
+                -- required symbol version. It was pinned for one release
+                -- because clients before 2026.8.5.2 compared a dep's version
+                -- half by string equality and silently dropped glibc's
+                -- exports; that is fixed, and this package shipped with the
+                -- fix. A floor is also what lets a newer glibc satisfy this —
+                -- glibc is backward compatible, so a 2.44 runtime runs this
+                -- 2.39-built payload, and a pin would refuse it.
+                "xim:glibc@>=2.38",
             },
             exports = {
                 runtime = { libdirs = { "lib" } },

--- a/pkgs/w/wayland.lua
+++ b/pkgs/w/wayland.lua
@@ -17,7 +17,7 @@ package = {
 
     xpm = {
         linux = {
-            deps = { "xim:libffi@>=3.4", "xim:glibc@2.39" },
+            deps = { "xim:libffi@>=3.4", "xim:glibc@>=2.38" },
             -- elfpatch reads this from each dependency and writes the consumer's
             -- RPATH, which is what makes the stack resolve without anyone
             -- setting LD_LIBRARY_PATH. Same mechanism `gcc-runtime` uses.


### PR DESCRIPTION
glibc is backward compatible and not forward compatible, so a **newer** runtime hosts more — every payload here, plus anything built elsewhere against a glibc up to 2.44. A version pin is exactly what refuses it.

- glibc 2.44 built from source and published to both mirrors; `latest` deliberately stays 2.39
- 21 glibc deps → floors (`>=2.38` measured for the graphics stack, `>=2.39` elsewhere)
- 10 other ABI-stable pins → floors; `libllvm` stays exact (97 mangled symbols tagged @LLVM_20.1), openssl and `claude` left alone

Safe to do now because xlings 2026.8.5.2 fixed the string-equality comparison that made a ranged dep silently drop its exports.

Two defects only a second glibc version could expose, both fixed: a hardcoded `libm-2.39.a` in the library list, and an install() that located the payload by filename and — when that failed — left the download cache as the payload while returning true.

**Verified**: a subos with `--runtime glibc@2.44` running the whole stack, S1–S4 PASS with no /usr, probe INTERP is 2.44's ld.so; and a fresh home from the ranged recipes resolving glibc to 2.44 alone.