### PR TITLE
feat(codex): the official release package, not npm

### DIFF
--- a/.agents/skills/xpkg-creater/SKILL.md
+++ b/.agents/skills/xpkg-creater/SKILL.md
@@ -130,6 +130,18 @@ xpm = {
 
 测试也应默认锁定这条边界：import 只能来自 `xim.libxpkg.*`，路径、错误处理、文件 IO 优先用标准 Lua 或 `libxpkg` 可移植封装。
 
+**hook runtime 里没绑定的东西会静默毁掉安装。** 已确认不可用的：
+
+| 写法 | 现象 | 换成 |
+|------|------|------|
+| `os.exists(p)` | `attempt to call a nil value (field 'exists')` | `os.isdir(p) or os.isfile(p)` |
+| `os.arch()` | 返回 nil / `_RUNTIME.arch` 为空 | 从 `pkginfo.install_file()` 推导 |
+
+危险的地方在于**表现形式**：install hook 抛错之后，安装目录里往往只剩一个 `.xpkg.lua`、
+没有 payload，而外层可能仍然打印 `✓ N package(s) installed`。所以
+`install()` 结尾一定要断言真正的产物存在（`raise(...)` 或 `return os.isfile(exe)`），
+别只 `return true`；验收时也要真的去 `ls` 安装目录，不要只看安装命令的退出码。
+
 ### 2.1.2 配置型包的 Lua 边界
 
 对 `type = "config"` 且会写入用户工具配置的包（例如 Claude/LLM 配置）：

--- a/pkgs/c/codex.lua
+++ b/pkgs/c/codex.lua
@@ -1,5 +1,112 @@
+-- Codex CLI — OpenAI's official prebuilt release package.
+--
+-- This recipe used to `npm install @openai/codex`, which meant node +
+-- npm as dependencies for a program that is a Rust binary. Upstream
+-- publishes the binary directly, so both deps are gone.
+--
+-- Upstream ships two shapes per target and they are NOT interchangeable:
+--
+--   codex-<target>.tar.gz          one file, the bare `codex` binary,
+--                                  named after the target
+--   codex-package-<target>.tar.gz  the real install layout
+--
+-- This uses the **package**, because codex is not just its own binary.
+-- The archive expands to:
+--
+--   bin/codex[.exe]                the entrypoint
+--   bin/codex-code-mode-host[.exe]
+--   codex-path/rg[.exe]            ripgrep, prepended to codex's PATH
+--   codex-resources/bwrap          sandbox helper (linux)
+--   codex-resources/zsh/bin/zsh    the shell its command tool runs in
+--   codex-resources/codex-command-runner.exe   (windows)
+--   codex-package.json             { layoutVersion, version, target,
+--                                    entrypoint, resourcesDir, pathDir }
+--
+-- codex-package.json is upstream *declaring* that layout, and codex
+-- resolves the helpers through it at runtime. So install() moves the
+-- tree across whole and never cherry-picks the entrypoint out of it:
+-- lifting `bin/codex` alone would produce a codex with no ripgrep, no
+-- sandbox and no shell — working enough to pass `--version` and broken
+-- in use.
+--
+-- All six targets upstream builds are covered:
+--   linux   x86_64-unknown-linux-musl / aarch64-unknown-linux-musl
+--   macosx  x86_64-apple-darwin       / aarch64-apple-darwin
+--   windows x86_64-pc-windows-msvc    / aarch64-pc-windows-msvc
+--
+-- No `deps` on any platform, and unlike claude.lua that needs no
+-- argument: linux is the **musl** target and Rust links it static —
+-- `file bin/codex` reports `static-pie linked`, so there is no
+-- interpreter, no NEEDED entry and nothing for elfpatch to rewrite.
+-- macOS and Windows binaries are self-contained the same way.
+--
+-- Versions: upstream tags releases `rust-v<version>`, and the
+-- `codex-package-*` assets start at 0.133.0 — 0.128.0 and older only
+-- ever shipped the bare `codex-<target>` binary, so the pins this recipe
+-- used to carry for them cannot be served natively and are dropped
+-- rather than left pointing at npm. Pre-releases (`rust-v*-alpha.*`) are
+-- deliberately not tracked.
+--
+-- GLOBAL = the authoritative upstream GitHub release.
+-- CN     = gitcode.com/xlings-res/codex, a byte-identical copy under the
+--          same filenames (tag drops the `rust-v` prefix), so mainland
+--          China installs don't go through github.com. Only the version
+--          `latest` points at is mirrored — the six assets run
+--          ~120-146 MB each.
+
+local _CODEX_GH = "https://github.com/openai/codex/releases/download"
+local _CODEX_CN = "https://gitcode.com/xlings-res/codex/releases/download"
+
+local function _asset(target)
+    return "codex-package-" .. target .. ".tar.gz"
+end
+
+-- Upstream only. Used for the historical pins, which are not mirrored.
+local function _up(ver, target, sha256)
+    return {
+        url = string.format("%s/rust-v%s/%s", _CODEX_GH, ver, _asset(target)),
+        sha256 = sha256,
+    }
+end
+
+-- Upstream + the CN mirror of the same bytes.
+local function _mirrored(ver, target, sha256)
+    return {
+        url = {
+            GLOBAL = string.format("%s/rust-v%s/%s", _CODEX_GH, ver, _asset(target)),
+            CN = string.format("%s/%s/%s", _CODEX_CN, ver, _asset(target)),
+        },
+        sha256 = sha256,
+    }
+end
+
+-- One platform's per-arch resource map (Shape B). `mirrored` opts the
+-- version into the CN table; without it the entry stays upstream-only.
+local function _entry(x86_target, arm_target, ver, sha_x86_64, sha_aarch64, mirrored)
+    local res = mirrored and _mirrored or _up
+    return {
+        x86_64 = res(ver, x86_target, sha_x86_64),
+        aarch64 = res(ver, arm_target, sha_aarch64),
+    }
+end
+
+local function _linux(ver, sha_x86_64, sha_aarch64, mirrored)
+    return _entry("x86_64-unknown-linux-musl", "aarch64-unknown-linux-musl",
+                  ver, sha_x86_64, sha_aarch64, mirrored)
+end
+
+local function _macosx(ver, sha_x86_64, sha_aarch64, mirrored)
+    return _entry("x86_64-apple-darwin", "aarch64-apple-darwin",
+                  ver, sha_x86_64, sha_aarch64, mirrored)
+end
+
+local function _windows(ver, sha_x86_64, sha_aarch64, mirrored)
+    return _entry("x86_64-pc-windows-msvc", "aarch64-pc-windows-msvc",
+                  ver, sha_x86_64, sha_aarch64, mirrored)
+end
+
 package = {
-    spec = "1",
+    spec = "2",
 
     name = "codex",
     description = "Codex CLI from OpenAI",
@@ -7,6 +114,12 @@ package = {
     licenses = {"Apache-2.0"},
     repo = "https://github.com/openai/codex",
     docs = "https://github.com/openai/codex#readme",
+
+    -- No `package.ci`: upstream tags are `rust-v<version>` and the
+    -- release stream is dominated by `-alpha.*` pre-releases, which
+    -- version-check.py's `normalize_version()` would propose as literal
+    -- version keys. Bumps are done by hand together with the CN mirror
+    -- push.
 
     type = "package",
     archs = {"x86_64", "aarch64"},
@@ -19,73 +132,133 @@ package = {
 
     xpm = {
         linux = {
-            deps = {"node", "npm"},
-            ["latest"] = { ref = "0.145.0" },
-            ["0.145.0"] = {},
-            ["0.144.1"] = { ref = "0.144.1" },
-            ["0.133.0"] = { ref = "0.133.0" },
-            ["0.128.0"] = { ref = "0.128.0" },
-            ["0.125.0"] = { ref = "0.125.0" },
-            ["0.122.0"] = { ref = "0.122.0" },
-            ["0.120.0"] = { ref = "0.120.0" },
-            ["0.118.0"] = { ref = "0.118.0" },
-            ["0.106.0"] = {},
+            ["latest"] = { ref = "0.146.1" },
+            ["0.146.1"] = _linux("0.146.1",
+                "15d9b6aaa47ee02743266581f8ab96b6049e3a2a13a82fbd7920745ba9fc34cb",
+                "a72b2bd37dd69ece77f5584a418bc34ecfa4b28e769727134a1d604b4b2b8e5f", true),
+            ["0.145.0"] = _linux("0.145.0",
+                "71a28d362c96ac9829bf8203a2c71be451aeb726adb843167fdaf0eae8fe7dd9",
+                "54f79a05aba6f9abf8ef988abcae8bf2fcefba20beb549b4ff2b3acdb2cb6f54"),
+            ["0.144.1"] = _linux("0.144.1",
+                "3fd50cf96809b1eea294bbfba0a5c3a576871b4876a1f0e91226e520c1923be1",
+                "218ab48bdda98dde3e10df184cc0c4eb92c4372d9ca924ef1aa5fc81b4f6a38e"),
+            -- Oldest release with `codex-package-*` assets.
+            ["0.133.0"] = _linux("0.133.0",
+                "cad5f38b92247186a532157111ea43edca77d3427eb6127e603b7887db484473",
+                "7a77d416f9ce16f18e09fdc57622a15aab6ad131c34e078ab9d55a13bb3d9b05"),
         },
         macosx = {
-            deps = {"node", "npm"},
-            ["latest"] = { ref = "0.145.0" },
-            ["0.145.0"] = {},
-            ["0.144.1"] = { ref = "0.144.1" },
-            ["0.133.0"] = { ref = "0.133.0" },
-            ["0.128.0"] = { ref = "0.128.0" },
-            ["0.125.0"] = { ref = "0.125.0" },
-            ["0.122.0"] = { ref = "0.122.0" },
-            ["0.120.0"] = { ref = "0.120.0" },
-            ["0.118.0"] = { ref = "0.118.0" },
-            ["0.106.0"] = {},
+            ["latest"] = { ref = "0.146.1" },
+            ["0.146.1"] = _macosx("0.146.1",
+                "5b61e447baa14747e1ea6ad10ad8fca1f8ef0d5e11f53ca88a144bf52cf12e06",
+                "a0be385972f38d02e81f9b40de1f842daf8354636fc295666b8630d2f6a5aec6", true),
+            ["0.145.0"] = _macosx("0.145.0",
+                "9d402c9ca814655fddc07b548d7086491c0afcebe1f746cdeba1045fd6f62646",
+                "ece937169d4c9e910d60826a6ea4ae7848a16c089403d122e70e7da4ac41ba34"),
+            ["0.144.1"] = _macosx("0.144.1",
+                "1c797880977549b281eeb4ecd9dbd145542c4ce262a2835ea2847f19922ed30c",
+                "326198829dfb4b68da59723cf605478a2e9bec89ff47feb645814a4c5eaf5f6c"),
+            ["0.133.0"] = _macosx("0.133.0",
+                "79ce0bfee5996c8a40661d92b67a45f3cbdb3d81425d2ebb786d3955870804e0",
+                "7da572ce5631deccb8b05c4cb4bbb608d65d5b3197f5e2c79fa7a156c02fc6d6"),
         },
         windows = {
-            deps = {"node", "npm"},
-            ["latest"] = { ref = "0.145.0" },
-            ["0.145.0"] = {},
-            ["0.144.1"] = { ref = "0.144.1" },
-            ["0.133.0"] = { ref = "0.133.0" },
-            ["0.128.0"] = { ref = "0.128.0" },
-            ["0.125.0"] = { ref = "0.125.0" },
-            ["0.122.0"] = { ref = "0.122.0" },
-            ["0.120.0"] = { ref = "0.120.0" },
-            ["0.118.0"] = { ref = "0.118.0" },
-            ["0.106.0"] = {},
+            ["latest"] = { ref = "0.146.1" },
+            ["0.146.1"] = _windows("0.146.1",
+                "6b26524c4287564a2c6c3511e73dcd32ea3c8c0a994cc1caa731b63f7844c8b6",
+                "2048300c1572b94d3809df3c852e46c391ce702d70b08212557432749b994f49", true),
+            ["0.145.0"] = _windows("0.145.0",
+                "8d0d281346aedf63c4cc3922997df822fbb8881f7ffb2b57416f48e8c52a734e",
+                "753b97a27805e83a209492b5537c46dbf178eeffe1980f6c784924e3cc9b4184"),
+            ["0.144.1"] = _windows("0.144.1",
+                "ce94e1fb84693d3f7332ceeab5be73e93de38725da4b82dff863cd2c795b4730",
+                "a471e55e85bdada7a9d1cb081bed896688a0e7fe0f0fdcd61027187aaa59f8a1"),
+            ["0.133.0"] = _windows("0.133.0",
+                "b7996b021590f3f877b1b2e9088b6c0e43ec781ff3def8a67ae8f14fa703237e",
+                "a133778c79f6116e78c475ad4767397ef042c6addb748e6cf7e56551f27dcc0a"),
         },
-    }
+    },
 }
 
 import("xim.libxpkg.pkginfo")
 import("xim.libxpkg.xvm")
+import("xim.libxpkg.system")
+
+-- The top level of every `codex-package-*` archive, identical across all
+-- six targets. Moved across as a unit — see the header for why the
+-- entrypoint must not be lifted out on its own.
+local _PAYLOAD = { "bin", "codex-path", "codex-resources", "codex-package.json" }
+
+local function _bindir()
+    return path.join(pkginfo.install_dir(), "bin")
+end
+
+local function _installed_exe()
+    return path.join(_bindir(), os.host() == "windows" and "codex.exe" or "codex")
+end
 
 function install()
+    -- Idempotent across xim engines: never wipe install_dir before a
+    -- replacement payload is confirmed, and never report success unless
+    -- the entrypoint landed — a bare `return true` gets stamped as
+    -- installed and leaves a dangling shim over an empty directory.
+    local exe = _installed_exe()
+    if os.isfile(exe) then
+        return true
+    end
+
+    -- The archive expands into the download directory with no wrapper
+    -- directory of its own, so the payload entries sit beside the
+    -- tarball rather than under a `codex-0.146.1/` root.
+    local download_dir = path.directory(pkginfo.install_file())
+
     os.tryrm(pkginfo.install_dir())
     os.mkdir(pkginfo.install_dir())
 
-    local npm_install = string.format(
-        [[npm install --prefix "%s" --no-fund --no-audit "@openai/codex@%s"]],
-        pkginfo.install_dir(),
-        pkginfo.version()
-    )
-    os.exec(npm_install)
+    for _, entry in ipairs(_PAYLOAD) do
+        local src = path.join(download_dir, entry)
+        -- `os.exists` is NOT bound in the xim hook runtime — calling it
+        -- fails the install with `attempt to call a nil value (field
+        -- 'exists')`, and what you see is an install dir holding only
+        -- `.xpkg.lua`. Ask about the two kinds separately.
+        if os.isdir(src) or os.isfile(src) then
+            os.mv(src, path.join(pkginfo.install_dir(), entry))
+        end
+    end
 
-    return true
+    if not os.isfile(exe) then
+        raise("codex payload has no bin/codex after install")
+    end
+    -- codex-package.json is what codex reads to find codex-path and
+    -- codex-resources; without it the helpers are unreachable even
+    -- though they are on disk.
+    if not os.isfile(path.join(pkginfo.install_dir(), "codex-package.json")) then
+        raise("codex payload has no codex-package.json after install")
+    end
+
+    if os.host() ~= "windows" then
+        -- tar preserves the executable bit, but restoring it explicitly
+        -- keeps the recipe correct on extractors that drop unix modes —
+        -- and it has to cover the helpers, not just the entrypoint.
+        system.exec(string.format([[chmod -R +x "%s"]], _bindir()))
+        system.exec(string.format([[chmod -R +x "%s"]],
+                                  path.join(pkginfo.install_dir(), "codex-path")))
+        system.exec(string.format([[chmod -R +x "%s"]],
+                                  path.join(pkginfo.install_dir(), "codex-resources")))
+    end
+
+    return os.isfile(exe)
 end
 
 function config()
-    local bindir = path.join(pkginfo.install_dir(), "node_modules", ".bin")
-    local alias = "codex"
-
-    if is_host("windows") then
-        alias = "codex.cmd"
-    end
-
-    xvm.add("codex", { bindir = bindir, alias = alias })
+    -- `bindir` rather than the install root: the entrypoint lives in
+    -- bin/, and codex locates codex-path/ and codex-resources/ relative
+    -- to itself through codex-package.json, so the layout above it has
+    -- to stay where it is. Only `codex` is registered —
+    -- codex-code-mode-host is codex's own helper, not a user-facing
+    -- command, and registering it would put a name in the subos that
+    -- nobody types.
+    xvm.add("codex", { bindir = _bindir() })
     return true
 end
 

--- a/tests/c/test_codex.py
+++ b/tests/c/test_codex.py
@@ -1,4 +1,6 @@
 """测试 codex 包"""
+import re
+
 import pytest
 from tests.lib.xpkg_parser import parse_xpkg
 from tests.lib.assertions import (
@@ -12,6 +14,23 @@ from tests.lib.platform_utils import skip_if_not
 
 PKG = "codex"
 PKG_FILE = "pkgs/c/codex.lua"
+
+# 上游为每个 target 构建的六个三元组
+TARGETS = [
+    "x86_64-unknown-linux-musl", "aarch64-unknown-linux-musl",
+    "x86_64-apple-darwin", "aarch64-apple-darwin",
+    "x86_64-pc-windows-msvc", "aarch64-pc-windows-msvc",
+]
+
+
+def lua_code(path=PKG_FILE):
+    """去掉 `--` 行注释后的配方正文
+
+    注释里会引用 npm 包名和 `codex-<target>` 这个不该用的裸二进制来解释
+    为什么不那么做，直接扫全文会把说明本身当成违规。
+    """
+    content = open(path, encoding='utf-8').read()
+    return re.sub(r'--[^\n]*', '', content)
 
 
 @pytest.fixture(scope='module')
@@ -59,6 +78,101 @@ class TestIsolation:
     @pytest.mark.isolation
     def test_new_api(self):
         assert_uses_new_api(PKG_FILE)
+
+
+class TestDesign:
+    @pytest.mark.static
+    def test_all_platforms_declared(self, meta):
+        """三平台都要声明 —— 上游对每个平台都发 codex-package"""
+        for plat in ("linux", "windows", "macosx"):
+            assert meta.platforms.get(plat), f"xpm 缺少 {plat} 平台"
+
+    @pytest.mark.static
+    def test_native_binary_not_npm(self):
+        """原生发布包，不再经由 npm 安装"""
+        code = lua_code()
+        assert "github.com/openai/codex/releases/download" in code
+        assert "npm install" not in code
+        assert "@openai/codex" not in code
+        assert "node_modules" not in code
+        # node/npm 曾是 xpm.<platform>.deps
+        assert '"node", "npm"' not in code
+
+    @pytest.mark.static
+    def test_all_six_targets_covered(self):
+        """六个 target 一个都不能少"""
+        code = lua_code()
+        for t in TARGETS:
+            assert t in code, f"缺少 target {t}"
+
+    @pytest.mark.static
+    def test_uses_the_package_asset_not_the_bare_binary(self):
+        """必须用 codex-package-*，不能用裸 codex-<target>
+
+        裸二进制没有 codex-path/rg、codex-resources/{bwrap,zsh}，装出来的
+        codex 能过 --version 但用起来是残的。
+        """
+        code = lua_code()
+        assert re.search(r'"codex-package-"\s*\.\.', code), "asset 名必须是 codex-package-<target>"
+        for t in TARGETS:
+            # 不能出现直接拼裸二进制名的写法
+            assert not re.search(r'"codex-"\s*\.\.\s*target', code)
+
+    @pytest.mark.static
+    def test_keeps_the_whole_package_layout(self):
+        """整包搬运，不挑出 entrypoint
+
+        codex 通过 codex-package.json 在运行时定位 codex-path / codex-resources。
+        """
+        code = lua_code()
+        for entry in ("bin", "codex-path", "codex-resources", "codex-package.json"):
+            assert '"%s"' % entry in code, f"_PAYLOAD 缺少 {entry}"
+        assert "codex-package.json" in code
+        # 装完必须校验 entrypoint 和 layout 描述文件都在
+        assert re.search(r'raise\(', code), "install() 必须在 payload 不完整时 raise"
+
+    @pytest.mark.static
+    def test_no_os_exists_in_hooks(self):
+        """`os.exists` 在 xim hook runtime 里没有绑定
+
+        调用它会让 install 以 `attempt to call a nil value (field 'exists')`
+        失败,而现象是安装目录里只剩一个 `.xpkg.lua`、没有 payload。
+        问两次 `os.isdir` / `os.isfile` 代替。
+        """
+        code = lua_code()
+        assert "os.exists(" not in code, \
+            "os.exists 在 hook runtime 不可用, 用 os.isdir/os.isfile"
+
+    @pytest.mark.static
+    def test_no_deps_needed(self):
+        """linux 是 musl target 且 Rust 静态链接，不需要任何 libc 依赖"""
+        code = lua_code()
+        assert not re.search(r'^\s*deps\s*=', code, re.M), \
+            "codex 是 static-pie 的自包含二进制, 不应声明 deps"
+
+    @pytest.mark.static
+    def test_cn_mirror_present(self):
+        """CN 加速镜像必须覆盖 latest 指向的版本的三个平台"""
+        code = lua_code()
+        assert "gitcode.com/xlings-res/codex" in code
+        refs = set(re.findall(r'\["latest"\]\s*=\s*\{\s*ref\s*=\s*"([^"]+)"', code))
+        assert len(refs) == 1, f"三平台 latest.ref 不一致: {refs}"
+        latest = refs.pop()
+        mirrored = re.findall(
+            r'\["%s"\]\s*=\s*_(?:linux|macosx|windows)\([^)]*,\s*true\)' % re.escape(latest),
+            code)
+        assert len(mirrored) == 3, \
+            f"latest={latest} 应在三个平台都开启 CN 镜像, 实际 {len(mirrored)}"
+
+    @pytest.mark.static
+    def test_every_version_has_six_checksums(self):
+        """每个版本 × 每个平台 × 每个架构都要有 sha256"""
+        code = lua_code()
+        versions = set(re.findall(r'\["(\d+\.\d+\.\d+)"\]\s*=\s*_(?:linux|macosx|windows)\(', code))
+        assert versions, "没有解析到版本条目"
+        shas = re.findall(r'"[0-9a-f]{64}"', code)
+        assert len(shas) == len(versions) * 6, \
+            f"{len(versions)} 个版本应有 {len(versions) * 6} 个 sha256, 实际 {len(shas)}"
 
 
 class TestLifecycle:


### PR DESCRIPTION
## Summary

codex 是个 Rust 二进制，配方却在 `npm install @openai/codex` —— 为一个既不需要 node 也不需要
npm 的程序拖了两个依赖。上游直接发二进制，这里换过去，同时补 CN 加速和最新版本。

### 用 `codex-package-*`，不是裸的 `codex-*`

上游每个 target 发两种形态，**不能互换**：

| 资产 | 内容 |
|---|---|
| `codex-<target>.tar.gz` | 一个文件，裸的 `codex` 二进制 |
| `codex-package-<target>.tar.gz` | 完整安装布局 |

用 package，因为 codex 不只是它自己的二进制：

```
bin/codex[.exe]                     entrypoint
bin/codex-code-mode-host[.exe]
codex-path/rg[.exe]                 ripgrep，会被 prepend 到 codex 的 PATH
codex-resources/bwrap               linux 沙箱
codex-resources/zsh/bin/zsh         command tool 跑命令用的 shell
codex-resources/codex-command-runner.exe   (windows)
codex-package.json                  { layoutVersion, version, target,
                                      entrypoint, resourcesDir, pathDir }
```

`codex-package.json` 是上游**自己声明**这套布局，codex 运行时靠它定位那些 helper。所以
`install()` 整棵树搬过去、**不把 entrypoint 单独挑出来** —— 只拿 `bin/codex` 会得到一个没有
ripgrep、没有沙箱、没有 shell 的 codex：`--version` 能过，真用起来是残的。

### 全平台

六个 target 全覆盖：`{x86_64,aarch64}` × `{unknown-linux-musl, apple-darwin, pc-windows-msvc}`。
六个 target 的顶层布局一致，只有 exe 后缀不同（windows 的 `entrypoint` 是 `bin/codex.exe`）。

**任何平台都不声明 `deps`**，而且这里不需要辩解：linux 用的是 musl target，Rust 静态链接 ——
`file bin/codex` 报 `static-pie linked`，没有 interpreter、没有 NEEDED，elfpatch 无从下手。
macOS / Windows 同样自包含。

### 版本

`0.146.1`（新 latest）、`0.145.0`、`0.144.1`、`0.133.0`。

`codex-package-*` 资产从 **0.133.0** 才开始有，所以原配方里 `0.128.0` 及更老的 pin 没法用二进制
提供 —— 直接删掉，而不是留着继续指向 npm。上游 tag 是 `rust-v<version>`，`-alpha.*` 预发布不跟踪。
每个 sha256 都取自上游 release 自己的 digest。

### CN 加速

`gitcode.com/xlings-res/codex`（本次新建）@ tag `0.146.1`，6 个资产（每个 ~116-139 MB），
文件名与上游一致，逐字节校验。

## 顺带记下一条 hook runtime 的坑

**`os.exists` 在 xim hook runtime 里没有绑定。** 用了它之后 install 以
`attempt to call a nil value (field 'exists')` 失败，而从外面看到的现象是
**安装目录里只剩一个 `.xpkg.lua`、没有 payload**。改成分别问 `os.isdir` / `os.isfile`。

这条已写进 `.agents/skills/xpkg-creater/SKILL.md` §2.1.1，连同结论：
`install()` 结尾必须断言真正的产物存在，验收要真的 `ls` 安装目录、不能只看退出码。
新增回归测试 `test_no_os_exists_in_hooks`。

## Test plan

本地已验证：

- **资产调研**：6 个 target 的 `codex-package.json` 逐个确认（`layoutVersion: 1`，
  linux/macOS `entrypoint = bin/codex`，windows `= bin/codex.exe`）。
- **sha256**：本地下载 6 个资产，与 GitHub API 的 `digest` 逐个一致；24 个 checksum
  （4 版本 × 6 target）全部取自上游 digest。
- **真实安装**（`local:codex@0.146.1`）：整包布局落地完整 —— `bin/{codex,codex-code-mode-host}`、
  `codex-path/rg`、`codex-resources/{bwrap,zsh}`、`codex-package.json` 一个不少。
- **跑起来**：`codex --version` → `codex-cli 0.146.1`；经 xvm shim
  （`~/.xlings/subos/current/bin/codex`）同样正常；`codex --help` 正常。
- **内置 helper 可用**：`rg --version` → `ripgrep 15.2.0`（static-pie）；
  `zsh --version` → `zsh 5.9.0.3-test`。
- **pytest**：`-m "static or isolation"` 全仓 1138 passed。

CI 需要覆盖：三平台 install/uninstall。

> 注：本机 `xvm info` 输出缺字段，`assert_xvm_registered` 类 verify 用例对所有包都失败
> （已用其它包对照），依赖 CI。