### PR TITLE
feat(aria2-next): add 2.5.5 for all platforms

### DIFF
--- a/pkgs/a/aria2-next.lua
+++ b/pkgs/a/aria2-next.lua
@@ -1,0 +1,105 @@
+package = {
+    spec = "2",
+
+    homepage = "https://github.com/AnInsomniacy/aria2-next",
+    name = "aria2-next",
+    description = "Aria2 Next — a maintained aria2 fork with extensive bug fixes and a modernized architecture",
+
+    authors = {"AnInsomniacy"},
+    licenses = {"GPL-2.0"},
+    repo = "https://github.com/AnInsomniacy/aria2-next",
+    docs = "https://github.com/AnInsomniacy/aria2-next#readme",
+
+    -- xim pkg info
+    type = "package",
+    archs = {"x86_64", "aarch64"},
+    status = "stable",
+    categories = {"tools", "download"},
+    keywords = {"aria2", "download", "bt", "torrent", "aria2-next"},
+
+    programs = {"aria2-next"},
+
+    xvm_enable = true,
+
+    -- aria2-next ships standalone per-arch executables on GitHub Releases
+    -- (no archive wrapper). The release tag carries a `v` prefix while the
+    -- asset name does not, and macOS names its arch `arm64` — so explicit
+    -- per-arch resource maps (V2 Shape B) rather than a URL template. Every
+    -- sha256 below is from the release's own checksums.sha256 file.
+    xpm = {
+        linux = {
+            ["latest"] = { ref = "2.5.5" },
+            ["2.5.5"] = {
+                x86_64 = {
+                    url = "https://github.com/AnInsomniacy/aria2-next/releases/download/v2.5.5/aria2-next-2.5.5-linux-x86_64",
+                    sha256 = "b6f2cdadcd34ba16dd7fcb29de4b84c36f893f9b223a9a05157d1892687a45a0",
+                },
+                aarch64 = {
+                    url = "https://github.com/AnInsomniacy/aria2-next/releases/download/v2.5.5/aria2-next-2.5.5-linux-aarch64",
+                    sha256 = "fd4b07aeb50fb02a9d19dd55e3ff5cea99e5a6263db1cc6a554c216dc49fa987",
+                },
+            },
+        },
+        macosx = {
+            ["latest"] = { ref = "2.5.5" },
+            ["2.5.5"] = {
+                x86_64 = {
+                    url = "https://github.com/AnInsomniacy/aria2-next/releases/download/v2.5.5/aria2-next-2.5.5-macos-x86_64",
+                    sha256 = "49a39dd624d45f693a41ecca0e6359ec0bd91df9efa16cf994f2f200aa45d415",
+                },
+                aarch64 = {
+                    url = "https://github.com/AnInsomniacy/aria2-next/releases/download/v2.5.5/aria2-next-2.5.5-macos-arm64",
+                    sha256 = "1417eec59edba6ac436b5f3b1bbcc2add01696d62333e8de8c3900677bd45926",
+                },
+            },
+        },
+        windows = {
+            ["latest"] = { ref = "2.5.5" },
+            ["2.5.5"] = {
+                x86_64 = {
+                    url = "https://github.com/AnInsomniacy/aria2-next/releases/download/v2.5.5/aria2-next-2.5.5-windows-x86_64.exe",
+                    sha256 = "554f2f81ca53731dc9e01710cfb16081a34759f3276ff16eb4b12656c1b6e5b9",
+                },
+                aarch64 = {
+                    url = "https://github.com/AnInsomniacy/aria2-next/releases/download/v2.5.5/aria2-next-2.5.5-windows-arm64.exe",
+                    sha256 = "fe029b00c72014690f128c17830f51924b6c07bafee28e28763d1fed93cb393e",
+                },
+            },
+        },
+    },
+}
+
+import("xim.libxpkg.fs")
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+
+function install()
+    local install_dir = pkginfo.install_dir()
+    local bin_name = "aria2-next"
+    if os.host() == "windows" then
+        bin_name = "aria2-next.exe"
+    end
+
+    -- The asset is a raw standalone executable (no archive wrapper); move it
+    -- into our install dir under the canonical name.
+    os.tryrm(install_dir)
+    fs.mkdir_p(install_dir)
+    os.mv(pkginfo.install_file(), path.join(install_dir, bin_name))
+    if os.host() ~= "windows" then
+        os.exec("chmod +x \"" .. path.join(install_dir, bin_name) .. "\"")
+    end
+    return os.isfile(path.join(install_dir, bin_name))
+end
+
+function config()
+    -- The binary is named after the package, so registering the program
+    -- doubles as the package-name anchor (no separate group node — a group
+    -- under the same name would collide with the program registration).
+    xvm.add(package.name, { bindir = pkginfo.install_dir() })
+    return true
+end
+
+function uninstall()
+    xvm.remove(package.name)
+    return true
+end

