### PR TITLE
fix: four recipes declared deps their provider does not ship, and one registered twice

### DIFF
--- a/pkgs/c/configure-project-installer.lua
+++ b/pkgs/c/configure-project-installer.lua
@@ -16,11 +16,26 @@ package = {
 
     xpm = {
         linux = {
-            deps = { "make", "gcc", "xpkg-helper" },
+            deps = { "xim:make", "xim:gcc", "xim:xpkg-helper" },
             ["latest"] = { ref = "0.0.1" },
             ["0.0.1"] = {}
         },
-        macosx = { ref = "linux" },
+        -- NOT `ref = "linux"`. That inherited linux's `deps` as well as its
+        -- versions, and two of them -- `make` and `gcc` -- have no macosx
+        -- section in this index at all. On macOS both come from the Xcode
+        -- command line tools, which is where this script's `./configure` and
+        -- `make -j20` have always found them.
+        --
+        -- It only looked fine because the names were bare: an unqualified dep
+        -- that resolves to nothing was tolerated, so the declaration was
+        -- inert rather than correct. Namespacing them made the same
+        -- declaration a hard resolve and macos-install-test failed on the
+        -- first run -- the latent bug becoming visible, not a new one.
+        macosx = {
+            deps = { "xim:xpkg-helper" },
+            ["latest"] = { ref = "0.0.1" },
+            ["0.0.1"] = {}
+        },
     },
 }
 

