### PR TITLE
feat(musl): the musl runtime, and the shared-name rule it exposed

### DIFF
--- a/.agents/skills/xpkg-creater/SKILL.md
+++ b/.agents/skills/xpkg-creater/SKILL.md
@@ -156,6 +156,57 @@ xpm = {
 - 或 `xvm.add("tool", { bindir = ..., alias = ... })`
 - 可执行文件不在安装根目录时，必须明确 `bindir`
 
+### 2.3.1 共享名与 flavor 版本（注册前必查）
+
+一个 xvm 名字（程序名或 lib 名）可能被**多个包**提供：`java` 来自每个 JDK 发行版，
+`gcc` 来自 gcc.lua 和 musl-gcc.lua，`crt1.o`/`libc.so` 来自 glibc.lua 和 musl.lua。
+用裸版本号注册共享名有**两种**失败方式，长得完全不一样：
+
+| 情况 | 结果 |
+|------|------|
+| 两个包注册**同名同版本** | xvm 直接拒绝，第二个包整批 config 失败：`another package already owns this exact name and version` |
+| 两个包注册**同名不同版本** | **接受**，名字变成双 owner。一次 `xvm use` 落到另一侧就静默改写共享 `lib/` 里的符号链接 |
+
+第二种更危险，因为安装当下一切正常。实测（musl 加入前）：
+
+```
+crt1.o = {"active": "glibc-2.39", "installed": ["glibc-2.39", "musl-1.2.5"]}
+```
+
+`crt1.o` 一旦切到 musl 那侧，该 subos 里所有 glibc C 链接全部静默挂掉。
+
+**做法**：共享名注册到 **`<version>-<flavor>`**，并在配方里把撞名集合**单独列成一张表**。
+
+```lua
+-- 和 glibc.lua 的 glibc_libs 求交集算出来的，不是眼估的
+local SHARED_LIBS = { "crt1.o", "crti.o", "crtn.o", "Scrt1.o", "libc.a",
+                      "libc.so", "libdl.a", "libm.a", "libpthread.a",
+                      "librt.a", "libutil.a" }
+local MUSL_ONLY_LIBS = { "ld-musl-x86_64.so.1", "rcrt1.o", "libcrypt.a",
+                         "libresolv.a", "libxnet.a" }
+local FLAVOR = "musl"
+local function flavor_version() return pkginfo.version() .. "-" .. FLAVOR end
+```
+
+规则：
+
+1. **撞名集合要算，不要估。** 拿对方配方里的注册表和自己 payload 里真实的目录求交集，
+   并用测试锁住这个集合 —— 上游改了文件集，测试要能发现。
+2. **撞名的必须带 flavor；不撞名的也一起带**，这样整组能被同一次 `xlings use` 切换，
+   将来第三个包进来也是撞上约定而不是撞上一个恰好空着的版本号。
+3. **绑定根用 `type = "group"`。** 根节点不对应任何可执行文件（没有 `bin/musl`），
+   留成默认的 program 类型会生成一个永远失败的 shim
+   （`subos/*/bin/musl -> bin/xlings`），`self doctor` 会把它报成 orphan
+   （openxlings/xlings#452）。
+4. **`uninstall()` 必须版本内收敛**：`xvm.remove(name, flavor_version())`。
+   用裸名删会把对方包的注册一起删掉。
+5. **头文件同理。** 两个 libc 的 `stdio.h`/`features.h` 内容不同，散进共享
+   `usr/include` 后落地的那个会静默赢下整个 subos 的编译 —— 非 system libc 的头
+   要落到自己的命名空间（`usr/include/musl`）。
+
+已有先例（新包照抄即可）：`jdk-temurin/corretto/zulu` 的 `25.0.4+7-temurin`、
+`musl-gcc.lua` 的 `16.1.0-musl`、`musl.lua` 的 `1.2.5-musl`。
+
 ### 2.4 禁止事项（隔离合规）
 
 - 不要 `os.exec("xvm add ...")` / `os.exec("xvm remove ...")`

--- a/.agents/tools/build-musl.sh
+++ b/.agents/tools/build-musl.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# Build musl libc from source into an xlings payload.
+#
+# musl is far less hostile to package than glibc (see
+# graphics/build-glibc.sh), but two of its defaults are wrong for a payload
+# that has to be relocatable:
+#
+#   * `--syslibdir` defaults to /lib, and `make install` puts the loader
+#     symlink `ld-musl-<arch>.so.1` THERE, not under --prefix. A payload built
+#     with the default has no loader in it at all — the one artifact the
+#     package exists to ship. Point it inside the prefix.
+#   * that symlink is written as an ABSOLUTE path to $prefix/lib/libc.so, and
+#     $prefix is a build-machine path that does not exist on any user's disk.
+#     Rewrite it relative so the payload resolves wherever it is unpacked.
+#
+# `--disable-gcc-wrapper` is deliberate too: musl ships a `musl-gcc` wrapper
+# script, and `pkgs/m/musl-gcc.lua` already registers that program name with
+# xvm. Two packages claiming one (name, version) is refused outright, so this
+# package must not ship it.
+#
+# Unlike glibc, musl bakes no default library search path from --prefix into
+# the loader (it reads /etc/ld-musl-<arch>.path, else falls back to
+# /lib:/usr/local/lib:/usr/lib), so the prefix here only has to be inert. It
+# follows glibc's shape for consistency.
+#
+# Usage:  build-musl.sh <version>            (e.g. build-musl.sh 1.2.6)
+set -uo pipefail
+
+VERSION="${1:?usage: build-musl.sh <version>}"
+NAME=musl
+ARCH="$(uname -m)"
+WORK="${XLINGS_MUSL_WORK:-${TMPDIR:-/tmp}/xlings-musl}"
+SRC="$WORK/src"
+STAGE="$WORK/stage/$NAME-$VERSION"
+DIST="$WORK/dist"
+
+log()  { echo "[build:$NAME] $*"; }
+fail() { echo "[build:$NAME] FAIL: $*" >&2; exit 1; }
+
+[[ "$ARCH" == "x86_64" ]] || fail "this script only builds the x86_64 payload (host is $ARCH)"
+
+rm -rf "$STAGE"; mkdir -p "$SRC" "$STAGE" "$DIST"
+
+PREFIX="/home/xlings/.xlings_data/xim/xpkgs/fromsource-x-$NAME/$VERSION"
+
+TARBALL="$SRC/musl-$VERSION.tar.gz"
+[[ -f "$TARBALL" ]] || {
+    log "fetching musl-$VERSION.tar.gz"
+    curl -fsSL --retry 3 -o "$TARBALL" \
+        "https://musl.libc.org/releases/musl-$VERSION.tar.gz" || fail "download"
+}
+
+BUILDDIR="$SRC/musl-$VERSION"
+rm -rf "$BUILDDIR"; mkdir -p "$BUILDDIR"
+tar xf "$TARBALL" -C "$BUILDDIR" --strip-components=1 || fail "extract"
+
+cd "$BUILDDIR" || fail "cd"
+
+# musl builds against the kernel headers and its own tree only. Anything
+# inherited from a subos here would put another libc's headers ahead of the
+# one being built.
+unset CPPFLAGS LDFLAGS LD_LIBRARY_PATH
+
+log "configuring $VERSION (prefix=$PREFIX)"
+./configure \
+    --prefix="$PREFIX" \
+    --syslibdir="$PREFIX/lib" \
+    --disable-gcc-wrapper \
+    --enable-shared \
+    --enable-static \
+    > "$WORK/$NAME-configure.log" 2>&1 \
+    || { tail -30 "$WORK/$NAME-configure.log"; fail "configure"; }
+
+log "building"
+make -j"$(nproc)" > "$WORK/$NAME-build.log" 2>&1 \
+    || { tail -30 "$WORK/$NAME-build.log"; fail "make"; }
+
+log "staging"
+make install DESTDIR="$STAGE" >> "$WORK/$NAME-build.log" 2>&1 \
+    || { tail -30 "$WORK/$NAME-build.log"; fail "make install"; }
+
+PAYLOAD="$WORK/payload/$NAME-$VERSION"
+rm -rf "$PAYLOAD"; mkdir -p "$PAYLOAD"
+cp -a "$STAGE$PREFIX/." "$PAYLOAD/" || fail "payload copy"
+
+# The loader symlink, made relative. `cp -a` preserved whatever `make install`
+# wrote, which is an absolute path into $PREFIX.
+LOADER_LINK="$PAYLOAD/lib/ld-musl-$ARCH.so.1"
+if [[ -L "$LOADER_LINK" ]]; then
+    ln -sfn libc.so "$LOADER_LINK" || fail "loader symlink"
+fi
+
+# lib64 beside lib. Nothing in this package points at lib64, but a consumer
+# elfpatched against a glibc payload looks there, and a subos holding both
+# should find a directory rather than a dangling path.
+[[ -d "$PAYLOAD/lib64" ]] || ln -s lib "$PAYLOAD/lib64" || fail "lib64 link"
+
+# ── the checks ──────────────────────────────────────────────────────────
+log "checking the payload"
+leaks=0
+
+LOADER="$PAYLOAD/lib/libc.so"
+[[ -f "$LOADER" ]] || { echo "    no lib/libc.so in the payload"; leaks=$((leaks+1)); }
+[[ -L "$LOADER_LINK" ]] || { echo "    no lib/ld-musl-$ARCH.so.1 symlink"; leaks=$((leaks+1)); }
+[[ -e "$LOADER_LINK" ]] || { echo "    loader symlink is dangling"; leaks=$((leaks+1)); }
+
+# The one that matters: the loader has to run and report the version we asked
+# for. A libc that builds and does not run is not detectable from file lists.
+if [[ -f "$LOADER" ]]; then
+    got="$("$LOADER" 2>&1 | head -2 | tr '\n' ' ')"
+    case "$got" in
+        *"$VERSION"*) log "  loader reports: $got" ;;
+        *) echo "    loader reports '$got', expected $VERSION"; leaks=$((leaks+1)) ;;
+    esac
+fi
+
+# And a program actually linked against it has to run under it. This is the
+# pairing that gets used, and the only check that would catch a payload whose
+# loader and libc disagree.
+if [[ -f "$LOADER" ]]; then
+    cat > "$WORK/hello.c" <<'EOF'
+#include <stdio.h>
+int main(void) { printf("musl payload ok\n"); return 0; }
+EOF
+    if gcc -nostdinc -nostdlib -static-libgcc \
+           -isystem "$PAYLOAD/include" \
+           -o "$WORK/hello" \
+           "$PAYLOAD/lib/crt1.o" "$PAYLOAD/lib/crti.o" \
+           "$WORK/hello.c" \
+           -L"$PAYLOAD/lib" -lc "$PAYLOAD/lib/crtn.o" \
+           -Wl,--dynamic-linker="$LOADER_LINK" \
+           > "$WORK/hello.log" 2>&1; then
+        out="$("$WORK/hello" 2>&1)"
+        [[ "$out" == "musl payload ok" ]] \
+            || { echo "    program linked against the payload printed '$out'"; leaks=$((leaks+1)); }
+    else
+        tail -10 "$WORK/hello.log"
+        echo "    could not link a program against the payload"
+        leaks=$((leaks+1))
+    fi
+fi
+
+# musl-gcc must not be in here (musl-gcc.lua owns that xvm program name).
+if [[ -e "$PAYLOAD/bin/musl-gcc" ]]; then
+    echo "    payload ships bin/musl-gcc — --disable-gcc-wrapper did not take"
+    leaks=$((leaks+1))
+fi
+
+(( leaks == 0 )) || fail "$leaks problem(s) — payload not packaged"
+
+TAR="$DIST/$NAME-$VERSION-linux-$ARCH.tar.gz"
+rm -f "$TAR"
+tar czf "$TAR" -C "$(dirname "$PAYLOAD")" "$(basename "$PAYLOAD")" || fail "tar"
+log "packaged $(basename "$TAR") ($(du -h "$TAR" | cut -f1))"
+log "sha256 $(sha256sum "$TAR" | cut -d' ' -f1)"

