### PR TITLE
feat(loader): switch llvm-tools to our loader; the JDKs measured and left alone

### DIFF
--- a/pkgs/c/code.lua
+++ b/pkgs/c/code.lua
@@ -43,6 +43,26 @@ package = {
             },
             ["1.93.1"] = _win_url("1.93.1"),
         },
+        -- INTENTIONALLY ON THE HOST LOADER. This is a decision, not an
+        -- unfinished migration, and it is recorded here so the next sweep for
+        -- payloads still using the host's ld-linux does not "fix" it.
+        --
+        -- Measured on the 1.108.0 payload: 27 external sonames with no provider
+        -- in this index — libgtk-3, libgdk-3, libatk, libatk-bridge, libatspi,
+        -- libdbus-1, libgbm, libsecret-1, libsoup-3.0, libwebkit2gtk-4.1,
+        -- libnss3/libnspr4/libsmime3/libnssutil3, libudev, libcurl, libasound,
+        -- libxkbfile, libXcomposite, libXdamage and friends. That is a desktop
+        -- environment, not a dependency list.
+        --
+        -- Electron is designed to use the host's desktop stack: the portals,
+        -- the theme, the a11y bus, the keyring and the GPU compositor all have
+        -- to be the ones the user is logged into. Vendoring them would not make
+        -- this package self-contained, it would make it a second, worse desktop.
+        --
+        -- And switching the interpreter without vendoring them is not a partial
+        -- win either. Our glibc's ld.so has a cache path that exists on no
+        -- machine, so PT_INTERP moving to it removes the host fallback outright
+        -- (see jdk-temurin.lua for the measurement). `code` would stop starting.
         linux = {
             ["latest"] = { ref = "1.132.0" },
             ["1.132.0"] = _linux_url("1.132.0", "acdaf0fa557bda1720956ff65ca0de0965e92d68f97e2db22341984400937aed"),

--- a/pkgs/g/glibc.lua
+++ b/pkgs/g/glibc.lua
@@ -35,6 +35,25 @@ package = {
             -- (regenerated post 2026-05-02 design) reads this and patches
             -- consumer ELFs automatically. `abi` is the disambiguation tag
             -- when a subos hosts both glibc and musl xpkgs.
+            --
+            -- WHAT DECLARING THIS COSTS THE CONSUMER, because it is not
+            -- obvious and it is not reversible at runtime: our ld.so carries
+            -- the build machine's cache path,
+            -- `/home/xlings/.xlings_data/.../etc/ld.so.cache`, which exists on
+            -- no machine (`strings` it; the host's says `/etc/ld.so.cache`).
+            -- On a multiarch distro essentially every system library lives in
+            -- /usr/lib/<triple> and is reachable ONLY through that cache, so a
+            -- payload whose PT_INTERP points here has no host fallback at all.
+            --
+            -- That is the intended end state — the 2.44 build prefix is
+            -- literally `/nonexistent/xlings-use-rpath-not-default-search` —
+            -- but it makes the declaration all-or-nothing. A consumer's closure
+            -- must cover every library it will ever load, dlopen'd ones
+            -- included. Reasoning "the missing ones are optional, so behaviour
+            -- degrades no further than today" is false: today they resolve off
+            -- the host, afterwards they resolve nowhere. Measured on
+            -- jdk-temurin, where it is the difference between a working AWT and
+            -- UnsatisfiedLinkError; see that recipe.
             exports = {
                 runtime = {
                     loader = "lib64/ld-linux-x86-64.so.2",
@@ -168,6 +187,8 @@ function install()
     log.info("Relocating glibc files(path) ...")
     __relocate()
 
+    __check_nss_coverage()
+
     return true
 end
 
@@ -237,6 +258,74 @@ function uninstall()
 end
 
 -- private
+
+-- Does the NSS module set we ship cover what this host's nsswitch.conf asks for?
+--
+-- glibc does not link its name-service backends; it dlopens `libnss_<mod>.so.2`
+-- at the moment of the first lookup, and the module MUST come from the same
+-- glibc as the caller. So a process that switched to our loader stops using the
+-- host's modules and starts using ours — for `getpwnam`, `getaddrinfo`, group
+-- lookups, everything.
+--
+-- We ship compat, db, dns, files and hesiod. A host configured with systemd's
+-- (`systemd`, `resolve`, `myhostname`, `mymachines`), Avahi's (`mdns4_minimal`)
+-- or NIS's modules names backends we do not have.
+--
+-- Warn, do not fail. On an ordinary machine the user is in /etc/passwd and
+-- `files` answers, so the missing modules never get consulted and the install
+-- is fine; failing here would break the common case to report the rare one.
+-- The rare one is real though — LDAP, NIS or systemd-homed users are resolved
+-- by exactly the modules we lack, and the failure mode is not an error but an
+-- empty answer: `getpwuid` returns nothing and the caller reports something
+-- else entirely (a missing home directory, a numeric username, a failed
+-- lookup). `xlings doctor` has a cell for the other half of this — whether
+-- getpwuid actually resolves in a home that has already switched.
+function __check_nss_coverage()
+    local conf = "/etc/nsswitch.conf"
+    if not os.isfile(conf) then
+        -- Not a pass. Say which one it is, or "no warnings" reads as "checked".
+        log.debug("no %s on this host; NSS coverage not compared", conf)
+        return
+    end
+
+    local content = io.readfile(conf)
+    if not content or content == "" then
+        log.debug("%s is empty or unreadable; NSS coverage not compared", conf)
+        return
+    end
+
+    local libdir = path.join(pkginfo.install_dir(), "lib64")
+    local seen, missing = {}, {}
+    for line in content:gmatch("[^\r\n]+") do
+        -- Comments off first, then the `db: mod [STATUS=action] mod` shape.
+        -- The bracketed reactions are control flow, not modules; leaving them
+        -- in would report `NOTFOUND` and `UNAVAIL` as missing backends.
+        local body = line:gsub("#.*", "")
+        local _, rest = body:match("^%s*([%w_]+)%s*:%s*(.*)$")
+        if rest then
+            rest = rest:gsub("%[.-%]", " ")
+            for mod in rest:gmatch("[%w_%-]+") do
+                if not seen[mod] then
+                    seen[mod] = true
+                    if not os.isfile(path.join(libdir, "libnss_" .. mod .. ".so.2")) then
+                        table.insert(missing, mod)
+                    end
+                end
+            end
+        end
+    end
+
+    if #missing == 0 then
+        log.info("NSS: every backend named in %s is present in this payload", conf)
+        return
+    end
+
+    log.warn("NSS: %s names backend(s) this glibc does not ship: %s. "
+             .. "Programs that switch to this loader will not consult them — "
+             .. "harmless if your users resolve via `files`, but users defined "
+             .. "only by those backends will silently not be found.",
+             conf, table.concat(missing, ", "))
+end
 
 -- The version key this package's entries are stored under.
 --

--- a/pkgs/j/jdk-temurin.lua
+++ b/pkgs/j/jdk-temurin.lua
@@ -81,6 +81,39 @@ package = {
     -- is relocatable as shipped. Alpine / distroless support means an
     -- INTERP rewrite across that tree; that is a separate, real-machine
     -- verified change, not something to declare blind here.
+    --
+    -- That change has now been measured, and it does NOT work yet. Declaring
+    -- `xim:glibc` would be enough to trigger it — elfpatch's predicate keys off
+    -- the loader glibc exports — and the headless result is perfect: patching a
+    -- copy of this payload to our loader with the dependency closure as RPATH
+    -- gives a working `java -version`, `javac`, libzip, libnet,
+    -- `InetAddress.getByName`, NSS `user.name`, UTF-8 default charset. The
+    -- `$ORIGIN` entries are not even missed: 14 libraries in lib/ name
+    -- libjvm.so from lib/server/ and resolve it anyway, because libjli has
+    -- already loaded it into the global scope by then.
+    --
+    -- AWT is what breaks, and it breaks hard (verified against an unpatched
+    -- control on the same machine, DISPLAY=:1):
+    --
+    --   unpatched   Toolkit.getDefaultToolkit() -> ok, 2560x1440
+    --   patched     UnsatisfiedLinkError: libawt_xawt.so: libX11.so.6:
+    --               cannot open shared object file
+    --
+    -- The reason is general and worth knowing before switching ANY package: our
+    -- glibc's ld.so has the build machine's cache path compiled in
+    -- (`/home/xlings/.xlings_data/.../etc/ld.so.cache`), which exists on no
+    -- machine. On a multiarch distro libX11 lives in /usr/lib/x86_64-linux-gnu
+    -- and is reachable ONLY through that cache. So moving PT_INTERP does not
+    -- merely stop us from *shipping* those libraries — it removes the host
+    -- fallback entirely. "Only dlopen'd on demand, so no worse than today" is
+    -- false: today they resolve off the host, afterwards they resolve nowhere.
+    --
+    -- So the closure has to be complete for soft deps too. libX11, libXext,
+    -- libXi and libXrender are already in this index (the graphics work); the
+    -- blockers are `libXtst` and `libasound`, which are not. When both exist,
+    -- declare glibc plus those six and the switch is a one-line change.
+    -- Until then this stays on the host loader deliberately, because a
+    -- self-contained JVM that cannot open a window is a regression.
     xpm = {
         linux = {
             ["latest"] = { ref = "25.0.4+7" },

--- a/pkgs/j/jdk-zulu.lua
+++ b/pkgs/j/jdk-zulu.lua
@@ -52,7 +52,15 @@ package = {
     -- ARCH / PLATFORM COVERAGE — linux and macosx ship x86_64 + aarch64,
     -- windows ships x86_64 only.
     --
-    -- RUNTIME DEPS — none, for the reason recorded in jdk-temurin.lua.
+    -- RUNTIME DEPS — none, for the reason recorded in jdk-temurin.lua, which
+    -- now includes the measured result of trying the interpreter switch: it is
+    -- clean headless and breaks AWT, because our loader has no host fallback.
+    -- Zulu measures the same as Temurin with one addition — its libjli.so,
+    -- libsplashscreen.so and libinstrument.so name `libz.so.1`, which Temurin's
+    -- do not. libjli is loaded by `bin/java` itself, so when this package does
+    -- switch, `xim:zlib` is a HARD dep here, not an optional one: leave it out
+    -- and `java` fails to start rather than degrading. Same blockers otherwise
+    -- (`libXtst`, `libasound`).
     xpm = {
         linux = {
             ["latest"] = { ref = "25.0.4" },

--- a/pkgs/l/llvm-tools.lua
+++ b/pkgs/l/llvm-tools.lua
@@ -18,6 +18,26 @@ package = {
 
     xpm = {
         linux = {
+            -- These three are the payload's ENTIRE external closure, measured
+            -- rather than guessed: every bin/ ELF here needs exactly
+            -- libm/libc/ld-linux (glibc), libstdc++/libgcc_s (gcc-runtime) and
+            -- libz (zlib), and lib/ holds only clang's header tree, no
+            -- libraries at all.
+            --
+            -- Declaring glibc is also what switches the interpreter. elfpatch's
+            -- predicate fires when a runtime dep exports `runtime.loader`, which
+            -- glibc does; xlings then rewrites PT_INTERP and sets RPATH to the
+            -- dependency closure at install time. Without the declaration the
+            -- payload keeps upstream's INTERP, the HOST's ld-linux.
+            --
+            -- The other two are not optional extras once the interpreter moves.
+            -- Our loader's compiled-in cache path is the build machine's
+            -- (`/home/xlings/.xlings_data/.../etc/ld.so.cache`) and exists
+            -- nowhere, so after the switch there is NO host fallback: a library
+            -- absent from the closure is not found, full stop. Declaring only
+            -- glibc here would leave libstdc++ and libz unresolvable and the
+            -- tools would not start.
+            deps = { "xim:glibc", "xim:gcc-runtime", "xim:zlib" },
             ["latest"] = { ref = "22.1.8" },
             ["20.1.7"] = {
                 url = {


### PR DESCRIPTION
Split out of one large PR — **5 recipes**, so the install test covers five packages, not forty-six.

## llvm-tools switched

`deps = { "xim:glibc", "xim:gcc-runtime", "xim:zlib" }` — **three, not one**. The plan's "0 unsatisfied sonames" counted what the home *has*, not what the recipe *declares*; that is precisely the gap the closure check exists for.

Verified by patching a real copy: `clang-format`/`clang-tidy` give byte-identical output to an unpatched control, and `clangd` completes an LSP `initialize`.

## The JDKs measured, and deliberately left on the host loader

Declaring `xim:glibc` would be enough to switch them, and headless is flawless. AWT is what breaks — with an unpatched control on the same machine:

| jdk-temurin 25.0.4+7 | `Toolkit.getDefaultToolkit()` |
|---|---|
| unpatched | ok, 2560x1440 |
| our loader | `UnsatisfiedLinkError: libawt_xawt.so: libX11.so.6` |

**The reason is general.** Our glibc's `ld.so` has the build machine's cache path compiled in — a path that exists on no machine. On multiarch distros host libraries are reachable *only* through that cache, so moving `PT_INTERP` removes the host fallback **entirely**. "Only dlopen'd, so no worse than today" is false: today they resolve off the host, afterwards they resolve nowhere.

Blockers: `libXtst` and `libasound` (the other four X libs are already in the index). A self-contained JVM that cannot open a window is a regression.

Zulu will additionally need `xim:zlib` — its `libjli.so` names libz and Temurin's does not, and `libjli` is loaded by `bin/java` itself.

## code marked intentionally host-dependent

27 external sonames with no provider here — GTK, atk, dbus, gbm, webkit2gtk, the NSS trio. That's a desktop environment, not a dependency list. Recorded so the next sweep doesn't "fix" it.

## glibc NSS coverage warning

Compares `/etc/nsswitch.conf` against the `libnss_*` modules shipped, and warns (this host: `systemd`, `mdns4_minimal`, `nis`). Warn, not fail — ordinary users resolve via `files`, but LDAP/systemd-homed users are resolved by exactly the modules we lack, and NSS answers "no such user" identically to a user who doesn't exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