--- a/tests/a/test_aria2_next.py
+++ b/tests/a/test_aria2_next.py
@@ -1,0 +1,80 @@
+"""测试 aria2-next 包"""
+import pytest
+from tests.lib.xpkg_parser import parse_xpkg
+from tests.lib.assertions import (
+    assert_required_fields, assert_valid_spec, assert_valid_type,
+    assert_no_typos, assert_no_exec_xvm, assert_no_bashrc_modification,
+    assert_no_direct_path_modification, assert_uses_new_api,
+    assert_xim_add_succeeds, assert_install_succeeds,
+    assert_command_output, assert_xvm_shim_exists,
+)
+from tests.lib.platform_utils import skip_if_not
+
+PKG = "aria2-next"
+PKG_FILE = "pkgs/a/aria2-next.lua"
+
+
+@pytest.fixture(scope='module')
+def meta():
+    return parse_xpkg(PKG_FILE)
+
+
+class TestStatic:
+    @pytest.mark.static
+    def test_required_fields(self, meta):
+        assert_required_fields(meta)
+
+    @pytest.mark.static
+    def test_valid_spec(self, meta):
+        assert_valid_spec(meta)
+
+    @pytest.mark.static
+    def test_valid_type(self, meta):
+        assert_valid_type(meta)
+
+    @pytest.mark.static
+    def test_no_typos(self):
+        assert_no_typos(PKG_FILE)
+
+
+class TestIndex:
+    @pytest.mark.index
+    def test_xim_add(self):
+        assert_xim_add_succeeds(PKG_FILE)
+
+
+class TestIsolation:
+    @pytest.mark.isolation
+    def test_no_exec_xvm(self):
+        assert_no_exec_xvm(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_no_bashrc(self):
+        assert_no_bashrc_modification(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_no_path_modification(self):
+        assert_no_direct_path_modification(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_new_api(self):
+        assert_uses_new_api(PKG_FILE)
+
+
+class TestLifecycle:
+    @pytest.mark.lifecycle
+    @skip_if_not('linux')
+    def test_install(self):
+        assert_install_succeeds(PKG)
+
+
+class TestVerify:
+    @pytest.mark.verify
+    @skip_if_not('linux')
+    def test_version(self):
+        assert_command_output("aria2-next --version", contains="Aria2 Next version")
+
+    @pytest.mark.verify
+    @skip_if_not('linux')
+    def test_shim(self):
+        assert_xvm_shim_exists("aria2-next")


### PR DESCRIPTION
## Summary
Add a new **aria2-next** package (`pkgs/a/aria2-next.lua`, latest **2.5.5** — a maintained aria2 fork with extensive bug fixes) on linux / macosx / windows, with mirror test `tests/a/test_aria2_next.py`.

## Resources — all sha256 from the release's own `checksums.sha256`
- **linux x86_64**: `aria2-next-2.5.5-linux-x86_64` — `b6f2cdadcd34ba16dd7fcb29de4b84c36f893f9b223a9a05157d1892687a45a0` (verified by download + sha256sum)
- **linux aarch64**: `aria2-next-2.5.5-linux-aarch64` — `fd4b07aeb50fb02a9d19dd55e3ff5cea99e5a6263db1cc6a554c216dc49fa987`
- **macosx x86_64**: `aria2-next-2.5.5-macos-x86_64` — `49a39dd624d45f693a41ecca0e6359ec0bd91df9efa16cf994f2f200aa45d415`
- **macosx aarch64**: `aria2-next-2.5.5-macos-arm64` — `1417eec59edba6ac436b5f3b1bbcc2add01696d62333e8de8c3900677bd45926`
- **windows x86_64**: `aria2-next-2.5.5-windows-x86_64.exe` — `554f2f81ca53731dc9e01710cfb16081a34759f3276ff16eb4b12656c1b6e5b9`
- **windows aarch64**: `aria2-next-2.5.5-windows-arm64.exe` — `fe029b00c72014690f128c17830f51924b6c07bafee28e28763d1fed93cb393e`

`spec = "2"`, `archs = {"x86_64","aarch64"}`. Assets are raw per-arch executables (release tag has a `v` prefix; macOS names its arch `arm64`), so the recipe uses explicit per-arch resource maps (V2 Shape B) rather than a URL template.

## Install / uninstall behavior
- Assets are standalone executables, no archive wrapper: `install()` moves the downloaded file into `install_dir` as `aria2-next` (`.exe` on windows) and `chmod +x` on POSIX.
- `config()` registers the program under `package.name` (binary is named after the package, so it doubles as the package anchor — no separate group node, which would collide). Nothing touches PATH / shell config / host package managers.
- `uninstall()` removes it.

## Test plan
- `pytest tests/a/test_aria2_next.py -m "static or isolation"` → 8 passed
- `pytest tests/ -m "static or isolation"` → **1093 passed**, 4 xpassed (pre-existing xfail); D1/D3 spec tests over all packages included
- `version-check.py --workspace .` and `check-no-direct-ld-libpath.sh` → exit 0
- `parse-xpkg-meta.py` → name=aria2-next, programs=[aria2-next], has_linux/macosx/windows=true
- **Isolated install verified locally**: register → `install local:aria2-next` ✓ → `aria2-next --version` prints `Aria2 Next version 2.5.5` → `list` ✓ → `remove` ✓ payload cleaned
- CI will run install/uninstall on linux, windows, macos runners