### PR TITLE
fix(codex): revert #526 — os.mv was never the bug, and say what was

### DIFF
--- a/.agents/skills/xpkg-creater/SKILL.md
+++ b/.agents/skills/xpkg-creater/SKILL.md
@@ -142,6 +142,25 @@ xpm = {
 `install()` 结尾一定要断言真正的产物存在（`raise(...)` 或 `return os.isfile(exe)`），
 别只 `return true`；验收时也要真的去 `ls` 安装目录，不要只看安装命令的退出码。
 
+注意 `raise()` 本身也不进汇总 —— 它不会让外层报失败；而 hook 里的 **Lua 运行时错误会**
+浮出来（`[error] [pkg] failed: ...`）。所以 `raise` 只是给读日志的人看的，不能当成保护。
+
+#### "安装目录是空的"最常见的原因不是 hook 有问题
+
+**xlings 在同名同版本已经装在另一个 namespace 下时，会整个跳过 install hook，并且照样
+打印成功。** `xim:foo@1.2.3` 已装的情况下，每一次 `local:foo@1.2.3` 安装都是静默 no-op，
+只写下 `.xpkg.lua` —— 看起来和 install hook 坏掉一模一样。测之前先清两边：
+
+```bash
+rm -rf ~/.xlings/data/xpkgs/{xim,local}-x-<pkg>/<version>
+```
+
+（这条是用 hook 里塞 `io.writefile` 探针确认的：日志文件根本没生成。曾因此把一个好端端的
+`os.mv` 误判成 bug —— 实测 xlings 会重新解压、归档没了也会重新下载，`os.mv` 连装两次没问题。）
+
+另外：往 local index 里放两个 `package.name` 相同的文件，会让**整个 local repo 静默从搜索
+路径消失**（`package 'local:foo' not found, searched repos: [xim, scode]`）。删掉重复文件即恢复。
+
 ### 2.1.2 配置型包的 Lua 边界
 
 对 `type = "config"` 且会写入用户工具配置的包（例如 Claude/LLM 配置）：

--- a/pkgs/c/codex.lua
+++ b/pkgs/c/codex.lua
@@ -197,6 +197,20 @@ local function _installed_exe()
     return path.join(_bindir(), os.host() == "windows" and "codex.exe" or "codex")
 end
 
+-- A note for whoever verifies a change to this hook, because it cost a
+-- day: **xlings skips install() entirely when the same name and version
+-- is already installed under another namespace, and still prints
+-- `✓ 1 package(s) installed`.** With `xim:codex@0.146.1` present, every
+-- `local:codex@0.146.1` install was a silent no-op that left an install
+-- dir holding only `.xpkg.lua` — which reads exactly like a broken
+-- install hook. Clear both before testing:
+--
+--     rm -rf ~/.xlings/data/xpkgs/{xim,local}-x-codex/<version>
+--
+-- Related: a `raise()` in here does not reach the summary either, so a
+-- genuinely failed install can still be reported as succeeding. A Lua
+-- *runtime* error does surface. Verify by listing the install directory,
+-- never by the exit code.
 function install()
     -- Idempotent across xim engines: never wipe install_dir before a
     -- replacement payload is confirmed, and never report success unless
@@ -215,24 +229,29 @@ function install()
     os.tryrm(pkginfo.install_dir())
     os.mkdir(pkginfo.install_dir())
 
-    -- COPY, never move. That directory is xlings' shared download and
-    -- extraction cache, and it is reused: on a second install of the
-    -- same version the archive is still cached and is NOT re-extracted,
-    -- so anything a previous install moved out is simply gone. Moving
-    -- made the first install work and every later one fail — and fail
-    -- invisibly, because the raise below does not reach the summary and
-    -- the outer command still prints `✓ 1 package(s) installed` over an
-    -- install dir holding nothing but `.xpkg.lua`. Reproduced by
-    -- installing twice: the second run found no `bin/` because the first
-    -- had taken it, and clearing the cache made it pass again.
+    -- `os.mv`, the same as every other recipe in the index. #526 changed
+    -- this to `os.cp` on the theory that moving consumed a shared cache
+    -- xlings would not re-extract; that theory is wrong. Measured after
+    -- the fact: delete `bin/` out of the download directory and install
+    -- again and xlings puts it straight back — it re-extracts, and it
+    -- re-downloads when the archive itself is gone. `os.mv` installs
+    -- cleanly twice in a row. godot.lua and cc-switch.lua, suspected of
+    -- the same "bug", were tested and are fine too.
+    --
+    -- What actually produced the empty install directories was the trap
+    -- documented at the top of install(): xlings skips the install hook
+    -- entirely when the same name and version is already installed under
+    -- another namespace, and still reports success. Proven with an
+    -- `io.writefile` probe inside the hook — the log file was never
+    -- created.
     for _, entry in ipairs(_PAYLOAD) do
         local src = path.join(download_dir, entry)
         -- `os.exists` is NOT bound in the xim hook runtime — calling it
         -- fails the install with `attempt to call a nil value (field
-        -- 'exists')`, and what you see is the same empty install dir.
-        -- Ask about the two kinds separately.
+        -- 'exists')`, and what you see is an install dir holding only
+        -- `.xpkg.lua`. Ask about the two kinds separately.
         if os.isdir(src) or os.isfile(src) then
-            os.cp(src, path.join(pkginfo.install_dir(), entry), { force = true })
+            os.mv(src, path.join(pkginfo.install_dir(), entry))
         end
     end
 

--- a/tests/c/test_codex.py
+++ b/tests/c/test_codex.py
@@ -132,18 +132,16 @@ class TestDesign:
         assert re.search(r'raise\(', code), "install() 必须在 payload 不完整时 raise"
 
     @pytest.mark.static
-    def test_payload_is_copied_not_moved(self):
-        """不能从下载/解压目录 os.mv 出来
+    def test_documents_the_cross_namespace_skip(self):
+        """必须写清楚"同名同版本已装在另一个 namespace 会跳过 install hook"
 
-        那是 xlings 的共享缓存。第二次装同一个版本时归档还在缓存里、不会被
-        重新解压,上一次 mv 走的东西就永远没了 —— 第一次装成功、之后每次都失败,
-        而且是静默的:安装目录里只剩 `.xpkg.lua`,外层照样打印
-        `✓ 1 package(s) installed`。
+        这是真正会让人误判的地方:装出来只剩 `.xpkg.lua`、外层却打印
+        `✓ 1 package(s) installed`,看起来像 install hook 坏了,其实 hook
+        根本没跑。#526 就是因此把 os.mv 误判成 bug 的。
         """
-        code = lua_code()
-        assert not re.search(r'os\.mv\(\s*src\b', code), \
-            "payload 必须 os.cp 而不是 os.mv, 否则重装会失败"
-        assert re.search(r'os\.cp\(\s*src\b', code)
+        content = open(PKG_FILE, encoding='utf-8').read()
+        assert "namespace" in content and "skips install()" in content, \
+            "install() 上方必须保留 cross-namespace skip 的说明"
 
     @pytest.mark.static
     def test_no_os_exists_in_hooks(self):


### PR DESCRIPTION
## 结论先说

**cc-switch.lua 和 godot.lua 不需要改。** 我先前说它们"有同一类潜在 bug"，实测不成立。
而且 #526 本身的前提就是错的，这个 PR 把它 revert 掉。

## 我实测了什么

### 1. godot：没复现

装一次 → 只删 store 目录（缓存留着）→ 再装：

```
=== install once ===        payload: godot
=== wipe store, again ===   payload: godot        ← 正常
```

### 2. cc-switch：没复现

```
=== install once ===        payload: cc-switch   cache: 只剩 .lock（AppImage 被 mv 走了）
=== wipe store, again ===   payload: cc-switch   size: 91802104   ← 重新下载了，正常
```

### 3. 决定性实验：xlings 到底会不会跳过重新解压

#526 的前提是"归档还在缓存里就不会重新解压"。直接测：把 `bin/` 从下载目录删掉、
store 目录清空，再装 —— 

```
runtimedir bin/ back? YES
payload: bin codex-package.json codex-path codex-resources
```

**会重新解压。** 归档本身没了也会重新下载。前提不成立。

### 4. 公平复测 #526 之前的 os.mv 版本

```
=== os.mv round 1 ===   payload: bin codex-package.json codex-path codex-resources
=== os.mv round 2 ===   payload: bin codex-package.json codex-path codex-resources
```

**`os.mv` 从来没坏过。**

## 那当初到底是什么把安装目录搞空的

**xlings 在同名同版本已经装在另一个 namespace 下时，会整个跳过 install hook，并且照样打印
`✓ 1 package(s) installed`。**

`xim:codex@0.146.1` 已装的情况下，每一次 `local:codex@0.146.1` 安装都是静默 no-op，
只留下 `.xpkg.lua` —— 和 install hook 坏掉的表现一模一样。

用 `io.writefile` 往 hook 里塞探针确认：**日志文件根本没生成**，hook 压根没跑。

这也解释了 #526 当时那个自相矛盾的现象 —— "修复后第一轮也失败"、后来又"成功"：两次都是 no-op。

## 这个 PR 做了什么

- `os.mv` 改回来，和索引里其它 ~40 个配方一致，也省掉每次安装多出来的 ~130MB 拷贝。
- `install()` 上方补一段说明，写清三件会误导人的事：
  1. cross-namespace 跳过 hook（附清理命令）；
  2. hook 里的 `raise()` **不进汇总**，而 Lua 运行时错误**会**浮出来 —— 所以 `raise` 只能给人看日志，不能当保护；
  3. 验收要 `ls` 安装目录，不能只看退出码。
- skill §2.1.1 里继承的那套错误说法一并改掉。
- 把 `test_payload_is_copied_not_moved`（锁的是错结论）换成 `test_documents_the_cross_namespace_skip`。

## Test plan

- revert 后的配方**连装两轮**：payload 完整、`codex-cli 0.146.1` 都跑通。
- pytest `-m "static or isolation"` 全仓 1139 passed。