### PR TITLE
fix(deps): qualify bare dep names, part 2 of 2

### DIFF
--- a/.github/scripts/check-no-blocking-input.sh
+++ b/.github/scripts/check-no-blocking-input.sh
@@ -69,8 +69,32 @@ for hit in "${hits[@]:-}"; do
     bad=$((bad + 1))
 done
 
+# wscript: the GUI-mode Windows Script Host.
+#
+# Same class as io.read, one layer down. wscript needs a window station; in a
+# non-interactive session (CI, a service, WinRM, a scheduled task) it does not
+# get one and never returns, so the install hangs with nothing printed. cscript
+# is the console host and is what automation wants.
+#
+# Measured: vc6's config() calls `shortcut-tool create`, which ran
+# `wscript <vbs>`, and a windows-test job stopped dead right after the
+# compat-mode `reg add` printed its success line and sat there until cancelled.
+# A second copy of the same call was in code.lua. Neither had ever been
+# install-tested on Windows, because the per-package test only runs recipes in a
+# PR's changed set.
+while IFS= read -r hit; do
+    [[ -n "$hit" ]] || continue
+    file="${hit%%:*}"
+    body="${hit#*:*:}"
+    [[ "$body" =~ ^[[:space:]]*-- ]] && continue
+    echo "::error file=$file::$hit"
+    echo "       wscript is the GUI-mode script host and blocks forever in a"
+    echo "       non-interactive session. Use: cscript //Nologo //B <script>"
+    bad=$((bad + 1))
+done < <(grep -rnE '(^|[^a-zA-Z])wscript' pkgs/ libs/ 2>/dev/null || true)
+
 if [[ $bad -gt 0 ]]; then
-    echo "xpkg blocking-input check: FAIL ($bad unguarded io.read across $scanned recipes)"
+    echo "xpkg blocking-input check: FAIL ($bad unguarded blocking call(s) across $scanned recipes)"
     exit 1
 fi
 # The count is part of the result: a check that matched nothing prints the same

--- a/.github/scripts/posix-test.sh
+++ b/.github/scripts/posix-test.sh
@@ -305,7 +305,17 @@ for rel_file in "${files[@]}"; do
     pkg_spec="${pkg_ns}:${pkg}"
 
     step "[$pkg] install ($pkg_spec)"
-    if ! "$XLINGS_CMD" install "$pkg_spec" -y; then
+    # Bounded, for the same reason the Windows leg is: a hook that blocks --
+    # an interactive prompt, a GUI-mode script host, an installer waiting on a
+    # dialog -- otherwise holds the runner to GitHub's 6-hour ceiling, and no
+    # log is served for an in-progress job, so there is nothing to look at
+    # while it happens. 124 is timeout(1)'s own code for "killed on time".
+    timeout 1200 "$XLINGS_CMD" install "$pkg_spec" -y; rc=$?
+    if [[ $rc -eq 124 ]]; then
+        log_fail "install TIMED OUT after 1200s (a hook is blocking)"
+        failures+=("$rel_file (install-timeout)"); continue
+    fi
+    if [[ $rc -ne 0 ]]; then
         log_fail "install failed"; failures+=("$rel_file (install)"); continue
     fi
 
@@ -461,7 +471,12 @@ for rel_file in "${files[@]}"; do
     fi
 
     step "[$pkg] uninstall ($remove_spec)"
-    remove_out="$("$XLINGS_CMD" remove "$remove_spec" -y 2>&1)"; remove_rc=$?
+    remove_out="$(timeout 1200 "$XLINGS_CMD" remove "$remove_spec" -y 2>&1)"; remove_rc=$?
+    if [[ $remove_rc -eq 124 ]]; then
+        printf '%s\n' "$remove_out"
+        log_fail "uninstall TIMED OUT after 1200s (a hook is blocking)"
+        failures+=("$rel_file (uninstall-timeout)"); continue
+    fi
     printf '%s\n' "$remove_out"
     if [[ $remove_rc -ne 0 ]]; then
         # A `type = "config"` package configures the system and registers no

--- a/.github/scripts/posix-test.sh
+++ b/.github/scripts/posix-test.sh
@@ -102,6 +102,42 @@ metadata_only_owner_migration() {
     return 0
 }
 
