### PR TITLE
fix(verify): the self-containment cell could report a pass having run nothing

### DIFF
--- a/.agents/tools/graphics/selfcontained-check.sh
+++ b/.agents/tools/graphics/selfcontained-check.sh
@@ -34,7 +34,21 @@ SUBOS_NAME="${XLINGS_GFX_SUBOS:-gfxcheck}"
 
 log()  { echo "[gfx-check] $*"; }
 fail() { echo "[gfx-check] FAIL: $*" >&2; exit 1; }
-skip() { echo "[gfx-check] SKIP: $*"; exit 0; }
+
+# Exit 3, not 0.
+#
+# `skip` used to exit 0, and 0 is what the caller reads as "S1-S4 pass". So a
+# machine without bwrap, or without xlings on PATH, made verify-stack print
+#
+#     ✓ empty-host self-containment      S1-S4 pass
+#
+# for a check that ran nothing at all. That is the bug class this whole tool
+# exists to catch, sitting inside the tool: not-run and succeeded produced the
+# same output. It was masked only because verify-stack happens to probe bwrap
+# itself before calling here — every other skip was live.
+#
+# 0 = proven, 1 = broken, 2 = inconclusive, 3 = could not be exercised here.
+skip() { echo "[gfx-check] SKIP: $*"; exit 3; }
 
 command -v bwrap  >/dev/null || skip "bwrap not available (xlings install bwrap)"
 XLINGS_BIN="${XLINGS_BIN:-$(command -v xlings)}"
@@ -58,7 +72,9 @@ if [[ ! -x "$PROBE" || "$HERE/glprobe.c" -nt "$PROBE" ]]; then
     # reads as a broken graphics stack. A compiler outside the subos also
     # cannot prove anything about a subos that is meant to be self-contained.
     CC="$SUBOS_DIR/bin/gcc"
-    [[ -x "$CC" ]] || fail "no gcc in subos '$SUBOS_NAME' (xlings install gcc)"
+    # skip, not fail: a subos without a compiler cannot exercise this cell,
+    # which is a different statement from "the stack is not self-contained".
+    [[ -x "$CC" ]] || skip "no gcc in subos '$SUBOS_NAME' (xlings install gcc)"
     # No pipe into head here: the exit status would be head's, and a failed
     # compile would sail past `|| fail` to be reported later as a missing
     # binary inside the container — which reads as an incomplete closure
@@ -66,6 +82,7 @@ if [[ ! -x "$PROBE" || "$HERE/glprobe.c" -nt "$PROBE" ]]; then
     if ! "$CC" -O1 -o "$PROBE" "$HERE/glprobe.c" \
             -I"$SUBOS_DIR/usr/include" -L"$SUBOS_DIR/lib" -L"$SUBOS_DIR/usr/lib" \
             -Wl,-rpath,"$SUBOS_DIR/usr/lib" -Wl,-rpath,"$SUBOS_DIR/lib" \
+            -Wl,-rpath-link,"$SUBOS_DIR/lib" -Wl,-rpath-link,"$SUBOS_DIR/usr/lib" \
             -lEGL -lGL > "$SUBOS_DIR/glprobe-build.log" 2>&1; then
         sed 's/^/    /' "$SUBOS_DIR/glprobe-build.log" | head -15
         fail "cannot build glprobe against the subos (is libglvnd installed?)"

--- a/.agents/tools/graphics/verify-stack.sh
+++ b/.agents/tools/graphics/verify-stack.sh
@@ -146,7 +146,8 @@ if [[ -n "$CC" && -f "$HERE/glprobe.c" ]]; then
   INC="$(find "$XLINGS_HOME/data/xpkgs" -maxdepth 4 -type d -path '*libglvnd*/include' 2>/dev/null | head -1)"
   if "$CC" -O0 -o /tmp/gfxverify-probe "$HERE/glprobe.c" ${INC:+-I"$INC"} \
         -L"$S/lib" -lEGL -lGL -Wl,--dynamic-linker="$S/lib/ld-linux-x86-64.so.2" \
-        -Wl,-rpath,"$S/lib" -Wl,--disable-new-dtags 2>/tmp/gfxverify-probe.log; then
+        -Wl,-rpath,"$S/lib" -Wl,-rpath-link,"$S/lib" -Wl,-rpath-link,"$S/usr/lib" \
+        -Wl,--disable-new-dtags 2>/tmp/gfxverify-probe.log; then
     PROBE=/tmp/gfxverify-probe
   fi
 fi
@@ -325,6 +326,7 @@ else
   case $rc in
     0) ok "empty-host self-containment" "S1-S4 pass" ;;
     2) na "empty-host self-containment" "INCONCLUSIVE — the control run also failed; see /tmp/gfxverify-sc.log" ;;
+    3) na "empty-host self-containment" "$(grep -oE 'SKIP:.*' /tmp/gfxverify-sc.log | head -1 | sed 's/^SKIP: //')" ;;
     *) bad "empty-host self-containment" "$(grep -oE 'FAIL:.*' /tmp/gfxverify-sc.log | head -1)" ;;
   esac
 fi


### PR DESCRIPTION
Found by running the matrix against a home built from the **published** index rather than a working copy.

- `skip()` exited 0 → verify-stack read that as `✓ S1-S4 pass`. No bwrap, or no xlings on PATH, produced a pass for a check that ran nothing. Now 0/1/2/3 = proven/broken/inconclusive/could-not-exercise.
- A subos without a compiler was a FAIL; it is the third outcome.
- The probe link line lacked `-rpath-link`, so indirect `DT_NEEDED` (`libGLX.so.0`, `libGLdispatch.so.0`) went unresolved and the failure blamed libglvnd.

The third hid behind the first two — the passing cell was reusing a probe binary compiled hours earlier, so the build path was never exercised. Rebuilt probe on a published-index home: **pass 14, fail 0, not-exercised 5**.