### PR TITLE
feat: glibc deps become floors, and the resolver's answer gets documented

### DIFF
--- a/.github/scripts/posix-test.sh
+++ b/.github/scripts/posix-test.sh
@@ -287,6 +287,49 @@ for rel_file in "${files[@]}"; do
         info "no new shim appeared (type='$pkg_type'; programs='$programs' may have been re-pointed)"
     fi
 
+    # A payload's loader and its libc must come from the same payload.
+    #
+    # `ld.so` and `libc.so.6` are two halves of one build, talking over
+    # GLIBC_PRIVATE symbols that promise nothing across versions. A package
+    # that got them from different payloads installs cleanly, passes every
+    # check above, and faults before `main` on the user's machine with a
+    # message naming neither package nor version.
+    #
+    # xlings 2026.8.5.3 refuses to finish such an install, so this should
+    # never fire. It is here because the check that never fires is exactly
+    # the one worth keeping: it costs one string compare per binary, and it
+    # is what turns "we believe that cannot happen" into something CI states.
+    if [[ "$HOST_OS" == "linux" ]] && command -v patchelf >/dev/null 2>&1; then
+        step "[$pkg] loader/libc same-source"
+        split_found=0
+        while IFS= read -r -d '' elf; do
+            [[ "$(head -c4 "$elf" 2>/dev/null)" == $'\x7fELF' ]] || continue
+            interp="$(patchelf --print-interpreter "$elf" 2>/dev/null)" || continue
+            [[ -n "$interp" ]] || continue
+            payload_of() { sed -E 's#(.*/xpkgs/[^/]+/[^/]+)/.*#\1#' <<<"$1"; }
+            iroot="$(payload_of "$interp")"
+            [[ "$iroot" == *"/xpkgs/"* ]] || continue
+            provider="$(sed -E 's#.*/xpkgs/([^/]+)/[^/]+$#\1#' <<<"$iroot")"
+            rp="$(patchelf --print-rpath "$elf" 2>/dev/null)"
+            same=0; other=""
+            IFS=: read -ra parts <<<"$rp"
+            for part in "${parts[@]}"; do
+                case "$part" in *"/xpkgs/$provider/"*)
+                    r="$(payload_of "$part")"
+                    [[ "$r" == "$iroot" ]] && same=1 || other="$r" ;;
+                esac
+            done
+            if [[ -n "$other" && $same -eq 0 ]]; then
+                log_fail "loader/libc split: ${elf##*/} interp=$iroot rpath=$other"
+                split_found=1
+            fi
+        done < <(find "$XPKGS_DIR" -type f ! -type l -print0 2>/dev/null)
+        if [[ $split_found -eq 1 ]]; then
+            failures+=("$rel_file (loader/libc split)"); continue
+        fi
+        log_pass "loader and libc come from one payload"
+    fi
+
     step "[$pkg] uninstall ($pkg_spec)"
     if ! "$XLINGS_CMD" remove "$pkg_spec" -y; then
         log_fail "uninstall failed"; failures+=("$rel_file (uninstall)"); continue

--- a/docs/V2/xpackage-spec.md
+++ b/docs/V2/xpackage-spec.md
@@ -217,6 +217,79 @@ manifest export the same values. `doctor` reports every conflict rather than
 resolving it quietly. A variable the **user** already exported wins over a
 `set`; `prepend` still composes with it.
 
+## `resolved_deps` — what the resolver decided, for hooks that need it
+
+A recipe writes a dependency as a **question**:
+
+```lua
+deps = { "xim:glibc@>=2.38" }
+```
+
+`_RUNTIME.resolved_deps` is the **answer**, available in `install()` and
+`config()` from xlings 2026.8.5.3 / libxpkg 0.0.50:
+
+```lua
+_RUNTIME.resolved_deps["xim:glibc@>=2.38"] = {
+    name        = "xim:glibc",
+    version     = "2.44",                      -- what it resolved TO
+    install_dir = "<store>/xpkgs/xim-x-glibc/2.44",
+    libdirs     = { "<store>/xpkgs/xim-x-glibc/2.44/lib64" },
+    source      = "plan-range",                -- why this one
+}
+```
+
+**Total, unlike `deps_exports`.** Every runtime dep is here whether or not it
+declared `exports`. A dep missing from this table means the CLIENT does not
+send it, not that the dep declared nothing — those two used to be
+indistinguishable, and telling them apart is the point.
+
+### Use it instead of looking a dependency up yourself
+
+`pkginfo.dep_install_dir(name)` consults this table first, so most recipes need
+nothing new. What a recipe must NOT do is re-derive the answer:
+
+```lua
+-- WRONG: a second answer to a question that already has one.
+local dir = "<...>/xpkgs/xim-x-glibc/" .. some_version .. "/lib64"
+
+-- WRONG: also a second answer, just spelled with an API.
+for _, sub in ipairs({"lib64", "lib"}) do ... end
+```
+
+Both were real code. With two versions of a package installed they answered
+differently from the resolver, and the product was a binary whose interpreter
+came from one payload and whose RUNPATH from another — a fault before `main`
+reporting `undefined symbol: __pointer_chk_guard, version GLIBC_PRIVATE`,
+which names neither package nor version.
+
+xlings now refuses to finish an install that produced one, and `xlings doctor`
+reports existing ones. Design and the invariant:
+`xlings/.agents/docs/2026-08-05-dependency-resolution-single-source.md`
+
+### Probing for it
+
+```lua
+if type(_RUNTIME.resolved_deps) == "table" then
+    -- use it
+end
+```
+
+`type()`, never `if _RUNTIME.resolved_deps then`. See the next section — the
+same trap applies to every capability added after a client shipped.
+
+### Inspecting it after the fact
+
+Each install writes `<install_dir>/.xlings-resolution.json`, and
+
+```
+xlings why <package> [dependency]
+```
+
+reads it back: the version, the payload, and `source`. That is what makes
+"why is it 2.39 on this machine" answerable without reproducing the machine.
+
+---
+
 ## Adopting a capability older clients do not have
 
 The index serves every client version at once. Two kinds of change behave very