--- a/pkgs/c/claude.lua
+++ b/pkgs/c/claude.lua
@@ -31,6 +31,23 @@
 -- highest referenced symbol version is GLIBC_2.17 (readelf -V), i.e.
 -- every mainstream distro since 2012.
 --
+-- `xim:musl` now exists, so the obvious next thought is to ship the musl
+-- asset against it and stop depending on the host libc at all. It really
+-- does work — `<musl>/lib/ld-musl-x86_64.so.1 claude --version` prints
+-- 2.1.222, and --help / doctor / `mcp list` all run — but only by
+-- invoking the loader explicitly, and that is not free:
+--
+--   $ claude doctor                            → Running: native
+--   $ /lib64/ld-linux-x86-64.so.2 claude doctor → Running: package-manager
+--
+-- Same binary, different answer. Under explicit-loader invocation the
+-- kernel points /proc/self/exe at the LOADER, not the program (measured:
+-- it reads back as `.../lib/libc.so`), and this binary contains three
+-- references to /proc/self/exe — it is how Bun computes
+-- `process.execPath`. Everything that re-spawns the CLI from that path
+-- would exec libc.so. `--version` passing proves nothing about it. So
+-- the glibc asset stays, and the host loader with it.
+--
 -- `deps` is deliberately EMPTY on linux, and that is load-bearing.
 -- Declaring `xim:glibc@...` would hand xlings' predicate-driven elfpatch
 -- a loader provider to key off, and **patchelf destroys this binary**:
