### PR TITLE
feat(graphics): the Wayland cell now answers, instead of saying na both ways

### DIFF
--- a/.agents/tools/graphics/verify-stack.sh
+++ b/.agents/tools/graphics/verify-stack.sh
@@ -299,9 +299,79 @@ if [[ $has_display -eq 1 ]]; then
 else
   na "X11 / GLX reachable" "DISPLAY unset"
 fi
-[[ $has_wayland -eq 1 ]] \
-  && na "Wayland" "WAYLAND_DISPLAY set but no Wayland probe exists yet (O4)" \
-  || na "Wayland" "WAYLAND_DISPLAY unset"
+# O4: EGL on Wayland, against OUR vendor library.
+#
+# This cell used to report `na` in BOTH directions -- "compositor present and it
+# works" and "no compositor" produced the same non-answer -- which is how the
+# Wayland question stayed open long enough for me to misclassify it three times
+# (unwritten probe -> hardware -> mesa build option -> back to unwritten probe).
+# It was always the probe.
+#
+# The compositor is started here rather than required from the environment: a
+# headless one is enough to exercise the platform, and demanding that the
+# developer already be in a Wayland session would leave this cell `na` on every
+# X11 machine -- which is most of them. Started, used, killed.
+#
+# GL_RENDERER is llvmpipe under a headless compositor by nature: the client gets
+# no DRM master, so mesa falls back from the dri2 screen. That is expected and
+# NOT what this cell asserts. What it asserts is that the WAYLAND EGL platform
+# path works and that every object driving it came from our payload.
+wl_probe() {
+  local comp; comp="$(command -v mutter || command -v weston || command -v sway || true)"
+  [[ -n "$comp" ]] || { na "Wayland" "no compositor to start (mutter/weston/sway)"; return; }
+  [[ -f "$HERE/wlprobe.c" ]] || { na "Wayland" "no wlprobe.c"; return; }
+  [[ -n "$PROBE" ]] || { na "Wayland" "$PROBE_WHY"; return; }
+
+  local rt="${XDG_RUNTIME_DIR:-}"
+  [[ -n "$rt" && -d "$rt" ]] || { na "Wayland" "no XDG_RUNTIME_DIR for a compositor socket"; return; }
+
+  local wlbin="$S/bin/wlprobe" wlname="xlings-verify-wl"
+  local ffi; ffi="$(ls -d "$XLINGS_HOME"/data/xpkgs/*-x-libffi/*/ 2>/dev/null | head -1)"
+  local wl;  wl="$(ls -d "$XLINGS_HOME"/data/xpkgs/*-x-wayland/*/ 2>/dev/null | head -1)"
+  [[ -n "$wl" ]] || { na "Wayland" "no wayland package in the stack"; return; }
+
+  # -rpath-link for libffi: libwayland-client needs it INDIRECTLY, and without
+  # it the link fails on ffi_* symbols in a way that reads as a broken wayland
+  # package rather than a short link line.
+  if ! "$S/bin/gcc" -O1 -o "$wlbin" "$HERE/wlprobe.c" \
+        -I"$S/usr/include" -I"$wl/include" \
+        -L"$S/usr/lib" -L"$S/lib" -L"$wl/lib" \
+        -Wl,-rpath,"$S/usr/lib" -Wl,-rpath,"$S/lib" -Wl,-rpath,"$wl/lib" \
+        -Wl,-rpath-link,"$S/lib" -Wl,-rpath-link,"$S/usr/lib" \
+        ${ffi:+-Wl,-rpath-link,"$ffi/lib"} \
+        -lEGL -lGLESv2 -lwayland-client >"$S/wlprobe-build.log" 2>&1; then
+    bad "Wayland" "wlprobe failed to build (see $S/wlprobe-build.log)"; return
+  fi
+
+  "$comp" --headless --wayland --wayland-display="$wlname" --no-x11 \
+      >"$S/wl-compositor.log" 2>&1 &
+  local cpid=$!
+  local i=0
+  while [[ $i -lt 20 && ! -S "$rt/$wlname" ]]; do sleep 0.5; i=$((i+1)); done
+  if [[ ! -S "$rt/$wlname" ]]; then
+    kill $cpid 2>/dev/null
+    na "Wayland" "$(basename "$comp") did not create a socket (see $S/wl-compositor.log)"
+    return
+  fi
+
+  local out; out="$(WAYLAND_DISPLAY="$wlname" timeout 60 "$wlbin" 2>&1)"; local rc=$?
+  kill $cpid 2>/dev/null; wait $cpid 2>/dev/null
+
+  if [[ $rc -ne 0 ]] || ! grep -q "^RESULT=ok" <<<"$out"; then
+    bad "Wayland" "$(grep -m1 '^RESULT=' <<<"$out" || echo "probe exited $rc")"; return
+  fi
+  if ! grep -q "^PIXEL=336699$" <<<"$out"; then
+    bad "Wayland" "pixel readback $(sed -n 's/^PIXEL=//p' <<<"$out")"; return
+  fi
+  # The assertion that separates our stack from the host's: no mapped object may
+  # come from outside XLINGS_HOME.
+  local hostobjs; hostobjs="$(sed -n 's/^LOADED=//p' <<<"$out" | grep -cv "^$XLINGS_HOME" || true)"
+  if [[ "${hostobjs:-0}" -gt 0 ]]; then
+    bad "Wayland" "$hostobjs mapped object(s) came from the host, not our payload"; return
+  fi
+  ok "Wayland" "EGL on Wayland, $(sed -n 's/^LOADED=//p' <<<"$out" | wc -l) objects all ours"
+}
+wl_probe
 
 # ── a real application ──────────────────────────────────────────────────
 sect "5. a real GUI application, not a probe"