--- a/pkgs/h/hermes-agent.lua
+++ b/pkgs/h/hermes-agent.lua
@@ -20,7 +20,7 @@ package = {
 
     xpm = {
         linux = {
-            deps = {"python"},
+            deps = {"xim:python"},
             ["latest"] = { ref = "2026.4.23" },
             ["2026.4.23"] = {
                 url = "https://github.com/NousResearch/hermes-agent/archive/refs/tags/v2026.4.23.tar.gz",
@@ -32,7 +32,8 @@ package = {
             },
         },
         macosx = {
-            deps = {"python"},
+            -- No python dep on macOS: xim:python has no macosx section, so this
+            -- resolves to nothing. macOS ships python3 in the CLT / system.
             ["latest"] = { ref = "2026.4.23" },
             ["2026.4.23"] = {
                 url = "https://github.com/NousResearch/hermes-agent/archive/refs/tags/v2026.4.23.tar.gz",

--- a/pkgs/r/rosdep.lua
+++ b/pkgs/r/rosdep.lua
@@ -20,7 +20,7 @@ package = {
 
     xpm = {
         linux = {
-            deps = {"python"},
+            deps = {"xim:python"},
             ["latest"] = { ref = "0.26.0" },
             ["0.26.0"] = {
                 url = "https://files.pythonhosted.org/packages/bd/c1/15c5c296f41e6a290e6c3515316b2676be580c66b10e26372200a0ecbdd7/rosdep-0.26.0-py3-none-any.whl",
@@ -28,7 +28,8 @@ package = {
             },
         },
         macosx = {
-            deps = {"python"},
+            -- No python dep on macOS: xim:python has no macosx section, so this
+            -- resolves to nothing. macOS ships python3 in the CLT / system.
             ["latest"] = { ref = "0.26.0" },
             ["0.26.0"] = {
                 url = "https://files.pythonhosted.org/packages/bd/c1/15c5c296f41e6a290e6c3515316b2676be580c66b10e26372200a0ecbdd7/rosdep-0.26.0-py3-none-any.whl",
@@ -36,7 +37,7 @@ package = {
             },
         },
         windows = {
-            deps = {"python"},
+            deps = {"xim:python"},
             ["latest"] = { ref = "0.26.0" },
             ["0.26.0"] = {
                 url = "https://files.pythonhosted.org/packages/bd/c1/15c5c296f41e6a290e6c3515316b2676be580c66b10e26372200a0ecbdd7/rosdep-0.26.0-py3-none-any.whl",

--- a/pkgs/t/trendradar.lua
+++ b/pkgs/t/trendradar.lua
@@ -20,7 +20,7 @@ package = {
 
     xpm = {
         linux = {
-            deps = {"python"},
+            deps = {"xim:python"},
             ["latest"] = { ref = "6.6.1" },
             ["6.6.1"] = {
                 url = "https://github.com/sansan0/TrendRadar/archive/refs/tags/v6.6.1.tar.gz",
@@ -117,7 +117,16 @@ function install()
     __write_wrapper("trendradar")
     __write_wrapper("trendradar-mcp")
 
-    __xvm_add()
+    -- Registration lives in config(), which xlings runs right after this, and
+    -- calling __xvm_add() here too registered the same name and version twice:
+    --
+    --   [error] duplicate exact registration node
+    --           at: trendradar@6.6.1   field: /nodes/2
+    --
+    -- Pre-existing since the package was added (#81) and platform-independent
+    -- -- reproduced on Linux as well as macOS. It stayed invisible because this
+    -- recipe had never been in a PR's changed set, so the install test had
+    -- never run it.
     __write_subos_shim("trendradar")
     __write_subos_shim("trendradar-mcp")
     return true

--- a/pkgs/v/vcstool.lua
+++ b/pkgs/v/vcstool.lua
@@ -20,7 +20,7 @@ package = {
 
     xpm = {
         linux = {
-            deps = {"python"},
+            deps = {"xim:python"},
             ["latest"] = { ref = "0.3.0" },
             ["0.3.0"] = {
                 url = "https://files.pythonhosted.org/packages/6c/d5/4aca2c05481a0fb74bd2660b14b0dd0ea975e4f38bc150511a64c55af986/vcstool-0.3.0-py3-none-any.whl",
@@ -28,7 +28,8 @@ package = {
             },
         },
         macosx = {
-            deps = {"python"},
+            -- No python dep on macOS: xim:python has no macosx section, so this
+            -- resolves to nothing. macOS ships python3 in the CLT / system.
             ["latest"] = { ref = "0.3.0" },
             ["0.3.0"] = {
                 url = "https://files.pythonhosted.org/packages/6c/d5/4aca2c05481a0fb74bd2660b14b0dd0ea975e4f38bc150511a64c55af986/vcstool-0.3.0-py3-none-any.whl",
@@ -36,7 +37,7 @@ package = {
             },
         },
         windows = {
-            deps = {"python"},
+            deps = {"xim:python"},
             ["latest"] = { ref = "0.3.0" },
             ["0.3.0"] = {
                 url = "https://files.pythonhosted.org/packages/6c/d5/4aca2c05481a0fb74bd2660b14b0dd0ea975e4f38bc150511a64c55af986/vcstool-0.3.0-py3-none-any.whl",

--- a/pkgs/v/virtualbox-ubuntu.lua
+++ b/pkgs/v/virtualbox-ubuntu.lua
@@ -22,7 +22,7 @@ package = {
 
     xpm = {
         windows = {
-            deps = { "virtualbox" },
+            -- xim:virtualbox ships linux only, so this dep resolved to nothing here.
             ["latest"] = { ref = "24.04.4" },
             ["24.04.4"] = {
                 url = {
@@ -33,7 +33,7 @@ package = {
             },
         },
         linux = {
-            deps = { "virtualbox" },
+            deps = { "xim:virtualbox" },
             ["latest"] = { ref = "24.04.4" },
             ["24.04.4"] = {
                 url = {
@@ -45,7 +45,7 @@ package = {
         },
         ubuntu = { ref = "linux" },
         macosx = {
-            deps = { "virtualbox" },
+            -- xim:virtualbox ships linux only, so this dep resolved to nothing here.
             ["latest"] = { ref = "24.04.4" },
             ["24.04.4"] = {
                 url = {

--- a/tests/v/test_virtualbox_ubuntu.py
+++ b/tests/v/test_virtualbox_ubuntu.py
@@ -36,7 +36,11 @@ class TestStatic:
 
     @pytest.mark.static
     def test_depends_on_virtualbox(self, meta):
-        assert 'deps = { "virtualbox" }' in meta.raw_content
+        # Namespaced, not bare: a bare name is ambiguous the moment a second
+        # index offers `virtualbox`, and CI registers every CHANGED recipe a
+        # second time under `local:`. Enforced index-wide by
+        # .github/scripts/check-dep-namespace.sh.
+        assert 'deps = { "xim:virtualbox" }' in meta.raw_content
 
 
 class TestIndex:


### PR DESCRIPTION
Five latent defects, all surfaced because an index-wide namespace sweep put these recipes in a PR's changed set for the first time in months. **None is a regression.**

## A dep the provider doesn't ship on that platform

`xim:python` has **linux and windows sections only** — yet `rosdep`, `vcstool` and `hermes-agent` each declared it under `macosx` too. `xim:virtualbox` is **linux only** — yet `virtualbox-ubuntu` declared it under `macosx` and `windows`.

On macOS python comes from the command line tools, which is where these tools have always found it. So the deps are dropped for those platforms rather than faked.

`configure-project-installer` is the same defect through a different door: its `macosx` section was `ref = "linux"`, which inherits the linux `deps` along with its versions — and `make`/`gcc` have no macosx section at all.

**Why they were invisible:** the names were bare. An unqualified dep that resolves to nothing was tolerated, so the declaration was **inert rather than correct** — wrong for as long as the line existed. Namespacing turns the same text into a hard resolve, which is what made `macos-install-test` red on the first run.

## trendradar registered itself twice

```
[error] duplicate exact registration node
        at: trendradar@6.6.1   field: /nodes/2
```

`__xvm_add()` ran at the end of `install()` **and** from `config()`, which xlings runs immediately after — so `config()` always failed and neither declared program was ever registered.

Broken since the package landed (#81), and **not** macOS-specific — reproduced on Linux. Verified with a remove + payload delete + clean reinstall: 3 packages installed, both programs registered, both shims present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