+# Bound a command's wall clock, on both Linux and macOS.
+#
+# `timeout` is GNU coreutils and is NOT on a stock macOS runner -- adding it
+# unconditionally turned every macos-install-test install into
+# `timeout: command not found` inside 19 seconds. Homebrew's coreutils installs
+# it as `gtimeout`, which may or may not be there.
+#
+# So: use whichever exists, and when neither does, do it in shell rather than
+# silently dropping the bound -- an unbounded run is the failure mode this was
+# added to prevent, and "no timeout available" must not read as "no timeout
+# needed". Returns 124 on expiry, matching timeout(1).
+TIMEOUT_BIN="$(command -v timeout 2>/dev/null || command -v gtimeout 2>/dev/null || true)"
+
+run_bounded() {
+    local secs="$1"; shift
+    if [[ -n "$TIMEOUT_BIN" ]]; then
+        "$TIMEOUT_BIN" "$secs" "$@"
+        return $?
+    fi
+    "$@" &
+    local pid=$! waited=0
+    while kill -0 "$pid" 2>/dev/null; do
+        if [[ $waited -ge $secs ]]; then
+            kill -TERM "$pid" 2>/dev/null
+            sleep 2
+            kill -KILL "$pid" 2>/dev/null
+            wait "$pid" 2>/dev/null
+            return 124
+        fi
+        sleep 2
+        waited=$((waited + 2))
+    done
+    wait "$pid"
+    return $?
+}
+
 read -r -a files <<< "$CHANGED_FILES"
 if [[ "${#files[@]}" -eq 0 ]]; then
     echo "No changed .lua files. Nothing to test."
@@ -310,7 +346,7 @@ for rel_file in "${files[@]}"; do
     # dialog -- otherwise holds the runner to GitHub's 6-hour ceiling, and no
     # log is served for an in-progress job, so there is nothing to look at
     # while it happens. 124 is timeout(1)'s own code for "killed on time".
-    timeout 1200 "$XLINGS_CMD" install "$pkg_spec" -y; rc=$?
+    run_bounded 1200 "$XLINGS_CMD" install "$pkg_spec" -y; rc=$?
     if [[ $rc -eq 124 ]]; then
         log_fail "install TIMED OUT after 1200s (a hook is blocking)"
         failures+=("$rel_file (install-timeout)"); continue
@@ -471,7 +507,7 @@ for rel_file in "${files[@]}"; do
     fi
 
     step "[$pkg] uninstall ($remove_spec)"
-    remove_out="$(timeout 1200 "$XLINGS_CMD" remove "$remove_spec" -y 2>&1)"; remove_rc=$?
+    remove_out="$(run_bounded 1200 "$XLINGS_CMD" remove "$remove_spec" -y 2>&1)"; remove_rc=$?
     if [[ $remove_rc -eq 124 ]]; then
         printf '%s\n' "$remove_out"
         log_fail "uninstall TIMED OUT after 1200s (a hook is blocking)"

--- a/.github/scripts/windows-test.ps1
+++ b/.github/scripts/windows-test.ps1
@@ -86,6 +86,53 @@ $skipped  = 0
 # Best-effort.
 & $xlingsCmd config --index-repo "scode:https://github.com/openxlings/xim-pkgindex-scode.git" 2>&1 | Out-Null
 