--- a/.agents/tools/graphics/wlprobe.c
+++ b/.agents/tools/graphics/wlprobe.c
@@ -1,0 +1,156 @@
+// wlprobe — does EGL-on-Wayland work, on OUR vendor library?
+//
+// The O4 cell of verify-stack.sh used to report `na` in both directions:
+//
+//     && na "Wayland" "WAYLAND_DISPLAY set but no Wayland probe exists yet (O4)"
+//     || na "Wayland" "WAYLAND_DISPLAY unset"
+//
+// so "we have a compositor and it works" and "we have no compositor" produced
+// the same non-answer. This is the missing half.
+//
+// WHAT IT PROVES, AND WHAT IT DOES NOT
+//
+// Proves: a real compositor is reachable; mesa's Wayland EGL platform
+// initialises against it (eglGetPlatformDisplay with EGL_PLATFORM_WAYLAND_KHR,
+// which is a different code path from the surfaceless platform glprobe uses);
+// a context on that display renders and the pixel reads back.
+//
+// Does NOT prove: window presentation, xdg-shell, damage tracking, or that a
+// toolkit can drive it. Committing an xdg-shell binding here would duplicate
+// section 5's job -- that section runs a real application (godot) precisely
+// because a probe cannot stand in for one. Kept deliberately small.
+//
+// LOADED is the assertion that matters, for the reason glprobe.c spells out:
+// "EGL initialised on Wayland" is printed just as happily by the HOST's mesa.
+// Only the path each object was mapped from separates "our payload drove this"
+// from "we measured the host".
+//
+// Prints one KEY=VALUE per line:
+//   WL_DISPLAY=<name>         the compositor socket actually connected to
+//   EGL_VENDOR / EGL_VERSION
+//   GL_RENDERER
+//   PIXEL=RRGGBB
+//   LOADED=<abs path>         one per GL/EGL/vendor object mapped
+//   RESULT=ok|fail:<why>
+#include <EGL/egl.h>
+#include <EGL/eglext.h>
+#include <GLES2/gl2.h>
+#include <wayland-client.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static void dump_loaded(void) {
+    FILE *f = fopen("/proc/self/maps", "r");
+    if (!f) { printf("LOADED=<maps unreadable>\n"); return; }
+    char line[4096], seen[64][512];
+    int n = 0;
+    while (fgets(line, sizeof line, f)) {
+        char *p = strchr(line, '/');
+        if (!p) continue;
+        p[strcspn(p, "\n")] = 0;
+        const char *base = strrchr(p, '/');
+        base = base ? base + 1 : p;
+        if (!(strstr(base, "_mesa.so") || strstr(base, "libgallium")
+              || strstr(base, "libEGL") || strstr(base, "libGLdispatch")
+              || strstr(base, "libGLESv2") || strstr(base, "libwayland-")))
+            continue;
+        int dup = 0;
+        for (int i = 0; i < n; i++) if (!strcmp(seen[i], p)) { dup = 1; break; }
+        if (dup || n >= 64) continue;
+        snprintf(seen[n], sizeof seen[n], "%s", p);
+        printf("LOADED=%s\n", seen[n]);
+        n++;
+    }
+    fclose(f);
+}
+
+#define FAIL(why) do { printf("RESULT=fail:%s\n", why); return 1; } while (0)
+
+int main(void) {
+    const char *want = getenv("WAYLAND_DISPLAY");
+    printf("WL_DISPLAY=%s\n", want ? want : "<unset>");
+
+    // NULL means "read WAYLAND_DISPLAY, else wayland-0". A failure here is the
+    // compositor's absence, not the stack's -- the caller maps it to exit 3.
+    struct wl_display *wl = wl_display_connect(NULL);
+    if (!wl) FAIL("wl_display_connect (no compositor)");
+
+    // The whole point of this probe: the WAYLAND platform, not surfaceless.
+    // eglGetPlatformDisplay is EGL 1.5; going through the EXT entry point as a
+    // fallback keeps this working on an older libEGL than the one we ship.
+    EGLDisplay dpy = EGL_NO_DISPLAY;
+    PFNEGLGETPLATFORMDISPLAYEXTPROC getPlatformDisplay =
+        (PFNEGLGETPLATFORMDISPLAYEXTPROC)
+        eglGetProcAddress("eglGetPlatformDisplayEXT");
+    if (getPlatformDisplay)
+        dpy = getPlatformDisplay(EGL_PLATFORM_WAYLAND_KHR, wl, NULL);
+    if (dpy == EGL_NO_DISPLAY)
+        FAIL("eglGetPlatformDisplay(EGL_PLATFORM_WAYLAND_KHR)");
+
+    EGLint major = 0, minor = 0;
+    if (!eglInitialize(dpy, &major, &minor)) FAIL("eglInitialize");
+    printf("EGL_VENDOR=%s\n", eglQueryString(dpy, EGL_VENDOR));
+    printf("EGL_VERSION=%s\n", eglQueryString(dpy, EGL_VERSION));
+
+    // Surfaceless context on a Wayland display. Rendering to an FBO rather than
+    // to a wl_surface is what keeps this probe small; see the header note on
+    // what that does and does not establish.
+    const char *exts = eglQueryString(dpy, EGL_EXTENSIONS);
+    if (!exts || !strstr(exts, "EGL_KHR_surfaceless_context"))
+        FAIL("no EGL_KHR_surfaceless_context on the Wayland display");
+
+    EGLint cfg_attrs[] = {
+        EGL_SURFACE_TYPE, EGL_WINDOW_BIT,
+        EGL_RENDERABLE_TYPE, EGL_OPENGL_ES2_BIT,
+        EGL_RED_SIZE, 8, EGL_GREEN_SIZE, 8, EGL_BLUE_SIZE, 8,
+        EGL_NONE
+    };
+    EGLConfig cfg; EGLint ncfg = 0;
+    if (!eglChooseConfig(dpy, cfg_attrs, &cfg, 1, &ncfg) || ncfg < 1)
+        FAIL("eglChooseConfig");
+    if (!eglBindAPI(EGL_OPENGL_ES_API)) FAIL("eglBindAPI");
+
+    EGLint ctx_attrs[] = { EGL_CONTEXT_CLIENT_VERSION, 2, EGL_NONE };
+    EGLContext ctx = eglCreateContext(dpy, cfg, EGL_NO_CONTEXT, ctx_attrs);
+    if (ctx == EGL_NO_CONTEXT) FAIL("eglCreateContext");
+    if (!eglMakeCurrent(dpy, EGL_NO_SURFACE, EGL_NO_SURFACE, ctx))
+        FAIL("eglMakeCurrent (surfaceless)");
+
+    printf("GL_RENDERER=%s\n", (const char *)glGetString(GL_RENDERER));
+
+    // Render, then read it back. eglInitialize succeeding and a renderer string
+    // printing are both things a half-working stack does; only the pixel proves
+    // something ran. 0x336699 matches glprobe so the harness asserts one value.
+    GLuint fbo = 0, tex = 0;
+    glGenFramebuffers(1, &fbo);
+    glBindFramebuffer(GL_FRAMEBUFFER, fbo);
+    glGenTextures(1, &tex);
+    glBindTexture(GL_TEXTURE_2D, tex);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 16, 16, 0, GL_RGBA,
+                 GL_UNSIGNED_BYTE, NULL);
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
+                           GL_TEXTURE_2D, tex, 0);
+    if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE)
+        FAIL("framebuffer incomplete");
+
+    glViewport(0, 0, 16, 16);
+    glClearColor(0x33 / 255.0f, 0x66 / 255.0f, 0x99 / 255.0f, 1.0f);
+    glClear(GL_COLOR_BUFFER_BIT);
+    glFinish();
+
+    unsigned char px[4] = { 0, 0, 0, 0 };
+    glReadPixels(8, 8, 1, 1, GL_RGBA, GL_UNSIGNED_BYTE, px);
+    printf("PIXEL=%02X%02X%02X\n", px[0], px[1], px[2]);
+
+    dump_loaded();
+
+    if (px[0] != 0x33 || px[1] != 0x66 || px[2] != 0x99)
+        FAIL("pixel readback mismatch");
+
+    eglMakeCurrent(dpy, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
+    eglTerminate(dpy);
+    wl_display_disconnect(wl);
+    printf("RESULT=ok\n");
+    return 0;
+}