--- a/pkgs/b/binutils.lua
+++ b/pkgs/b/binutils.lua
@@ -30,7 +30,7 @@ package = {
 
     xpm = {
         linux = {
-            deps = { "xim:glibc@2.39" },
+            deps = { "xim:glibc@>=2.39" },
             ["latest"] = { ref = "2.42" },
             ["2.42"] = "XLINGS_RES",
         },

--- a/pkgs/b/bun.lua
+++ b/pkgs/b/bun.lua
@@ -26,7 +26,7 @@ package = {
             -- (NEEDED libc.so.6 / libdl.so.2 / libm.so.6 /
             -- libpthread.so.0; no libgcc_s/libstdc++).
             deps = {
-                runtime = { "xim:glibc@2.39" },
+                runtime = { "xim:glibc@>=2.39" },
                 build   = { "xim:node", "xim:npm" },
             },
             ["latest"] = { ref = "1.3.11" },

--- a/pkgs/c/cmake.lua
+++ b/pkgs/c/cmake.lua
@@ -27,7 +27,7 @@ package = {
             -- libc/libdl/librt/libpthread/libm from glibc. No libstdc++
             -- (statically linked into the binary).
             deps = {
-                runtime = { "xim:glibc@2.39" },
+                runtime = { "xim:glibc@>=2.39" },
             },
             ["latest"] = { ref = "4.0.2" },
             ["4.0.2"] = "XLINGS_RES",

--- a/pkgs/d/d2x.lua
+++ b/pkgs/d/d2x.lua
@@ -35,7 +35,7 @@ package = {
             ["0.1.1"] = "XLINGS_RES",
         },
         linux = {
-            deps = { "xim:glibc@2.39", "xim:openssl@3.1.5" },
+            deps = { "xim:glibc@>=2.39", "xim:openssl@3.1.5" },
             ["latest"] = { ref = "2026.08.02.2" },
             ["2026.08.02.2"] = "XLINGS_RES",
             ["2026.08.02.1"] = "XLINGS_RES",

--- a/pkgs/g/gcc-runtime.lua
+++ b/pkgs/g/gcc-runtime.lua
@@ -39,7 +39,7 @@ package = {
             ["15.1.0"] = "XLINGS_RES",
 
             deps = {
-                runtime = { "xim:glibc@2.39" },
+                runtime = { "xim:glibc@>=2.39" },
             },
             exports = {
                 runtime = {

--- a/pkgs/g/gcc.lua
+++ b/pkgs/g/gcc.lua
@@ -32,7 +32,7 @@ package = {
     xpm = {
         linux = {
             deps = {
-                "xim:glibc@2.39", "xim:binutils@2.42",
+                "xim:glibc@>=2.39", "xim:binutils@2.42",
                 -- fix xmake project --project=.  -k compile_commands
                 -- home/xlings/.xlings_data/subos/linux/usr/include/bits/errno.h:26:11: fatal error: linux/errno.h: No such file or directory
                 "xim:linux-headers@5.11.1",

--- a/pkgs/g/godot.lua
+++ b/pkgs/g/godot.lua
@@ -119,7 +119,7 @@ package = {
             -- without X11/wayland can only run --headless.
             deps = {
                 runtime = {
-                    "xim:glibc@2.39",
+                    "xim:glibc@>=2.39",
                     "xim:freetype@2.13.2",
                     "xim:expat@2.6.2",
                 },

--- a/pkgs/g/griddycode.lua
+++ b/pkgs/g/griddycode.lua
@@ -35,7 +35,7 @@ package = {
             -- ship; users on hermetic distros won't be able to run
             -- griddycode anyway without an X11/Wayland session.
             deps = {
-                runtime = { "xim:glibc@2.39" },
+                runtime = { "xim:glibc@>=2.39" },
             },
             url_template = "https://github.com/face-hh/griddycode/releases/download/v{version}/Linux.zip",
             ["latest"] = { ref = "1.2.2" },

--- a/pkgs/l/llvm.lua
+++ b/pkgs/l/llvm.lua
@@ -24,7 +24,7 @@ package = {
             -- is a thin delegator to scode:linux-headers, so the install-test harness
             -- registers the scode sub-index (see .github/scripts).
             deps = {
-                "xim:glibc@2.39",
+                "xim:glibc@>=2.39",
                 "xim:linux-headers@5.11.1",
                 "xim:zlib@1.3.1",
                 "xim:libxml2@2.13.5",

--- a/pkgs/n/node.lua
+++ b/pkgs/n/node.lua
@@ -74,7 +74,7 @@ package = {
             -- No build deps — install hook is just `os.mv` of the extracted
             -- prebuilt; nothing is compiled at install time.
             deps = {
-                runtime = { "xim:glibc@2.39", "xim:gcc-runtime@15.1.0" },
+                runtime = { "xim:glibc@>=2.39", "xim:gcc-runtime@15.1.0" },
             },
             ["latest"] = { ref = "24.15.0" },
             ["25.9.0"] = _linux_url("25.9.0"),

--- a/pkgs/n/nvidia-gl-host-link.lua
+++ b/pkgs/n/nvidia-gl-host-link.lua
@@ -68,7 +68,7 @@ package = {
                 "xim:libglvnd@>=1.7",
                 "xim:libX11@>=1.8",
                 "xim:libXext@>=1.3",
-                "xim:glibc@2.39",
+                "xim:glibc@>=2.39",
             },
             exports = {
                 runtime = { libdirs = { "lib" } },

--- a/pkgs/n/nvim.lua
+++ b/pkgs/n/nvim.lua
@@ -46,7 +46,7 @@ package = {
             -- (GCC unwind runtime, ships in xim:gcc-runtime). No
             -- libstdc++ — neovim itself is C, not C++.
             deps = {
-                runtime = { "xim:glibc@2.39", "xim:gcc-runtime@15.1.0" },
+                runtime = { "xim:glibc@>=2.39", "xim:gcc-runtime@15.1.0" },
             },
             source = {
                 GLOBAL = "https://github.com/neovim/neovim/releases/download/v${version}/nvim-linux-x86_64.tar.gz",

--- a/pkgs/o/ollama.lua
+++ b/pkgs/o/ollama.lua
@@ -44,7 +44,7 @@ package = {
             --     into each cuda_v* dir below.
             deps = {
                 runtime = {
-                    "xim:glibc@2.39",
+                    "xim:glibc@>=2.39",
                     "xim:gcc-runtime@15.1.0",
                     "xim:libcuda-host-link@0.0.1",
                 },

--- a/pkgs/o/openssl.lua
+++ b/pkgs/o/openssl.lua
@@ -21,7 +21,7 @@ package = {
 
     xpm = {
         linux = {
-            deps = { "xim:glibc@2.39" },
+            deps = { "xim:glibc@>=2.39" },
             ["latest"] = { ref = "3.1.5" },
             ["3.1.5"] = "XLINGS_RES",
         },

--- a/pkgs/p/pnpm.lua
+++ b/pkgs/p/pnpm.lua
@@ -42,7 +42,7 @@ package = {
             -- which ship C++ panic-unwind + std). Same as xim:node /
             -- xim:ollama deps shape.
             deps = {
-                runtime = { "xim:glibc@2.39", "xim:gcc-runtime@15.1.0" },
+                runtime = { "xim:glibc@>=2.39", "xim:gcc-runtime@15.1.0" },
             },
             url_template = "https://github.com/pnpm/pnpm/releases/download/v{version}/pnpm-linux-x64.tar.gz",
             ["latest"] = { ref = "11.12.0" },

--- a/pkgs/p/python.lua
+++ b/pkgs/p/python.lua
@@ -23,7 +23,7 @@ package = {
             -- dep declaring exports.runtime.loader the predicate never fires
             -- and the payload keeps python-build-standalone's INTERP, which is
             -- the HOST's /lib64/ld-linux-x86-64.so.2.
-            deps = { "xim:glibc@2.39" },
+            deps = { "xim:glibc@>=2.39" },
             ["latest"] = { ref = "3.13.12" },
             ["3.13.12"] = {
                 url = "https://gitcode.com/xlings-res/mirror-cn/releases/download/python/cpython-3.13.12%2B20260310-x86_64-unknown-linux-gnu-install_only.tar.gz",


### PR DESCRIPTION
Sixteen recipes pinned `xim:glibc@2.39`. That pin was the only safe option while "which version is this dependency" had several independent answers — a package could get its interpreter from one payload and its libc from another.

xlings 2026.8.5.3 + libxpkg 0.0.50 make that unconstructible, so a floor is safe, and a floor is what these recipes mean. It is also what makes `xim:glibc@2.44` usable at all.

Verified locally before pushing — this change was attempted once and CI found four failures. All four now run clean through `.github/scripts/posix-test.sh` with the fixed client.

Spec gains `resolved_deps`, including the two shapes a recipe must **not** write.