### PR TITLE
fix(deps): qualify bare dep names, part 1 of 2

### DIFF
--- a/pkgs/c/cairo.lua
+++ b/pkgs/c/cairo.lua
@@ -14,7 +14,7 @@ package = {
     xvm_enable = true,
     xpm = {
         linux = {
-            deps = { "freetype@2.13.2", "fontconfig@2.15.0", "libpng@1.6.43", "pixman@0.42.2" },
+            deps = { "xim:freetype@2.13.2", "xim:fontconfig@2.15.0", "xim:libpng@1.6.43", "xim:pixman@0.42.2" },
             ["latest"] = { ref = "1.18.0" },
             ["1.18.0"] = {
                 url = {

--- a/pkgs/d/devcpp.lua
+++ b/pkgs/d/devcpp.lua
@@ -20,7 +20,7 @@ package = {
 
     xpm = {
         windows = {
-            deps = { "shortcut-tool", "windows-acp" },
+            deps = { "xim:shortcut-tool", "xim:windows-acp" },
             ["latest"] = { ref = "5.11" },
             ["5.11"] = {
                 url = "https://gitcode.com/xlings-res/dev-cpp/releases/download/5.11/dev-cpp-5.11-windows-x86_64.zip",

--- a/pkgs/g/git.lua
+++ b/pkgs/g/git.lua
@@ -30,7 +30,7 @@ package = {
 
     xpm = {
         windows = {
-            deps = { "shortcut-tool" },
+            deps = { "xim:shortcut-tool" },
             ["latest"] = { ref = "2.51.1" },
             ["2.51.1"] = "XLINGS_RES",
         },

--- a/pkgs/g/glib.lua
+++ b/pkgs/g/glib.lua
@@ -14,7 +14,7 @@ package = {
     xvm_enable = true,
     xpm = {
         linux = {
-            deps = { "libffi@3.4.4", "zlib@1.3.1", "pcre2@10.42" },
+            deps = { "xim:libffi@3.4.4", "xim:zlib@1.3.1", "xim:pcre2@10.42" },
             ["latest"] = { ref = "2.80.0" },
             ["2.80.0"] = {
                 url = {

--- a/pkgs/g/graphics.lua
+++ b/pkgs/g/graphics.lua
@@ -79,22 +79,22 @@ package = {
                     -- Sentinel: WSL2's Windows-side D3D12 userspace.
                     -- A no-op anywhere that is not WSL2.
                     --
-                    -- BARE, unlike its two siblings above, and the asymmetry is
-                    -- the point: `wsl-gl-host-link` is NEW in this change, so it
-                    -- does not exist in the `xim` namespace yet. CI registers a
-                    -- changed recipe under `local`, and an `xim:` prefix can only
-                    -- resolve from that one namespace -- so a batch of new
-                    -- interdependent packages can never install until every one
-                    -- of them is already published. Measured here as
+                    -- This was BARE, unlike its two siblings above, while
+                    -- `wsl-gl-host-link` was NEW: CI registers a changed recipe
+                    -- under `local`, and an `xim:` prefix resolves from that one
+                    -- namespace alone -- so a batch of new interdependent
+                    -- packages can never install until every one of them is
+                    -- already published. Measured then as
                     -- `package 'xim:wsl-gl-host-link@>=0.1' not found`; #498 hit
                     -- the same wall and fixed it the same way.
                     --
-                    -- `mesa` and `nvidia-gl-host-link` keep their prefix because
-                    -- they ARE published: a changed recipe exists under BOTH
-                    -- `xim` and `local` during CI, and a bare name is then
-                    -- ambiguous -- the resolver refuses to guess. New package:
-                    -- bare. Existing package: namespaced.
-                    "wsl-gl-host-link@>=0.1",
+                    -- That exemption lasts exactly until the package ships, and
+                    -- then inverts. #540 published it. A published recipe that a
+                    -- PR also CHANGES exists under BOTH `xim` and `local`, and a
+                    -- bare name is ambiguous there -- the resolver refuses to
+                    -- guess. New package: bare, and say so here. Published
+                    -- package: namespaced, which is what CI now enforces.
+                    "xim:wsl-gl-host-link@>=0.1",
 
                     -- The rest of what a GUI PROGRAM needs, as opposed to what
                     -- mesa needs.
@@ -130,11 +130,11 @@ package = {
                     "xim:fontconfig@>=2.14",
                     -- Non-fatal when absent (single-screen fallback), which is
                     -- exactly why it went unnoticed until a real toolkit ran.
-                    "libXinerama@>=1.1",
+                    "xim:libXinerama@>=1.1",
                     -- An ICD is a driver; a driver needs a loader. mesa ships
                     -- RADV and its manifest, and without libvulkan.so.1 nothing
                     -- ever reads it -- which also leaves zink dead.
-                    "vulkan-loader@>=1.4",
+                    "xim:vulkan-loader@>=1.4",
                 },
             },
             ["latest"] = { ref = "0.1.0" },

--- a/pkgs/h/harfbuzz.lua
+++ b/pkgs/h/harfbuzz.lua
@@ -14,7 +14,7 @@ package = {
     xvm_enable = true,
     xpm = {
         linux = {
-            deps = { "freetype@2.13.2" },
+            deps = { "xim:freetype@2.13.2" },
             ["latest"] = { ref = "8.3.0" },
             ["8.3.0"] = {
                 url = {

--- a/pkgs/l/libpng.lua
+++ b/pkgs/l/libpng.lua
@@ -14,7 +14,7 @@ package = {
     xvm_enable = true,
     xpm = {
         linux = {
-            deps = { "zlib@1.3.1" },
+            deps = { "xim:zlib@1.3.1" },
             ["latest"] = { ref = "1.6.43" },
             ["1.6.43"] = {
                 url = {

--- a/pkgs/p/pango.lua
+++ b/pkgs/p/pango.lua
@@ -16,8 +16,8 @@ package = {
         linux = {
             -- fromsource 漏了 glib/fribidi, 这里补全(pango 运行时确需)
             deps = {
-                "glib@2.80.0", "harfbuzz@8.3.0", "fribidi@1.0.13",
-                "cairo@1.18.0", "freetype@2.13.2", "fontconfig@2.15.0",
+                "xim:glib@2.80.0", "xim:harfbuzz@8.3.0", "xim:fribidi@1.0.13",
+                "xim:cairo@1.18.0", "xim:freetype@2.13.2", "xim:fontconfig@2.15.0",
             },
             ["latest"] = { ref = "1.52.1" },
             ["1.52.1"] = {

--- a/pkgs/s/seeme-report.lua
+++ b/pkgs/s/seeme-report.lua
@@ -23,7 +23,7 @@ package = {
 
     xpm = {
         windows = {
-            deps = {"python@3"},
+            deps = {"xim:python@3"},
             ["latest"] = { ref = "0.0.2" },
             ["0.0.2"] = {
                 url = "https://github.com/2412322029/seeme/releases/download/pub/seeme-report.zip",

--- a/pkgs/s/seeme-server.lua
+++ b/pkgs/s/seeme-server.lua
@@ -23,7 +23,7 @@ package = {
 
     xpm = {
         windows = {
-            deps = {"python@3"},
+            deps = {"xim:python@3"},
             ["latest"] = { ref = "0.0.2" },
             ["0.0.2"] = {
                 url = "https://github.com/2412322029/seeme/releases/download/pub/seeme-server.zip",
@@ -31,7 +31,7 @@ package = {
             },
         },
         debian = {
-            deps = {"python@3"},
+            deps = {"xim:python@3"},
             ["latest"] = { ref = "0.0.2" },
             ["0.0.2"] = {
                 url = "https://github.com/2412322029/seeme/releases/download/pub/seeme-server.zip",


### PR DESCRIPTION
Batch **1 of 2** of the index-wide sweep, split so the per-package install test covers **ten** packages rather than forty-six. The guard that enforces this lands with batch 2, once no bare name is left for it to trip on.

> Merge [#549](https://github.com/openxlings/xim-pkgindex/pull/549) first — `cpp` in batch 2 needs its `type = "config"` uninstall tolerance.

## The defect

A dep declared `expat@2.6.2` rather than `xim:expat@2.6.2` resolves only while exactly one index provides that name. CI registers every **changed** recipe a second time under `local:`, so the moment a PR touches both consumer and dependency, resolution reports `package 'expat@2.6.2' is ambiguous` and the install stops.

Latent by construction: the failure is a property of the *changed set*, not of the recipe — so it surfaces by accident on an unrelated PR (fontconfig, #497) rather than on the one that introduced it.

## Why the recipes are loaded, not grepped

`npm` assigns one table to `xpm.{linux,windows,macosx}` *after* the literal, so a text sweep sees one dep where the load sees three rows on three platforms. `code` builds its version entries from top-level functions. Both parse correctly only because the recipe is executed.

## One file changes more than a prefix

`graphics.lua`'s `wsl-gl-host-link` dep was deliberately bare, with a comment explaining the package was new and unpublished — **correct at the time**. That inverts once it ships (#540): a published recipe a PR also changes exists under both namespaces, where a bare name is ambiguous. Prefix added, comment rewritten to say why the exemption ended rather than left asserting the opposite of the code.

## Verification

Every changed file re-parsed and its deps re-enumerated per platform. Stripping `xim:` from both sides makes **nine of ten byte-identical to main**; the tenth differs only by that comment block. 1116 static tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