### PR DESCRIPTION
The O4 cell reported `na` **in both directions** — "compositor present and it works" and "no compositor at all" produced the same non-answer.

That kept the Wayland question open long enough for me to misclassify it **three times in one day**: unwritten probe → hardware → mesa build option → back to unwritten probe. It was always the probe.

```
✓ Wayland    EGL on Wayland, 7 objects all ours
pass 15   fail 0   not-exercised-here 4
```

## What the probe does

`eglGetPlatformDisplay(EGL_PLATFORM_WAYLAND_KHR)` — a different code path from the surfaceless platform `glprobe` uses — then renders to an FBO and reads the pixel back, because `eglInitialize` succeeding and a renderer string printing are both things a half-working stack does.

**`LOADED=` is the load-bearing assertion**, for the reason `glprobe.c` already gives: "EGL initialised on Wayland" is printed just as happily by the *host's* mesa. The cell fails if any mapped object came from outside `XLINGS_HOME`. Here all seven are ours — `libEGL_mesa`, `libgallium`, libglvnd's three, and wayland's client + server.

The harness starts the compositor itself (headless, killed after) rather than requiring a Wayland session — otherwise this cell stays `na` on every X11 machine, which is most of them.

## Two notes for the next reader

`GL_RENDERER` is **llvmpipe here by nature** — a headless compositor gives the client no DRM master, so mesa falls back from the dri2 screen. Not what the cell asserts; must not be "fixed".

The link needs `-Wl,-rpath-link` for libffi: `libwayland-client` needs it *indirectly*, and without it the link dies on `ffi_*` symbols in a way that reads as a broken wayland package. `wayland.lua` declares `xim:libffi` correctly — the omission was mine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
