### PR TITLE
fix(musl): uninstall left every lib node behind outside the xim namespace

### DIFF
--- a/.agents/skills/xpkg-creater/SKILL.md
+++ b/.agents/skills/xpkg-creater/SKILL.md
@@ -198,8 +198,27 @@ local function flavor_version() return pkginfo.version() .. "-" .. FLAVOR end
    留成默认的 program 类型会生成一个永远失败的 shim
    （`subos/*/bin/musl -> bin/xlings`），`self doctor` 会把它报成 orphan
    （openxlings/xlings#452）。
-4. **`uninstall()` 必须版本内收敛**：`xvm.remove(name, flavor_version())`。
+4. **`uninstall()` 必须版本内收敛**：`xvm.remove(name, <stored key>)`。
    用裸名删会把对方包的注册一起删掉。
+
+   ⚠️ **`xvm.add` 会自己补索引命名空间前缀，`xvm.remove` 不会。**
+   从 `local:` 或任何非 `xim` 的索引仓库安装时，`version = "1.2.5-musl"` 实际存成
+   `local:1.2.5-musl`；卸载时传裸键匹配不到，根节点删了、所有 lib 节点全留下。
+   **CI 抓不到**——`posix-test.sh` 的卸载后检查只看 `bin/` 里残留的 shim，
+   而 lib 节点不产生 shim。照 glibc.lua 的 `__version_key()` 写：
+
+   ```lua
+   function __stored_version()
+       local store = path.filename(path.directory(pkginfo.install_dir()))
+       local ns = store:match("^(.-)%-x%-")   -- <data>/xpkgs/<ns>-x-<name>/<version>
+       local bare = flavor_version()
+       if ns and ns ~= "" and ns ~= "xim" then return ns .. ":" .. bare end
+       return bare
+   end
+   ```
+
+   验收方式：装完 → 看 `subos/<name>/.xlings.json` 的 `workspace` → 卸载 → 再看一次，
+   必须回到 `null`。只跑 `posix-test.sh` 不足以说明卸载干净。
 5. **头文件同理。** 两个 libc 的 `stdio.h`/`features.h` 内容不同，散进共享
    `usr/include` 后落地的那个会静默赢下整个 subos 的编译 —— 非 system libc 的头
    要落到自己的命名空间（`usr/include/musl`）。

--- a/pkgs/m/musl.lua
+++ b/pkgs/m/musl.lua
@@ -272,7 +272,7 @@ end
 function uninstall()
     -- Version-scoped on purpose: glibc's registration of the same eleven
     -- names, and any other installed musl release, must survive this.
-    local v = flavor_version()
+    local v = __stored_version()
     for _, set in ipairs({ SHARED_LIBS, MUSL_ONLY_LIBS }) do
         for _, lib in ipairs(set) do
             xvm.remove(lib, v)
@@ -280,6 +280,39 @@ function uninstall()
     end
     xvm.remove("musl", pkginfo.version())
     return true
+end
+
+-- The key the lib nodes are actually STORED under.
+--
+-- `xvm.add` prefixes the index namespace itself: registering
+-- `version = "1.2.5-musl"` stores a bare `1.2.5-musl` from the primary
+-- `xim` namespace but `local:1.2.5-musl` from any other. `xvm.remove`
+-- does NOT prefix — hand it the bare key from a secondary namespace and
+-- it matches nothing.
+--
+-- Measured after `xlings remove local:musl`: the package root was gone
+-- and every lib node was still there —
+--
+--     crt1.o = {"active": "glibc-2.39",
+--               "installed": ["glibc-2.39", "local:1.2.5-musl"]}
+--
+-- i.e. uninstall left musl owning eleven of glibc's names, which is the
+-- exact state the flavor tag exists to keep switchable-but-clean. It
+-- passes CI because posix-test.sh's post-uninstall check looks for
+-- leftover *shims* in `bin/`, and lib nodes make none.
+--
+-- `xim:musl` was symmetric all along, so this only ever bit secondary
+-- namespaces — which is every local test and every CI run.
+--
+-- Same shape as glibc.lua's `__version_key()`. The namespace is not
+-- exposed to a hook, but the store directory is:
+-- `<data>/xpkgs/<ns>-x-musl/<version>`.
+function __stored_version()
+    local store = path.filename(path.directory(pkginfo.install_dir()))
+    local ns = store:match("^(.-)%-x%-")
+    local bare = flavor_version()
+    if ns and ns ~= "" and ns ~= "xim" then return ns .. ":" .. bare end
+    return bare
 end
 
 -- private