@@ -45,6 +62,12 @@
 -- aarch64-linux-musl-gcc.lua's "no deps" note — same conclusion from the
 -- other side: there the payload needs no patching because it is static,
 -- here it must not be patched at all.
+--
+-- Adding `xim:musl` to `deps` would not change this: elfpatch IS
+-- patchelf, so pointing the dep at a musl loader instead of a glibc one
+-- reaches the same SIGSEGV by the same route. The only patch-free way to
+-- redirect the loader is the explicit invocation above, and it costs
+-- `process.execPath`.
 --
 -- GLOBAL = downloads.claude.ai, the authoritative upstream.
 -- CN     = gitcode.com/xlings-res/claude, a byte-identical copy of the

--- a/pkgs/m/musl.lua
+++ b/pkgs/m/musl.lua
@@ -1,0 +1,325 @@
+-- musl libc — the runtime, as a peer of glibc.lua.
+--
+-- The index already had musl *toolchains* (musl-gcc.lua,
+-- x86_64-linux-musl-gcc.lua, aarch64-linux-musl-gcc.lua) but no musl
+-- runtime you could install on its own. glibc.lua's own comment names
+-- the gap: it tags its loader export `abi = "linux-x86_64-glibc"`
+-- because that is "the disambiguation tag when a subos hosts both glibc
+-- and musl xpkgs" — a subos that could not, until now, host the musl
+-- one.
+--
+-- What it is for — the gap, measured in a subos sandbox on a glibc host:
+--
+--   $ musl-gcc -o h h.c && ./h
+--   cannot execute: required file not found     # INTERP is the canonical
+--                                               # /lib/ld-musl-x86_64.so.1,
+--                                               # which a glibc host has not got
+--   $ <musl>/lib/ld-musl-x86_64.so.1 ./h
+--   hello from musl                             # runs under this payload
+--   $ musl-gcc -Wl,--dynamic-linker=<musl>/lib/ld-musl-x86_64.so.1 -o h2 h.c
+--   $ ./h2
+--   hello from musl                             # or link straight at it
+--
+-- So: running a musl-linked prebuilt (an Alpine-built binary, or a
+-- vendor's `-musl` asset) on a glibc host, without root and without
+-- touching /lib; giving a musl-targeting build a runtime inside the
+-- subos; `xlings subos new <name> --runtime musl@1.2.6`.
+--
+-- It does NOT replace a musl toolchain: musl-gcc.lua carries its own
+-- musl sysroot (including its own loader) and does not read this
+-- package. The two coexist — verified in one subos, `gcc` still building
+-- and running glibc binaries while these libs were registered.
+--
+-- Versions: 1.2.5 is the one in the field — Alpine 3.20/3.21/3.22 ship
+-- it, so it is what "a musl binary" is overwhelmingly built against —
+-- and 1.2.6 is upstream's current release. `latest` is 1.2.5 for the
+-- same reason glibc's is 2.39 rather than 2.44: musl is backward
+-- compatible, so the older runtime is the one that runs both, and
+-- moving the default is a decision to make on purpose rather than as a
+-- side effect of adding a version. Ask for the newer one explicitly.
+--
+-- x86_64 only, matching glibc.lua. Cross-building the aarch64 payload is
+-- easy (musl takes CROSS_COMPILE and the index ships
+-- aarch64-linux-musl-gcc), but the build script's checks actually RUN
+-- the loader and link a program against it, and none of that can run
+-- here — an aarch64 payload would ship unverified.
+--
+-- Payload comes from .agents/tools/build-musl.sh, which exists because
+-- two musl defaults are wrong for a relocatable payload: `--syslibdir`
+-- puts the `ld-musl-*.so.1` loader symlink in /lib rather than under
+-- --prefix (so a default build ships no loader at all), and that symlink
+-- is absolute into the build prefix. See the script for the rest.
+
+package = {
+    spec = "1",
+
+    homepage = "https://musl.libc.org",
+    -- base info
+    name = "musl",
+    description = "musl - a lightweight, fast, simple, free, standards-conformant C library",
+
+    authors = {"Rich Felker", "musl contributors"},
+    licenses = {"MIT"},
+    repo = "https://git.musl-libc.org/cgit/musl",
+    docs = "https://musl.libc.org/doc/1.2.5/manual.html",
+
+    -- xim pkg info
+    type = "package",
+    archs = {"x86_64"},
+    status = "stable", -- dev, stable, deprecated
+    categories = {"libc"},
+    keywords = {"libc", "musl", "static", "alpine"},
+
+    -- xvm: xlings version management
+    xvm_enable = true,
+
+    -- No CLI shims. musl has no `ldd` binary of its own (its "ldd" is the
+    -- loader invoked under that name) and its `musl-gcc` wrapper is
+    -- deliberately not built — musl-gcc.lua already owns that xvm program
+    -- name, and two packages claiming one (name, version) is refused.
+    -- The .so / .a / crt files are registered as libs in config().
+    programs = {},
+
+    xpm = {
+        linux = {
+            -- Declare the dynamic linker we ship so consumers don't have
+            -- to hardcode a path into their own hooks. xlings
+            -- predicate-driven elfpatch reads this and patches consumer
+            -- ELFs automatically; `abi` is what keeps it from confusing
+            -- this loader with glibc's in a subos holding both.
+            --
+            -- musl's loader IS libc.so — `lib/ld-musl-x86_64.so.1` is a
+            -- relative symlink to it, which is why libdirs falls through
+            -- to the {lib64, lib} convention and finds everything.
+            exports = {
+                runtime = {
+                    loader = "lib/ld-musl-x86_64.so.1",
+                    abi    = "linux-x86_64-musl",
+                },
+            },
+            ["latest"] = { ref = "1.2.5" },
+            -- Explicit urls rather than XLINGS_RES: an XLINGS_RES entry
+            -- carries no checksum, and a libc payload is the last thing
+            -- that should install unverified. Same reasoning as glibc 2.44.
+            ["1.2.6"] = {
+                url = {
+                    GLOBAL = "https://github.com/xlings-res/musl/releases/download/1.2.6/musl-1.2.6-linux-x86_64.tar.gz",
+                    CN     = "https://gitcode.com/xlings-res/musl/releases/download/1.2.6/musl-1.2.6-linux-x86_64.tar.gz",
+                },
+                sha256 = "44f6b63ddd6fcb3e668d76fe336cf91e42d4aa1c538bd228b09a298065284c49",
+            },
+            ["1.2.5"] = {
+                url = {
+                    GLOBAL = "https://github.com/xlings-res/musl/releases/download/1.2.5/musl-1.2.5-linux-x86_64.tar.gz",
+                    CN     = "https://gitcode.com/xlings-res/musl/releases/download/1.2.5/musl-1.2.5-linux-x86_64.tar.gz",
+                },
+                sha256 = "b48e958059906a4e5eef9b222d68e6e17a13c5640973d815bac6c2c66ba70d9a",
+            },
+        },
+    },
+}
+
+import("xim.libxpkg.log")
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.system")
+import("xim.libxpkg.xvm")
+import("xim.pkgindex.sysroot")
+
+function install()
+    -- The payload root, identified by CONTENT rather than by name.
+    --
+    -- glibc.lua learned this the hard way: deriving the directory from
+    -- `install_file() minus .tar.gz` was true of exactly one asset, and
+    -- when it stopped being true os.mv failed, install() returned true
+    -- anyway, and what shipped was a libc package with no loader in it,
+    -- reported as a successful install. The extraction directory is
+    -- shared, so "the only directory" is not a usable rule either.
+    local musldir = pkginfo.install_file():replace(".tar.gz", "")
+    if not os.isdir(musldir) then
+        local base = path.directory(musldir)
+        local found = nil
+        local f = io.popen(string.format([[ls -1 "%s" 2>/dev/null]], base))
+        if f then
+            for line in f:lines() do
+                local d = line:gsub("[\r\n]+$", "")
+                if d ~= "" then
+                    local cand = path.join(base, d)
+                    if os.isdir(cand) and os.isfile(path.join(cand, "lib", "libc.so")) then
+                        found = cand
+                        break
+                    end
+                end
+            end
+            f:close()
+        end
+        if not found then
+            raise(string.format(
+                "cannot find the payload root under '%s': no extracted "
+                .. "directory contains lib/libc.so", base))
+        end
+        musldir = found
+    end
+
+    os.tryrm(pkginfo.install_dir())
+    os.mv(musldir, pkginfo.install_dir())
+
+    -- Never report success without the one file the package exists for.
+    -- A `return true` here gets stamped as installed and leaves every
+    -- consumer elfpatched onto a loader that is not there.
+    local loader = path.join(pkginfo.install_dir(), "lib", "ld-musl-x86_64.so.1")
+    if not os.isfile(loader) then
+        raise("musl payload has no lib/ld-musl-x86_64.so.1 after install")
+    end
+
+    return true
+end
+
+-- ── the eleven names glibc.lua also registers ──────────────────────────
+--
+-- These are NOT musl's to own. glibc is the subos's system C library and
+-- registers every one of them into the shared `lib/` directory; musl
+-- ships a file under the same name, with incompatible contents. The
+-- overlap was computed against glibc.lua's `glibc_libs` list and this
+-- payload's actual `lib/`, not eyeballed.
+--
+-- Registered under the plain version, they become two-owner names —
+-- measured on a real install, not theorised:
+--
+--     crt1.o  = {"active": "glibc-2.39",
+--                "installed": ["glibc-2.39", "musl-1.2.5"]}
+--
+-- and one `xvm use` landing on the musl side repoints the subos's
+-- `crt1.o` at musl's, which silently breaks every glibc C link in that
+-- subos.
+--
+-- So they register as `<version>-musl`, the same idiom jdk-temurin.lua
+-- uses for `java`/`javac` (`25.0.4+7-temurin`) and musl-gcc.lua uses to
+-- share `gcc` with gcc.lua (`16.1.0-musl`). `xlings use crt1.o
+-- 1.2.5-musl` then names one libc unambiguously, and the whole set
+-- switches together through the binding root below.
+local SHARED_LIBS = {
+    "Scrt1.o", "crt1.o", "crti.o", "crtn.o",
+    "libc.a", "libc.so", "libdl.a", "libm.a",
+    "libpthread.a", "librt.a", "libutil.a",
+}
+
+-- ── names only musl ships ──────────────────────────────────────────────
+--
+-- No collision today, but they take the same flavor-tagged version so
+-- the whole set moves as one under `xlings use musl`, and so a second
+-- musl-ish libc arriving later meets the same convention rather than a
+-- plain number that happens to be free.
+--
+-- `libm.a`/`libpthread.a`/`librt.a`/`libdl.a`/`libcrypt.a`/`libutil.a`/
+-- `libxnet.a`/`libresolv.a` are all 8-byte empty archives: musl puts
+-- everything in libc and keeps these so a `-lm`/`-lpthread` on someone's
+-- link line resolves instead of erroring.
+local MUSL_ONLY_LIBS = {
+    "ld-musl-x86_64.so.1", "rcrt1.o",
+    "libcrypt.a", "libresolv.a", "libxnet.a",
+}
+
+local FLAVOR = "musl"
+
+local function flavor_version()
+    return pkginfo.version() .. "-" .. FLAVOR
+end
+
+function config()
+    -- Root of this release's binding group, so `xlings use musl 1.2.5`
+    -- switches every lib bound to it in one step.
+    --
+    -- `type = "group"` because the node names no artifact: there is no
+    -- `bin/musl` to exec. Left as the default `program` kind it becomes
+    -- a shim that can only ever fail — verified here before the fix, as
+    -- `subos/default/bin/musl -> ../../../bin/xlings`, exactly the
+    -- orphan `self doctor` reports (openxlings/xlings#452). Same idiom
+    -- as gcc.lua / rust.lua / jdk-temurin.lua.
+    local binding = "musl@" .. pkginfo.version()
+    xvm.add("musl", { type = "group" })
+
+    local musl_libdir = path.join(pkginfo.install_dir(), "lib")
+    local lib_config = {
+        version = flavor_version(),
+        type = "lib",
+        bindir = musl_libdir,
+        binding = binding,
+    }
+
+    log.debug("1 - config musl libs (%s)...", flavor_version())
+    for _, set in ipairs({ SHARED_LIBS, MUSL_ONLY_LIBS }) do
+        for _, lib in ipairs(set) do
+            -- Guarded the way glibc's registration is: a name absent
+            -- from this release's payload is skipped rather than
+            -- registered as a lib whose source file does not exist.
+            if os.isfile(path.join(musl_libdir, lib)) then
+                lib_config.filename = lib -- target file name
+                lib_config.alias = lib -- source file name
+                xvm.add(lib, lib_config)
+            end
+        end
+    end
+
+    log.debug("2 - musl config header files...")
+    __config_header(binding)
+
+    log.info("musl: libs registered as %s (glibc keeps the plain names)",
+             flavor_version())
+
+    return true
+end
+
+function uninstall()
+    -- Version-scoped on purpose: glibc's registration of the same eleven
+    -- names, and any other installed musl release, must survive this.
+    local v = flavor_version()
+    for _, set in ipairs({ SHARED_LIBS, MUSL_ONLY_LIBS }) do
+        for _, lib in ipairs(set) do
+            xvm.remove(lib, v)
+        end
+    end
+    xvm.remove("musl", pkginfo.version())
+    return true
+end
+
+-- private
+
+function __config_header(binding)
+    -- Declared where the client supports it, so the entries follow
+    -- `xlings use` and are removed with the release instead of outliving
+    -- it.
+    --
+    -- Unlike glibc, musl's headers are NOT safe to scatter into a shared
+    -- `usr/include` next to another libc's: the two disagree on the
+    -- contents of stdio.h, features.h and everything reachable from
+    -- them, and whichever lands second silently wins for every compile
+    -- in the subos. So they go to their own directory and a musl build
+    -- points at it explicitly (`-isystem`, or the toolchain's own
+    -- sysroot) rather than inheriting it by accident.
+    local include_dir = path.join(pkginfo.install_dir(), "include")
+    if not os.isdir(include_dir) then
+        return
+    end
+
+    if sysroot.declare_headers(pkginfo.install_dir(), "include",
+                               "usr/include/musl", binding) then
+        return
+    end
+
+    -- Legacy path for a client with no `xvm.files`. The stamp matters
+    -- for the same reason it does in glibc.lua: config() runs on every
+    -- dependent install, and without it each one re-copies the tree.
+    local subos_sysrootdir = system.subos_sysrootdir()
+    local sysroot_usrdir = path.join(subos_sysrootdir, "usr")
+    if not os.isdir(sysroot_usrdir) then os.mkdir(sysroot_usrdir) end
+
+    local stamp = path.join(sysroot_usrdir, ".musl-" .. pkginfo.version() .. ".stamp")
+    if os.isfile(stamp) then
+        log.debug("musl headers already in subos rootfs (stamp present), skipping copy.")
+        return
+    end
+
+    log.info("Linking musl headers into subos sysroot (usr/include/musl) ...")
+    sysroot.install_headers(include_dir, path.join(sysroot_usrdir, "include", "musl"))
+    io.writefile(stamp, pkginfo.version())
+end

--- a/tests/m/test_musl.py
+++ b/tests/m/test_musl.py
@@ -1,0 +1,195 @@
+"""测试 musl 包"""
+import re
+
+import pytest
+from tests.lib.xpkg_parser import parse_xpkg
+from tests.lib.assertions import (
+    assert_required_fields, assert_valid_spec, assert_valid_type,
+    assert_no_typos, assert_no_exec_xvm, assert_no_bashrc_modification,
+    assert_no_direct_path_modification, assert_uses_new_api,
+    assert_xim_add_succeeds, assert_install_succeeds,
+)
+from tests.lib.platform_utils import skip_if_not
+
+PKG = "musl"
+PKG_FILE = "pkgs/m/musl.lua"
+
+
+@pytest.fixture(scope='module')
+def meta():
+    return parse_xpkg(PKG_FILE)
+
+
+def lua_code(path=PKG_FILE):
+    """去掉 `--` 行注释后的配方正文
+
+    配方注释里会引用 musl-gcc、glibc 等名字来解释边界，直接扫全文会把说明
+    本身当成违规。
+    """
+    content = open(path, encoding='utf-8').read()
+    return re.sub(r'--[^\n]*', '', content)
+
+
+class TestStatic:
+    @pytest.mark.static
+    def test_required_fields(self, meta):
+        assert_required_fields(meta)
+
+    @pytest.mark.static
+    def test_valid_spec(self, meta):
+        assert_valid_spec(meta)
+
+    @pytest.mark.static
+    def test_valid_type(self, meta):
+        assert_valid_type(meta)
+
+    @pytest.mark.static
+    def test_no_typos(self):
+        assert_no_typos(PKG_FILE)
+
+
+class TestIndex:
+    @pytest.mark.index
+    def test_xim_add(self):
+        assert_xim_add_succeeds(PKG_FILE)
+
+
+class TestIsolation:
+    @pytest.mark.isolation
+    def test_no_exec_xvm(self):
+        assert_no_exec_xvm(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_no_bashrc(self):
+        assert_no_bashrc_modification(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_no_path_modification(self):
+        assert_no_direct_path_modification(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_new_api(self):
+        assert_uses_new_api(PKG_FILE)
+
+
+class TestDesign:
+    @pytest.mark.static
+    def test_declares_loader_and_abi(self):
+        """必须导出 loader 和 abi
+
+        loader 是 elfpatch 的 provider 谓词；abi 是同一个 subos 里同时装了
+        glibc 和 musl 时的区分标签 —— glibc.lua 的注释就是这么写的。
+        """
+        code = lua_code()
+        assert 'loader = "lib/ld-musl-x86_64.so.1"' in code
+        assert 'abi    = "linux-x86_64-musl"' in code
+
+    @pytest.mark.static
+    def test_every_version_has_sha256(self):
+        """libc payload 不允许无校验安装
+
+        XLINGS_RES 条目不带 checksum，所以这个包用显式 url + sha256。
+        """
+        code = lua_code()
+        assert "XLINGS_RES" not in code, "libc payload 必须带 sha256, 不能用 XLINGS_RES"
+        versions = re.findall(r'\["(\d+\.\d+\.\d+)"\]\s*=\s*\{', code)
+        assert versions, "没有解析到版本条目"
+        assert len(re.findall(r'sha256\s*=\s*"[0-9a-f]{64}"', code)) == len(versions), \
+            f"{len(versions)} 个版本, sha256 数量不匹配"
+
+    @pytest.mark.static
+    def test_cn_mirror_for_every_version(self):
+        """每个版本都要有 CN 加速"""
+        code = lua_code()
+        assert len(re.findall(r'GLOBAL\s*=', code)) == len(re.findall(r'CN\s*=', code))
+        assert "gitcode.com/xlings-res/musl" in code
+
+    @pytest.mark.static
+    def test_does_not_claim_musl_gcc(self):
+        """musl-gcc 这个 program 名归 musl-gcc.lua
+
+        同一个 (name, version) 被两个包注册会被直接拒绝，所以 payload 用
+        `--disable-gcc-wrapper` 构建，这里锁住它不会被登记。
+        """
+        code = lua_code()
+        assert not re.search(r'xvm\.add\(\s*"musl-gcc"', code)
+        assert not re.search(r'programs\s*=\s*\{[^}]*musl-gcc', code)
+
+    @pytest.mark.static
+    def test_shared_libc_names_are_listed_separately(self):
+        """和 glibc 撞名的部分必须单独列出
+
+        这 11 个名字是对着 glibc.lua 的 glibc_libs 和 payload 里真实的
+        lib/ 算出来的交集,不是眼估的。单独成表是为了让"哪些名字危险"
+        在配方里是显式的。
+        """
+        code = lua_code()
+        m = re.search(r'local SHARED_LIBS = \{(.*?)\}', code, re.S)
+        assert m, "缺少 SHARED_LIBS 列表"
+        shared = set(re.findall(r'"([^"]+)"', m.group(1)))
+        assert shared == {
+            "Scrt1.o", "crt1.o", "crti.o", "crtn.o",
+            "libc.a", "libc.so", "libdl.a", "libm.a",
+            "libpthread.a", "librt.a", "libutil.a",
+        }, f"SHARED_LIBS 和实测的 glibc 交集不一致: {sorted(shared)}"
+
+    @pytest.mark.static
+    def test_libs_register_under_flavor_tagged_version(self):
+        """撞名的 lib 必须挂在带 musl 标识的版本号上
+
+        用平版本号注册会让每个名字变成双 owner:
+
+            crt1.o = {"active": "glibc-2.39",
+                      "installed": ["glibc-2.39", "musl-1.2.5"]}
+
+        一次 xvm use 选到 musl 那侧,该 subos 里所有 glibc C 链接就静默挂掉。
+        用 `<version>-musl` 与 jdk-temurin 的 `<version>-temurin`、
+        musl-gcc 的 `16.1.0-musl` 是同一个 idiom。
+        """
+        code = lua_code()
+        assert re.search(r'local FLAVOR = "musl"', code)
+        assert re.search(r'pkginfo\.version\(\)\s*\.\.\s*"-"\s*\.\.\s*FLAVOR', code)
+        # lib 注册与 uninstall 都必须走 flavor_version(),不能是裸版本号
+        assert re.search(r'version\s*=\s*flavor_version\(\)', code)
+        assert re.search(r'xvm\.remove\(lib,\s*v\)', code)
+
+    @pytest.mark.static
+    def test_binding_root_is_a_group(self):
+        """musl 没有可执行文件,绑定根必须是 type = "group"
+
+        留成默认的 program 类型会生成一个永远失败的 shim
+        (subos/*/bin/musl -> bin/xlings),就是 openxlings/xlings#452 里
+        self doctor 报的 orphan。
+        """
+        code = lua_code()
+        assert re.search(r'xvm\.add\(\s*"musl"\s*,\s*\{\s*type\s*=\s*"group"\s*\}\s*\)', code)
+
+    @pytest.mark.static
+    def test_install_fails_loudly_without_loader(self):
+        """没有 loader 就不能报安装成功
+
+        glibc.lua 踩过：os.mv 失败、install() 照样 return true，结果是一个
+        没有 loader 的 libc 包被记为安装成功，而所有被 elfpatch 指过来的
+        consumer 都指向一个不存在的文件。
+        """
+        code = lua_code()
+        assert "ld-musl-x86_64.so.1" in code
+        assert re.search(r'raise\(', code), "install() 必须在 payload 不完整时 raise"
+
+    @pytest.mark.static
+    def test_headers_not_scattered_into_shared_usr_include(self):
+        """musl 头文件不能和另一个 libc 的混在同一个 usr/include
+
+        两者的 stdio.h / features.h 内容不同，后落地的那个会静默赢下整个
+        subos 的编译。
+        """
+        code = lua_code()
+        assert '"usr/include/musl"' in code
+        assert not re.search(r'declare_headers\([^)]*"usr/include"\s*,', code)
+
+
+class TestLifecycle:
+    @pytest.mark.lifecycle
+    @skip_if_not('linux')
+    def test_install(self):
+        assert_install_succeeds(PKG)


### PR DESCRIPTION
## 有 libc 的问题吗？

**现状（glibc 主机）没有。** claude 用的是 glibc 构建，NEEDED 只有
libc/libm/libdl/librt/libpthread，最高引用符号版本 `GLIBC_2.17`，2012 年以后的发行版全覆盖，
sandbox 里已验证跑通。

**但索引确实缺一块。** 在 glibc 宿主的 subos sandbox 里实测：

```
$ musl-gcc -o h h.c && ./h
cannot execute: required file not found     # INTERP 是 /lib/ld-musl-x86_64.so.1
```

编出来的 musl 二进制跑不了 —— 宿主没有那个 loader，而索引里没有任何包提供它。
glibc.lua 的注释早就点了名：它给 loader 打 `abi = "linux-x86_64-glibc"` 标签，理由是
"a subos hosts both glibc and musl xpkgs" —— 而那个 musl xpkg 一直不存在。本 PR 补上。

## 加了什么

`pkgs/m/musl.lua`，**1.2.5**（Alpine 3.20/3.21/3.22 在用，所以"一个 musl 二进制"
绝大多数是对着它构建的，`latest` 指它，理由和 glibc 的 latest 是 2.39 一样）和
**1.2.6**（上游最新）。x86_64，与 glibc.lua 同范围 —— 构建脚本的检查会**真的运行** loader
并链一个程序上去，aarch64 在这台机器上验不了，不发未验证的 payload。

payload 由 `.agents/tools/build-musl.sh` 从上游源码构建。它存在是因为 musl 有两个默认值
对可重定位 payload 是错的：`--syslibdir` 默认 `/lib`，`make install` 会把
`ld-musl-*.so.1` 装到那儿而不是 `--prefix` 下（默认构建出来的 payload **一个 loader 都没有**），
且那个符号链接是指向构建前缀的绝对路径。另外 `--disable-gcc-wrapper`，因为
`musl-gcc.lua` 已经拥有 `musl-gcc` 这个 xvm 名字。

资源：`github.com/xlings-res/musl` + `gitcode.com/xlings-res/musl`（两个仓库本次新建），
tag `1.2.5` / `1.2.6`，本地/GitHub/GitCode 三方 sha256 一致。

## 撞名：一个真实的坑，配方里装的是修好的版本不是坑

按常规写法注册 lib 之后实测到：

```
crt1.o = {"active": "glibc-2.39", "installed": ["glibc-2.39", "musl-1.2.5"]}
```

**11 个名字**（`crt1.o crti.o crtn.o Scrt1.o libc.a libc.so libdl.a libm.a libpthread.a
librt.a libutil.a`，对着 glibc.lua 的 `glibc_libs` 和 payload 真实 `lib/` 求交集算出来的）
同时属于 glibc。一次 `xvm use` 落到 musl 那侧就会改写 subos 共享 `lib/` 里的符号链接，
**该 subos 里所有 glibc C 链接静默挂掉**。

改成 jdk 那套：撞名集合**单独列表**，注册到 `<version>-musl`（和 jdk-temurin 的
`25.0.4+7-temurin`、musl-gcc 的 `16.1.0-musl` 同一个 idiom），绑定根用 `type = "group"`
—— 因为没有 `bin/musl` 可执行，留成默认 program 类型实测会生成
`subos/*/bin/musl -> bin/xlings` 这个永远失败的 shim，正是 openxlings/xlings#452 的 orphan。
`uninstall()` 版本内收敛。头文件落到 `usr/include/musl` 而不是共享 `usr/include`
（两个 libc 的 `stdio.h` 内容不同，后落地的会静默赢下整个 subos 的编译）。

这条规则已写进 `.agents/skills/xpkg-creater/SKILL.md` §2.3.1，包括最容易漏的一点：
**同名同版本是响亮地被拒绝，同名不同版本是被接受、之后才咬人。**

## claude.lua：两条约束改成有证据的陈述

有了 `xim:musl` 之后，"把 claude 换成 musl 构建"是显而易见的下一步。它**确实能跑**：

```
$ <musl>/lib/ld-musl-x86_64.so.1 claude --version   → 2.1.222 (Claude Code)
   （--help / doctor / mcp list 也都 rc=0）
```

但只能靠显式调用 loader，而这不是免费的：

```
$ claude doctor                             → Running: native
$ /lib64/ld-linux-x86-64.so.2 claude doctor → Running: package-manager
```

**同一个二进制、不同答案。** 显式 loader 调用下内核把 `/proc/self/exe` 指向 **loader**
（实测读回来是 `.../lib/libc.so`），而这个二进制里有 3 处 `/proc/self/exe` —— 那是 Bun 算
`process.execPath` 的方式。任何从该路径重新拉起 CLI 的流程都会去 exec `libc.so`。
`--version` 通过证明不了这件事。

所以 glibc 资产保持不变，两条注释保留，但现在写的是**为什么绕不过去**，而不只是断言。
往 `deps` 里加 `xim:musl` 也不行：elfpatch 就是 patchelf，换个 loader 目标只是换条路到同一个 SIGSEGV。

## Test plan

本地 + subos sandbox（bwrap）已验证：

- **构建自检**：脚本会运行 loader 并核对版本、链一个程序上去跑、确认 payload 里没有 `musl-gcc`。两个版本都过。
- **三方 sha256**：本地 = GitHub RES = GitCode RES，1.2.5 / 1.2.6 均一致。
- **sandbox `musl-verify`**：
  - `xlings install musl musl-gcc` 同装，`musl: libs registered as 1.2.5-musl (glibc keeps the plain names)`
  - musl 二进制裸跑失败 → 用本 payload 的 loader 跑通 → 直接 `-Wl,--dynamic-linker=` 链上去也跑通
  - `xlings use crt1.o 1.2.5-musl` 可命名可切换
  - 同一 subos 里 `gcc` 仍能编译并运行 glibc 二进制（共存验证）
  - `claude --version` → `2.1.222 (Claude Code)`，rc=0
  - `musl-gcc-static` 产出静态二进制并运行
- **注册表**：装 musl 后 `crt1.o` 的 `active` 仍是 `glibc-2.39`，共享 `lib/` 符号链接未被动；`bin/musl` orphan shim 不再产生；卸载后注册表干净回到只剩 glibc。
- **`.github/scripts/posix-test.sh`**（CI linux-install-test 同一脚本）本地跑通 musl + claude 的 register/install/shim/uninstall。
- **pytest**：`-m "static or isolation"` 全仓 1128 passed。

> 本机 `xvm info` 输出缺字段，`assert_xvm_registered` 类 verify 用例对所有包都失败（已用其它包对照），依赖 CI。