### PR TITLE
fix(rust, claude-llm): an install hook must never block on stdin

### DIFF
--- a/.github/scripts/check-no-blocking-input.sh
+++ b/.github/scripts/check-no-blocking-input.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# A recipe hook must not block on stdin.
+#
+# THE DEFECT
+# ----------
+# `io.read()` inside an install hook does not degrade when nobody is there to
+# answer it -- it blocks forever. An unattended install (CI, a Dockerfile, a
+# provisioning script, `xlings install <pkg> -y`) then HANGS rather than
+# failing, and a hang is strictly worse than an error: there is nothing to
+# read, and from the outside "slow" and "stuck" look identical.
+#
+# Measured 2026-08-08: `rust`'s windows hook asked
+#
+#     please input (1 or 2):
+#
+# and a windows-test job sat on it for four hours -- against a normal runtime of
+# under three minutes for that job. GitHub does not serve logs for an
+# in-progress job, so there was no way to see the prompt until someone watched
+# the runner live.
+#
+# It had been unreachable in CI by accident: `rust` declared a dependency that
+# resolved to nothing, so the install aborted before reaching the prompt.
+# Repairing that namespace is what let the hook run for the first time. That is
+# the shape to expect here -- these do not announce themselves, they wait behind
+# some other bug.
+#
+# THE RULE
+# --------
+# `io.read` is allowed only in a file that also consults the environment for the
+# answer, so the same decision can be made without a terminal. The pattern is:
+#
+#     local want = os.getenv("XLINGS_<SOMETHING>")   -- honour an explicit answer
+#     if os.getenv("XLINGS_NON_INTERACTIVE") or os.getenv("CI") then ... end
+#     -- only then prompt
+#
+# `io.readfile` is a different function and is not matched.
+#
+# Exit codes follow .agents/tools/README.md: 0 proven, 1 broken, 3 could-not-run.
+set -uo pipefail
+
+ROOT_DIR="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+cd "$ROOT_DIR" || { echo "::error::cannot cd to $ROOT_DIR"; exit 3; }
+
+command -v grep >/dev/null 2>&1 || { echo "  [SKIP] no grep"; exit 3; }
+
+# `io.read` but not `io.readfile`. -w is not enough: `io.readfile` contains
+# `io.read` as a prefix, so anchor on the character that follows.
+mapfile -t hits < <(grep -rnE 'io\.read[^f]' pkgs/ libs/ 2>/dev/null || true)
+
+scanned=$(find pkgs libs -name '*.lua' 2>/dev/null | wc -l)
+bad=0
+
+for hit in "${hits[@]:-}"; do
+    [[ -n "$hit" ]] || continue
+    file="${hit%%:*}"
+    # A commented line is documentation, not a call. This check exists because
+    # of a hook that blocked; the comments explaining that fix must not trip it.
+    body="${hit#*:*:}"
+    [[ "$body" =~ ^[[:space:]]*-- ]] && continue
+
+    if grep -q 'XLINGS_NON_INTERACTIVE' "$file" && grep -q 'os.getenv' "$file"; then
+        echo "  ok   $file  (reads stdin, but the answer can also come from the environment)"
+        continue
+    fi
+    echo "::error file=$file::$hit"
+    echo "       io.read() in a recipe hook blocks forever when nobody can answer."
+    echo "       Accept the answer from an environment variable, and fall back to a"
+    echo "       default (or a clear error) when XLINGS_NON_INTERACTIVE or CI is set."
+    bad=$((bad + 1))
+done
+
+if [[ $bad -gt 0 ]]; then
+    echo "xpkg blocking-input check: FAIL ($bad unguarded io.read across $scanned recipes)"
+    exit 1
+fi
+# The count is part of the result: a check that matched nothing prints the same
+# PASS as one that read every recipe, and this repo has shipped that confusion.
+echo "xpkg blocking-input check: PASS (${#hits[@]} io.read site(s) across $scanned recipes, all guarded)"
+exit 0

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -60,6 +60,18 @@ jobs:
           chmod +x .github/scripts/check-no-direct-ld-libpath.sh
           .github/scripts/check-no-direct-ld-libpath.sh
 
+      # An install hook that calls io.read() blocks forever when nobody is
+      # there to answer. `rust`'s windows hook parked a windows-test job for
+      # four hours on "please input (1 or 2):" -- against a normal runtime of
+      # under three minutes -- and GitHub serves no logs for an in-progress
+      # job, so the prompt was invisible until someone watched the runner.
+      # A hang is worse than a failure: there is no error, and from outside
+      # "slow" and "stuck" look the same.
+      - name: Lint xpkg blocking stdin reads
+        run: |
+          chmod +x .github/scripts/check-no-blocking-input.sh
+          .github/scripts/check-no-blocking-input.sh
+
       - name: version-check unit tests (url_template + XLINGS_RES bump)
         run: python3 .github/scripts/test_version_check.py
 

--- a/pkgs/c/claude-llm.lua
+++ b/pkgs/c/claude-llm.lua
@@ -122,7 +122,33 @@ local function __existing_deepseek_api_key(env)
     return existing_api_key
 end
 
+-- A secret has to be suppliable without a prompt.
+--
+-- `io.read()` in an install hook does not degrade when nobody is there to
+-- answer -- it blocks forever. Unattended installs (CI, a Dockerfile, a
+-- provisioning script) then hang instead of failing, which is strictly worse:
+-- there is no error to read and no way to tell "slow" from "stuck". A rust
+-- recipe with the same shape parked a windows-test job for four hours before
+-- anyone could see why.
+--
+-- So take the key from the environment when it is there, and fail with a clear
+-- message rather than block when there is no terminal to ask on.
 local function __read_deepseek_api_key(existing_api_key)
