### PR TITLE
ci: xlings pin 2026.7.29.0 -> 2026.8.5.2(解开 #463 的验证死结)

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Installation Xlings on Ubuntu
         run: |
           export XLINGS_NON_INTERACTIVE=1
-          export XLINGS_VERSION=v2026.7.29.0
+          export XLINGS_VERSION=v2026.8.5.2
           curl -fsSL https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.sh | bash
           echo "XLINGS_HOME=$HOME/.xlings" >> "$GITHUB_ENV"
           echo "PATH=$HOME/.xlings/subos/current/bin:$HOME/.xlings/bin:$PATH" >> "$GITHUB_ENV"
@@ -79,7 +79,7 @@ jobs:
         shell: pwsh
         run: |
           $env:XLINGS_NON_INTERACTIVE = "1"
-          $env:XLINGS_VERSION = "v2026.7.29.0"
+          $env:XLINGS_VERSION = "v2026.8.5.2"
           iex (Invoke-WebRequest `
             -Uri "https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.ps1" `
             -UseBasicParsing).Content
@@ -140,7 +140,7 @@ jobs:
       - name: Install xlings on Ubuntu
         run: |
           export XLINGS_NON_INTERACTIVE=1
-          export XLINGS_VERSION=v2026.7.29.0
+          export XLINGS_VERSION=v2026.8.5.2
           curl -fsSL https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.sh | bash
           echo "XLINGS_HOME=$HOME/.xlings" >> "$GITHUB_ENV"
           echo "$HOME/.xlings/bin"               >> "$GITHUB_PATH"
@@ -188,7 +188,7 @@ jobs:
       - name: Install xlings on macOS
         run: |
           export XLINGS_NON_INTERACTIVE=1
-          export XLINGS_VERSION=v2026.7.29.0
+          export XLINGS_VERSION=v2026.8.5.2
           curl -fsSL https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.sh | bash
           echo "XLINGS_HOME=$HOME/.xlings" >> "$GITHUB_ENV"
           echo "$HOME/.xlings/bin"               >> "$GITHUB_PATH"

--- a/.github/workflows/ci-xpkg-test.yml
+++ b/.github/workflows/ci-xpkg-test.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Install xlings
         run: |
           export XLINGS_NON_INTERACTIVE=1
-          export XLINGS_VERSION=v2026.7.29.0
+          export XLINGS_VERSION=v2026.8.5.2
           curl -fsSL https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.sh | bash
           echo "XLINGS_HOME=$HOME/.xlings" >> "$GITHUB_ENV"
           echo "PATH=$HOME/.xlings/subos/current/bin:$HOME/.xlings/bin:$PATH" >> "$GITHUB_ENV"


### PR DESCRIPTION
## 问题

CI 的 xlings 停在 **2026.7.29.0**,而 marker 展开(`${XLINGS_DYNAMIC_SUBOS_DIR}`,#460)是 **2026.7.31.2** 才有的 —— 差两天。

后果是 **[#463](https://github.com/openxlings/xim-pkgindex/pull/463) 无法被验证**:它按设计把 gcc alias 里的 `--sysroot=` 从「装它时那个 subos 的具体路径」改成 marker,而这条 CI 装的 xlings 根本不认那个 marker,于是 `windows-test` 必红。**那不是 #463 的 bug,是这个 pin 太旧。**

## #463 卡住的代价是真实的

`compat.openssl` 的 `install()` 从源码构建(Perl Configure + Make),用的是**裸 `gcc`**,因此对着**错误的 subos** 找系统头:

```
gcc  -I. -Iinclude ...
xim-x-gcc/16.1.0/lib/gcc/x86_64-linux-gnu/16.1.0/include/limits.h:210:
    fatal error: limits.h: No such file or directory
include/internal/common.h:14: fatal error: stdlib.h: No such file or directory
```

另一处直接点出了 subos 名字:

```
tests/examples/eui-neo-sdl2/.mcpp/.xlings/subos/_/usr/include/bits/local_lim.h:38:
    fatal error: linux/limits.h: No such file or directory
```

mcpp-index 今天的 CI 正因此挂着,而时间对照支持这个判断:

| | mcpp / 内带 xlings | `openssl` / `curl` / `asio-ssl` / `eui-neo-sdl2` |
|---|---|---|
| 08-04 nightly | 2026.8.3.3 / xlings **2026.7.28.4** | **全部通过**(openssl 真建了 150.50s) |
| 今天 | 2026.8.5.4 / xlings **2026.8.5.2** | 全部失败 |

跨过的正是 subos 那批重构 —— 机制换了,而 `pkgs/g/gcc.lua` 这份**数据**还在用旧写法把答案写死。

## 本 PR

只动 CI 的 pin,不碰任何 recipe:

```diff
-export XLINGS_VERSION=v2026.7.29.0
+export XLINGS_VERSION=v2026.8.5.2
```

`ci-test.yml`(4 处,含 windows 的 PowerShell 那处)与 `ci-xpkg-test.yml`(1 处)。

合入后 #463 才第一次在**认得 marker 的 xlings** 上被验证。

## 我没有验证的部分

**本机复现不出那个 openssl 失败的版本差异** —— 同一环境下 mcpp 2026.8.3.3 与 2026.8.5.4 都装不上 openssl(那个沙箱本身就装不上)。所以上面是**证据链**,不是我跑出来的因果。本 PR 本身只是把 pin 抬到 latest,风险独立于那条推断:CI 用两天前的 xlings 去验证依赖两天后能力的改动,无论如何都是不对的。