--- a/tests/m/test_musl.py
+++ b/tests/m/test_musl.py
@@ -149,9 +149,31 @@ class TestDesign:
         code = lua_code()
         assert re.search(r'local FLAVOR = "musl"', code)
         assert re.search(r'pkginfo\.version\(\)\s*\.\.\s*"-"\s*\.\.\s*FLAVOR', code)
-        # lib 注册与 uninstall 都必须走 flavor_version(),不能是裸版本号
+        # 注册走 flavor_version()
         assert re.search(r'version\s*=\s*flavor_version\(\)', code)
+
+    @pytest.mark.static
+    def test_uninstall_uses_the_namespaced_stored_key(self):
+        """卸载必须用带命名空间前缀的版本键
+
+        xvm.add 会自己补索引命名空间(`local:1.2.5-musl`),xvm.remove 不会。
+        用裸键从次级命名空间卸载匹配不到任何东西,结果是根节点删了、11 个
+        lib 节点全留下:
+
+            crt1.o = {"active": "glibc-2.39",
+                      "installed": ["glibc-2.39", "local:1.2.5-musl"]}
+
+        CI 抓不到,因为 posix-test.sh 的卸载后检查只看 bin/ 里残留的 shim,
+        而 lib 节点不产生 shim。
+        """
+        code = lua_code()
+        assert re.search(r'function __stored_version\(\)', code), \
+            "缺少命名空间感知的版本键 helper"
+        assert re.search(r'ns\s*~=\s*"xim"', code), \
+            "__stored_version 必须只在非主命名空间加前缀"
         assert re.search(r'xvm\.remove\(lib,\s*v\)', code)
+        assert re.search(r'local v = __stored_version\(\)', code), \
+            "uninstall 必须用 __stored_version(),不能用裸 flavor_version()"
 
     @pytest.mark.static
     def test_binding_root_is_a_group(self):


### PR DESCRIPTION
## Summary

#518 的后续修复，卸载不对称。

`xvm.add` 会**自己补索引命名空间前缀**，`xvm.remove` **不会**。注册时写
`version = "1.2.5-musl"`：主命名空间 `xim` 存成裸的 `1.2.5-musl`，其它索引仓库存成
`local:1.2.5-musl`。`uninstall()` 传的是裸键，从次级命名空间卸载时匹配不到任何东西：

```
crt1.o = {"active": "glibc-2.39", "installed": ["glibc-2.39", "local:1.2.5-musl"]}
```

包根节点摘掉了，**16 个 lib 节点全部留下** —— 也就是卸载之后 musl 仍然占着 glibc 的 11 个
名字，正是 flavor 标签本来要保证「可切换但干净」的那个状态被破坏了。

`xim:musl` 一直是对称的，所以这个 bug 只咬次级命名空间 —— 而那是**每一次本地测试和每一次
CI 跑的路径**。

**CI 为什么没抓到**：`posix-test.sh` 的卸载后检查只看 `bin/` 里残留的 shim，
而 lib 节点根本不产生 shim。

## Fix

照 `glibc.lua` 的 `__version_key()` 写一个命名空间感知的键：

```lua
function __stored_version()
    local store = path.filename(path.directory(pkginfo.install_dir()))
    local ns = store:match("^(.-)%-x%-")   -- <data>/xpkgs/<ns>-x-<name>/<version>
    local bare = flavor_version()
    if ns and ns ~= "" and ns ~= "xim" then return ns .. ":" .. bare end
    return bare
end
```

## Test plan

不看 `posix-test.sh`，直接读 `subos/<name>/.xlings.json` 的 `workspace` 前后对比。

`xim:musl`（修复前就正常，作为对照）：

```
AFTER install:   crt1.o {"active": "1.2.5-musl", "installed": ["1.2.5-musl"]}
AFTER uninstall: crt1.o null   libc.so null   ld-musl-x86_64.so.1 null   musl null
```

`local:musl`（修复后，本次验证，sandbox `musl-nsfix`）：

```
AFTER install:   crt1.o {"active": "local:1.2.5-musl", "installed": ["local:1.2.5-musl"]}
AFTER uninstall: crt1.o null   libc.so null   ld-musl-x86_64.so.1 null   musl null
LEAKED: none
```

16 个节点逐个检查（11 个 shared + 5 个 musl-only + 根），全部回到 `null`。

- 新增回归测试 `test_uninstall_uses_the_namespaced_stored_key`。
- pytest `-m "static or isolation"` 全仓 1129 passed。
- skill §2.3.1 补上这条，并写明**验收要读 workspace json，不能只信 `posix-test.sh`**。