### PR TITLE
fix(codex): reinstalling found the payload already moved away

### DIFF
--- a/pkgs/c/codex.lua
+++ b/pkgs/c/codex.lua
@@ -215,14 +215,24 @@ function install()
     os.tryrm(pkginfo.install_dir())
     os.mkdir(pkginfo.install_dir())
 
+    -- COPY, never move. That directory is xlings' shared download and
+    -- extraction cache, and it is reused: on a second install of the
+    -- same version the archive is still cached and is NOT re-extracted,
+    -- so anything a previous install moved out is simply gone. Moving
+    -- made the first install work and every later one fail — and fail
+    -- invisibly, because the raise below does not reach the summary and
+    -- the outer command still prints `✓ 1 package(s) installed` over an
+    -- install dir holding nothing but `.xpkg.lua`. Reproduced by
+    -- installing twice: the second run found no `bin/` because the first
+    -- had taken it, and clearing the cache made it pass again.
     for _, entry in ipairs(_PAYLOAD) do
         local src = path.join(download_dir, entry)
         -- `os.exists` is NOT bound in the xim hook runtime — calling it
         -- fails the install with `attempt to call a nil value (field
-        -- 'exists')`, and what you see is an install dir holding only
-        -- `.xpkg.lua`. Ask about the two kinds separately.
+        -- 'exists')`, and what you see is the same empty install dir.
+        -- Ask about the two kinds separately.
         if os.isdir(src) or os.isfile(src) then
-            os.mv(src, path.join(pkginfo.install_dir(), entry))
+            os.cp(src, path.join(pkginfo.install_dir(), entry), { force = true })
         end
     end
 

--- a/tests/c/test_codex.py
+++ b/tests/c/test_codex.py
@@ -132,6 +132,20 @@ class TestDesign:
         assert re.search(r'raise\(', code), "install() 必须在 payload 不完整时 raise"
 
     @pytest.mark.static
+    def test_payload_is_copied_not_moved(self):
+        """不能从下载/解压目录 os.mv 出来
+
+        那是 xlings 的共享缓存。第二次装同一个版本时归档还在缓存里、不会被
+        重新解压,上一次 mv 走的东西就永远没了 —— 第一次装成功、之后每次都失败,
+        而且是静默的:安装目录里只剩 `.xpkg.lua`,外层照样打印
+        `✓ 1 package(s) installed`。
+        """
+        code = lua_code()
+        assert not re.search(r'os\.mv\(\s*src\b', code), \
+            "payload 必须 os.cp 而不是 os.mv, 否则重装会失败"
+        assert re.search(r'os\.cp\(\s*src\b', code)
+
+    @pytest.mark.static
     def test_no_os_exists_in_hooks(self):
         """`os.exists` 在 xim hook runtime 里没有绑定
 


### PR DESCRIPTION
## Summary

#525 的后续修复。

`install()` 用 `os.mv` 把解压出来的树从下载目录搬走。那个目录是 **xlings 的共享下载/解压缓存**，
而且会被复用：第二次安装同一个版本时归档还在缓存里、**不会被重新解压**，于是上一次 mv 走的条目
就永远没了。第一次装成功，之后每次都得到一个只剩 `.xpkg.lua` 的安装目录。

**而且是静默失败**，这是更值得记的部分。`install()` 在这个条件下会
`raise("codex payload has no bin/codex after install")`，但这个 raise **不会进汇总** ——
命令照样在空目录上打印 `✓ 1 package(s) installed`。

对比：hook 里的 **Lua 运行时错误会浮出来**（#525 里那个 `os.exists` 笔误就是这么被抓到的：
`[error] [codex] failed: ... attempt to call a nil value (field 'exists')`），
但 **`raise()` 不会**。

## Fix

改成 `os.cp` —— `binutils.lua` 对它解压出来的 payload 也是这么做的。

## Test plan

清空缓存后**连续装两次**（这正是原来会挂的场景）：

```
===== round 1 =====
  payload:   bin codex-package.json codex-path codex-resources
  runs:      codex-cli 0.146.1
  cache kept: 3 of 3
===== round 2 =====
  payload:   bin codex-package.json codex-path codex-resources
  runs:      codex-cli 0.146.1
  cache kept: 3 of 3
```

第二轮能成功正是因为缓存里那 3 个条目还在 —— 这就是 `os.cp` 买到的东西。

新增回归测试 `test_payload_is_copied_not_moved`。pytest `-m "static or isolation"` 全仓 1139 passed。

## 验证时的一个坑（写在这里免得下一个人踩）

**xlings 在同名同版本已经装在另一个 namespace 下时，会整个跳过 install hook。**

`xim:codex@0.146.1` 存在的情况下，每一次 `local:codex@0.146.1` 安装都是静默 no-op，
但仍然打印成功 —— 我因此一度误判"`os.cp` 修不好"。实际是 hook 压根没跑：
往 hook 里塞 `io.writefile` 探针，日志文件根本没生成。

测这类改动前先把**两个 namespace 的 store 目录都清掉**：

```bash
rm -rf ~/.xlings/data/xpkgs/{xim,local}-x-<pkg>/<version>
```

另外：往 local index 里加了两个 `package.name` 相同的文件（`codex.lua` + `codex-probe.lua`）
会让**整个 local repo 静默从搜索路径里消失** —— 表现是 `package 'local:codex' not found,
searched repos: [xim, scode]`。删掉重复文件即恢复。