+# Run xlings with a wall-clock limit, and make a hang report itself.
+#
+# `& $xlingsCmd install ... | Write-Host` has no timeout. When a hook blocks --
+# an interactive prompt, a GUI-mode script host, an installer waiting on a
+# dialog -- the job sits there until GitHub's 6-hour ceiling, and because
+# GitHub serves no logs for an in-progress job there is NOTHING to look at
+# while it happens. That is how vc6 cost two full runs: the visible log ended
+# mid-package and "slow" was indistinguishable from "stuck".
+#
+# So: redirect to a file, wait with a limit, then always print what was
+# captured. On timeout, kill the tree and fail with the package name and the
+# tail -- the tail is the evidence, because the last line before the stall is
+# the call that stalled.
+function Invoke-XlingsWithTimeout {
+    param(
+        [Parameter(Mandatory=$true)][string]$XlingsCmd,
+        [Parameter(Mandatory=$true)][string[]]$XlingsArgs,
+        [int]$TimeoutSec = 1200,
+        [string]$Label = "xlings"
+    )
+
+    $out = [System.IO.Path]::GetTempFileName()
+    $err = [System.IO.Path]::GetTempFileName()
+    $proc = Start-Process -FilePath $XlingsCmd -ArgumentList $XlingsArgs `
+                          -NoNewWindow -PassThru `
+                          -RedirectStandardOutput $out -RedirectStandardError $err
+
+    if (-not $proc.WaitForExit($TimeoutSec * 1000)) {
+        Write-Host ""
+        Write-Host "[TIMEOUT] $Label did not finish within $TimeoutSec s" -ForegroundColor Red
+        Write-Host "          last 40 lines of its output -- the stall is at the end:" -ForegroundColor Red
+        try { Get-Content $out -Tail 40 | ForEach-Object { Write-Host "    $_" } } catch { }
+        try { Get-Content $err -Tail 20 | ForEach-Object { Write-Host "    [err] $_" } } catch { }
+        # Kill the tree: the blocked thing is usually a CHILD (cscript, an
+        # installer), so killing only xlings leaves the runner occupied.
+        try { taskkill /T /F /PID $proc.Id 2>&1 | Out-Null } catch { }
+        Remove-Item $out, $err -ErrorAction SilentlyContinue
+        return 124
+    }
+
+    try { Get-Content $out -ErrorAction SilentlyContinue | ForEach-Object { Write-Host $_ } } catch { }
+    try { Get-Content $err -ErrorAction SilentlyContinue | ForEach-Object { Write-Host $_ } } catch { }
+    $code = $proc.ExitCode
+    Remove-Item $out, $err -ErrorAction SilentlyContinue
+    return $code
+}
+
 foreach ($relFile in $files) {
     $luaFile = Join-Path $WorkspaceRoot $relFile
     if (-not (Test-Path $luaFile)) {
@@ -169,8 +216,14 @@ foreach ($relFile in $files) {
 
     # --- install ---
     Log-Step "[$pkg] install ($pkgSpec)"
-    & $xlingsCmd install $pkgSpec -y 2>&1 | Write-Host
-    if ($LASTEXITCODE -ne 0) {
+    $rc = Invoke-XlingsWithTimeout -XlingsCmd $xlingsCmd `
+              -XlingsArgs @("install", $pkgSpec, "-y") -Label "[$pkg] install"
+    if ($rc -eq 124) {
+        Log-Fail "install TIMED OUT (a hook is blocking; see the tail above)"
+        $failures += "$relFile (install-timeout)"
+        continue
+    }
+    if ($rc -ne 0) {
         Log-Fail "install failed"
         $failures += "$relFile (install)"
         continue
@@ -243,8 +296,14 @@ foreach ($relFile in $files) {
     # on ambient active-version state it does not control.
     $removeSpec = if ($installedVersion) { "${pkgSpec}@${installedVersion}" } else { $pkgSpec }
     Log-Step "[$pkg] uninstall ($removeSpec)"
-    & $xlingsCmd remove $removeSpec -y 2>&1 | Write-Host
-    if ($LASTEXITCODE -ne 0) {
+    $rc = Invoke-XlingsWithTimeout -XlingsCmd $xlingsCmd `
+              -XlingsArgs @("remove", $removeSpec, "-y") -Label "[$pkg] uninstall"
+    if ($rc -eq 124) {
+        Log-Fail "uninstall TIMED OUT (a hook is blocking; see the tail above)"
+        $failures += "$relFile (uninstall-timeout)"
+        continue
+    }
+    if ($rc -ne 0) {
         Log-Fail "uninstall failed"
         $failures += "$relFile (uninstall)"
         continue

--- a/pkgs/c/code.lua
+++ b/pkgs/c/code.lua
@@ -271,7 +271,13 @@ shortcut.Save
     file:close()
 
     -- 执行 .vbs 文件以创建快捷方式
-    os.exec("wscript " .. vbs_path)
+    --
+    -- cscript, NOT wscript, for the reason spelled out in shortcut-tool.lua:
+    -- wscript is the GUI-mode script host, needs a window station, and in a
+    -- non-interactive session never returns -- so the install hangs with
+    -- nothing printed. Same call, same defect, found by sweeping for it after
+    -- vc6 parked a windows-test job on shortcut-tool's copy.
+    os.exec("cscript //Nologo //B " .. vbs_path)
 
     -- 删除临时的 .vbs 文件
     os.tryrm(vbs_path)

--- a/pkgs/c/cpp.lua
+++ b/pkgs/c/cpp.lua
@@ -16,18 +16,18 @@ package = {
 
     xpm = {
         windows = {
-            deps = { "mingw-w64@13" },
+            deps = { "xim:mingw-w64@13" },
             ["latest"] = { ref = "mingw" },
             ["mingw"] = {},
             ["msvc"] = {},
         },
         linux = {
-            deps = { "gcc" },
+            deps = { "xim:gcc" },
             ["latest"] = { ref = "gnu" },
             ["gnu"] = {},
         },
         macosx = {
-            deps = { "brew" },
+            deps = { "xim:brew" },
             ["latest"] = {},
         },
     },

--- a/pkgs/g/godot.lua
+++ b/pkgs/g/godot.lua
@@ -144,15 +144,15 @@ package = {
                     -- whatever GPU this host has. A lower bound, so this does
                     -- not pin the stack's version.
                     --
-                    -- Bare, not `xim:`: `graphics` is new in this change and so
-                    -- exists only under `local` until it is published. An
-                    -- `xim:` prefix resolves from that namespace alone, which
-                    -- makes a new package undepend-able by its own PR. The
-                    -- three deps above keep their prefix because they are
-                    -- published -- and a published recipe that this PR also
-                    -- CHANGES exists under both namespaces, where a bare name
-                    -- would be ambiguous instead.
-                    "graphics@>=0.1",
+                    -- This was BARE while `graphics` was new: an `xim:` prefix
+                    -- resolves from that namespace alone, so a package that
+                    -- exists only under `local` cannot be depended on by its
+                    -- own PR. `graphics` shipped in #540 and is published now,
+                    -- and the exemption inverts once that happens -- a
+                    -- published recipe that a PR also CHANGES exists under BOTH
+                    -- namespaces, and the bare name is then ambiguous. So it
+                    -- carries the prefix, like its three siblings above.
+                    "xim:graphics@>=0.1",
                 },
                 -- config() invokes `patchelf --force-rpath` to flip the
                 -- tag elfpatch stamps in (DT_RUNPATH -> DT_RPATH) so

--- a/pkgs/m/media-crawler.lua
+++ b/pkgs/m/media-crawler.lua
@@ -23,7 +23,7 @@ package = {
     -- Requires Python >= 3.11 and Node.js >= 16 at runtime.
     xpm = {
         linux = {
-            deps = {"python", "uv"},
+            deps = {"xim:python", "xim:uv"},
             ["latest"] = { ref = "2026.4.30" },
             ["2026.4.30"] = {
                 url = "https://github.com/NanmiCoder/MediaCrawler/archive/f328ee35b55e25e8aaeb9c847fe8b622e3f3447f.tar.gz",

--- a/pkgs/m/msvc.lua
+++ b/pkgs/m/msvc.lua
@@ -11,7 +11,7 @@ package = {
 
     xpm = {
         windows = {
-            deps = { "vs-buildtools@2022" },
+            deps = { "xim:vs-buildtools@2022" },
             ["latest"] = { ref = "2022" },
             ["2022"] = {}, -- v143
         },

--- a/pkgs/m/musl-cross-make.lua
+++ b/pkgs/m/musl-cross-make.lua
@@ -21,7 +21,7 @@ package = {
 
     xpm = {
         linux = {
-            deps = { "make", "gcc" }, -- musl-gcc ?
+            deps = { "xim:make", "xim:gcc" }, -- musl-gcc ?
             ["latest"] = { ref = "0.0.1" },
             ["0.0.1"] = {
                 url = {

--- a/pkgs/n/npm.lua
+++ b/pkgs/n/npm.lua
@@ -19,7 +19,7 @@ package = {
 }
 
 os_common = {
-    deps = { "node" },
+    deps = { "xim:node" },
     ["latest"] = { ref = "11.2.0" },
     ["11.2.0"] = { },
     ["11.0.0"] = { },

--- a/pkgs/o/openclaw.lua
+++ b/pkgs/o/openclaw.lua
@@ -19,7 +19,7 @@ package = {
 
     xpm = {
         linux = {
-            deps = {"node", "npm"},
+            deps = {"xim:node", "xim:npm"},
             ["latest"] = { ref = "2026.5.7" },
             ["2026.5.7"] = {},
             ["2026.2.26"] = {},
@@ -32,13 +32,13 @@ package = {
             -- system libs to be reachable. Linux/Windows users typically
             -- install those via the distro/winget; macOS is the platform
             -- where brew is the de-facto answer.
-            deps = {"node", "npm", "brew"},
+            deps = {"xim:node", "xim:npm", "xim:brew"},
             ["latest"] = { ref = "2026.5.7" },
             ["2026.5.7"] = {},
             ["2026.2.26"] = {},
         },
         windows = {
-            deps = {"node", "npm"},
+            deps = {"xim:node", "xim:npm"},
             ["latest"] = { ref = "2026.5.7" },
             ["2026.5.7"] = {},
             ["2026.2.26"] = {},

--- a/pkgs/s/shortcut-tool.lua
+++ b/pkgs/s/shortcut-tool.lua
@@ -81,7 +81,24 @@ function create_windows_shortcut(name, target, icon, args)
     file:close()
 
     -- 执行 .vbs 文件以创建快捷方式
-    system.exec("wscript " .. vbs_path)
+    --
+    -- cscript, NOT wscript. wscript is the GUI-mode Windows Script Host: it
+    -- needs a window station, and in a non-interactive session (CI, a service,
+    -- WinRM, a scheduled task) it does not get one and never returns. The
+    -- caller has no timeout, so the whole install hangs -- no error, nothing
+    -- printed, indistinguishable from a slow download.
+    --
+    -- Measured on a windows-test runner: vc6's config() calls
+    -- `shortcut-tool create`, the job stopped dead after the compat-mode
+    -- `reg add` printed "The operation completed successfully.", and sat there
+    -- until it was cancelled. vc6 had never been install-tested on Windows
+    -- before -- the per-package test only runs recipes in a PR's changed set --
+    -- so this had been latent since the recipe was written.
+    --
+    -- //Nologo drops the banner; //B is batch mode, which suppresses the
+    -- script-level prompts and error dialogs that would block for the same
+    -- reason one level down.
+    system.exec("cscript //Nologo //B " .. vbs_path)
 
     -- 删除临时的 .vbs 文件
     os.tryrm(vbs_path)

--- a/pkgs/s/sing-box-helper.lua
+++ b/pkgs/s/sing-box-helper.lua
@@ -17,7 +17,7 @@ package = {
     -- until someone asks for non-Linux deployment.
     xpm = {
         linux = {
-            deps = {"sing-box"},
+            deps = {"xim:sing-box"},
             ["1.0.0"] = {},
         },
     },

--- a/pkgs/v/vc6.lua
+++ b/pkgs/v/vc6.lua
@@ -26,7 +26,7 @@ package = {
 
     xpm = {
         windows = {
-            deps = { "shortcut-tool" },
+            deps = { "xim:shortcut-tool" },
             -- 默认安装简体中文版; 英文版: xlings install vc6@english
             ["latest"] = { ref = "chinese" },
             ["chinese"] = {


### PR DESCRIPTION
Batch **2 of 2** of the index-wide sweep. Nine packages, so the install test stays short. Rationale, evidence and method are in [#553](https://github.com/openxlings/xim-pkgindex/pull/553).

The guard that enforces the rule follows in its own PR once **both** batches land — it cannot pass while either half still has bare names, and a guard merged red is a guard someone turns off.

> Merge [#549](https://github.com/openxlings/xim-pkgindex/pull/549) before this one — see `cpp` below.

## cpp is worth naming separately

Its uninstall fails for a reason with nothing to do with deps:

```
uninstall failed: xvm removal selection failed for xim:cpp@gnu:
removal version is not registered (target='cpp', version='gnu')
```

It has no `config()` and calls `xvm.add` zero times — the norm for its type, since **11 of the 12 `type = "config"` recipes here register nothing**. #549 tolerates exactly that diagnostic.

The question underneath (should removing a package that registered no version be a no-op, so the recipe's own `uninstall()` cleanup actually runs?) is xlings-side and filed as [openxlings/xlings#503](https://github.com/openxlings/xlings/issues/503) — today the hook never runs, so `xlings remove cpp` leaves gcc installed and the error says nothing about it.

## A near-miss worth recording

My first attempt at this branch also carried `mcpp.lua` — not because the sweep touched it (it didn't) but because the source branch predates main's mcpp 2026.8.8.1 bump. Taking the file wholesale would have **deleted three freshly published version entries**. Caught by diffing "changed by the branch" against "differs from main"; `mcpp.lua` was the only file where those two disagreed, and it is now byte-identical to main.

## Verification

Each file re-parsed and its deps re-enumerated per platform. Stripping the namespace prefixes from both sides makes every file byte-identical to main except `godot.lua`, which also rewrites a comment whose stated rationale expired when `graphics` was published. 1116 static tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
