### PR TITLE
feat(claude,cc-switch): native single-file binaries + CN mirror

### DIFF
--- a/pkgs/c/cc-switch.lua
+++ b/pkgs/c/cc-switch.lua
@@ -1,5 +1,87 @@
+-- cc-switch — provider switcher for Claude Code / Codex / OpenCode /
+-- Gemini CLI / openclaw. Upstream ships one self-contained artifact per
+-- platform: a Linux AppImage (a single executable ELF), a Windows
+-- portable zip holding just `cc-switch.exe`, and a macOS zip holding the
+-- signed `CC Switch.app` bundle. No installer, no runtime to bring
+-- along.
+--
+-- Why this is `spec = "2"` now: the recipe used to carry ONE url per
+-- platform while declaring `archs = {"x86_64", "aarch64"}`, so an ARM
+-- host was served `...-Linux-x86_64.AppImage` and got a binary it could
+-- not run. That is exactly the V1 hole V2 exists to close. Upstream has
+-- published `...-Linux-arm64.AppImage` since at least 3.14.1 and added
+-- `...-Windows-arm64-Portable.zip` in the 3.19 line, so every declared
+-- arch now resolves to a matching asset.
+--
+-- macOS is the exception: `CC-Switch-v<ver>-macOS.zip` is a universal
+-- (x86_64 + arm64) bundle, so both arch keys intentionally point at the
+-- same asset and the same sha256.
+--
+-- GLOBAL = the authoritative upstream GitHub release.
+-- CN     = gitcode.com/xlings-res/cc-switch, a byte-identical copy of
+--          those same assets under the same filenames, published so
+--          mainland-China installs don't go through github.com. Only the
+--          version `latest` points at is mirrored.
+--
+-- No `package.ci`: the auto-updater resolves one url per platform from a
+-- `url_template`, which cannot express the per-arch assets above — a
+-- bump it generated would silently reintroduce the wrong-arch bug. (It
+-- is also why #375 downgraded this package out of auto-mirroring.) Bumps
+-- are done by hand, together with the CN mirror push.
+
+local _CCS_GH = "https://github.com/farion1231/cc-switch/releases/download"
+local _CCS_CN = "https://gitcode.com/xlings-res/cc-switch/releases/download"
+
+-- Upstream tags are `v<ver>`; the CN mirror tags are plain `<ver>`.
+-- Asset filenames are identical on both sides.
+local function _res(ver, asset, sha256, mirrored)
+    local global = string.format("%s/v%s/%s", _CCS_GH, ver, asset)
+    if not mirrored then
+        return { url = global, sha256 = sha256 }
+    end
+    return {
+        url = {
+            GLOBAL = global,
+            CN = string.format("%s/%s/%s", _CCS_CN, ver, asset),
+        },
+        sha256 = sha256,
+    }
+end
+
+local function _linux(ver, sha_x86_64, sha_aarch64, mirrored)
+    return {
+        x86_64 = _res(ver, string.format("CC-Switch-v%s-Linux-x86_64.AppImage", ver),
+                      sha_x86_64, mirrored),
+        aarch64 = _res(ver, string.format("CC-Switch-v%s-Linux-arm64.AppImage", ver),
+                       sha_aarch64, mirrored),
+    }
+end
+
+local function _windows(ver, sha_x86_64, sha_aarch64, mirrored)
+    return {
+        x86_64 = _res(ver, string.format("CC-Switch-v%s-Windows-Portable.zip", ver),
+                      sha_x86_64, mirrored),
+        aarch64 = _res(ver, string.format("CC-Switch-v%s-Windows-arm64-Portable.zip", ver),
+                       sha_aarch64, mirrored),
+    }
+end
+
+-- Both arch keys resolve to one asset. That is the macOS universal
+-- bundle, and also the pre-3.19 Windows builds, which shipped no arm64
+-- zip at all.
+local function _universal(ver, asset, sha, mirrored)
+    return {
+        x86_64 = _res(ver, asset, sha, mirrored),
+        aarch64 = _res(ver, asset, sha, mirrored),
+    }
+end
+
+local function _macosx(ver, sha, mirrored)
+    return _universal(ver, string.format("CC-Switch-v%s-macOS.zip", ver), sha, mirrored)
+end
+
 package = {
-    spec = "1",
+    spec = "2",
 
     name = "cc-switch",
     description = "Cross-platform desktop tool for switching providers across Claude Code / Codex / OpenCode / Gemini CLI / openclaw",
@@ -7,14 +89,13 @@ package = {
     maintainers = {"farion1231"},
     licenses = {"MIT"},
     repo = "https://github.com/farion1231/cc-switch",
-    -- update only: cc-switch ships universal per-platform assets
-    -- (CC-Switch-*-macOS.zip / *-Windows-Portable.zip carry no arch token)
-    -- while declaring two arches, so it doesn't fit the per-arch mirror
-    -- model. It still auto-updates via url_template + latest.ref.
-    ci = { update = true },
     docs = "https://github.com/farion1231/cc-switch#readme",
 
-    type = "app",
+    -- Was the out-of-spec value "app" until now — the spec allows only
+    -- package / script / template / config, cc-switch was the one recipe
+    -- in the index using anything else, and having no test file is why
+    -- nobody noticed.
+    type = "package",
     archs = {"x86_64", "aarch64"},
     status = "stable",
     categories = {"app", "ai-agent", "tools"},
@@ -25,44 +106,49 @@ package = {
 
     xpm = {
         linux = {
-            url_template = "https://github.com/farion1231/cc-switch/releases/download/v{version}/CC-Switch-v{version}-Linux-x86_64.AppImage",
-            ["latest"] = { ref = "3.14.1" },
-            ["3.14.1"] = {
-                url = "https://github.com/farion1231/cc-switch/releases/download/v3.14.1/CC-Switch-v3.14.1-Linux-x86_64.AppImage",
-                sha256 = "a2e5c4183156437c96a1fe72df2a7b4b87ff6c857cdf0912e7057c34efcd5309",
-            },
+            ["latest"] = { ref = "3.19.1" },
+            ["3.19.1"] = _linux("3.19.1",
+                "199dbdf11c3f84fcb1219118728e7c22178d426108e9bd4697924b8d7d11849f",
+                "2791b86db0e381a7c8bb45b25b4c2db01f5f969ee547ab15cf58fedaaa6c9d53", true),
+            ["3.14.1"] = _linux("3.14.1",
+                "a2e5c4183156437c96a1fe72df2a7b4b87ff6c857cdf0912e7057c34efcd5309",
+                "b9188866dca0ec8c7a369c40d324fcc8ba72abab10a464201e23f29ff3fdd706"),
         },
         macosx = {
-            url_template = "https://github.com/farion1231/cc-switch/releases/download/v{version}/CC-Switch-v{version}-macOS.zip",
-            ["latest"] = { ref = "3.14.1" },
-            ["3.14.1"] = {
-                url = "https://github.com/farion1231/cc-switch/releases/download/v3.14.1/CC-Switch-v3.14.1-macOS.zip",
-                sha256 = "595cdbb510405b12578ccc6250dd096cc8c85dc3def2af0e0ac8c5d3e28b3807",
-            },
+            ["latest"] = { ref = "3.19.1" },
+            ["3.19.1"] = _macosx("3.19.1",
+                "4479f7774ee0be8ac358beff03e92dfdee8f1a6e3fd54f2c81235e6cebb09960", true),
+            ["3.14.1"] = _macosx("3.14.1",
+                "595cdbb510405b12578ccc6250dd096cc8c85dc3def2af0e0ac8c5d3e28b3807"),
         },
         windows = {
-            url_template = "https://github.com/farion1231/cc-switch/releases/download/v{version}/CC-Switch-v{version}-Windows-Portable.zip",
-            ["latest"] = { ref = "3.14.1" },
-            ["3.14.1"] = {
-                url = "https://github.com/farion1231/cc-switch/releases/download/v3.14.1/CC-Switch-v3.14.1-Windows-Portable.zip",
-                sha256 = "3747d1218e1fc7f3671b61d1ebf059f5a5aff556dd096b439484681b254eb866",
-            },
+            ["latest"] = { ref = "3.19.1" },
+            ["3.19.1"] = _windows("3.19.1",
+                "aaefbadc03e6a9d4797d22ef22214a050bce1d8a0d73583bb407ac001ab92f5e",
+                "492e03ccf529aa517555e2f6db479d96068cef5e9d17638c6f8255defaec841e", true),
+            -- 3.14.1 predates the Windows arm64 portable zip, so ARM
+            -- Windows takes the x64 build under emulation rather than
+            -- resolving to an asset that was never published.
+            ["3.14.1"] = _universal("3.14.1", "CC-Switch-v3.14.1-Windows-Portable.zip",
+                "3747d1218e1fc7f3671b61d1ebf059f5a5aff556dd096b439484681b254eb866"),
         },
     },
 }
 
 import("xim.libxpkg.pkginfo")
 import("xim.libxpkg.xvm")
+import("xim.libxpkg.system")
 
 -- Layout per platform:
---   Linux: download is the AppImage itself (a single self-contained ELF).
---          Rename to `cc-switch`, chmod +x, and that becomes the binary.
---   macOS: zip extracts a `CC Switch.app/` bundle containing the real
---          binary at `Contents/MacOS/cc-switch`. We move the whole .app
---          into install_dir and expose the inner binary via a symlink so
---          xvm's bindir model still works.
---   Windows: zip drops `cc-switch.exe` + `portable.ini` at the top level
---            of the extraction dir; we just lift `cc-switch.exe` out.
+--   Linux: the download is the AppImage itself (a single self-contained
+--          ELF). Rename to `cc-switch`, chmod +x, done.
+--   macOS: the zip extracts a `CC Switch.app/` bundle whose real binary
+--          sits at `Contents/MacOS/cc-switch`. Move the whole .app into
+--          install_dir (Contents/Resources and the code signature have
+--          to stay intact) and expose the inner binary via a symlink so
+--          xvm's bindir model still finds a lowercase `cc-switch`.
+--   Windows: the zip drops `cc-switch.exe` + `portable.ini` at the top
+--          level of the extraction dir; lift `cc-switch.exe` out.
 function install()
     os.tryrm(pkginfo.install_dir())
     os.mkdir(pkginfo.install_dir())
@@ -76,7 +162,6 @@ function install()
         local app_src = path.join(download_dir, "CC Switch.app")
         local app_dst = path.join(pkginfo.install_dir(), "CC Switch.app")
         os.mv(app_src, app_dst)
-        -- Symlink so xvm's bindir model keeps working with the bundle.
         -- xmake's sandbox exposes symlink creation through os.cp's
         -- `symlink = true` flag, not via a separate os.ln.
         os.cp(path.join(app_dst, "Contents", "MacOS", "cc-switch"),
@@ -85,7 +170,7 @@ function install()
     else
         os.mv(pkginfo.install_file(),
               path.join(pkginfo.install_dir(), "cc-switch"))
-        os.exec("chmod +x " .. path.join(pkginfo.install_dir(), "cc-switch"))
+        system.exec("chmod +x " .. path.join(pkginfo.install_dir(), "cc-switch"))
     end
 
     return true

--- a/pkgs/c/claude.lua
+++ b/pkgs/c/claude.lua
@@ -1,5 +1,111 @@
+-- Claude Code CLI — Anthropic's official *native* single-file executable.
+--
+-- Until 2.1.220 this recipe installed the npm package
+-- `@anthropic-ai/claude-code` and therefore dragged node + npm in as
+-- dependencies, ran a postinstall that downloaded the real binary a
+-- second time, and needed a runtime probe to tell the two historical
+-- layouts (`cli.js` vs `bin/claude.exe`) apart. Anthropic now publishes
+-- the platform binary directly — it is what
+-- `curl -fsSL https://claude.ai/install.sh | bash` fetches — so all of
+-- that is gone: one download, one file, chmod +x.
+--
+-- URL shape, read off the official installers (claude.ai/install.sh and
+-- claude.ai/install.ps1):
+--
+--   https://downloads.claude.ai/claude-code-releases/<version>/<platform>/claude      (unix)
+--   https://downloads.claude.ai/claude-code-releases/<version>/<platform>/claude.exe  (windows)
+--   platform = {linux,darwin,win32}-{x64,arm64}  (+ linux-*-musl variants)
+--
+--   https://downloads.claude.ai/claude-code-releases/<version>/manifest.json
+--     carries the authoritative per-platform sha256. Every hash below was
+--     taken from there; the ones for 2.1.222 were re-verified against the
+--     downloaded bytes before the CN mirror was published.
+--
+--   https://downloads.claude.ai/claude-code-releases/latest  -> "2.1.222"
+--   https://downloads.claude.ai/claude-code-releases/stable  -> "2.1.220"
+--
+-- Linux deliberately uses the **glibc** asset, not `linux-x64-musl`: the
+-- musl one is not static, it is dynamically linked against
+-- /lib/ld-musl-x86_64.so.1, which a glibc host does not have. The glibc
+-- build only needs NEEDED libc/libm/libdl/librt/libpthread and its
+-- highest referenced symbol version is GLIBC_2.17 (readelf -V), i.e.
+-- every mainstream distro since 2012.
+--
+-- `deps` is deliberately EMPTY on linux, and that is load-bearing.
+-- Declaring `xim:glibc@...` would hand xlings' predicate-driven elfpatch
+-- a loader provider to key off, and **patchelf destroys this binary**:
+-- it is a Bun single-file executable whose JS payload is appended after
+-- the ELF image, so rewriting the section table grows the file
+-- (289,467,400 -> 289,475,592 bytes on 2.1.222 linux-x64) and the
+-- payload can no longer be found — `claude --version` then dies with
+-- SIGSEGV. Verified 2026-08-06. With no dep the predicate never fires,
+-- the binary keeps its own absolute INTERP
+-- (/lib64/ld-linux-x86-64.so.2) and runs against the host glibc, which
+-- is exactly what the official installer produces too. Compare
+-- aarch64-linux-musl-gcc.lua's "no deps" note — same conclusion from the
+-- other side: there the payload needs no patching because it is static,
+-- here it must not be patched at all.
+--
+-- GLOBAL = downloads.claude.ai, the authoritative upstream.
+-- CN     = gitcode.com/xlings-res/claude, a byte-identical copy of the
+--          same bytes (asset renamed to claude-<version>-<platform> so
+--          all six platform binaries can live in one release), published
+--          so mainland-China installs don't have to reach
+--          downloads.claude.ai. Only the version `latest` points at is
+--          mirrored — each asset is ~250-280 MB, and older pins are rare
+--          enough not to be worth ~1.6 GB of mirror per release.
+
+local _CC_GLOBAL = "https://downloads.claude.ai/claude-code-releases"
+local _CC_CN = "https://gitcode.com/xlings-res/claude/releases/download"
+
+local function _asset(platform)
+    return platform:find("^win32") and "claude.exe" or "claude"
+end
+
+-- Upstream only. Used for the historical pins, which are not mirrored.
+local function _up(ver, platform, sha256)
+    return {
+        url = string.format("%s/%s/%s/%s", _CC_GLOBAL, ver, platform, _asset(platform)),
+        sha256 = sha256,
+    }
+end
+
+-- Upstream + the CN mirror of the same bytes.
+local function _mirrored(ver, platform, sha256)
+    local suffix = platform:find("^win32") and ".exe" or ""
+    return {
+        url = {
+            GLOBAL = string.format("%s/%s/%s/%s", _CC_GLOBAL, ver, platform, _asset(platform)),
+            CN = string.format("%s/%s/claude-%s-%s%s", _CC_CN, ver, ver, platform, suffix),
+        },
+        sha256 = sha256,
+    }
+end
+
+-- One platform's per-arch resource map (Shape B). `mirrored` opts the
+-- version into the CN table; without it the entry stays upstream-only.
+local function _entry(prefix, ver, sha_x86_64, sha_aarch64, mirrored)
+    local res = mirrored and _mirrored or _up
+    return {
+        x86_64 = res(ver, prefix .. "-x64", sha_x86_64),
+        aarch64 = res(ver, prefix .. "-arm64", sha_aarch64),
+    }
+end
+
+local function _linux(ver, sha_x86_64, sha_aarch64, mirrored)
+    return _entry("linux", ver, sha_x86_64, sha_aarch64, mirrored)
+end
+
+local function _macosx(ver, sha_x86_64, sha_aarch64, mirrored)
+    return _entry("darwin", ver, sha_x86_64, sha_aarch64, mirrored)
+end
+
+local function _windows(ver, sha_x86_64, sha_aarch64, mirrored)
+    return _entry("win32", ver, sha_x86_64, sha_aarch64, mirrored)
+end
+
 package = {
-    spec = "1",
+    spec = "2",
 
     name = "claude",
     description = "Claude Code CLI from Anthropic",
@@ -7,6 +113,11 @@ package = {
     licenses = {"MIT"},
     repo = "https://github.com/anthropics/claude-code",
     docs = "https://docs.anthropic.com/en/docs/claude-code/overview",
+
+    -- No `package.ci`: the version pointer lives at
+    -- downloads.claude.ai/claude-code-releases/latest, not in a git tag,
+    -- and version-check.py only knows how to read release tags. Bumps
+    -- are done by hand, together with the CN mirror push.
 
     type = "package",
     archs = {"x86_64", "aarch64"},
@@ -19,100 +130,143 @@ package = {
 
     xpm = {
         linux = {
-            deps = {"node", "npm"},
-            ["latest"] = { ref = "2.1.220" },
-            ["2.1.220"] = {},
-            ["2.1.218"] = {},
-            ["2.1.198"] = {},
-            ["2.1.156"] = { },
-            ["2.1.153"] = { },
-            ["2.1.142"] = { },
-            ["2.1.90"] = { },
-            ["2.1.63"] = { },
+            ["latest"] = { ref = "2.1.222" },
+            ["2.1.222"] = _linux("2.1.222",
+                "10caae8f22b915c26bfff0e013a4d45608c4f1ae287583626569156f447730e5",
+                "a04be0a8d7fe0259571ab7411d51d85658d71a4a26ce62b60c908290372e6016", true),
+            -- 2.1.220 is upstream's `stable` channel head; kept as a pin
+            -- for anyone who wants the slower-moving line.
+            ["2.1.220"] = _linux("2.1.220",
+                "674f61f20ff306f3100cf9200e4c36c4b70278b5bef2884549819b942a89c863",
+                "159e4a51d796f3bf14677577100f7efb845611b1ceaf0c30cbd8d4650d942185"),
+            ["2.1.218"] = _linux("2.1.218",
+                "e12071751a9336b8af1012c103358ff04ac18f9aaff4a738cff7ba5cdfaf63f2",
+                "295fd30481bd03b38450fdec2a6e25bb6472c2074f04b0c4a566cd5988f230bf"),
+            ["2.1.198"] = _linux("2.1.198",
+                "7066af42a5fe93038c13af5072d4c034dc3928092cb121fdd892c76b94b6b84d",
+                "99b50a6f2b1f3ef07bcaf1e58a2f9883c470c84e428afa321972b1aa20372e9a"),
+            ["2.1.156"] = _linux("2.1.156",
+                "6d83cd2264450c5e54fc988be1032c288cf418ee604294acfb8fc4ac28f5f7a3",
+                "7ed95d0a93aeb40e2b98e234b760d9295b7044ef678c62db8d1f5e14bfd57878"),
+            ["2.1.153"] = _linux("2.1.153",
+                "214f603f31942162dac9a65f18d43b3ac646ae215240fad481c4aad6c60f2e38",
+                "6277fbbea72228a069e4719fc3e5fa36f16749247a2321c520dae93e83e92d9c"),
+            ["2.1.142"] = _linux("2.1.142",
+                "1249a1dadfe2d48f320bd4e1b657a1a0d82435da76deb11ce509822407cf24ec",
+                "767b13fc28763ca9d663b00f90e501f134b356f1b72dcf0eea59b7e3bed86411"),
+            ["2.1.90"] = _linux("2.1.90",
+                "6074e3959989b2958a9abec60adf7b441a0f6f1c7e66401abff0fe54dad04fd6",
+                "15d5089ee7d9981faacf5463eabd427a012814d9fc02113883bb23a4f387ad4a"),
+            ["2.1.63"] = _linux("2.1.63",
+                "734447e461bb92f0ffd5f683bb6216c35a3c16e8dd84be8d150b43605d39b0d1",
+                "1fec8c8369606b4a6c00af963354b7d48aee793ed5db378fe4cf280149f3190a"),
         },
         macosx = {
-            deps = {"node", "npm"},
-            ["latest"] = { ref = "2.1.220" },
-            ["2.1.220"] = {},
-            ["2.1.218"] = {},
-            ["2.1.198"] = {},
-            ["2.1.156"] = { },
-            ["2.1.153"] = { },
-            ["2.1.142"] = { },
-            ["2.1.90"] = { },
-            ["2.1.63"] = { },
+            ["latest"] = { ref = "2.1.222" },
+            ["2.1.222"] = _macosx("2.1.222",
+                "36bfc6482a25730dbb1cee72589e522c66c45a4dc9ebfdd8a76a8113b01b6188",
+                "c66a6cc6fa2e8145bb1a6e77831f2caf4b83690ff04650500dfa6e2c05ca997c", true),
+            ["2.1.220"] = _macosx("2.1.220",
+                "dca7be0aa7d3d924836d440e0c6d8e3d47ef3c8e61fa5809b54b9017170ce2f3",
+                "8addc857f3fe64d5a0368af9ee50321b50afb4a6918ba3ef018ab84f5dbbe081"),
+            ["2.1.218"] = _macosx("2.1.218",
+                "9862b74a083e8a4ed572f99cbd4895185e0dd5a0a601affb0fb8e43d8d1f40e6",
+                "71abaff59312c9a9b6a1d818365048b42e4e95cc521a823660eded3e0880d9b7"),
+            ["2.1.198"] = _macosx("2.1.198",
+                "280b6cfc60dacc4caed31af1249e53c259c01759556e60633944c02405c82dd0",
+                "ab6f7ee109816ede414f7c285446633f805b623aa609f425609a64266451d61e"),
+            ["2.1.156"] = _macosx("2.1.156",
+                "ccd608c694677324e24dec7d1253b51f887a7be838cdb75b22d5362c97351107",
+                "9c1e8601031f5cbb3101e49dda22bf8ba31183692c705e267a6923585fa2ba09"),
+            ["2.1.153"] = _macosx("2.1.153",
+                "4b90521c64b728caabe221737ce8a83d362ef0852eee7d789f014f7ff73ce97b",
+                "449d9c89d7a63b1d427d912a7bd6e6f23f9a7b363866697c9fa9a0012546b254"),
+            ["2.1.142"] = _macosx("2.1.142",
+                "d00bc6fb38d0837ce811cc862a3b6822795b33dbce8361703b1e5e903bd240fd",
+                "772021afa051160b97e04d379738df84d4cacd311e8c199a325fb013b3eaa448"),
+            ["2.1.90"] = _macosx("2.1.90",
+                "9934675063ea4360665b7a43f649c92e6ba5cf93257324af7af1a6b490746395",
+                "73c1a7570501ca743cd2d7467cb4699103534a2138052a4e6cab53c0e09d79c8"),
+            ["2.1.63"] = _macosx("2.1.63",
+                "07842d6521f59bc68979d833ef33cbc1b985b9f5e09fa8975efe039989666aa9",
+                "2e8667322e0bd104087df2a8857f176acc75d7091aa02828825dfeb4a5708531"),
         },
         windows = {
-            deps = {"node", "npm"},
-            ["latest"] = { ref = "2.1.220" },
-            ["2.1.220"] = {},
-            ["2.1.218"] = {},
-            ["2.1.198"] = {},
-            ["2.1.156"] = { },
-            ["2.1.153"] = { },
-            ["2.1.142"] = { },
-            ["2.1.90"] = { },
-            ["2.1.63"] = { },
+            ["latest"] = { ref = "2.1.222" },
+            ["2.1.222"] = _windows("2.1.222",
+                "032cb799d2abfaa6ca440f6458304b9a2a250521063d21ebcea7f3c77c443db7",
+                "f760aa2782019e55b1e44fda9eddec85ca8499429da87efddd47ab18d4a716a2", true),
+            ["2.1.220"] = _windows("2.1.220",
+                "af5bf1f1b2aadffc768eccd787084c6fdf9ba81624cbe96c1c6d9ac1a1550231",
+                "07343ace8a2e9ba87eed716e9c0261ce4bda8954c316695e4cb26fd0605de13c"),
+            ["2.1.218"] = _windows("2.1.218",
+                "81fcf59bb7abb558aedc6f2361f4723b3d757d28e799962d88b18b4520df66ca",
+                "a7959fd87feb9557d56f4e5752f7ed1ddf405f3bea91b2571bf93af636efd193"),
+            ["2.1.198"] = _windows("2.1.198",
+                "6afd07cb03aa981c5e918808f53a1e2b729015b695122a944f6e41aaf5393933",
+                "10a6d21332f674c87f52b1dc09926945d0169f1bb82aced84ada100639ab70bc"),
+            ["2.1.156"] = _windows("2.1.156",
+                "188cc105e1caaed88f63ac2060283eb426ea17a69130810c10126b2c14f7dc7e",
+                "1e10b4fa9e8a4829cfdf77a9c55cfe0dd26c54f2afb4d3dd9d19ff9e99ca1887"),
+            ["2.1.153"] = _windows("2.1.153",
+                "8bda00dba0e8b44e67966a07ee32cf23032f7ebb90e77d4f82ab2e39b1118623",
+                "240240e32f10bc7d4124c1c5603313e243cabaae80e174e2c6eb27f5b1e1ebe9"),
+            ["2.1.142"] = _windows("2.1.142",
+                "0778b1c607ee3282ba8ea3f0c684edb05f597454cc0d21386a84576b5434b1c7",
+                "95a966b0729f9f7c28c68df3d63e7f5ac6ac72abab209392800e9a40292f3bfc"),
+            ["2.1.90"] = _windows("2.1.90",
+                "f6be38fbdcadc373e93f751d1286845f58b032690e32be8f64799380a295a79f",
+                "019f7210055cd7a884d13c4e6a0b6caf1a82348ee42950b7b5247a4b0484709c"),
+            ["2.1.63"] = _windows("2.1.63",
+                "d7e63e94966b716fa1c073c56d7ce67554505eadea9ccb254eb513027403a026",
+                "ad5759b5be7afc4d15fa20949310e64ac8827fa569043e4f2add2f7236ff8880"),
         },
-    }
+    },
 }
 
 import("xim.libxpkg.pkginfo")
 import("xim.libxpkg.xvm")
+import("xim.libxpkg.system")
 
-
--- 结构说明（基于 npm 包元数据 + 本地安装校验）:
---   1) 旧版（<= 2.1.100）：package.json 的 bin.claude = "cli.js"，
---      主入口位于 <install>/node_modules/@anthropic-ai/claude-code/cli.js，
---      需要通过 node 解释器执行。
---   2) 新版（>= 2.1.120）：package.json 的 bin.claude = "bin/claude.exe"，
---      install.cjs 在 postinstall 把对应平台的原生二进制覆盖到
---      <install>/node_modules/@anthropic-ai/claude-code/bin/claude.exe，
---      可直接执行（即使在 linux/macos 文件名也是 claude.exe）。
---   3) 这里运行时探测，向后兼容历史版本。npm .bin 包装在不同 OS 形态不同，
---      不直接依赖。
-function __claude_entry()
-    local pkg_root = path.join(pkginfo.install_dir(), "node_modules", "@anthropic-ai", "claude-code")
-    local native = path.join(pkg_root, "bin", "claude.exe")
-    if os.isfile(native) then
-        return { path = native, mode = "native" }
-    end
-    local js = path.join(pkg_root, "cli.js")
-    if os.isfile(js) then
-        return { path = js, mode = "node" }
-    end
-    return nil
+local function _installed_exe()
+    return path.join(pkginfo.install_dir(),
+                     os.host() == "windows" and "claude.exe" or "claude")
 end
 
+-- The download IS the executable, not an archive: xlings' auto-extract
+-- only fires on recognised compressed extensions, so install_file() is
+-- the binary itself and install() just has to move it into place under a
+-- stable name (upstream serves it as `claude`, the CN mirror as
+-- `claude-<version>-<platform>` — hence the rename rather than a copy).
 function install()
-    os.tryrm(pkginfo.install_dir())
-    os.mkdir(pkginfo.install_dir())
-
-    local npm_install = string.format(
-        [[npm install --prefix "%s" --no-fund --no-audit "@anthropic-ai/claude-code@%s"]],
-        pkginfo.install_dir(),
-        pkginfo.version()
-    )
-    os.exec(npm_install)
-
-    if not __claude_entry() then
-        raise("claude entry (bin/claude.exe or cli.js) not found after npm install")
+    local exe = _installed_exe()
+    if os.isfile(exe) then
+        return true
     end
 
-    return true
+    os.tryrm(pkginfo.install_dir())
+    os.mkdir(pkginfo.install_dir())
+    os.mv(pkginfo.install_file(), exe)
+
+    if os.host() ~= "windows" then
+        -- Served over plain HTTP, so the executable bit never survives
+        -- the download regardless of what upstream stored.
+        system.exec(string.format([[chmod +x "%s"]], exe))
+    end
+
+    return os.isfile(exe)
 end
 
 function config()
-    local entry = __claude_entry()
-    local alias
-    if entry.mode == "native" then
-        alias = string.format([["%s"]], entry.path)
-    else
-        alias = string.format([[node "%s"]], entry.path)
-    end
     xvm.add("claude", {
-        alias = alias,
+        bindir = pkginfo.install_dir(),
         envs = {
+            -- xvm owns which version is on PATH. The native binary's own
+            -- updater would install a second copy under
+            -- ~/.local/share/claude and put a `claude` on PATH that xim
+            -- neither tracks nor can remove, so version management stays
+            -- with `xvm use claude@<ver>`.
+            DISABLE_AUTOUPDATER = "1",
             -- should be set by user, not hardcoded here
             --CLAUDE_CONFIG_DIR = path.join(pkginfo.install_dir(), "config"),
         }

--- a/tests/c/test_cc_switch.py
+++ b/tests/c/test_cc_switch.py
@@ -1,0 +1,110 @@
+"""测试 cc-switch 包"""
+import re
+
+import pytest
+from tests.lib.xpkg_parser import parse_xpkg
+from tests.lib.assertions import (
+    assert_required_fields, assert_valid_spec, assert_valid_type,
+    assert_no_typos, assert_no_exec_xvm, assert_no_bashrc_modification,
+    assert_no_direct_path_modification, assert_uses_new_api,
+    assert_xim_add_succeeds, assert_install_succeeds,
+)
+from tests.lib.platform_utils import skip_if_not
+
+PKG = "cc-switch"
+PKG_FILE = "pkgs/c/cc-switch.lua"
+
+
+@pytest.fixture(scope='module')
+def meta():
+    return parse_xpkg(PKG_FILE)
+
+
+class TestStatic:
+    @pytest.mark.static
+    def test_required_fields(self, meta):
+        assert_required_fields(meta)
+
+    @pytest.mark.static
+    def test_valid_spec(self, meta):
+        assert_valid_spec(meta)
+
+    @pytest.mark.static
+    def test_valid_type(self, meta):
+        assert_valid_type(meta)
+
+    @pytest.mark.static
+    def test_no_typos(self):
+        assert_no_typos(PKG_FILE)
+
+    @pytest.mark.static
+    def test_all_platforms_declared(self, meta):
+        for plat in ("linux", "windows", "macosx"):
+            assert meta.platforms.get(plat), f"xpm 缺少 {plat} 平台"
+
+
+class TestIndex:
+    @pytest.mark.index
+    def test_xim_add(self):
+        assert_xim_add_succeeds(PKG_FILE)
+
+
+class TestIsolation:
+    @pytest.mark.isolation
+    def test_no_exec_xvm(self):
+        assert_no_exec_xvm(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_no_bashrc(self):
+        assert_no_bashrc_modification(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_no_path_modification(self):
+        assert_no_direct_path_modification(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_new_api(self):
+        assert_uses_new_api(PKG_FILE)
+
+
+class TestDesign:
+    @pytest.mark.static
+    def test_per_arch_assets(self):
+        """声明了 aarch64 就必须解析到 arm64 资源
+
+        旧版每个平台只有一个 url，ARM 主机会拿到 x86_64 的 AppImage。
+        """
+        content = open(PKG_FILE, encoding='utf-8').read()
+        assert "Linux-arm64.AppImage" in content
+        assert "Windows-arm64-Portable.zip" in content
+        # macOS 是 universal bundle，两个架构共用同一个 asset
+        assert "macOS.zip" in content
+
+    @pytest.mark.static
+    def test_cn_mirror_present(self):
+        """CN 加速镜像必须覆盖 latest 指向的版本的三个平台"""
+        content = open(PKG_FILE, encoding='utf-8').read()
+        assert "gitcode.com/xlings-res/cc-switch" in content
+        refs = set(re.findall(r'\["latest"\]\s*=\s*\{\s*ref\s*=\s*"([^"]+)"', content))
+        assert len(refs) == 1, f"三平台 latest.ref 不一致: {refs}"
+        latest = refs.pop()
+        mirrored = re.findall(
+            r'\["%s"\]\s*=\s*_(?:linux|macosx|windows)\([^)]*,\s*true\)' % re.escape(latest),
+            content)
+        assert len(mirrored) == 3, \
+            f"latest={latest} 应在三个平台都开启 CN 镜像, 实际 {len(mirrored)}"
+
+    @pytest.mark.static
+    def test_single_executable_layout(self):
+        """三平台都落到单个可执行文件 — linux AppImage / windows exe / macOS bundle 内的 Mach-O"""
+        content = open(PKG_FILE, encoding='utf-8').read()
+        assert 'path.join(pkginfo.install_dir(), "cc-switch.exe")' in content
+        assert 'path.join(pkginfo.install_dir(), "cc-switch")' in content
+        assert "symlink = true" in content
+
+
+class TestLifecycle:
+    @pytest.mark.lifecycle
+    @skip_if_not('linux')
+    def test_install(self):
+        assert_install_succeeds(PKG)

--- a/tests/c/test_claude.py
+++ b/tests/c/test_claude.py
@@ -1,4 +1,6 @@
 """测试 claude-code 包"""
+import re
+
 import pytest
 from tests.lib.xpkg_parser import parse_xpkg
 from tests.lib.assertions import (
@@ -12,6 +14,16 @@ from tests.lib.platform_utils import skip_if_not
 
 PKG = "claude"
 PKG_FILE = "pkgs/c/claude.lua"
+
+
+def lua_code(path=PKG_FILE):
+    """去掉 `--` 行注释后的配方正文
+
+    这个包的注释里会引用被禁止的写法（npm 包名、旧 deps 等）来解释为什么
+    不再那么做；直接扫全文会把说明本身当成违规。
+    """
+    content = open(path, encoding='utf-8').read()
+    return re.sub(r'--[^\n]*', '', content)
 
 
 @pytest.fixture(scope='module')
@@ -63,13 +75,53 @@ class TestIsolation:
 
 class TestDesign:
     @pytest.mark.static
-    def test_runtime_entry_supports_both_layouts(self):
+    def test_all_platforms_declared(self, meta):
+        """三平台都要声明 — 上游对每个平台都发原生二进制"""
+        for plat in ("linux", "windows", "macosx"):
+            assert meta.platforms.get(plat), f"xpm 缺少 {plat} 平台"
+
+    @pytest.mark.static
+    def test_native_binary_not_npm(self):
+        """原生单可执行文件，不再经由 npm 安装"""
+        code = lua_code()
+        assert "downloads.claude.ai/claude-code-releases" in code
+        assert "npm install" not in code
+        assert "@anthropic-ai/claude-code" not in code
+        # node/npm 曾是 xpm.<platform>.deps；原生二进制自带运行时
+        assert '"node", "npm"' not in code
+
+    @pytest.mark.static
+    def test_no_runtime_deps_on_linux(self):
+        """linux 不能声明 deps
+
+        声明 xim:glibc 会让 xlings 的 predicate-driven elfpatch 找到 loader
+        provider 并对二进制跑 patchelf。claude 是 Bun single-file
+        executable，JS payload 追加在 ELF 之后，patchelf 重写节表会让
+        payload 失联 —— `claude --version` 直接 SIGSEGV。
+        """
+        assert not re.search(r'^\s*deps\s*=', lua_code(), re.M), \
+            "claude 不能声明 deps: elfpatch 会破坏 Bun 单文件可执行程序"
+
+    @pytest.mark.static
+    def test_cn_mirror_present(self):
+        """CN 加速镜像必须覆盖 latest 指向的版本的每个平台/架构"""
         content = open(PKG_FILE, encoding='utf-8').read()
-        assert "function __claude_entry()" in content
-        assert "@anthropic-ai" in content
-        assert "claude.exe" in content
-        assert "cli.js" in content
-        assert "node \"%s\"" in content
+        assert "gitcode.com/xlings-res/claude" in content
+        refs = set(re.findall(r'\["latest"\]\s*=\s*\{\s*ref\s*=\s*"([^"]+)"', content))
+        assert len(refs) == 1, f"三平台 latest.ref 不一致: {refs}"
+        latest = refs.pop()
+        # 三平台 × 两架构 = 6 个 mirrored 资源，helper 的第 4 个实参
+        mirrored = re.findall(
+            r'\["%s"\]\s*=\s*_(?:linux|macosx|windows)\([^)]*,\s*true\)' % re.escape(latest),
+            content)
+        assert len(mirrored) == 3, \
+            f"latest={latest} 应在三个平台都开启 CN 镜像, 实际 {len(mirrored)}"
+
+    @pytest.mark.static
+    def test_autoupdater_disabled(self):
+        """版本由 xvm 管理，二进制自带的 updater 必须关掉"""
+        content = open(PKG_FILE, encoding='utf-8').read()
+        assert "DISABLE_AUTOUPDATER" in content
 
     @pytest.mark.static
     def test_claude_config_env(self):


### PR DESCRIPTION
## Summary

`claude` 改为 Anthropic 官方**原生单可执行文件**（不再走 npm），`cc-switch` 升到最新版并补齐
per-arch 资源；两个包都补上 GitCode `xlings-res` 的 **CN 加速镜像**，并升级到 XPackage Spec V2。

### claude — 从 npm 包换成原生二进制

旧配方装的是 npm 包 `@anthropic-ai/claude-code`：要拖 `node` + `npm` 两个依赖，postinstall
还会再下一次真正的二进制，另外需要一段运行时探测来区分历史上的两种布局（`cli.js` 和
`bin/claude.exe`）。上游现在直接发平台二进制 —— 就是
`curl -fsSL https://claude.ai/install.sh | bash` 拉的那个文件 —— 所以这些全部去掉：一次下载、
一个文件、`chmod +x`。

URL 形状来自官方安装脚本（`claude.ai/install.sh` / `claude.ai/install.ps1`）：

```
https://downloads.claude.ai/claude-code-releases/<version>/<platform>/claude      (unix)
https://downloads.claude.ai/claude-code-releases/<version>/<platform>/claude.exe  (windows)
platform = {linux,darwin,win32}-{x64,arm64}
https://downloads.claude.ai/claude-code-releases/<version>/manifest.json          (权威 sha256)
https://downloads.claude.ai/claude-code-releases/latest -> 2.1.222
https://downloads.claude.ai/claude-code-releases/stable -> 2.1.220
```

原有 9 个版本键全部保留并改写成原生 URL（上游对每个版本、每个平台/架构都有构建，逐一验证过），
所以 `xvm use claude@<旧版本>` 不会失效。新增 `2.1.222`，`latest` 指向它。

**两个关键取舍，都写进了配方注释：**

1. **linux 用 glibc 构建，不用 `linux-x64-musl`。** musl 那个资产不是静态的，它动态链接
   `/lib/ld-musl-x86_64.so.1`，glibc 主机上根本跑不起来。glibc 构建的 NEEDED 只有
   libc/libm/libdl/librt/libpthread，最高引用符号版本 `GLIBC_2.17`（`readelf -V`）。

2. **linux 故意不声明 `deps`。** 声明 `xim:glibc@...` 会让 xlings 的 predicate-driven elfpatch
   找到 loader provider 并对二进制跑 patchelf —— 而 **patchelf 会直接毁掉这个二进制**：它是
   Bun single-file executable，JS payload 追加在 ELF 映像之后，重写节表会让文件从
   289,467,400 涨到 289,475,592 字节，payload 再也定位不到，`claude --version` 直接 SIGSEGV
   （本地实测）。不声明依赖时 predicate 不触发，二进制保留自己的绝对 INTERP
   `/lib64/ld-linux-x86-64.so.2`，跑在宿主 glibc 上 —— 官方安装器装出来的也正是这个效果。

`config()` 里加了 `DISABLE_AUTOUPDATER=1`：版本归 `xvm use claude@<ver>` 管，二进制自带的
updater 会在 `~/.local/share/claude` 再装一份、并放一个 xim 既不跟踪也删不掉的 `claude` 到 PATH。

### cc-switch — 3.14.1 → 3.19.1，顺带修掉一个真实的架构 bug

旧配方每个平台只有一个 url，却声明了 `archs = {"x86_64", "aarch64"}` —— 也就是说 ARM 主机会
拿到 `...-Linux-x86_64.AppImage`，一个它跑不了的二进制。这正是 V2 要堵的洞。上游从 3.14.1 起
就有 `...-Linux-arm64.AppImage`，3.19 线又加了 `...-Windows-arm64-Portable.zip`，所以现在每个
声明的架构都能解析到对应资产：

- linux：`Linux-x86_64.AppImage` / `Linux-arm64.AppImage`（单文件自包含 ELF）
- windows：`Windows-Portable.zip` / `Windows-arm64-Portable.zip`（顶层就是 `cc-switch.exe`）
- macosx：`macOS.zip` 是 universal bundle，两个架构共用同一资产、同一 sha256

3.14.1 保留为可 pin 的旧版；它没有 Windows arm64 资产，所以那一档两个架构都落到 x64 包
（模拟运行），而不是指向一个从未发布过的 URL。

顺带把 `type` 从 `"app"` 改成 `"package"` —— `"app"` 不在 spec 的四个取值里，cc-switch 是全索引
唯一用它的配方，而没有测试文件正是没人发现的原因（本 PR 补上了 `tests/c/test_cc_switch.py`）。

### CN 加速

`latest` 指向的版本的每个平台/架构资产，都已经推到 GitCode 并逐字节校验：

| 包 | GitCode release | 资产数 |
|---|---|---|
| claude | `gitcode.com/xlings-res/claude` @ `2.1.222` | 6（linux/darwin/win32 × x64/arm64，共 ~1.6 GB）|
| cc-switch | `gitcode.com/xlings-res/cc-switch` @ `3.19.1` | 5 |

`xlings-res/claude` 仓库是本次新建的。旧版本不镜像 —— claude 单个资产 250-280 MB，
pin 旧版的场景稀少，不值得每次发版多传 ~1.6 GB。

## Test plan

本地已验证：

- **URL 全量存活检查**：两个配方里解析出的 74 个 URL 逐个 range-GET，全部 200/206/302，
  没有 404。
- **sha256 三方比对**：claude 6 个资产的本地下载 = 上游 `manifest.json` 的 checksum；
  cc-switch 5 个资产的本地下载 = GitHub API 的 `digest`；再从 GitCode 下回来比对一致。
- **patchelf 破坏性**：`patchelf --set-rpath` 后 `claude --version` → `Segmentation fault
  (core dumped)`，这就是 linux 不声明 deps 的原因。
- **`.github/scripts/posix-test.sh`**（CI 的 linux-install-test 同一份脚本）本地跑通两个包的
  register / install / shim / uninstall。
- **pytest**：`-m "static or isolation"` 全仓 1109 passed。

CI 需要覆盖：三平台 install/uninstall（claude 每个平台下载 ~260 MB）。

> 注：本机 `xvm info <target>` 输出缺 Program:/Version: 字段，`assert_xvm_registered` 类
> verify 用例在本地对所有包都失败（已用其它包做过对照），依赖 CI 验证。

## 系统影响

- 安装：只往 `<xpkgs>/<pkg>/<version>/` 落一个可执行文件（macOS cc-switch 是 `.app` bundle
  加一个 symlink），不写任何 shell profile、不改 PATH、不碰系统包管理器。
- 卸载：`xvm.remove()` 摘掉 shim。
- 环境变量：只有 claude 的 shim 上挂了 `DISABLE_AUTOUPDATER=1`（per-shim env，不外泄）。