+    local from_env = os.getenv("DEEPSEEK_API_KEY")
+    if from_env and __trim(from_env) ~= "" then
+        log.info("using DeepSeek API key from DEEPSEEK_API_KEY")
+        return __trim(from_env), false
+    end
+
+    if os.getenv("XLINGS_NON_INTERACTIVE") or os.getenv("CI") then
+        if existing_api_key then
+            log.warn("no terminal to ask on; reusing the existing DeepSeek key")
+            return existing_api_key, true
+        end
+        error("no DeepSeek API key: there is no terminal to prompt on. "
+              .. "Set DEEPSEEK_API_KEY and re-run.", 0)
+    end
+
     print("请先在 DeepSeek 平台创建或复制 API Key:")
     print("")
     print("  -> https://platform.deepseek.com/api_keys")

--- a/pkgs/r/rust.lua
+++ b/pkgs/r/rust.lua
@@ -28,15 +28,15 @@ package = {
 
     xpm = {
         windows = {
-            deps = {"rustup", "rustup-mirror"},
+            deps = {"xim:rustup", "config:rustup-mirror"},
             ["latest"] = { }
         },
         linux = {
-            deps = {"rustup", "rustup-mirror"},
+            deps = {"xim:rustup", "config:rustup-mirror"},
             ["latest"] = { }
         },
         macosx = {
-            deps = {"rustup", "rustup-mirror"},
+            deps = {"xim:rustup", "config:rustup-mirror"},
             ["latest"] = { }
         },
     },
@@ -105,8 +105,47 @@ end
 ---------------------- private
 
 -- host toolchain abi -- only for windows
+--
+-- The choice has to be expressible WITHOUT a prompt, because `io.read()` in an
+-- install hook does not degrade -- it blocks forever. On a CI runner stdin
+-- stays open and never delivers a line, so the install hangs rather than
+-- failing: observed at 4 hours on a windows-test job, parked on
+--
+--     please input (1 or 2):
+--
+-- with no way to tell "slow" from "stuck" from the outside. Any unattended
+-- install (a Dockerfile, a provisioning script, `xlings install rust -y`) has
+-- the same shape.
+--
+-- It went unnoticed because this line was unreachable in CI: rust declared a
+-- dep on `rustup-mirror` that resolved to nothing, so the install aborted at
+-- dependency resolution before ever getting here. Fixing that namespace is
+-- what let the hook run for the first time.
+--
+-- So: honour XLINGS_RUST_ABI when set, take the default when nobody can answer,
+-- and only prompt when there is a human present.
 function _choice_toolchain()
     local toolchain_abi = "x86_64-pc-windows-gnu"
+
+    local want = os.getenv("XLINGS_RUST_ABI")
+    if want == "msvc" or want == "x86_64-pc-windows-msvc" then
+        log.info("XLINGS_RUST_ABI=%s -- using the msvc toolchain", want)
+        pkgmanager.install("msvc@onlycompiler")
+        return "x86_64-pc-windows-msvc"
+    elseif want == "gnu" or want == "x86_64-pc-windows-gnu" then
+        log.info("XLINGS_RUST_ABI=%s -- using the gnu toolchain", want)
+        return toolchain_abi
+    elseif want then
+        log.warn("XLINGS_RUST_ABI='%s' is not 'gnu' or 'msvc'; ignoring it", want)
+    end
+
+    if os.getenv("XLINGS_NON_INTERACTIVE") or os.getenv("CI") then
+        log.warn("no terminal to ask on; defaulting to %s. "
+                 .. "Set XLINGS_RUST_ABI=msvc to choose the other one.",
+                 toolchain_abi)
+        return toolchain_abi
+    end
+
     log.debug("[xlings:xim]: Select toolchain ABI:")
     log.debug([[
 


### PR DESCRIPTION
`windows-test` sat for **four hours** on

```
please input (1 or 2):
```

against a normal runtime under three minutes. `rust`'s windows hook calls `io.read()` to pick the toolchain ABI — and `io.read()` doesn't degrade when nobody is there to answer, it **blocks forever**. GitHub serves no logs for an in-progress job, so the prompt was invisible; there was no way to tell *slow* from *stuck*.

A hang is worse than a failure. Every unattended install has this shape: CI, a Dockerfile, a provisioning script, `xlings install rust -y`.

## Two causes, same file

**1. Wrong namespace.** `rust` declared `xim:rustup-mirror`, but that package declares `namespace = "config"` — so the real name is `config:rustup-mirror` and the `xim:` spelling names nothing. `rust` failed on every platform with `package 'xim:rustup-mirror' not found`.

Repairing it is also what let the install run far enough to reach the prompt **for the first time** — the shape to expect from this class: they wait behind some other bug.

**2. The prompt.** The fix isn't "skip it", it's to make the answer expressible without a terminal:
- `XLINGS_RUST_ABI=gnu|msvc` honoured always
- under `XLINGS_NON_INTERACTIVE` or `CI`, take the default and warn, naming the variable

## claude-llm had the same shape

Asking for a DeepSeek API key — invisible in CI only because `namespace = "config"` recipes skip the lifecycle test entirely. Now reads `DEEPSEEK_API_KEY`, reuses an existing key, and errors actionably instead of blocking.

## Guard

`check-no-blocking-input.sh`: `io.read` (not `io.readfile`) is allowed only in a recipe that also consults the environment. Verified both ways — PASS with the site count printed, FAIL naming file and line when the guard is stripped from `rust.lua`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
