### PR TITLE
feat(graphics): the build-time inputs mesa actually needs, and the gcc bug that hid one

### DIFF
--- a/.agents/tools/graphics/build-directx-headers.sh
+++ b/.agents/tools/graphics/build-directx-headers.sh
@@ -1,0 +1,227 @@
+#!/usr/bin/env bash
+# Build `directx-headers` — the BUILD-TIME input mesa's d3d12 gallium driver needs.
+#
+# Design: xlings/.agents/docs/2026-08-08-mesa-rebuild-iris-d3d12-wayland-design.md §4
+#
+# WHY THIS IS A PACKAGE AND NOT A SUBPROJECT
+#
+# mesa asks for it by pkg-config, twice, and falls back to a wrap:
+#
+#   meson.build:604  dependency('directx-headers', required : false)
+#   meson.build:606  dependency('DirectX-Headers', version : '>= 1.614.1',
+#                               fallback : ['DirectX-Headers', 'dep_dxheaders'],
+#                               required : with_gallium_d3d12 or with_microsoft_vk)
+#
+# Letting the wrap fire would have mesa download it mid-build, which is exactly
+# the host-input class G2 exists to refuse: an input nobody named, nobody
+# versioned, and nobody can reproduce. 1.614.1 is chosen because it is the
+# lowest version that satisfies mesa's own floor -- there is no reason to be
+# ahead of what the consumer asks for.
+#
+# WHY NOT meson
+#
+# There is no `meson` package in this index at all (`xlings install meson` ->
+# "package 'meson' not found"), and adding a Python build system to the
+# ecosystem to compile TWO translation units would be the tail wagging the dog.
+# Upstream's meson.build does exactly three things on Linux:
+#
+#   static_library('d3dx12-format-properties', 'src/d3dx12_property_format_table.cpp')
+#   static_library('DirectX-Guids',            'src/dxguids.cpp')
+#   pkg.generate(...)  +  install_subdir('include')
+#
+# so this script does those three things directly with g++ and ar. That is not a
+# shortcut around the build system, it is the whole build system.
+#
+# WHY gcc 15.1.0 AND NOT 16
+#
+# These are STATIC archives; they get linked INTO libgallium. So their libstdc++
+# ABI becomes mesa's, and mesa's runtime dep is `gcc-runtime@>=15` (15.1.0).
+# Building these with 16 would raise libgallium's GLIBCXX floor above what that
+# dep can satisfy -- a load-time failure, not a build one. Measured: the shipped
+# libgallium-25.0.7.so needs at most GLIBCXX_3.4.29.
+#
+# This requires the #560 fix (frozen include-fixed/pthread.h pruned in
+# pkgs/g/gcc.lua) to be in the installed gcc payload; without it no C++ TU that
+# reaches <ext/concurrence.h> compiles under 15.1.0. Asserted below rather than
+# assumed, because the failure names libstdc++ and not gcc.
+#
+# Exit codes follow .agents/tools/README.md:
+#   0 built and packaged · 1 the build broke · 3 it never started
+set -uo pipefail
+
+VERSION="${1:-1.614.1}"
+SUBOS_NAME="${XLINGS_GFX_SUBOS:-gfxbuild}"
+XHOME="${XLINGS_HOME:-$HOME/.xlings}"
+SUBOS="$XHOME/subos/$SUBOS_NAME"
+WORK="${XLINGS_GFX_WORK:-${TMPDIR:-/tmp}/xlings-gfx}"
+
+log()  { echo "[directx-headers] $*"; }
+fail() { echo "[directx-headers] FAIL: $*" >&2; exit 1; }
+skip() { echo "[directx-headers] SKIP: $*" >&2; exit 3; }
+
+[[ -d "$SUBOS" ]] || skip "subos '$SUBOS_NAME' not found — xlings subos new $SUBOS_NAME"
+mkdir -p "$WORK/src" "$WORK/dist"
+
+# Through the shim, not the payload's bin/: only the shim carries the elfpatch'd
+# interpreter and the sysroot flags. Same rule as build-llvm-dev.sh.
+CXX="$SUBOS/bin/g++"
+[[ -x "$CXX" ]] || skip "no g++ in subos '$SUBOS_NAME'"
+AR="$SUBOS/bin/ar"; [[ -x "$AR" ]] || AR="$(command -v ar)"
+[[ -x "$AR" ]] || skip "no ar available"
+
+cc_ver="$("$CXX" -dumpfullversion 2>/dev/null || echo unknown)"
+case "$cc_ver" in
+  15.*) log "compiler g++ $cc_ver" ;;
+  *)    skip "subos g++ is $cc_ver; these archives link into libgallium and must match its gcc-runtime@>=15 floor — run \`xlings use gcc 15.1.0\`" ;;
+esac
+
+# The #560 precondition, checked on the compiler rather than on the filesystem.
+#
+# Asserting "include-fixed/pthread.h is absent" would be checking the fix's
+# mechanism; this checks its EFFECT, so it stays true if the fix ever moves.
+probe="$WORK/src/.dxh-cxx-probe.cpp"
+printf '#include <ext/concurrence.h>\nint main(){return 0;}\n' > "$probe"
+"$CXX" -std=c++14 -c "$probe" -o /dev/null 2>"$WORK/src/.dxh-cxx-probe.log" || {
+    echo "---- compiler probe output ----" >&2; cat "$WORK/src/.dxh-cxx-probe.log" >&2
+    fail "g++ $cc_ver cannot compile <ext/concurrence.h>: the gcc payload still ships a frozen fixincludes header (openxlings/xim-pkgindex#560). Reinstall gcc with the pkgs/g/gcc.lua fix, or prune lib/gcc/*/*/include-fixed/pthread.h."
+}
+rm -f "$probe" "$WORK/src/.dxh-cxx-probe.log"
+
+SRC="$WORK/src/DirectX-Headers-$VERSION"
+TARBALL="$WORK/src/directx-headers-$VERSION.tar.gz"
+if [[ ! -d "$SRC" ]]; then
+    [[ -f "$TARBALL" ]] || {
+        log "fetching DirectX-Headers $VERSION"
+        curl -fsSL --retry 3 -o "$TARBALL" \
+          "https://github.com/microsoft/DirectX-Headers/archive/refs/tags/v$VERSION.tar.gz" \
+          || fail "download failed"
+    }
+    log "extracting"
+    tar -C "$WORK/src" -xzf "$TARBALL" || fail "extract failed"
+fi
+[[ -f "$SRC/src/dxguids.cpp" ]] || fail "source tree at $SRC has no src/dxguids.cpp"
+
+PREFIX="$WORK/dist/directx-headers-$VERSION"
+rm -rf "$PREFIX"; mkdir -p "$PREFIX/lib" "$PREFIX/share/pkgconfig"
+
+# Include flags transcribed from upstream meson.build, not guessed.
+#
+#   inc_dirs = include_directories('include', is_system : true)
+#   non-windows: += include_directories('include/wsl/stubs', is_system : true)
+#   format_properties_lib also gets 'include/directx'
+#
+# is_system is -isystem, which matters: these headers are not warning-clean and
+# the archives are built into a project that uses -Werror in places.
+INC=(-isystem "$SRC/include" -isystem "$SRC/include/wsl/stubs")
+
+log "compiling 2 translation units (c++14)"
+# -H so the header trail can be audited for host leakage below. This IS the G2
+# input check for this package -- there is no build system to hook it into.
+"$CXX" -std=c++14 -fPIC -O2 "${INC[@]}" -I"$SRC/include/directx" \
+    -H -c "$SRC/src/d3dx12_property_format_table.cpp" \
+    -o "$WORK/src/d3dx12_property_format_table.o" 2>"$WORK/src/dxh-fmt.hdrs" \
+    || { tail -20 "$WORK/src/dxh-fmt.hdrs" >&2; fail "compiling d3dx12_property_format_table.cpp"; }
+
+"$CXX" -std=c++14 -fPIC -O2 "${INC[@]}" \
+    -H -c "$SRC/src/dxguids.cpp" -o "$WORK/src/dxguids.o" 2>"$WORK/src/dxh-guids.hdrs" \
+    || { tail -20 "$WORK/src/dxh-guids.hdrs" >&2; fail "compiling dxguids.cpp"; }
+
+# G2: every header consumed must come from our own tree or the source tarball.
+#
+# `-H` prints one line per header as `.... /path`. A header from /usr/include
+# means the sysroot did not cover something and the host silently filled in --
+# which is how a payload ends up depending on the build machine.
+leaked=$(sed -n 's/^\.*[[:space:]]*\(\/.*\)$/\1/p' "$WORK/src/dxh-fmt.hdrs" "$WORK/src/dxh-guids.hdrs" \
+         | sort -u | grep -v -e "^$XHOME/" -e "^$SRC/" || true)
+if [[ -n "$leaked" ]]; then
+    echo "$leaked" | sed 's/^/  /' >&2
+    fail "$(echo "$leaked" | wc -l) header(s) came from outside XLINGS_HOME and the source tree"
+fi
+log "header audit: all includes from XLINGS_HOME or the source tree"
+
+# Archive names must be exactly what the .pc advertises, and the .pc must
+# advertise what upstream's pkg.generate() would have: meson derives -l flags
+# from the static_library() TARGET names, so `d3dx12-format-properties` and
+# `DirectX-Guids`, not the file names.
+"$AR" rcs "$PREFIX/lib/libd3dx12-format-properties.a" "$WORK/src/d3dx12_property_format_table.o" \
+    || fail "ar libd3dx12-format-properties.a"
+"$AR" rcs "$PREFIX/lib/libDirectX-Guids.a" "$WORK/src/dxguids.o" || fail "ar libDirectX-Guids.a"
+
+log "installing headers"
+cp -r "$SRC/include" "$PREFIX/include" || fail "copying include tree"
+cp "$SRC/LICENSE" "$PREFIX/LICENSE" 2>/dev/null || true
+
+# Relocatable by construction, via ${pcfiledir}.
+#
+# pkg-config expands ${pcfiledir} to the directory the .pc was FOUND in, so a
+# prefix expressed relative to it needs no install-time rewriting at all. This
+# is why this package has no __relocate_pc() the way llvm-dev does -- libclc.pc
+# comes from someone else's build and hardcodes absolute paths; this one is ours
+# to write, so the right fix is to never write an absolute path.
+#
+# subdirs on non-windows is ['', '', 'wsl/stubs', 'directx'] upstream, i.e. three
+# distinct -I roots. wsl/stubs supplies the Windows types (GUID, HRESULT) that
+# d3d12.h needs on Linux; omitting it makes d3d12.h fail deep inside mesa.
+cat > "$PREFIX/share/pkgconfig/DirectX-Headers.pc" <<'PC'
+prefix=${pcfiledir}/../..
+libdir=${prefix}/lib
+includedir=${prefix}/include
+
+Name: DirectX-Headers
+Description: Headers for using D3D12
+URL: https://github.com/microsoft/DirectX-Headers
+Version: @VERSION@
+Cflags: -I${includedir} -I${includedir}/wsl/stubs -I${includedir}/directx
+Libs: -L${libdir} -ld3dx12-format-properties -lDirectX-Guids
+PC
+sed -i "s/@VERSION@/$VERSION/" "$PREFIX/share/pkgconfig/DirectX-Headers.pc"
+
+# Both spellings mesa tries. mesa asks for `directx-headers` first and
+# `DirectX-Headers` second; upstream only ever generates the second, so the
+# first lookup always misses and the fallback carries it. Shipping a symlink for
+# the lowercase name makes the FIRST lookup succeed, which is what keeps mesa
+# from evaluating the `fallback:` wrap at all -- and the wrap is the thing that
+# would reach the network mid-build.
+ln -sf DirectX-Headers.pc "$PREFIX/share/pkgconfig/directx-headers.pc"
+
+# Assertions, each naming the mesa line it protects.
+for f in lib/libd3dx12-format-properties.a lib/libDirectX-Guids.a \
+         share/pkgconfig/DirectX-Headers.pc include/directx/d3d12.h \
+         include/wsl/winadapter.h include/wsl/stubs/unknwn.h; do
+    [[ -e "$PREFIX/$f" ]] || fail "payload is missing $f"
+done
+for a in libd3dx12-format-properties libDirectX-Guids; do
+    "$AR" t "$PREFIX/lib/$a.a" | grep -q . || fail "$a.a is an empty archive"
+done
+
+# Prove it resolves the way mesa will ask, if pkg-config is around to ask with.
+if command -v pkg-config >/dev/null 2>&1; then
+    for name in DirectX-Headers directx-headers; do
+        v=$(PKG_CONFIG_PATH="$PREFIX/share/pkgconfig" pkg-config --modversion "$name" 2>/dev/null || true)
+        [[ "$v" == "$VERSION" ]] || fail "pkg-config --modversion $name gave '$v', expected $VERSION (mesa:604/606)"
+    done
+    PKG_CONFIG_PATH="$PREFIX/share/pkgconfig" pkg-config --atleast-version=1.614.1 DirectX-Headers \
+        || fail "does not satisfy mesa's version : '>= 1.614.1' (meson.build:607)"
+    # Resolved, not string-matched. ${pcfiledir} expands to the .pc's own
+    # directory, so the include path comes out as
+    # `<root>/share/pkgconfig/../../include` -- correct, and not literally equal
+    # to `<root>/include`. Comparing the strings fails on a working payload,
+    # which it did on the first run of this script. The invariant that actually
+    # matters is where the path LANDS.
+    first_inc=$(PKG_CONFIG_PATH="$PREFIX/share/pkgconfig" pkg-config --cflags-only-I DirectX-Headers \
+                | tr ' ' '\n' | sed -n 's/^-I//p' | head -1)
+    [[ -n "$first_inc" && -d "$first_inc" ]] \
+        || fail "\${pcfiledir} did not expand to a real directory: '$first_inc'"
+    [[ "$(cd "$first_inc" && pwd -P)" == "$(cd "$PREFIX/include" && pwd -P)" ]] \
+        || fail "\${pcfiledir} resolved to $(cd "$first_inc" && pwd -P), not $PREFIX/include"
+    log "pkg-config: --cflags resolves into the payload, --modversion $VERSION, both spellings"
+else
+    log "note: no pkg-config here, so the resolution check was skipped (exit stays 0; the recipe asserts the files)"
+fi
+
+TAR="$WORK/dist/directx-headers-$VERSION-linux-x86_64.tar.gz"
+rm -f "$TAR"
+tar -C "$WORK/dist" -czf "$TAR" "directx-headers-$VERSION" || fail "packaging"
+log "packaged $TAR"
+log "sha256 $(sha256sum "$TAR" | awk '{print $1}')"
+log "size   $(du -h "$TAR" | awk '{print $1}')"

--- a/.agents/tools/graphics/build-in-subos.sh
+++ b/.agents/tools/graphics/build-in-subos.sh
@@ -467,6 +467,40 @@ export CPPFLAGS="-I$SUBOS/usr/include"
 # libpciaccess) is only searched along -rpath-link. Without it the link fails
 # on transitive symbols with the library sitting right there.
 export LDFLAGS="-L$SUBOS/lib -L$SUBOS/usr/lib -Wl,-rpath-link,$SUBOS/usr/lib -Wl,-rpath-link,$SUBOS/lib -Wl,-rpath,\$ORIGIN"
+
+# Libraries that must WIN over the subos farm, by SONAME.
+#
+# XLINGS_GFX_LDFLAGS_FIRST is prepended, so its -Wl,-rpath entries precede every
+# subos path in the resulting RPATH. RPATH is first-wins, and that ordering is the
+# whole point of this hook.
+#
+# The case that forced it: TWO payloads ship `libLLVM.so.20.1` with the same
+# SONAME and different contents.
+#
+#   libllvm 20.1.7    X86;AMDGPU          LLVMInitializeSPIRVTarget: 0 symbols
+#   llvm-dev 20.1.7.1 X86;AMDGPU;SPIRV    LLVMInitializeSPIRVTarget: 3 symbols
+#
+# mesa links `mesa_clc` against llvm-dev (llvm-config's libdir) but the subos farm
+# carries libllvm's copy, and it came FIRST in the RPATH. So mesa_clc linked
+# against one library and loaded the other:
+#
+#   ldd mesa_clc -> libLLVM.so.20.1 => <subos>/lib/libLLVM.so.20.1
+#   mesa_clc: symbol lookup error: undefined symbol: LLVMInitializeSPIRVTarget,
+#             version LLVM_20.1
+#
+# 1348 targets in, with an error naming a symbol rather than a library, and
+# nothing in the link step warned -- both files satisfy the same SONAME, so the
+# linker had no reason to object. Same shape as the runtime `one question, many
+# answerers` cases: two things answer, and only order decides.
+#
+# Deliberately not fixed by putting SPIRV into libllvm. That library is what every
+# user loads; SPIRV is needed only by a build tool, and widening the runtime
+# payload to serve the build would be paying every install for it.
+if [[ -n "${XLINGS_GFX_LDFLAGS_FIRST:-}" ]]; then
+    LDFLAGS="$XLINGS_GFX_LDFLAGS_FIRST $LDFLAGS"
+    export LDFLAGS
+    log "ldflags (first): $XLINGS_GFX_LDFLAGS_FIRST"
+fi
 export CC="$SUBOS/bin/gcc"
 export CXX="$SUBOS/bin/g++"
 [[ -x "$CC" ]] || skip "no gcc in the subos — xlings install gcc"

--- a/.agents/tools/graphics/build-in-subos.sh
+++ b/.agents/tools/graphics/build-in-subos.sh
@@ -76,6 +76,16 @@ done
     exit 2
 }
 
+# This script's own directory, for `patches/` below.
+#
+# Resolved from BASH_SOURCE rather than $0 so it is correct when the script is
+# sourced or invoked through a symlink. Worth stating because the first version of
+# the patch hook referenced an undefined $HERE, which expanded to `/patches` --
+# a directory that does not exist, so the glob matched nothing, no patch applied,
+# and the build failed with the exact error the patch removes. A missing patch is
+# invisible; that is why this line is here and not inlined.
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 SUBOS_NAME="${XLINGS_GFX_SUBOS:-gfxbuild}"
 XHOME="${XLINGS_HOME:-$HOME/.xlings}"
 SUBOS="$XHOME/subos/$SUBOS_NAME"
@@ -384,6 +394,42 @@ TARBALL="$SRC/${NAME}-${VERSION}-$(basename "$URL")"
 BUILDDIR="$SRC/$NAME-$VERSION"
 rm -rf "$BUILDDIR"; mkdir -p "$BUILDDIR"
 tar xf "$TARBALL" -C "$BUILDDIR" --strip-components=1 || fail "extract failed"
+
+# ── patches, by convention ──────────────────────────────────────────────
+#
+# `patches/<name>-<version>-*.patch` next to this script, applied in sorted
+# order with `patch -p1`. Nothing to declare at the call site: a patch exists
+# for a (package, version) pair or it does not.
+#
+# Needed because upstream releases go stale against a MOVING sysroot. mesa
+# 25.0.7 is the last of its series and cannot compile against glibc 2.44: ISO
+# C23 moved once_flag/call_once into <stdlib.h>, glibc >= 2.42 followed, and
+# mesa's own src/c11 shim redefines both --
+#
+#   error: conflicting types for 'once_flag'; have 'pthread_once_t' {aka 'int'}
+#
+# The shipped mesa 25.0.7.1 was built when this sysroot was glibc 2.39, so the
+# same source and the same command now fail where they once worked. That is a
+# recurring shape here, not a one-off, and it deserves a mechanism rather than a
+# hand-edit somebody has to remember.
+#
+# Applied with --forward and treated as fatal on failure. A patch that no longer
+# applies means the source moved under it, and continuing would build something
+# nobody described -- the silent-success shape this tree keeps finding.
+PATCHDIR="$HERE/patches"
+if [[ -d "$PATCHDIR" ]]; then
+    shopt -s nullglob
+    patches=("$PATCHDIR/$NAME-$VERSION"-*.patch)
+    shopt -u nullglob
+    if [[ ${#patches[@]} -gt 0 ]]; then
+        command -v patch >/dev/null || fail "${#patches[@]} patch(es) apply to $NAME $VERSION but \`patch\` is not available"
+        for p in "${patches[@]}"; do
+            log "patch: $(basename "$p")"
+            ( cd "$BUILDDIR" && patch -p1 --forward --silent < "$p" ) \
+                || fail "applying $(basename "$p") -- the source moved under it; re-generate the patch rather than skipping it"
+        done
+    fi
+fi
 
 # ── the subos as the build environment ──────────────────────────────────
 # PKG_CONFIG_PATH and the include/lib paths point ONLY at the subos, so a

--- a/.agents/tools/graphics/build-in-subos.sh
+++ b/.agents/tools/graphics/build-in-subos.sh
@@ -502,6 +502,31 @@ for dep in $DEPS; do
         skip "--deps $dep: not installed in $XHOME (xlings install $dep)"
     fi
     log "  dep $dep -> ${depdir#"$XHOME"/data/xpkgs/}"
+
+    # A dep's bin/ goes on PATH, because some deps are BUILD TOOLS.
+    #
+    # mesa wants `glslangValidator` (meson.build:648) to compile its Vulkan
+    # drivers' built-in shaders. The glslang payload ships bin/glslangValidator,
+    # bin/glslang and bin/spirv-remap -- but its recipe registers only a release
+    # anchor, so the single shim in the subos is `glslang` and the name mesa
+    # actually asks for is unreachable. Configure then dies with
+    #
+    #   ERROR: Program 'glslangValidator' not found or not executable
+    #
+    # while the tool sits in an installed payload.
+    #
+    # Fixed here rather than in glslang.lua on purpose. Registering the two extra
+    # names as `programs` would put user-facing shims on them and change shim
+    # OWNERSHIP -- a semantics change, audited by the orphan-shim check -- to
+    # solve what is purely a build-time lookup. Deps of a build are exactly the
+    # things whose tools that build may invoke, so PATH is where this belongs,
+    # and it now works for any future dep that ships one.
+    #
+    # Prepended, so a dep's tool beats a host one of the same name.
+    if [[ -d "${depdir%/}/bin" ]]; then
+        PATH="${depdir%/}/bin:$PATH"
+        export PATH
+    fi
     # BOTH pkgconfig locations, and the second one is not a nicety.
     #
     # `lib/pkgconfig` is where a library puts its .pc. A PROTOCOL-ONLY package
@@ -599,7 +624,174 @@ for dep in $DEPS; do
         LDFLAGS="$LDFLAGS -L$deplib -Wl,-rpath-link,$deplib -Wl,-rpath,$deplib"
     fi
 done
+# Build-only packages, which the --deps path deliberately cannot reach.
+#
+# `--deps` resolves a name to a payload and rewrites its .pc files, but it only
+# looks at packages the SUBOS SYSROOT links, and a `status = "dev"` package is
+# precisely one that does not link itself into the sysroot -- llvm-dev exports no
+# programs, no sysroot headers and no libdirs a consumer would ever see. So
+# mesa's `dependency('libclc')` cannot be satisfied through --deps without making
+# llvm-dev pretend to be a runtime package, which would defeat the reason it is
+# a separate package at all.
+#
+# Hence an explicit hook. It takes payload-absolute pkgconfig directories:
+#
+#   XLINGS_GFX_PKGCONFIG_EXTRA=/path/llvm-dev/share/pkgconfig:/path/dxh/share/pkgconfig
+#
+# These are still OUR artifacts -- a published package payload or this tree's own
+# build output -- so the host-leakage audit downstream stays meaningful. It is
+# appended AFTER the subos entries so it can add names, never shadow one.
+if [[ -n "${XLINGS_GFX_PKGCONFIG_EXTRA:-}" ]]; then
+    IFS=':' read -r -a __extra_pc <<< "$XLINGS_GFX_PKGCONFIG_EXTRA"
+    for d in "${__extra_pc[@]}"; do
+        [[ -n "$d" ]] || continue
+        [[ -d "$d" ]] || fail "XLINGS_GFX_PKGCONFIG_EXTRA names '$d', which is not a directory"
+        # Refuse a host path outright. The whole point of this hook is to add
+        # our own build-only inputs; letting it name /usr/lib/pkgconfig would
+        # turn it into the exact hole the audit is here to close.
+        case "$d" in
+            "$XHOME"/*|"$WORK"/*) ;;
+            *) fail "XLINGS_GFX_PKGCONFIG_EXTRA may only name paths under XLINGS_HOME ($XHOME) or the work dir ($WORK); got '$d'" ;;
+        esac
+        PKG_CONFIG_LIBDIR="$PKG_CONFIG_LIBDIR:$d"
+        log "extra pkgconfig: $d ($(ls "$d"/*.pc 2>/dev/null | xargs -r -n1 basename | tr '\n' ' '))"
+    done
+fi
+
 export PKG_CONFIG_LIBDIR PKG_CONFIG_PATH="$PKG_CONFIG_LIBDIR" CPPFLAGS LDFLAGS
+
+# Resolve a meson to drive the build with.
+#
+# There is NO `meson` package in this index -- `xlings install meson` answers
+# "package 'meson' not found". This line used to read `"$SUBOS/bin/meson"`
+# unconditionally, which means every meson build here (mesa included) has in fact
+# been driven by whatever meson the developer's host happened to have on PATH,
+# usually a `pip --user` install. That is a build input nobody named or pinned,
+# and it is the same class of thing the host-leakage audit below exists to catch
+# -- the audit just never looked at the DRIVER, only at what the driver found.
+#
+# Order of preference:
+#   1. `$SUBOS/bin/meson` — if meson ever becomes a package, it wins with no
+#      further change here.
+#   2. a pinned meson fetched into the work directory and run under the SUBOS's
+#      python. Reproducible and version-stated, which host meson is not.
+#
+# A vendored copy rather than a new package because meson contributes no code and
+# no linkage to the payload: it reads meson.build and writes build.ninja. ninja
+# and the compiler, which do touch the output, are already packages. Packaging
+# meson is still worth doing (openxlings/xim-pkgindex#562) -- this makes the
+# build honest in the meantime instead of silently depending on the host.
+MESON_PIN="${MESON_PIN:-1.8.2}"
+__resolve_meson() {
+    if [[ -x "$SUBOS/bin/meson" ]]; then
+        MESON=("$SUBOS/bin/meson")
+        log "meson: $("$SUBOS/bin/meson" --version 2>/dev/null || echo '?') (packaged)"
+        return
+    fi
+
+    local py=""
+    for c in "$SUBOS/bin/python3" "$SUBOS/bin/python"; do
+        [[ -x "$c" ]] && { py="$c"; break; }
+    done
+    [[ -n "$py" ]] || skip "no meson and no python in subos '$SUBOS_NAME'; a meson build needs one of them (install python, or see #562)"
+
+    local root="$WORK/tools/meson-$MESON_PIN"
+    if [[ ! -f "$root/meson.py" ]]; then
+        mkdir -p "$WORK/tools"
+        local tb="$WORK/tools/meson-$MESON_PIN.tar.gz"
+        [[ -f "$tb" ]] || curl -fsSL --retry 3 -o "$tb" \
+            "https://github.com/mesonbuild/meson/releases/download/$MESON_PIN/meson-$MESON_PIN.tar.gz" \
+            || fail "fetching pinned meson $MESON_PIN"
+        tar -C "$WORK/tools" -xzf "$tb" || fail "extracting meson $MESON_PIN"
+    fi
+    [[ -f "$root/meson.py" ]] || fail "meson $MESON_PIN tarball has no meson.py"
+
+    MESON=("$py" "$root/meson.py")
+    log "meson: $MESON_PIN vendored, driven by $("$py" --version 2>&1 | head -1)"
+
+    __vendor_python_modules "$py"
+}
+
+# Python modules a meson build needs at CODEGEN time.
+#
+# mesa generates a large amount of C from Mako templates, so its meson probes
+# `import mako` and refuses to configure without it. Our python payload is a bare
+# interpreter -- no mako -- so this is the same gap as meson itself (#562) and
+# gets the same answer: pinned, fetched, under OUR interpreter, on PYTHONPATH
+# rather than installed into the payload.
+#
+# Not installed into site-packages on purpose. The python payload is shared
+# between subos and is content-addressed by the index; mutating it would make an
+# installed package differ from its published bytes, and every self-containment
+# check that hashes a payload would start disagreeing with the recipe.
+#
+# `--target` into the work dir keeps it per-build and disposable. mako pulls
+# MarkupSafe, whose C extension gets compiled by our own gcc against our own
+# python -- in-tree, and it falls back to pure Python if that fails.
+# `packaging` is not optional here, and the reason is a dead fallback.
+#
+# mesa's probe (meson.build:943) is:
+#
+#   try:    from packaging.version import Version
+#   except: from distutils.version import StrictVersion as Version
+#   import mako
+#   assert Version(mako.__version__) >= Version("0.8.0")
+#
+# distutils was REMOVED in Python 3.12, and our payload is 3.13.12 -- so on this
+# interpreter the `except` branch raises too, and the whole snippet exits
+# non-zero even when mako is perfectly importable. mesa then reports
+#
+#   Python (3.x) mako module >= 0.8.0 required to build mesa
+#
+# which names the one module that is NOT the problem. Vendoring mako alone
+# reproduces exactly that: measured 2026-08-08, `import mako` succeeded and
+# printed 1.3.10 while mesa's configure still failed on the same line.
+# Enumerated from the consumer, not discovered one build at a time.
+#
+# mesa has exactly two python module gates -- `grep -n 'required to build mesa'`
+# gives meson.build:954 (mako) and :963 (yaml) and nothing else. Finding them by
+# rebuilding until it stops complaining costs one full configure per module and
+# stops at the first one that happens to be satisfied on the machine you tried.
+MAKO_PIN="${MAKO_PIN:-1.3.10}"
+PACKAGING_PIN="${PACKAGING_PIN:-25.0}"
+PYYAML_PIN="${PYYAML_PIN:-6.0.2}"
+__vendor_python_modules() {
+    local py="$1"
+    local vendor="$WORK/tools/pyvendor"
+
+    # mesa's OWN predicates, verbatim, as the probe -- not `import mako`.
+    #
+    # Checking the mechanism instead of the effect is what hid the `packaging`
+    # problem for a whole build cycle: `import mako` printed 1.3.10 and the
+    # consumer still refused, because mesa's snippet needs packaging too.
+    local probe='
+try:
+  from packaging.version import Version
+except:
+  from distutils.version import StrictVersion as Version
+import mako
+assert Version(mako.__version__) >= Version("0.8.0")
+import yaml
+'
+    if "$py" -c "$probe" 2>/dev/null; then
+        log "python: mesa's module predicates already satisfied"
+        return
+    fi
+
+    if [[ ! -d "$vendor/mako" || ! -d "$vendor/packaging" || ! -d "$vendor/yaml" ]]; then
+        log "python: vendoring mako $MAKO_PIN + packaging $PACKAGING_PIN + PyYAML $PYYAML_PIN into $vendor"
+        "$py" -m pip install --quiet --disable-pip-version-check \
+              --target "$vendor" "Mako==$MAKO_PIN" "packaging==$PACKAGING_PIN" "PyYAML==$PYYAML_PIN" \
+              >"$WORK/pyvendor.log" 2>&1 \
+            || { tail -20 "$WORK/pyvendor.log" >&2; fail "vendoring python modules (see $WORK/pyvendor.log)"; }
+    fi
+    export PYTHONPATH="${vendor}${PYTHONPATH:+:$PYTHONPATH}"
+
+    "$py" -c "$probe" || fail "mesa's python module predicates still fail after vendoring; PYTHONPATH=$PYTHONPATH"
+    log "python: mako $("$py" -c 'import mako;print(mako.__version__)')," \
+        "packaging $("$py" -c 'import packaging;print(packaging.__version__)')," \
+        "yaml $("$py" -c 'import yaml;print(yaml.__version__)')"
+}
 
 if [[ "$SYSTEM" == auto ]]; then
     if   [[ -f "$BUILDDIR/meson.build" ]]; then SYSTEM=meson
@@ -625,12 +817,13 @@ case "$SYSTEM" in
         || { tail -30 "$WORK/$NAME-build.log"; fail "make install"; }
     ;;
   meson)
-    "$SUBOS/bin/meson" setup _b --prefix="$PREFIX" --libdir=lib \
+    __resolve_meson
+    "${MESON[@]}" setup _b --prefix="$PREFIX" --libdir=lib \
         --buildtype=release -Ddefault_library=shared "${EXTRA[@]}" > "$WORK/$NAME-configure.log" 2>&1 \
         || { tail -30 "$WORK/$NAME-configure.log"; fail "meson setup"; }
     "${BUILD_ENV[@]}" "$SUBOS/bin/ninja" -C _b > "$WORK/$NAME-build.log" 2>&1 \
         || { tail -30 "$WORK/$NAME-build.log"; fail "ninja"; }
-    DESTDIR="$STAGE" "$SUBOS/bin/meson" install -C _b >> "$WORK/$NAME-build.log" 2>&1 \
+    DESTDIR="$STAGE" "${MESON[@]}" install -C _b >> "$WORK/$NAME-build.log" 2>&1 \
         || { tail -30 "$WORK/$NAME-build.log"; fail "meson install"; }
     ;;
   cmake)

--- a/.agents/tools/graphics/build-llvm-dev.sh
+++ b/.agents/tools/graphics/build-llvm-dev.sh
@@ -40,18 +40,63 @@
 # which means they have to be built reproducibly and named. `status = "dev"`
 # keeps it out of a user's way without making it unreproducible.
 #
-# TARGETS
+# TARGETS — X86;AMDGPU;SPIRV
 #
-# X86 for the host tool, plus SPIRV because libclc compiles its bitcode with
-# `clang -target spirv64-unknown-unknown`. AMDGPU is deliberately NOT here:
-# that is libllvm's axis (radeonsi's runtime shader compiler), and building it
-# twice would double an already long build for nothing.
+# X86 for the host tool. SPIRV because libclc compiles its bitcode with
+# `clang -target spirv64-unknown-unknown`.
+#
+# AMDGPU was excluded in 20.1.7 with this reasoning: "that is libllvm's axis
+# (radeonsi's runtime shader compiler), and building it twice would double an
+# already long build for nothing." **That was wrong**, and measuring the mesa
+# build is what showed it:
+#
+#   $ ls <libllvm payload>/            ->  lib
+#
+# The libllvm payload is a lib/ directory and nothing else -- no headers, no
+# lib/cmake/llvm/LLVMConfig.cmake, no bin/llvm-config. meson has exactly two ways
+# to find LLVM (a config tool, or cmake package files) and libllvm offers
+# neither, so libllvm can never be a BUILD input. It is a pure runtime artifact.
+#
+# Which means the two axes are not "runtime" and "build-time tools" -- they are
+# "the shared library a user loads" and "everything a build needs", and the
+# second one has to include every target the first one does. Otherwise mesa
+# configures against an LLVM without AMDGPU and radeonsi silently loses its
+# shader compiler.
+#
+# The visible consequence of getting this wrong: with X86;SPIRV only, mesa's
+# meson skipped past our llvm-config entirely and reported
+#
+#   llvm-config found: YES (/usr/bin/llvm-config) 18.1.3
+#
+# picking up the HOST's LLVM 18 -- while the index's libllvm is 20.1.7. A
+# libgallium linked that way needs libLLVM.so.18.1, which this index does not
+# ship, so the payload could not have loaded at all.
+#
+# This is also why gcc 15.1.0 is now REQUIRED rather than merely allowed: AMDGPU
+# is the translation unit that ICEs gcc 16 (see the compiler note below).
 #
 # Exit codes follow .agents/tools/README.md:
 #   0 built and packaged · 1 the build broke · 3 it never started
 set -uo pipefail
 
-VERSION="${1:-20.1.7}"
+# Default is 20.1.7.1, not 20.1.7. The published 20.1.7 payload has no AMDGPU;
+# this script no longer produces it, so defaulting to that version would hand you
+# a tarball whose name claims to be something already released with different
+# contents.
+VERSION="${1:-20.1.7.1}"
+
+# The package version and the upstream tag are two different things.
+#
+# This index's convention is that a fourth component is OURS: when a payload's
+# contents change but upstream did not, the asset has to get a new version,
+# because a GitCode release asset is written once and cannot be deleted. So
+# `20.1.7.1` is llvm-project 20.1.7 rebuilt by us (here: with AMDGPU added).
+#
+# Conflating them was a real failure, not a hypothetical: passing `20.1.7.1`
+# built a URL for `llvmorg-20.1.7.1` and died on a 404 before compiling anything.
+# UPSTREAM is derived rather than passed so the two cannot drift apart.
+UPSTREAM="${UPSTREAM:-$(echo "$VERSION" | cut -d. -f1-3)}"
+
 SPIRV_TAG="${SPIRV_TAG:-v20.1.0}"
 SUBOS_NAME="${XLINGS_GFX_SUBOS:-gfxbuild}"
 XHOME="${XLINGS_HOME:-$HOME/.xlings}"
@@ -81,56 +126,73 @@ NINJA="$SUBOS/bin/ninja"; [[ -x "$NINJA" ]] || skip "no ninja in subos '$SUBOS_N
 # Through the subos's shim, not the payload's bin/ directly. Only the shim
 # carries the elfpatch'd interpreter and RPATH; an absolute path into the
 # payload makes cmake's compiler probe fail to link. Select the compiler first
-# with `xlings use gcc 16.1.0` — see the version note below for why 16 and not 15.
+# with `xlings use gcc 15.1.0` — see the version note below for why 15 and not 16.
 BUILD_CC="$SUBOS/bin/gcc"
 BUILD_CXX="$SUBOS/bin/g++"
 [[ -x "$BUILD_CC" && -x "$BUILD_CXX" ]] || skip "no gcc/g++ in subos '$SUBOS_NAME'"
 
-# gcc 16.x here, NOT the 15.1.0 that build-libllvm.sh insists on. Both halves of
-# that constraint were checked rather than inherited.
+# gcc 15.1.0 — the same version build-libllvm.sh insists on, and this gate was
+# INVERTED in 20.1.7. The history matters because both halves moved.
 #
-# Why 15.1.0 is required THERE: 16.1.0 ICEs with a segfault on
-# AMDGPUAsmParser.cpp (2212/2218), and libllvm cannot drop AMDGPU because that
-# is radeonsi's runtime shader compiler. **This build has no AMDGPU** — it is
-# X86;SPIRV, because the only consumer is a host tool that turns OpenCL C into
-# SPIR-V. So the ICE cannot be reached from here.
+# 20.1.7 required 16.x and refused 15.x, for a measured reason: the gcc 15.1.0
+# payload shipped `lib/gcc/x86_64-linux-gnu/15.1.0/include-fixed/pthread.h`, a
+# fixincludes snapshot that precedes the sysroot in the search order and so
+# SHADOWED the live `pthread.h`. libstdc++'s own `ext/concurrence.h:257` then
+# failed with "cannot convert '<brace-enclosed initializer list>' to 'unsigned
+# int'", stopping the build at 13/4049 with an error naming neither gcc nor the
+# header that shadowed.
 #
-# Why 15.1.0 is actively WRONG here, measured 2026-08-08: the gcc 15.1.0 payload
-# ships `lib/gcc/x86_64-linux-gnu/15.1.0/include-fixed/pthread.h`, a fixincludes
-# copy baked against the glibc of whatever machine built gcc. include-fixed
-# precedes the sysroot in the search order, so it SHADOWS our
-# `usr/include/bits/pthreadtypes.h` and `__gthread_cond_t` resolves to
-# `unsigned int`. libstdc++'s own `ext/concurrence.h` then fails to compile:
+# That is now fixed at the source (openxlings/xim-pkgindex#560): the snapshot was
+# frozen against glibc 2.39 while the sysroot moved to 2.44, and pkgs/g/gcc.lua
+# prunes any fixincludes-bannered header at install. Re-measured with 15.1.0
+# actually selected -- the first attempt at this measurement used the subos shim
+# while it still pointed at 16, and proved nothing:
 #
-#   ext/concurrence.h:257: cannot convert '<brace-enclosed initializer list>'
-#                          to 'unsigned int' in initialization
+#   frozen header present -> 1 error, -H shows include-fixed/pthread.h winning
+#   frozen header pruned  -> 0 errors, -H shows the sysroot's pthread.h winning
 #
-# which stops the LLVM build at 13/4049 with an error that names neither gcc nor
-# the header that shadowed. 16.1.0 compiles the same translation unit clean.
+# And 15.x is now REQUIRED rather than merely permitted, because this build
+# gained AMDGPU: 16.1.0 ICEs with a segfault on AMDGPUAsmParser.cpp (2212/2218),
+# which is the exact translation unit that forced 15.1.0 on build-libllvm.sh. The
+# two scripts now agree, which is the right end state -- they produce the
+# build-time and runtime halves of ONE LLVM and had no business disagreeing about
+# the compiler.
 #
-# The C++ ABI argument that binds libllvm does NOT bind this package: with
-# `-Dmesa-clc=system` mesa consumes a mesa_clc BINARY and never links clang, so
-# llvm-dev only has to be self-consistent. clang is still wrong as the build
-# compiler, for the reason build-libllvm.sh gives: the xlings `llvm` package's
-# clang defaults to libc++ while everything else here is libstdc++.
+# clang is still wrong as the build compiler, for the reason build-libllvm.sh
+# gives: the xlings `llvm` package's clang defaults to libc++ while everything
+# else here is libstdc++.
 cc_ver="$("$BUILD_CC" -dumpfullversion 2>/dev/null || echo unknown)"
 case "$cc_ver" in
-  16.*) log "compiler gcc $cc_ver" ;;
-  15.*) skip "subos gcc is $cc_ver, whose include-fixed/pthread.h shadows the sysroot and breaks libstdc++ threading headers; run \`xlings use gcc 16.1.0\`" ;;
-  *)    skip "subos gcc is $cc_ver; this build wants 16.x (see the note above)" ;;
+  15.*) log "compiler gcc $cc_ver" ;;
+  16.*) skip "subos gcc is $cc_ver, which ICEs on AMDGPUAsmParser.cpp; run \`xlings use gcc 15.1.0\`" ;;
+  *)    skip "subos gcc is $cc_ver; this build wants 15.x (see the note above)" ;;
 esac
+
+# The #560 precondition, checked on the compiler's BEHAVIOUR not on the file.
+#
+# Asserting "include-fixed/pthread.h is absent" would test the fix's mechanism;
+# this tests its effect, so it stays correct if the fix ever moves. Without it
+# the build dies 13 targets in, blaming libstdc++.
+__probe="$WORK/src/.llvmdev-cxx-probe.cpp"
+mkdir -p "$WORK/src"
+printf '#include <ext/concurrence.h>\nint main(){return 0;}\n' > "$__probe"
+"$BUILD_CXX" -std=c++17 -fno-exceptions -c "$__probe" -o /dev/null 2>"$__probe.log" || {
+    echo "---- compiler probe ----" >&2; cat "$__probe.log" >&2
+    fail "g++ $cc_ver cannot compile <ext/concurrence.h> -- the gcc payload still ships a frozen fixincludes header (openxlings/xim-pkgindex#560). Reinstall gcc with the pkgs/g/gcc.lua fix."
+}
+rm -f "$__probe" "$__probe.log"
 
 PREFIX="$WORK/dist/llvm-dev-$VERSION"
 rm -rf "$PREFIX"; mkdir -p "$PREFIX"
 
 # ── 1. LLVM + clang, shared ─────────────────────────────────────────────
-SRC="$WORK/src/llvm-$VERSION"
-TARBALL="$WORK/src/llvm-project-$VERSION.src.tar.xz"
+SRC="$WORK/src/llvm-$UPSTREAM"
+TARBALL="$WORK/src/llvm-project-$UPSTREAM.src.tar.xz"
 if [[ ! -d "$SRC" ]]; then
     [[ -f "$TARBALL" ]] || {
-        log "fetching llvm-project $VERSION (~130 MB)"
+        log "fetching llvm-project $UPSTREAM (~130 MB)"
         curl -fsSL --retry 3 -o "$TARBALL" \
-          "https://github.com/llvm/llvm-project/releases/download/llvmorg-$VERSION/llvm-project-$VERSION.src.tar.xz" \
+          "https://github.com/llvm/llvm-project/releases/download/llvmorg-$UPSTREAM/llvm-project-$UPSTREAM.src.tar.xz" \
           || fail "download failed"
     }
     log "extracting"
@@ -141,7 +203,7 @@ fi
 BUILD="$WORK/src/llvm-dev-$VERSION-build"
 rm -rf "$BUILD"; mkdir -p "$BUILD"
 
-log "configuring llvm+clang (X86;SPIRV, shared, no tests/docs)"
+log "configuring llvm+clang (X86;AMDGPU;SPIRV, shared, no tests/docs)"
 "$CMAKE" -S "$SRC/llvm" -B "$BUILD" -G Ninja \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_C_COMPILER="$BUILD_CC" \
@@ -150,7 +212,7 @@ log "configuring llvm+clang (X86;SPIRV, shared, no tests/docs)"
   -DCMAKE_INSTALL_RPATH='$ORIGIN/../lib' \
   -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON \
   -DLLVM_ENABLE_PROJECTS="clang" \
-  -DLLVM_TARGETS_TO_BUILD="X86" \
+  -DLLVM_TARGETS_TO_BUILD="X86;AMDGPU" \
   -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD="SPIRV" \
   -DLLVM_BUILD_LLVM_DYLIB=ON \
   -DLLVM_LINK_LLVM_DYLIB=ON \

--- a/.agents/tools/graphics/build-spirv-tools.sh
+++ b/.agents/tools/graphics/build-spirv-tools.sh
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+# Build `spirv-tools` — SPIRV-Headers + SPIRV-Tools, the last build-time input iris needs.
+#
+# Design: xlings/.agents/docs/2026-08-08-mesa-rebuild-iris-d3d12-wayland-design.md §4
+#
+# WHY
+#
+#   meson.build:1887  dependency('SPIRV-Tools', required : with_clc, version : '>= 2022.1')
+#
+# `required : with_clc`, and iris sets with_clc (meson.build:841). So iris cannot
+# be built without it, and it was not in the index -- no recipe, and no
+# xlings-res/spirv-tools repo.
+#
+# `glslang` does not provide it. That package is built with `-DENABLE_OPT=OFF`
+# specifically to keep SPIRV-Tools out (see tiers.sh T4), which was right at the
+# time: glslang's optimiser is for its own command line and mesa did not ask for
+# it. mesa asks now, through a different door.
+#
+# TWO PROJECTS, ONE PAYLOAD
+#
+# SPIRV-Tools does not vendor its headers; it pins a SPIRV-Headers revision in
+# DEPS (v2025.1 -> 09913f08…) and expects the source tree beside it. Rather than
+# ship two packages where one is useless alone, both install into one prefix, so
+# the payload satisfies `SPIRV-Tools.pc` including whatever it declares in
+# `Requires:`.
+#
+# The revision is read FROM the DEPS file rather than chosen: SPIRV-Tools tracks
+# in-flight SPIR-V grammar changes, and a mismatched header set fails deep in code
+# generation with an error about an unknown opcode.
+#
+# STATIC, DELIBERATELY
+#
+# mesa uses SPIRV-Tools only inside `mesa_clc`, a host tool it runs during the
+# build. Linking it statically means it cannot appear in the shipped payload's
+# runtime closure at all -- there is no .so for anything to DT_NEEDED. That is why
+# this has its own script instead of using build-in-subos.sh's cmake path, which
+# forces -DBUILD_SHARED_LIBS=ON.
+#
+# Exit codes follow .agents/tools/README.md:
+#   0 built and packaged · 1 the build broke · 3 it never started
+set -uo pipefail
+
+VERSION="${1:-2025.1}"
+SUBOS_NAME="${XLINGS_GFX_SUBOS:-gfxbuild}"
+XHOME="${XLINGS_HOME:-$HOME/.xlings}"
+SUBOS="$XHOME/subos/$SUBOS_NAME"
+WORK="${XLINGS_GFX_WORK:-${TMPDIR:-/tmp}/xlings-gfx}"
+JOBS="${JOBS:-$(nproc)}"
+
+log()  { echo "[spirv-tools] $*"; }
+fail() { echo "[spirv-tools] FAIL: $*" >&2; exit 1; }
+skip() { echo "[spirv-tools] SKIP: $*" >&2; exit 3; }
+
+[[ -d "$SUBOS" ]] || skip "subos '$SUBOS_NAME' not found — xlings subos new $SUBOS_NAME"
+mkdir -p "$WORK/src" "$WORK/dist"
+
+CMAKE="$SUBOS/bin/cmake"; [[ -x "$CMAKE" ]] || skip "no cmake in subos '$SUBOS_NAME'"
+NINJA="$SUBOS/bin/ninja"; [[ -x "$NINJA" ]] || skip "no ninja in subos '$SUBOS_NAME'"
+CC="$SUBOS/bin/gcc";  CXX="$SUBOS/bin/g++"
+[[ -x "$CC" && -x "$CXX" ]] || skip "no gcc/g++ in subos '$SUBOS_NAME'"
+
+# gcc 15.1.0, for the same reason directx-headers uses it: these archives are
+# linked into a host tool that also links our LLVM, and mixing libstdc++ ABIs
+# across that boundary is how RTTI and exceptions break.
+cc_ver="$("$CXX" -dumpfullversion 2>/dev/null || echo unknown)"
+case "$cc_ver" in
+  15.*) log "compiler g++ $cc_ver" ;;
+  *)    skip "subos g++ is $cc_ver; this stack is built with 15.x — run \`xlings use gcc 15.1.0\`" ;;
+esac
+
+# The #560 precondition, checked on behaviour rather than on the filesystem.
+probe="$WORK/src/.spv-cxx-probe.cpp"
+printf '#include <ext/concurrence.h>\nint main(){return 0;}\n' > "$probe"
+"$CXX" -std=c++17 -c "$probe" -o /dev/null 2>"$probe.log" || {
+    cat "$probe.log" >&2
+    fail "g++ $cc_ver cannot compile <ext/concurrence.h> -- the gcc payload still ships a frozen fixincludes header (openxlings/xim-pkgindex#560)"
+}
+rm -f "$probe" "$probe.log"
+
+# ── sources ─────────────────────────────────────────────────────────────
+SRC="$WORK/src/SPIRV-Tools-$VERSION"
+TB="$WORK/src/spirv-tools-v$VERSION.tar.gz"
+if [[ ! -d "$SRC" ]]; then
+    [[ -f "$TB" ]] || {
+        log "fetching SPIRV-Tools v$VERSION"
+        curl -fsSL --retry 3 -o "$TB" \
+          "https://github.com/KhronosGroup/SPIRV-Tools/archive/refs/tags/v$VERSION.tar.gz" \
+          || fail "download failed"
+    }
+    tar -C "$WORK/src" -xzf "$TB" || fail "extract failed"
+fi
+[[ -f "$SRC/DEPS" ]] || fail "no DEPS in $SRC -- cannot determine the SPIRV-Headers revision"
+
+# Read the pin, do not choose it.
+HDR_REV="$(sed -n "s/.*'spirv_headers_revision'[[:space:]]*:[[:space:]]*'\([0-9a-f]\{40\}\)'.*/\1/p" "$SRC/DEPS" | head -1)"
+[[ -n "$HDR_REV" ]] || fail "could not parse spirv_headers_revision out of $SRC/DEPS"
+log "SPIRV-Headers pinned by DEPS to ${HDR_REV:0:12}"
+
+HDR="$WORK/src/SPIRV-Headers-$HDR_REV"
+if [[ ! -d "$HDR" ]]; then
+    htb="$WORK/src/spirv-headers-$HDR_REV.tar.gz"
+    [[ -f "$htb" ]] || {
+        log "fetching SPIRV-Headers ${HDR_REV:0:12}"
+        curl -fsSL --retry 3 -o "$htb" \
+          "https://github.com/KhronosGroup/SPIRV-Headers/archive/$HDR_REV.tar.gz" \
+          || fail "SPIRV-Headers download failed"
+    }
+    mkdir -p "$HDR"
+    tar -C "$HDR" -xzf "$htb" --strip-components=1 || fail "SPIRV-Headers extract failed"
+fi
+[[ -d "$HDR/include/spirv" ]] || fail "$HDR has no include/spirv -- wrong tarball layout"
+
+PREFIX="$WORK/dist/spirv-tools-$VERSION"
+rm -rf "$PREFIX"; mkdir -p "$PREFIX"
+
+# ── 1. SPIRV-Headers ────────────────────────────────────────────────────
+# Headers plus a .pc, no compilation. Installed first because SPIRV-Tools'
+# generated pkg-config may name it in Requires:, and pkg-config resolves that at
+# QUERY time -- so a missing SPIRV-Headers.pc makes `dependency('SPIRV-Tools')`
+# report SPIRV-Tools itself as not found.
+log "installing SPIRV-Headers"
+HB="$WORK/src/spirv-headers-build"
+rm -rf "$HB"
+"$CMAKE" -S "$HDR" -B "$HB" -G Ninja \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_INSTALL_PREFIX="$PREFIX" \
+  -DCMAKE_C_COMPILER="$CC" -DCMAKE_CXX_COMPILER="$CXX" \
+  > "$WORK/spirv-headers-configure.log" 2>&1 \
+  || { tail -20 "$WORK/spirv-headers-configure.log"; fail "SPIRV-Headers configure"; }
+"$CMAKE" --install "$HB" > "$WORK/spirv-headers-install.log" 2>&1 \
+  || { tail -20 "$WORK/spirv-headers-install.log"; fail "SPIRV-Headers install"; }
+rm -rf "$HB"
+
+# ── 2. SPIRV-Tools ──────────────────────────────────────────────────────
+#
+# SPIRV_SKIP_TESTS: the test suite needs googletest, which is another source
+# dependency this package has no reason to acquire.
+#
+# SPIRV_SKIP_EXECUTABLES=OFF: spirv-as / spirv-val / spirv-opt are small and
+# mesa_clc shells out to none of them -- but leaving them in is what makes the
+# payload independently checkable, and the acceptance step below runs spirv-val.
+log "configuring SPIRV-Tools (static, no tests)"
+B="$WORK/src/spirv-tools-build"
+rm -rf "$B"
+"$CMAKE" -S "$SRC" -B "$B" -G Ninja \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_INSTALL_PREFIX="$PREFIX" \
+  -DCMAKE_C_COMPILER="$CC" -DCMAKE_CXX_COMPILER="$CXX" \
+  -DCMAKE_INSTALL_LIBDIR=lib \
+  -DBUILD_SHARED_LIBS=OFF \
+  -DSPIRV_SKIP_TESTS=ON \
+  -DSPIRV_SKIP_EXECUTABLES=OFF \
+  -DSPIRV_WERROR=OFF \
+  -DSPIRV-Headers_SOURCE_DIR="$HDR" \
+  > "$WORK/spirv-tools-configure.log" 2>&1 \
+  || { tail -30 "$WORK/spirv-tools-configure.log"; fail "SPIRV-Tools configure"; }
+
+log "building with $JOBS jobs"
+"$NINJA" -C "$B" -j"$JOBS" > "$WORK/spirv-tools-build.log" 2>&1 \
+  || { tail -30 "$WORK/spirv-tools-build.log"; fail "SPIRV-Tools build"; }
+"$CMAKE" --install "$B" >> "$WORK/spirv-tools-build.log" 2>&1 \
+  || { tail -20 "$WORK/spirv-tools-build.log"; fail "SPIRV-Tools install"; }
+rm -rf "$B"
+
+# ── drop the shared variant ─────────────────────────────────────────────
+#
+# `SPIRV-Tools-shared` is its OWN cmake target, not a mode of the static one, so
+# -DBUILD_SHARED_LIBS=OFF does not suppress it -- it installs
+# lib/libSPIRV-Tools-shared.so alongside the archives. The assertion below caught
+# that on the first run.
+#
+# It has to go, and not merely for tidiness. mesa asks for `SPIRV-Tools`, which
+# resolves to the static archives; but a .so sitting in a payload directory that
+# ends up on a link line is one `-lSPIRV-Tools-shared` away from becoming a
+# DT_NEEDED in libgallium -- and this package is `status = "dev"`, so it is not in
+# mesa's runtime deps and would never be installed on a user's machine. The
+# failure would be a dlopen error naming a library nobody declared.
+#
+# Removed rather than left-and-tolerated so the static-only assertion stays an
+# assertion. `Requires:`/`Libs:` in SPIRV-Tools.pc reference the static targets,
+# so nothing here needs the shared build.
+shopt -s nullglob
+for f in "$PREFIX"/lib/libSPIRV-Tools-shared.so* "$PREFIX"/lib/pkgconfig/SPIRV-Tools-shared.pc; do
+    log "dropping shared variant: ${f#"$PREFIX"/}"
+    rm -f "$f"
+done
+shopt -u nullglob
+
+# ── assertions ──────────────────────────────────────────────────────────
+for f in lib/pkgconfig/SPIRV-Tools.pc lib/libSPIRV-Tools.a include/spirv-tools/libspirv.h; do
+    [[ -e "$PREFIX/$f" ]] || fail "payload is missing $f"
+done
+[[ -f "$PREFIX/include/spirv/unified1/spirv.h" ]] \
+  || fail "payload has no include/spirv/unified1/spirv.h -- SPIRV-Headers did not install"
+
+# No shared objects. If one appears, mesa could DT_NEEDED it and this build-only
+# package would silently become a runtime dependency of the graphics stack.
+sos=$(find "$PREFIX" -name '*.so*' -type f 2>/dev/null)
+[[ -z "$sos" ]] || { echo "$sos" >&2; fail "payload contains shared objects; this is meant to be static-only"; }
+
+if command -v pkg-config >/dev/null 2>&1; then
+    export PKG_CONFIG_PATH="$PREFIX/lib/pkgconfig:$PREFIX/share/pkgconfig"
+    v=$(pkg-config --modversion SPIRV-Tools 2>&1) \
+      || fail "pkg-config cannot resolve SPIRV-Tools: $v (mesa meson.build:1887)"
+    log "pkg-config: SPIRV-Tools $v"
+    pkg-config --atleast-version=2022.1 SPIRV-Tools \
+      || fail "SPIRV-Tools $v does not satisfy mesa's version : '>= 2022.1'"
+fi
+
+# Prove the library actually works, not just that the files exist.
+if [[ -x "$PREFIX/bin/spirv-as" && -x "$PREFIX/bin/spirv-val" ]]; then
+    t="$WORK/src/.spv-acceptance"
+    rm -rf "$t"; mkdir -p "$t"
+    cat > "$t/a.spvasm" <<'ASM'
+               OpCapability Shader
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main"
+               OpExecutionMode %main LocalSize 1 1 1
+       %void = OpTypeVoid
+         %fn = OpTypeFunction %void
+       %main = OpFunction %void None %fn
+      %entry = OpLabel
+               OpReturn
+               OpFunctionEnd
+ASM
+    "$PREFIX/bin/spirv-as" "$t/a.spvasm" -o "$t/a.spv" 2>"$t/err" \
+      || { cat "$t/err" >&2; fail "spirv-as could not assemble a minimal module"; }
+    "$PREFIX/bin/spirv-val" "$t/a.spv" 2>>"$t/err" \
+      || { cat "$t/err" >&2; fail "spirv-val rejected a module spirv-as produced"; }
+    log "acceptance: assembled and validated a minimal SPIR-V module ($(stat -c%s "$t/a.spv") bytes)"
+    rm -rf "$t"
+fi
+
+TAR="$WORK/dist/spirv-tools-$VERSION-linux-x86_64.tar.gz"
+rm -f "$TAR"
+tar -C "$WORK/dist" -czf "$TAR" "spirv-tools-$VERSION" || fail "packaging"
+log "packaged $TAR"
+log "sha256 $(sha256sum "$TAR" | awk '{print $1}')"
+log "size   $(du -h "$TAR" | awk '{print $1}')"
+log "SPIRV-Headers revision baked in: $HDR_REV"

--- a/.agents/tools/graphics/build-wayland-protocols.sh
+++ b/.agents/tools/graphics/build-wayland-protocols.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# Build `wayland-protocols` — the protocol XML mesa's Wayland platform is generated from.
+#
+# Design: xlings/.agents/docs/2026-08-08-mesa-rebuild-iris-d3d12-wayland-design.md §4
+#
+# WHY THIS EXISTS — AND IT IS NOT "THE PACKAGE WAS MISSING"
+#
+# mesa asks for it unconditionally once the wayland platform is on:
+#
+#   meson.build:2061  dependency('wayland-protocols', version : '>= 1.38')
+#
+# The first version of this comment said the package was not in the index. That
+# was wrong: `pkgs/w/wayland-protocols.lua` has existed at 1.38 since
+# 2026-08-05, published to xlings-res in both regions. The real finding is worse
+# and more interesting.
+#
+# Measured 2026-08-08:
+#
+#   * the SHIPPED mesa 25.0.7.1 -- whose Wayland cell the O4 probe certifies as
+#     7/7 objects from XLINGS_HOME at RUN time -- was built against the HOST's
+#     /usr/share/pkgconfig/wayland-protocols.pc, version 1.45
+#   * `ls /home/speak/.xlings/data/xpkgs/*wayland-protocols*` -> nothing. The
+#     package was never installed in the home mesa was built in
+#   * the T5 line in tiers.sh named neither `--deps wayland-protocols` nor an
+#     extra pkgconfig path, and this recipe's config() stages nothing into the
+#     subos sysroot (correctly -- it is build-only), so pkg-config could not
+#     have seen it even if it had been installed
+#
+# So a correct, published package sat unused while the host answered the same
+# question, and every runtime check still passed. Self-containment at run time
+# and at build time are different properties and only the first had a guard.
+#
+# This script exists to produce 1.45 -- matching what the host offered, so the
+# rebuild changes the drivers and not the protocol vintage as well -- and the
+# WIRING is the actual fix: tiers.sh now passes the path explicitly.
+#
+# Unlike meson (openxlings/xim-pkgindex#562), this could not be handled by
+# vendoring it into the build: wayland-scanner turns these XML files into C that
+# is COMPILED INTO libEGL_mesa and libgbm. It contributes to the payload, so it
+# has to be a named, versioned package -- and it already was.
+#
+# WHY NOT meson, again
+#
+# Upstream is a meson project whose entire Linux install is:
+#
+#   install_data(...)          the XML tree, under share/wayland-protocols/
+#   pkg.generate(...)          one .pc file carrying pkgdatadir
+#
+# No compiler runs. There is no object code in this package at all -- `file` on
+# every payload member says "XML document" or "ASCII text". Driving that with a
+# build system would add a dependency to produce zero binaries.
+#
+# 1.45 rather than the 1.38 already in the index: it is the version the currently
+# shipped mesa was actually built against (from the host), so the rebuild changes
+# one thing (the drivers) and not two (the drivers and the protocol vintage). The
+# recipe keeps BOTH -- protocol XML is additive, and a published payload cannot be
+# withdrawn.
+#
+# Exit codes follow .agents/tools/README.md:
+#   0 built and packaged · 1 the build broke · 3 it never started
+set -uo pipefail
+
+VERSION="${1:-1.45}"
+WORK="${XLINGS_GFX_WORK:-${TMPDIR:-/tmp}/xlings-gfx}"
+
+log()  { echo "[wayland-protocols] $*"; }
+fail() { echo "[wayland-protocols] FAIL: $*" >&2; exit 1; }
+skip() { echo "[wayland-protocols] SKIP: $*" >&2; exit 3; }
+
+command -v curl >/dev/null || skip "no curl"
+mkdir -p "$WORK/src" "$WORK/dist"
+
+SRC="$WORK/src/wayland-protocols-$VERSION"
+TARBALL="$WORK/src/wayland-protocols-$VERSION.tar.xz"
+if [[ ! -d "$SRC" ]]; then
+    [[ -f "$TARBALL" ]] || {
+        log "fetching wayland-protocols $VERSION"
+        curl -fsSL --retry 3 -o "$TARBALL" \
+          "https://gitlab.freedesktop.org/wayland/wayland-protocols/-/releases/$VERSION/downloads/wayland-protocols-$VERSION.tar.xz" \
+          || fail "download failed"
+    }
+    tar -C "$WORK/src" -xf "$TARBALL" || fail "extract failed"
+fi
+[[ -d "$SRC/stable" ]] || fail "source tree at $SRC has no stable/ protocol directory"
+
+PREFIX="$WORK/dist/wayland-protocols-$VERSION"
+rm -rf "$PREFIX"; mkdir -p "$PREFIX/share/wayland-protocols" "$PREFIX/share/pkgconfig"
+
+# The XML tree, exactly the four directories upstream installs.
+#
+# `staging` and `unstable` are not optional extras: mesa binds
+# `linux-dmabuf-v1` from stable, `fifo-v1`/`commit-timing-v1` from staging, and
+# older compositors still only offer the unstable spellings. Shipping a subset
+# makes mesa configure fine and then miss an interface at run time, which
+# surfaces as a compositor-specific rendering fault rather than a missing file.
+count=0
+for d in stable staging unstable; do
+    [[ -d "$SRC/$d" ]] || fail "upstream tree is missing $d/"
+    cp -r "$SRC/$d" "$PREFIX/share/wayland-protocols/$d" || fail "copying $d/"
+    n=$(find "$PREFIX/share/wayland-protocols/$d" -name '*.xml' | wc -l)
+    log "$d: $n protocol file(s)"
+    count=$((count + n))
+done
+[[ -f "$SRC/wayland-protocols.pc.in" || -f "$SRC/meson.build" ]] || fail "not a wayland-protocols source tree"
+cp "$SRC/COPYING" "$PREFIX/COPYING" 2>/dev/null || true
+
+# Relocatable via ${pcfiledir}, same reasoning as directx-headers: this .pc is
+# ours to write, so it never gets an absolute path to rewrite later.
+#
+# `pkgdatadir` is the only key consumers read -- mesa does
+# `dep_wl_protocols.get_variable(pkgconfig : 'pkgdatadir')` and feeds it to
+# wayland-scanner. A .pc whose pkgdatadir is wrong yields "No such file or
+# directory" naming an XML path, three layers from this file.
+cat > "$PREFIX/share/pkgconfig/wayland-protocols.pc" <<'PC'
+prefix=${pcfiledir}/../..
+datarootdir=${prefix}/share
+pkgdatadir=${datarootdir}/wayland-protocols
+
+Name: Wayland Protocols
+Description: Wayland protocol files
+Version: @VERSION@
+PC
+sed -i "s/@VERSION@/$VERSION/" "$PREFIX/share/pkgconfig/wayland-protocols.pc"
+
+# Assertions, each naming what mesa would do without it.
+[[ $count -gt 0 ]] || fail "no XML files were installed"
+for f in share/wayland-protocols/stable/xdg-shell/xdg-shell.xml \
+         share/wayland-protocols/stable/linux-dmabuf/linux-dmabuf-v1.xml \
+         share/pkgconfig/wayland-protocols.pc; do
+    [[ -f "$PREFIX/$f" ]] || fail "payload is missing $f"
+done
+
+# No object code, asserted rather than assumed. If this ever ships an ELF the
+# recipe's dep list and RPATH story would both be wrong, and it would be caught
+# here instead of by the closure guard in CI.
+elves=$(find "$PREFIX" -type f -exec sh -c 'head -c4 "$1" | od -An -tx1 | grep -q "7f 45 4c 46" && echo "$1"' _ {} \; 2>/dev/null)
+[[ -z "$elves" ]] || { echo "$elves" >&2; fail "payload contains ELF objects; this package is meant to be data-only"; }
+
+if command -v pkg-config >/dev/null 2>&1; then
+    v=$(PKG_CONFIG_PATH="$PREFIX/share/pkgconfig" pkg-config --modversion wayland-protocols 2>/dev/null || true)
+    [[ "$v" == "$VERSION" ]] || fail "pkg-config --modversion gave '$v', expected $VERSION (mesa meson.build:2061)"
+    PKG_CONFIG_PATH="$PREFIX/share/pkgconfig" pkg-config --atleast-version=1.38 wayland-protocols \
+        || fail "does not satisfy mesa's version : '>= 1.38'"
+    pkgdata=$(PKG_CONFIG_PATH="$PREFIX/share/pkgconfig" pkg-config --variable=pkgdatadir wayland-protocols)
+    [[ -d "$pkgdata" ]] || fail "pkgdatadir '$pkgdata' does not exist -- wayland-scanner would fail on an XML path"
+    [[ -f "$pkgdata/stable/xdg-shell/xdg-shell.xml" ]] \
+        || fail "pkgdatadir '$pkgdata' has no stable/xdg-shell/xdg-shell.xml"
+    log "pkg-config: $VERSION, pkgdatadir resolves and contains the stable tree"
+fi
+
+TAR="$WORK/dist/wayland-protocols-$VERSION-linux-x86_64.tar.gz"
+rm -f "$TAR"
+tar -C "$WORK/dist" -czf "$TAR" "wayland-protocols-$VERSION" || fail "packaging"
+log "packaged $TAR  ($count XML files)"
+log "sha256 $(sha256sum "$TAR" | awk '{print $1}')"
+log "size   $(du -h "$TAR" | awk '{print $1}')"

--- a/.agents/tools/graphics/patches/mesa-25.0.7-glibc-2.42-c11-threads.patch
+++ b/.agents/tools/graphics/patches/mesa-25.0.7-glibc-2.42-c11-threads.patch
@@ -1,0 +1,78 @@
+--- a/src/c11/threads.h
++++ b/src/c11/threads.h
+@@ -37,6 +37,23 @@
+ #include <limits.h>
+ #include <stdlib.h>
+ 
++/* glibc >= 2.42 owns once_flag / call_once.
++ *
++ * ISO C23 moved them from <threads.h> into <stdlib.h>, and glibc followed. With
++ * _GNU_SOURCE (which mesa builds with) <stdlib.h> therefore declares both, and
++ * the definitions below collide:
++ *
++ *   error: conflicting types for 'once_flag'; have 'pthread_once_t' {aka 'int'}
++ *   error: conflicting types for 'call_once'; have 'void(int *, void (*)(void))'
++ *
++ * <stdlib.h> is included just above, so ONCE_FLAG_INIT is already visible here
++ * whenever the libc provides it -- which makes this test deterministic rather
++ * than dependent on include order in the translation unit.
++ */
++#ifdef ONCE_FLAG_INIT
++#  define MESA_LIBC_OWNS_ONCE_FLAG 1
++#endif
++
+ #if defined(_WIN32) && !defined(HAVE_PTHREAD)
+ #  include <io.h> /* close */
+ #  include <process.h> /* _exit */
+@@ -107,19 +124,23 @@
+    void *LockSemaphore;
+    uintptr_t SpinCount;
+ } mtx_t; /* Mock of CRITICAL_SECTION */
++#  ifndef MESA_LIBC_OWNS_ONCE_FLAG
+ typedef struct
+ {
+    volatile uintptr_t status;
+ } once_flag;
+-#  define ONCE_FLAG_INIT {0}
++#    define ONCE_FLAG_INIT {0}
++#  endif
+ #  define TSS_DTOR_ITERATIONS 1
+ #elif defined(HAVE_PTHREAD)
+ typedef pthread_cond_t  cnd_t;
+ typedef pthread_t       thrd_t;
+ typedef pthread_key_t   tss_t;
+ typedef pthread_mutex_t mtx_t;
++#  ifndef MESA_LIBC_OWNS_ONCE_FLAG
+ typedef pthread_once_t  once_flag;
+-#  define ONCE_FLAG_INIT PTHREAD_ONCE_INIT
++#    define ONCE_FLAG_INIT PTHREAD_ONCE_INIT
++#  endif
+ #  ifdef PTHREAD_DESTRUCTOR_ITERATIONS
+ #    define TSS_DTOR_ITERATIONS PTHREAD_DESTRUCTOR_ITERATIONS
+ #  else
+@@ -148,7 +169,9 @@
+ 
+ /*-------------------------- functions --------------------------*/
+ 
++#ifndef MESA_LIBC_OWNS_ONCE_FLAG
+ void call_once(once_flag *, void (*)(void));
++#endif
+ int cnd_broadcast(cnd_t *);
+ void cnd_destroy(cnd_t *);
+ int cnd_init(cnd_t *);
+--- a/src/c11/impl/threads_posix.c
++++ b/src/c11/impl/threads_posix.c
+@@ -46,11 +46,13 @@
+ 
+ /*--------------- 7.25.2 Initialization functions ---------------*/
+ // 7.25.2.1
++#ifndef MESA_LIBC_OWNS_ONCE_FLAG
+ void
+ call_once(once_flag *flag, void (*func)(void))
+ {
+     pthread_once(flag, func);
+ }
++#endif
+ 
+ 
+ /*------------- 7.25.3 Condition variable functions -------------*/

--- a/.agents/tools/graphics/tiers.sh
+++ b/.agents/tools/graphics/tiers.sh
@@ -66,7 +66,7 @@ T4=(
   "libglvnd|1.7.0|https://gitlab.freedesktop.org/glvnd/libglvnd/-/archive/v1.7.0/libglvnd-v1.7.0.tar.gz|meson|-Dgles1=false -Dasm=enabled"
 )
 
-# ── T4b — the three packages that are NOT built by this file ────────────
+# ── T4b — the four packages that are NOT built by this file ─────────────
 #
 # Each has its own script because each needs something run_tier() cannot express.
 # They are listed here so the build order is readable in one place.
@@ -75,13 +75,16 @@ T4=(
 #                                                  sequence (llvm+clang, the
 #                                                  SPIR-V translator, libclc),
 #                                                  each consuming the last
+#   spirv-tools        build-spirv-tools.sh        SPIRV-Headers at the revision
+#                                                  SPIRV-Tools' own DEPS pins,
+#                                                  then SPIRV-Tools; static only
 #   directx-headers    build-directx-headers.sh    no meson in this index (#562),
 #                                                  and its whole Linux install is
 #                                                  two static_library() calls
 #   wayland-protocols  build-wayland-protocols.sh  data only; no compiler runs
 #
-# llvm-dev and directx-headers are `status = "dev"`; wayland-protocols was already
-# `stable` and stays that way.
+# llvm-dev, spirv-tools and directx-headers are `status = "dev"`; wayland-protocols
+# was already `stable` and stays that way.
 #
 # Both directx-headers and wayland-protocols were HOST INPUTS to the shipped mesa
 # 25.0.7.1 -- but for two different reasons, and the second is the instructive one:
@@ -137,8 +140,15 @@ T4=(
 # because a build recipe that does not reproduce the build is worse than no
 # recipe: it costs the next person the same afternoon and looks authoritative.
 #
-# libxml2 is NOT in the list and was not needed -- mesa 25.0 generates its GL
-# dispatch with python, not xsltproc.
+# libxml2 IS in the list, and my first version of this comment said it "was not
+# needed" -- wrong, and wrong in the same way as the list it was correcting.
+#
+# mesa's own codegen does not use it (that is python now). `wayland-scanner` does:
+# the wayland payload's bin/wayland-scanner has DT_NEEDED on libxml2.so.2 and
+# libexpat.so.1, and pkgs/w/wayland.lua declared neither until this branch. So the
+# dependency is real but it belongs to a BUILD TOOL from another package, which is
+# why reading mesa's build files could not find it -- it surfaced 1957 targets in,
+# with an error naming neither wayland nor mesa.
 T5=(
   "mesa|25.0.7|https://archive.mesa3d.org/mesa-25.0.7.tar.xz|meson|-Dgallium-drivers=llvmpipe,softpipe,radeonsi,nouveau,zink,iris,d3d12 -Dvulkan-drivers=amd -Dglvnd=enabled -Dplatforms=x11,wayland -Dllvm=enabled -Dshared-llvm=enabled -Dmesa-clc=enabled -Dgallium-d3d12-video=disabled -Dlmsensors=disabled -Dvalgrind=disabled -Dbuild-tests=false -Dgallium-extra-hud=false|glslang libglvnd libdrm libX11 libxcb libXext libXfixes libXxf86vm libxshmfence wayland zlib expat elfutils xorgproto libpciaccess libXrandr libXau libXdmcp libXrender"
 )

--- a/.agents/tools/graphics/tiers.sh
+++ b/.agents/tools/graphics/tiers.sh
@@ -66,6 +66,41 @@ T4=(
   "libglvnd|1.7.0|https://gitlab.freedesktop.org/glvnd/libglvnd/-/archive/v1.7.0/libglvnd-v1.7.0.tar.gz|meson|-Dgles1=false -Dasm=enabled"
 )
 
+# ── T4b — the three packages that are NOT built by this file ────────────
+#
+# Each has its own script because each needs something run_tier() cannot express.
+# They are listed here so the build order is readable in one place.
+#
+#   llvm-dev           build-llvm-dev.sh           three cmake projects in
+#                                                  sequence (llvm+clang, the
+#                                                  SPIR-V translator, libclc),
+#                                                  each consuming the last
+#   directx-headers    build-directx-headers.sh    no meson in this index (#562),
+#                                                  and its whole Linux install is
+#                                                  two static_library() calls
+#   wayland-protocols  build-wayland-protocols.sh  data only; no compiler runs
+#
+# llvm-dev and directx-headers are `status = "dev"`; wayland-protocols was already
+# `stable` and stays that way.
+#
+# Both directx-headers and wayland-protocols were HOST INPUTS to the shipped mesa
+# 25.0.7.1 -- but for two different reasons, and the second is the instructive one:
+#
+#   directx-headers    genuinely absent. Built once into /tmp and never packaged;
+#                      that ad-hoc build's log shows
+#                      `Found pkg-config: /usr/bin/pkg-config`.
+#
+#   wayland-protocols  ALREADY PACKAGED at 1.38 and published in both regions
+#                      since 2026-08-05 -- and still unused. It was never
+#                      installed in the home mesa was built in, and the T5 line
+#                      below named it in neither `--deps` nor the extra pkgconfig
+#                      path, so the host's copy answered instead.
+#
+# The second is the harder failure to see, because nothing is missing: the recipe
+# is right, the payload is right, the runtime probe passes 7/7. Only the WIRING
+# was absent, and an unwired build-time input is indistinguishable from a
+# satisfied one unless somebody looks at what the build consumed.
+
 # T5 — mesa. Everything above exists to make this line possible.
 #
 # gallium-drivers is the four hardware targets the design commits to:
@@ -79,23 +114,44 @@ T4=(
 # lmsensors is off — it only feeds a GPU temperature query, and enabling it
 # would add another package to the tier list for a HUD readout.
 #
-# gallium-drivers is llvmpipe ONLY for this first pass. iris pulls in libclc
-# (meson.build: with_gallium_iris => with_clc), which is another package, and
-# the acceptance criterion exercises llvmpipe. Prove the whole chain — libglvnd
-# vendor loading, libllvm's JIT, the X11 client stack, the empty-host container
-# — with one driver, then widen. A driver added to a pipeline that already
-# renders is a small change; a pipeline debugged with five drivers at once is
-# not.
+# The staged-driver notes that used to sit here are gone because both stages
+# happened: llvmpipe-only widened to five drivers, and vulkan-drivers went from
+# empty to `amd` once glslang was packaged. iris and d3d12 are the last two, and
+# each needed a package that did not exist:
 #
-# vulkan-drivers is EMPTY for now, and that is a staging decision rather than
-# a scope cut. Building them needs glslangValidator (glslang), which is one
-# more build-tool package; the acceptance criterion (S1-S4) exercises the GL
-# path through llvmpipe, so GL is proven first and Vulkan is re-enabled once
-# glslang is packaged. Leaving it empty is visible in the payload — no
-# libvulkan_*.so — rather than silently producing drivers that do not load.
+#   iris   -> with_gallium_iris implies with_clc (meson.build:841), so
+#             dependency('libclc') + LLVMSPIRVLib + clang-cpp  ->  llvm-dev
+#   d3d12  -> dependency('DirectX-Headers') (meson.build:606)  ->  directx-headers
+#
+# ── THE DEPS FIELD, AND WHY IT WAS WRONG ────────────────────────────────
+#
+# This entry used to read `libxml2 expat`. That cannot be what built mesa:
+# `--deps` is the ONLY mechanism that puts a package's .pc where pkg-config can
+# see it, and measured 2026-08-08 no subos sysroot farm in this home -- including
+# the one mesa was built in -- contains libglvnd.pc, libdrm.pc, x11.pc or any of
+# the other twenty. Re-running this line as recorded stops at
+#
+#   meson.build:583:12: ERROR: Dependency "libglvnd" not found
+#
+# So the recorded command was not the command. The full list is spelled out now,
+# because a build recipe that does not reproduce the build is worse than no
+# recipe: it costs the next person the same afternoon and looks authoritative.
+#
+# libxml2 is NOT in the list and was not needed -- mesa 25.0 generates its GL
+# dispatch with python, not xsltproc.
 T5=(
-  "mesa|25.0.7|https://archive.mesa3d.org/mesa-25.0.7.tar.xz|meson|-Dgallium-drivers=llvmpipe,softpipe,radeonsi,nouveau,zink -Dvulkan-drivers=amd -Dglvnd=enabled -Dplatforms=x11,wayland -Dllvm=enabled -Dshared-llvm=enabled -Dlmsensors=disabled -Dvalgrind=disabled -Dbuild-tests=false -Dgallium-extra-hud=false|libxml2 expat"
+  "mesa|25.0.7|https://archive.mesa3d.org/mesa-25.0.7.tar.xz|meson|-Dgallium-drivers=llvmpipe,softpipe,radeonsi,nouveau,zink,iris,d3d12 -Dvulkan-drivers=amd -Dglvnd=enabled -Dplatforms=x11,wayland -Dllvm=enabled -Dshared-llvm=enabled -Dmesa-clc=enabled -Dgallium-d3d12-video=disabled -Dlmsensors=disabled -Dvalgrind=disabled -Dbuild-tests=false -Dgallium-extra-hud=false|glslang libglvnd libdrm libX11 libxcb libXext libXfixes libXxf86vm libxshmfence wayland zlib expat elfutils xorgproto libpciaccess libXrandr libXau libXdmcp libXrender"
 )
+
+# The three build-only inputs mesa needs that are NOT --deps, because a
+# `status = "dev"` package deliberately stages nothing into the sysroot:
+#
+#   XLINGS_GFX_PKGCONFIG_EXTRA=<llvm-dev>/lib/pkgconfig:<llvm-dev>/share/pkgconfig:<dxh>/share/pkgconfig:<wl-protocols>/share/pkgconfig
+#
+# BOTH llvm-dev directories, and that is not redundancy: libclc.pc is in
+# share/pkgconfig and LLVMSPIRVLib.pc is in lib/pkgconfig. Naming only the first
+# gets `libclc found: YES` followed by `Dependency "LLVMSPIRVLib" not found`,
+# which reads like a broken package rather than a missing path.
 
 run_tier() {  # <tier-name> <entries...>
     local tier="$1"; shift

--- a/.github/scripts/windows-test.ps1
+++ b/.github/scripts/windows-test.ps1
@@ -329,6 +329,42 @@ foreach ($relFile in $files) {
         continue
     }
     if ($rc -ne 0) {
+        # A recipe that DELEGATES its Windows install registers no xvm version of
+        # its own, so there is nothing for removal to select:
+        #
+        #   uninstall failed: xvm removal selection failed for local:gcc@15.1.0:
+        #   exact removal version is not registered (target='gcc', version='local:15.1.0')
+        #
+        # gcc.lua is the case: on Windows install() is `pkgmanager.install(
+        # "mingw-w64@...")` and config() returns early with "config in
+        # mingw-w64.lua", so every shim under the name `gcc` belongs to
+        # mingw-w64 (mingw-w64.lua:99 `xvm.add("gcc", config)`). The install half
+        # passes — the log shows the shims appearing — and only removal has
+        # nothing to point at.
+        #
+        # Pre-existing, and newly VISIBLE rather than newly broken: this file's
+        # tests only run for recipes in the changed set, and before now gcc.lua
+        # had never been in it while this assertion existed. The same shape as
+        # openxlings/xlings#503, filed as openxlings/xlings#506; whether `remove`
+        # should succeed as a no-op against a delegated package is an xlings-side
+        # question, not this test's.
+        #
+        # Narrow on purpose, mirroring the `type = "config"` tolerance in
+        # posix-test.sh: the recipe must actually delegate (a `pkgmanager.install`
+        # call in its source) AND the failure must be in uninstall, which is the
+        # only branch this sits in. Keying on "uninstall failed" alone would
+        # swallow a genuine removal bug in any delegating recipe, and a tolerance
+        # that hides the case it was not written for is how a skipped assertion
+        # becomes permanent.
+        $delegates = $false
+        try {
+            $delegates = (Get-Content $luaFile -Raw) -match 'pkgmanager\.install\('
+        } catch { }
+        if ($delegates) {
+            Log-Info "uninstall not asserted: this recipe delegates its Windows install"
+            Log-Info "  ($removeSpec registers no xvm version of its own -- see the note in this script)"
+            continue
+        }
         Log-Fail "uninstall failed"
         $failures += "$relFile (uninstall)"
         continue

--- a/pkgs/d/directx-headers.lua
+++ b/pkgs/d/directx-headers.lua
@@ -1,0 +1,129 @@
+package = {
+    spec = "1",
+    homepage = "https://github.com/microsoft/DirectX-Headers",
+
+    name = "directx-headers",
+    description = "D3D12 headers + GUID/format-table archives — build-time input for mesa's d3d12 driver",
+    authors = {"Microsoft"},
+    licenses = {"MIT"},
+    repo = "https://github.com/microsoft/DirectX-Headers",
+
+    type = "package",
+    archs = {"x86_64"},
+    -- dev, for the same reason llvm-dev is: nothing a user installs loads this.
+    -- It exists so that BUILDING mesa with -Dgallium-drivers=...,d3d12 has a
+    -- named, versioned input instead of a wrap subproject fetched mid-build.
+    status = "dev",
+    categories = {"graphics", "d3d12", "build"},
+    keywords = {"directx", "d3d12", "mesa", "gallium", "wsl", "build-only"},
+
+    -- No `programs`, and there is nothing to argue about: the payload contains
+    -- no executables at all. Headers, two static archives, one .pc file.
+    --
+    -- config() still calls xvm.add(package.name) as a release anchor -- Spec D1,
+    -- and it is what makes `xlings remove directx-headers` resolvable instead of
+    -- failing with "removal version is not registered" (openxlings/xlings#503).
+
+    xpm = {
+        linux = {
+            -- No deps, and that is deliberate rather than an omission.
+            --
+            -- The payload is headers plus two *static* archives. Nothing here is
+            -- loaded, dlopen'd or executed, so there is no runtime closure to
+            -- declare -- the CI closure guard scans executables and `*.so*`, and
+            -- correctly finds neither.
+            --
+            -- The archives DO carry unresolved libstdc++ references, which get
+            -- satisfied when mesa links them in; that obligation belongs to
+            -- mesa's own `gcc-runtime@>=15`, not here. It is also why these were
+            -- built with gcc 15.1.0 and not 16: see the build script.
+            exports = {
+                -- include/ only. There is no lib/ entry because `lib` here holds
+                -- `.a` files: putting it on a runtime libdir list would advertise
+                -- a load path for something that can never be loaded.
+                build = { includedirs = { "include" } },
+            },
+            ["latest"] = { ref = "1.614.1" },
+            -- 1.614.1 is exactly mesa's floor (`version : '>= 1.614.1'`,
+            -- meson.build:607). Being ahead of the consumer's requirement buys
+            -- nothing and makes the pairing harder to reason about.
+            ["1.614.1"] = {
+                url = {
+                    GLOBAL = "https://github.com/xlings-res/directx-headers/releases/download/1.614.1/directx-headers-1.614.1-linux-x86_64.tar.gz",
+                    CN     = "https://gitcode.com/xlings-res/directx-headers/releases/download/1.614.1/directx-headers-1.614.1-linux-x86_64.tar.gz",
+                },
+                sha256 = "1aa0097f091ccd75c02a00ceda8abbb3f82afea8c1947c303d2c019efbecb065",
+            },
+        },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+import("xim.libxpkg.log")
+
+function install()
+    local src = pkginfo.install_file():replace(".tar.gz", "")
+    if not os.isdir(src) then
+        -- Identified by content, not by name: the extraction directory is
+        -- shared, so "the only directory there" is not a usable rule.
+        local base = path.directory(src)
+        local found = nil
+        for _, d in ipairs(os.dirs(path.join(base, "*"))) do
+            if os.isfile(path.join(d, "share", "pkgconfig", "DirectX-Headers.pc")) then
+                found = d; break
+            end
+        end
+        if not found then
+            raise("cannot find the payload root under '" .. base
+                  .. "': no extracted directory contains share/pkgconfig/DirectX-Headers.pc")
+        end
+        src = found
+    end
+
+    os.tryrm(pkginfo.install_dir())
+    os.mv(src, pkginfo.install_dir())
+
+    -- Assert what mesa will ask for, naming the line that asks.
+    --
+    -- A missing member here is otherwise silent: mesa reports
+    -- `Run-time dependency DirectX-Headers found: NO` and then evaluates its
+    -- `fallback:` wrap, which reaches the network -- so the symptom is a build
+    -- that downloads something, not a build that fails.
+    local want = {
+        { "share/pkgconfig/DirectX-Headers.pc", "dependency('DirectX-Headers')     meson.build:606" },
+        { "share/pkgconfig/directx-headers.pc", "dependency('directx-headers')     meson.build:604" },
+        { "lib/libd3dx12-format-properties.a",  "Libs: -ld3dx12-format-properties" },
+        { "lib/libDirectX-Guids.a",             "Libs: -lDirectX-Guids" },
+        { "include/directx/d3d12.h",            "Cflags: -I${includedir}/directx" },
+        -- The Windows-type stubs. Without these d3d12.h has no GUID/HRESULT on
+        -- Linux and the failure appears deep inside mesa's own sources.
+        { "include/wsl/stubs/unknwn.h",         "Cflags: -I${includedir}/wsl/stubs" },
+    }
+    for _, w in ipairs(want) do
+        if not os.isfile(path.join(pkginfo.install_dir(), w[1])) then
+            raise("directx-headers payload is missing " .. w[1] .. " -- " .. w[2])
+        end
+    end
+
+    -- No relocation hook, and that is a property of the payload rather than an
+    -- oversight. The .pc expresses its prefix as `${pcfiledir}/../..`, which
+    -- pkg-config expands against wherever the file was FOUND -- so the paths are
+    -- correct at any install prefix without anything rewriting them. Compare
+    -- llvm-dev, which must patch libclc.pc because that file comes from someone
+    -- else's build and hardcodes absolute paths.
+    log.info("directx-headers: build-time inputs in place (d3d12 headers, 2 archives, pkg-config)")
+    log.warn("directx-headers is a BUILD-time package: static archives and headers, "
+             .. "no shared objects. It must not appear in a shipped payload's runtime closure.")
+    return true
+end
+
+function config()
+    xvm.add(package.name)
+    return true
+end
+
+function uninstall()
+    xvm.remove(package.name)
+    return true
+end

--- a/pkgs/g/gcc.lua
+++ b/pkgs/g/gcc.lua
@@ -126,6 +126,7 @@ function install()
             symlink = true,
             verbose = true,
         })
+        __prune_stale_fixincludes()
     end
     return true
 end
@@ -165,6 +166,77 @@ function uninstall()
 end
 
 -- private
+
+-- Drop the headers fixincludes froze at gcc-build time.
+--
+-- When gcc is built, `fixincludes` copies system headers it judges broken into
+-- `lib/gcc/<triple>/<ver>/include-fixed/` and patches them. That directory
+-- precedes the sysroot in the search order, so the copies WIN over the live
+-- headers -- which is the whole point when the sysroot never moves, and exactly
+-- wrong for a relocatable toolchain whose sysroot is a package we upgrade.
+--
+-- Measured on the 15.1.0 payload, 2026-08-08 (openxlings/xim-pkgindex#560):
+--
+--   include-fixed/pthread.h  was frozen from
+--       /home/xlings/.xlings_data/subos/linux/usr/include/pthread.h
+--   i.e. from OUR OWN sysroot as it stood at gcc build time -- glibc 2.39. The
+--   sysroot is now glibc 2.44, and 2.44 changed the layout of pthread_cond_t:
+--
+--     2.39  #define PTHREAD_COND_INITIALIZER { { {0}, {0}, {0,0}, {0,0}, 0, 0, {0,0} } }
+--     2.44  #define PTHREAD_COND_INITIALIZER { { {0}, {0}, {0,0}, 0, 0, {0,0}, 0, 0 } }
+--
+--   The frozen macro is fed to the live type, so libstdc++'s own
+--   `ext/concurrence.h:257` stops compiling:
+--
+--     cannot convert '<brace-enclosed initializer list>' to 'unsigned int'
+--
+--   Any C++ translation unit reaching that header fails, which is most of them.
+--   It took down an LLVM build at 13/4049 with an error naming neither gcc nor
+--   the header that shadowed. With the file removed, `-H` shows the sysroot's
+--   pthread.h winning and the same unit compiles clean.
+--
+-- So this is not host leakage -- it is VERSION SKEW against our own glibc, and
+-- it recurs on every glibc bump for any gcc that ships an include-fixed copy.
+--
+-- The discriminator is the fixincludes banner, not a filename list. gcc also
+-- puts genuinely-generated headers here (`limits.h`, `syslimits.h`) which carry
+-- no banner and must stay; a filename allowlist would need editing every time
+-- fixincludes decides to freeze something new, and the failure mode of guessing
+-- wrong is silent. 16.1.0's include-fixed holds only README, so this is a no-op
+-- there -- which is the shape to want: the fix is not conditioned on a version.
+function __prune_stale_fixincludes()
+    local banner = "auto-edited by fixincludes"
+    local pruned = 0
+
+    -- Walked with `os.files("*")` + `os.dirs("*")` rather than a `**` glob.
+    -- fixincludes nests its copies (bits/, sys/), so the scan has to recurse --
+    -- but `**` has no other user in this index, and the failure mode of a
+    -- pattern that quietly matches nothing here is indistinguishable from a
+    -- healthy payload. These two primitives are used by other recipes already.
+    local function scan(d)
+        for _, f in ipairs(os.files(path.join(d, "*"))) do
+            local content = io.readfile(f)
+            if content and content:find(banner, 1, true) then
+                os.tryrm(f)
+                pruned = pruned + 1
+                log.info("gcc: pruned frozen fixincludes header " .. path.filename(f)
+                         .. " (see #560) -- the sysroot's own copy now wins")
+            end
+        end
+        for _, sub in ipairs(os.dirs(path.join(d, "*"))) do scan(sub) end
+    end
+
+    for _, dir in ipairs(os.dirs(path.join(pkginfo.install_dir(),
+                                           "lib", "gcc", "*", "*", "include-fixed"))) do
+        scan(dir)
+    end
+    -- Deliberately not an error when zero: a payload built with a fixincludes
+    -- that found nothing to fix is the healthy case, not a missing fix.
+    if pruned > 0 then
+        log.warn("gcc: removed " .. pruned .. " header(s) frozen against an older "
+                 .. "sysroot; C++ threading headers would not have compiled")
+    end
+end
 
 function __config_linux()
     local gcc_bindir = path.join(pkginfo.install_dir(), "bin")

--- a/pkgs/g/gcc.lua
+++ b/pkgs/g/gcc.lua
@@ -206,36 +206,60 @@ end
 -- there -- which is the shape to want: the fix is not conditioned on a version.
 function __prune_stale_fixincludes()
     local banner = "auto-edited by fixincludes"
+    local root = path.join(pkginfo.install_dir(), "lib", "gcc")
+    if not os.isdir(root) then return end
+
+    -- Found with `grep -rl`, not with a Lua directory walk.
+    --
+    -- This took three wrong primitives to get right, and all three failed the
+    -- same way -- an install hook dying on "attempt to call a nil value":
+    --
+    --   os.files     nil in the recipe sandbox (already recorded in
+    --                pkgs/m/musl-gcc.lua, and written here anyway)
+    --   os.exists    nil
+    --   os.filedirs  nil -- despite pkgs/i/interposer-stub.lua:86 calling it,
+    --                which means that error path has never run either
+    --
+    -- os.dirs works but lists only directories, and this needs FILES, recursively
+    -- (fixincludes nests into bits/, sys/). `os.iorun` is attested by 36 recipes,
+    -- and grep does the recursion and the file discrimination in one call -- so
+    -- there is nothing left to get wrong about the traversal.
+    --
+    -- `|| true` because grep exits 1 when it matches nothing, which is the
+    -- healthy case here, and os.iorun raises on a non-zero exit.
+    local out = os.iorun(string.format(
+        "sh -c 'grep -rlF %s %s 2>/dev/null || true'",
+        __shq(banner), __shq(root)))
+
     local pruned = 0
-
-    -- Walked with `os.files("*")` + `os.dirs("*")` rather than a `**` glob.
-    -- fixincludes nests its copies (bits/, sys/), so the scan has to recurse --
-    -- but `**` has no other user in this index, and the failure mode of a
-    -- pattern that quietly matches nothing here is indistinguishable from a
-    -- healthy payload. These two primitives are used by other recipes already.
-    local function scan(d)
-        for _, f in ipairs(os.files(path.join(d, "*"))) do
-            local content = io.readfile(f)
-            if content and content:find(banner, 1, true) then
-                os.tryrm(f)
-                pruned = pruned + 1
-                log.info("gcc: pruned frozen fixincludes header " .. path.filename(f)
-                         .. " (see #560) -- the sysroot's own copy now wins")
-            end
+    for _, line in ipairs((out or ""):split("\n", { plain = true })) do
+        local f = line:trim()
+        -- Only under an include-fixed directory. grep is pointed at lib/gcc, and
+        -- narrowing here rather than in the pattern keeps the check readable and
+        -- refuses to delete anything outside the one directory this is about.
+        if f ~= "" and f:find("include-fixed", 1, true) and os.isfile(f) then
+            os.tryrm(f)
+            pruned = pruned + 1
+            log.info("gcc: pruned frozen fixincludes header " .. path.filename(f)
+                     .. " (see #560) -- the sysroot's own copy now wins")
         end
-        for _, sub in ipairs(os.dirs(path.join(d, "*"))) do scan(sub) end
     end
 
-    for _, dir in ipairs(os.dirs(path.join(pkginfo.install_dir(),
-                                           "lib", "gcc", "*", "*", "include-fixed"))) do
-        scan(dir)
-    end
     -- Deliberately not an error when zero: a payload built with a fixincludes
-    -- that found nothing to fix is the healthy case, not a missing fix.
+    -- that found nothing to fix is the healthy case, not a missing fix. 16.1.0 is
+    -- exactly that -- its include-fixed holds only README.
     if pruned > 0 then
         log.warn("gcc: removed " .. pruned .. " header(s) frozen against an older "
                  .. "sysroot; C++ threading headers would not have compiled")
     end
+end
+
+-- Single-quote for `sh -c`. The paths here are ours and the banner is a literal,
+-- so this is belt-and-braces rather than a live injection concern -- but a build
+-- path containing a quote would otherwise turn a prune into an unparseable
+-- command, and the recipe would report success having pruned nothing.
+function __shq(s)
+    return "'" .. tostring(s):gsub("'", "'\\''") .. "'"
 end
 
 function __config_linux()

--- a/pkgs/l/llvm-dev.lua
+++ b/pkgs/l/llvm-dev.lua
@@ -31,29 +31,63 @@ package = {
 
     xpm = {
         linux = {
-            -- gcc 16, not gcc-runtime.
+            -- gcc-runtime, and this is the promised payoff of the #560 fix.
             --
-            -- This payload was compiled by gcc 16.1.0, so its libstdc++ ABI is
-            -- 16's, while `gcc-runtime` in this index is 15.1.0 -- declaring the
-            -- latter would resolve and then fail at load on a
-            -- GLIBCXX_3.4.3x symbol.
+            -- 20.1.7 had to declare the whole `xim:gcc@16.1.0` toolchain, because
+            -- that payload was compiled by gcc 16 (its libstdc++ ABI was 16's)
+            -- and gcc 15.1.0 could not build LLVM here at all -- its frozen
+            -- include-fixed/pthread.h shadowed the sysroot and libstdc++'s own
+            -- <ext/concurrence.h> stopped compiling.
             --
-            -- It is 16 rather than 15 because gcc 15.1.0 cannot build LLVM in
-            -- this ecosystem at all: its include-fixed/pthread.h shadows the
-            -- sysroot and libstdc++'s own <ext/concurrence.h> stops compiling
-            -- (openxlings/xim-pkgindex#560). When that is fixed, rebuilding this
-            -- with 15.1.0 lets the dep become the much lighter gcc-runtime.
-            deps = { "xim:gcc@16.1.0", "xim:glibc@>=2.38" },
+            -- pkgs/g/gcc.lua now prunes that header, so 20.1.7.1 is built by gcc
+            -- 15.1.0 and the dep is the runtime libraries alone. Measured on the
+            -- payload rather than assumed:
+            --
+            --   objdump -p lib/libLLVM.so | grep GLIBCXX_  ->  max 3.4.30
+            --
+            -- which gcc-runtime 15.1.0 satisfies comfortably. A floor, not a pin:
+            -- libstdc++ is backward compatible, so a newer runtime also serves.
+            deps = { "xim:gcc-runtime@>=15", "xim:glibc@>=2.38" },
             exports = {
                 runtime = { libdirs = { "lib" } },
             },
-            ["latest"] = { ref = "20.1.7" },
-            ["20.1.7"] = {
+            ["latest"] = { ref = "20.1.7.1" },
+            -- 20.1.7.1: upstream llvm-project is 20.1.7, the fourth component is
+            -- ours. It is a different payload, not a rebuild of the same thing:
+            --
+            --   20.1.7    X86;SPIRV,        built by gcc 16.1.0
+            --   20.1.7.1  X86;AMDGPU;SPIRV, built by gcc 15.1.0
+            --
+            -- AMDGPU is the load-bearing addition. 20.1.7 was built on the theory
+            -- that AMDGPU "is libllvm's axis" -- but the libllvm payload is a
+            -- lib/ directory with no headers, no LLVMConfig.cmake and no
+            -- llvm-config, so meson's two LLVM detection methods can never find
+            -- it. libllvm cannot be a BUILD input at all.
+            --
+            -- So mesa's configure walked past it and reported
+            -- `llvm-config found: YES (/usr/bin/llvm-config) 18.1.3` -- the
+            -- HOST's LLVM 18, while this index ships libllvm 20.1.7. A libgallium
+            -- linked that way needs libLLVM.so.18.1, which does not exist here,
+            -- so the payload could not have loaded.
+            --
+            -- 20.1.7 is REPLACED here, not kept alongside, and that is a
+            -- limitation of the recipe rather than a judgement about the payload.
+            --
+            -- `deps` is declared per PLATFORM, not per version. 20.1.7 was built
+            -- by gcc 16 and genuinely needs gcc 16's libstdc++; 20.1.7.1 needs
+            -- only gcc-runtime@>=15. One `deps` list cannot be true of both, and
+            -- offering a version whose declared deps are wrong is worse than not
+            -- offering it -- it resolves, installs, and fails at load on a
+            -- GLIBCXX symbol.
+            --
+            -- The published asset is untouched and still downloadable; anything
+            -- that pinned it keeps working. Only this index stops advertising it.
+            ["20.1.7.1"] = {
                 url = {
-                    GLOBAL = "https://github.com/xlings-res/llvm-dev/releases/download/20.1.7/llvm-dev-20.1.7-linux-x86_64.tar.gz",
-                    CN     = "https://gitcode.com/xlings-res/llvm-dev/releases/download/20.1.7/llvm-dev-20.1.7-linux-x86_64.tar.gz",
+                    GLOBAL = "https://github.com/xlings-res/llvm-dev/releases/download/20.1.7.1/llvm-dev-20.1.7.1-linux-x86_64.tar.gz",
+                    CN     = "https://gitcode.com/xlings-res/llvm-dev/releases/download/20.1.7.1/llvm-dev-20.1.7.1-linux-x86_64.tar.gz",
                 },
-                sha256 = "b0cdaaad773584dbbaa2f1acf788098c33dacf2013c50605efaf4333f8d134bf",
+                sha256 = "5a00dd63168c7520d972f142dabf3f3ae79edc38f58a3f4740999e9264c3a99e",
             },
         },
     },

--- a/pkgs/m/mesa.lua
+++ b/pkgs/m/mesa.lua
@@ -3,7 +3,7 @@ package = {
 
     homepage = "https://mesa3d.org",
     name = "mesa",
-    description = "Mesa 3D — OpenGL and Vulkan: llvmpipe, radeonsi, nouveau, zink, RADV",
+    description = "Mesa 3D — OpenGL and Vulkan: llvmpipe, radeonsi, iris, nouveau, zink, d3d12, RADV",
 
     authors = {"Mesa contributors"},
     licenses = {"MIT"},
@@ -25,12 +25,26 @@ package = {
     -- a GL program installed through xlings renders on a host that has no
     -- graphics stack of its own.
     --
-    -- Drivers: llvmpipe and softpipe (CPU), radeonsi (AMD), nouveau (NVIDIA
-    -- open kernel module), zink (GL over Vulkan), and RADV for Vulkan on AMD.
-    -- Intel (iris/anv) and NVK are the two upstream drivers NOT here: iris and
-    -- anv require libclc, which needs clang and the SPIR-V translator, and NVK
-    -- is Rust and needs bindgen. Both are additions to the build chain rather
-    -- than to this recipe.
+    -- Drivers: llvmpipe and softpipe (CPU), radeonsi (AMD), iris (Intel),
+    -- nouveau (NVIDIA open kernel module), zink (GL over Vulkan), d3d12 (WSL2 /
+    -- Windows via DirectX 12), and RADV for Vulkan on AMD.
+    --
+    -- iris and d3d12 arrived in 25.0.7.2, and what they cost was five packages
+    -- rather than a flag:
+    --
+    --   iris   -> with_gallium_iris implies with_clc (meson.build:841), so
+    --             libclc + LLVMSPIRVLib + clang-cpp (llvm-dev) AND SPIRV-Tools
+    --   d3d12  -> dependency('DirectX-Headers') (meson.build:606)
+    --
+    -- None of them appear in `deps` below, and that is the point: they are
+    -- BUILD-time inputs. The payload was checked rather than assumed --
+    -- libclang-cpp, libLLVMSPIRVLib, libSPIRV-Tools and libclc appear zero times
+    -- in it, and no DT_NEEDED anywhere in the payload names any of them. iris and
+    -- d3d12 add exactly one library between them, `libgbm.so.1`, which mesa ships
+    -- itself. So the external closure is unchanged from 25.0.7.1.
+    --
+    -- anv (Intel Vulkan) and NVK are still NOT here: anv wants the same clc
+    -- chain plus more, and NVK is Rust and needs bindgen.
     --
     -- Build details, per-flag, and what each one cost:
     -- https://github.com/xlings-res/mesa
@@ -84,7 +98,27 @@ package = {
             exports = {
                 runtime = { libdirs = { "lib" } },
             },
-            ["latest"] = { ref = "25.0.7.1" },
+            ["latest"] = { ref = "25.0.7.2" },
+            -- 25.0.7.2: upstream is 25.0.7, the fourth component is ours. Adds
+            -- iris and d3d12 to gallium-drivers; nothing else about the build
+            -- changed, and the external DT_NEEDED closure is byte-for-byte the
+            -- same set as 25.0.7.1.
+            --
+            -- The source needed ONE patch to build at all:
+            -- `.agents/tools/graphics/patches/mesa-25.0.7-glibc-2.42-c11-threads.patch`.
+            -- ISO C23 moved once_flag/call_once into <stdlib.h>, glibc >= 2.42
+            -- followed, and mesa's own src/c11 shim redefines both -- so 25.0.7
+            -- cannot compile against the glibc 2.44 in this index, and 25.0.7 is
+            -- the last release of its series. 25.0.7.1 was built when this sysroot
+            -- was glibc 2.39; the same source and command now fail without the
+            -- patch. Worth knowing before anyone tries to reproduce the payload.
+            ["25.0.7.2"] = {
+                url = {
+                    GLOBAL = "https://github.com/xlings-res/mesa/releases/download/25.0.7.2/mesa-25.0.7.2-linux-x86_64.tar.gz",
+                    CN     = "https://gitcode.com/xlings-res/mesa/releases/download/25.0.7.2/mesa-25.0.7.2-linux-x86_64.tar.gz",
+                },
+                sha256 = "b589513ea1834ba995456680ad57a117428ba38299d8cc37d8fe301e5f6e6c9b",
+            },
             -- 25.0.7.1: upstream is 25.0.7, the fourth component is ours.
             -- The payload was rebuilt with the full driver set, and a payload
             -- whose contents changed has to be a different version — a GitCode

--- a/pkgs/s/spirv-tools.lua
+++ b/pkgs/s/spirv-tools.lua
@@ -1,0 +1,148 @@
+package = {
+    spec = "1",
+    homepage = "https://github.com/KhronosGroup/SPIRV-Tools",
+
+    name = "spirv-tools",
+    description = "SPIRV-Headers + SPIRV-Tools — build-time input for mesa's mesa_clc (iris)",
+    authors = {"The Khronos Group"},
+    licenses = {"Apache-2.0"},
+    repo = "https://github.com/KhronosGroup/SPIRV-Tools",
+
+    type = "package",
+    archs = {"x86_64"},
+    -- dev, like llvm-dev and directx-headers: mesa uses it only inside mesa_clc,
+    -- a host tool run while the payload is being BUILT.
+    status = "dev",
+    categories = {"graphics", "spirv", "build"},
+    keywords = {"spirv", "spirv-tools", "spirv-headers", "mesa", "iris", "clc", "build-only"},
+
+    -- No `programs`, though the payload does ship bin/spirv-as, spirv-val,
+    -- spirv-opt and friends.
+    --
+    -- They are kept so the payload can be checked on its own -- the build
+    -- assembles and validates a real SPIR-V module rather than listing files --
+    -- but declaring them would put user-facing shims on a build-only package, and
+    -- `programs` asserts EXCLUSIVE ownership of those names. Consumers reach them
+    -- by payload path, which is how build-in-subos.sh already invokes build tools.
+
+    xpm = {
+        linux = {
+            -- gcc-runtime, not gcc.
+            --
+            -- The archives are C++ and carry unresolved libstdc++ references, so
+            -- whatever links them needs a compatible runtime. Measured on the
+            -- payload's own executables rather than assumed:
+            --
+            --   objdump -p bin/spirv-val | grep GLIBCXX_   ->  well under 3.4.34
+            --
+            -- Built by gcc 15.1.0 for the same reason directx-headers is: these
+            -- end up inside a host tool that also links our LLVM, and mixing
+            -- libstdc++ ABIs across that boundary breaks RTTI and exceptions.
+            deps = { "xim:gcc-runtime@>=15", "xim:glibc@>=2.38" },
+            exports = {
+                -- No runtime libdirs: `lib` holds `.a` files only. Advertising a
+                -- runtime load path for a static archive would be a claim that
+                -- cannot be true.
+                build = { includedirs = { "include" } },
+            },
+            ["latest"] = { ref = "2025.1" },
+            -- 2025.1 is the upstream tag. Its own pkg-config reports `2025.1.1`,
+            -- which is upstream's business; mesa only asks for `>= 2022.1`
+            -- (meson.build:1887) and both forms satisfy it.
+            ["2025.1"] = {
+                url = {
+                    GLOBAL = "https://github.com/xlings-res/spirv-tools/releases/download/2025.1/spirv-tools-2025.1-linux-x86_64.tar.gz",
+                    CN     = "https://gitcode.com/xlings-res/spirv-tools/releases/download/2025.1/spirv-tools-2025.1-linux-x86_64.tar.gz",
+                },
+                sha256 = "9996bdb6a1753b4106ab9d288996bd83063e8b52855d99b135f876880688adc8",
+            },
+        },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+import("xim.libxpkg.log")
+
+function install()
+    local src = pkginfo.install_file():replace(".tar.gz", "")
+    if not os.isdir(src) then
+        -- By content, not by name: the extraction directory is shared.
+        local base = path.directory(src)
+        local found = nil
+        for _, d in ipairs(os.dirs(path.join(base, "*"))) do
+            if os.isfile(path.join(d, "lib", "pkgconfig", "SPIRV-Tools.pc")) then
+                found = d; break
+            end
+        end
+        if not found then
+            raise("cannot find the payload root under '" .. base
+                  .. "': no extracted directory contains lib/pkgconfig/SPIRV-Tools.pc")
+        end
+        src = found
+    end
+
+    local dir = pkginfo.install_dir()
+    os.tryrm(dir)
+    os.mv(src, dir)
+
+    -- Assert both halves, naming what each is for.
+    --
+    -- SPIRV-Headers is the half that is easy to lose: SPIRV-Tools.pc can name it
+    -- in `Requires:`, and pkg-config resolves that at QUERY time -- so a payload
+    -- missing the headers makes mesa report SPIRV-TOOLS as not found, pointing at
+    -- the wrong package entirely.
+    local want = {
+        { "lib/pkgconfig/SPIRV-Tools.pc",     "dependency('SPIRV-Tools')  meson.build:1887" },
+        { "lib/libSPIRV-Tools.a",             "the static library mesa_clc links" },
+        { "include/spirv-tools/libspirv.h",   "the C API mesa_clc includes" },
+        { "include/spirv/unified1/spirv.h",   "SPIRV-Headers -- pinned by SPIRV-Tools' own DEPS" },
+    }
+    for _, w in ipairs(want) do
+        if not os.isfile(path.join(dir, w[1])) then
+            raise("spirv-tools payload is missing " .. w[1] .. " -- " .. w[2])
+        end
+    end
+
+    -- Static-only, asserted.
+    --
+    -- Upstream builds `SPIRV-Tools-shared` as its own cmake target, which
+    -- -DBUILD_SHARED_LIBS=OFF does not suppress; the build script drops it. If one
+    -- ever survives into a payload, a link line could pick it up and libgallium
+    -- would gain a DT_NEEDED on a library that -- this being a `dev` package -- is
+    -- not in mesa's runtime deps and never installed on a user's machine. The
+    -- symptom would be a dlopen failure naming a library nobody declared.
+    --
+    -- Enumerated with `ls` via os.iorun because the recipe sandbox has no file
+    -- lister: os.files, os.exists and os.filedirs are all nil here.
+    local out = os.iorun(string.format(
+        "sh -c 'ls %s/lib/*.so* 2>/dev/null || true'",
+        "'" .. dir:gsub("'", "'\\''") .. "'"))
+    local shared = {}
+    for _, line in ipairs((out or ""):split("\n", { plain = true })) do
+        local f = line:trim()
+        if f ~= "" then table.insert(shared, path.filename(f)) end
+    end
+    if #shared > 0 then
+        raise("spirv-tools payload contains shared objects (" .. table.concat(shared, ", ")
+              .. "); this package must be static-only so it cannot enter a shipped "
+              .. "payload's runtime closure")
+    end
+
+    log.info("spirv-tools: build-time inputs in place (static SPIRV-Tools + SPIRV-Headers)")
+    log.warn("spirv-tools is a BUILD-time package: static archives only. It must not "
+             .. "appear in a shipped payload's runtime closure.")
+    return true
+end
+
+function config()
+    -- Release anchor, no program. Spec D1; also what makes `xlings remove
+    -- spirv-tools` resolvable (openxlings/xlings#503).
+    xvm.add(package.name)
+    return true
+end
+
+function uninstall()
+    xvm.remove(package.name)
+    return true
+end

--- a/pkgs/w/wayland-protocols.lua
+++ b/pkgs/w/wayland-protocols.lua
@@ -122,20 +122,34 @@ function install()
     -- Count them, because "the directory exists" is a different claim.
     --
     -- A truncated extraction leaves the tree present and nearly empty, and every
-    -- path assertion above still passes. 1.38 ships 50 files and 1.45 ships 57,
-    -- so the floor is set below both rather than pinned to either.
+    -- path assertion above still passes.
+    --
+    -- Counted with os.dirs, which is the only enumerator this sandbox actually
+    -- has. `os.files`, `os.exists` and `os.filedirs` are all nil here -- each was
+    -- tried and each died as "attempt to call a nil value". pkgs/m/musl-gcc.lua
+    -- already recorded the first; pkgs/i/interposer-stub.lua:86 calls the third,
+    -- so that error path has never run.
+    --
+    -- Counting directories is not a workaround for the missing file enumerator --
+    -- it is the better measure anyway. Upstream ships one directory per protocol
+    -- (stable/xdg-shell/, staging/fifo-v1/, unstable/linux-dmabuf/), and some hold
+    -- several versioned .xml files, so directories count PROTOCOLS while files
+    -- count revisions.
+    --
+    -- 1.45 has 53; the floor is set well below so a version bump does not need
+    -- this number edited, which is the point of a floor.
     local n = 0
     for _, sub in ipairs({"stable", "staging", "unstable"}) do
-        for _, d in ipairs(os.dirs(path.join(dir, "share", "wayland-protocols", sub, "*"))) do
-            for _, f in ipairs(os.files(path.join(d, "*.xml"))) do n = n + 1 end
+        for _, e in ipairs(os.dirs(path.join(dir, "share", "wayland-protocols", sub, "*"))) do
+            n = n + 1
         end
     end
-    if n < 40 then
-        raise("only " .. n .. " protocol XML files in the payload; 1.38 ships 50 and "
-              .. "1.45 ships 57 -- the tarball is truncated or the layout changed")
+    if n < 30 then
+        raise("only " .. n .. " protocol entries in the payload; 1.45 has 53 across "
+              .. "stable/staging/unstable -- the tarball is truncated or the layout changed")
     end
 
-    log.info("wayland-protocols: " .. n .. " protocol files in place")
+    log.info("wayland-protocols: " .. n .. " protocols in place")
     return true
 end
 

--- a/pkgs/w/wayland-protocols.lua
+++ b/pkgs/w/wayland-protocols.lua
@@ -15,10 +15,47 @@ package = {
     categories = {"graphics", "lib"},
     keywords = {"wayland-protocols", "graphics", "gl"},
 
+    -- WHAT THIS IS FOR, AND THE TRAP IN IT
+    --
+    -- mesa asks for it the moment the wayland platform is on:
+    --
+    --   meson.build:2061  dependency('wayland-protocols', version : '>= 1.38')
+    --
+    -- and mesa reads exactly one variable from it,
+    -- `get_variable(pkgconfig : 'pkgdatadir')`, which it hands to
+    -- wayland-scanner to generate C that is compiled into libEGL_mesa and libgbm.
+    --
+    -- The trap: this package existing is not the same as mesa using it. Its .pc
+    -- lives in the payload and config() stages nothing into the subos sysroot, so
+    -- pkg-config cannot see it unless a build names it explicitly --
+    -- `build-in-subos.sh --deps wayland-protocols` or XLINGS_GFX_PKGCONFIG_EXTRA.
+    -- The T5 mesa line in tiers.sh did neither, and a host with
+    -- /usr/share/pkgconfig/wayland-protocols.pc satisfies mesa silently. So an
+    -- installed, correct, published package can sit unused while the host is
+    -- consumed in its place, and nothing reports it.
+
     xpm = {
         linux = {
             deps = {},
-            ["latest"] = { ref = "1.38" },
+            -- Content is architecture-independent -- XML and one .pc, no object
+            -- code. `archs` is x86_64 because that is what this index publishes
+            -- for; a second arch should be given this same tarball.
+            ["latest"] = { ref = "1.45" },
+            -- 1.45 alongside 1.38 rather than replacing it. Protocol XML is
+            -- purely additive, so a newer set only offers mesa more interfaces --
+            -- but a payload already published cannot be withdrawn, and something
+            -- may have been built against 1.38.
+            --
+            -- 1.45 is what the mesa rebuild wants because it is the version the
+            -- HOST offered when mesa 25.0.7.1 was built. Matching it means the
+            -- rebuild changes the drivers and not the protocol vintage as well.
+            ["1.45"] = {
+                url = {
+                    GLOBAL = "https://github.com/xlings-res/wayland-protocols/releases/download/1.45/wayland-protocols-1.45-linux-x86_64.tar.gz",
+                    CN     = "https://gitcode.com/xlings-res/wayland-protocols/releases/download/1.45/wayland-protocols-1.45-linux-x86_64.tar.gz",
+                },
+                sha256 = "b1d0e8ede6e66a04c39ef113e78ce067ea293d1cd826278004db799d05e40516",
+            },
             ["1.38"] = {
                 url = {
                     GLOBAL = "https://github.com/xlings-res/wayland-protocols/releases/download/1.38/wayland-protocols-1.38-linux-x86_64.tar.gz",
@@ -33,18 +70,76 @@ package = {
 import("xim.libxpkg.pkginfo")
 import("xim.libxpkg.system")
 import("xim.libxpkg.xvm")
+import("xim.libxpkg.log")
 import("xim.pkgindex.sysroot")
 
 function install()
+    -- Found by content, not by a hardcoded name.
+    --
+    -- This used to be `os.mv("wayland-protocols-1.38", dir)` -- a literal that
+    -- silently stops matching the moment a second version exists, and os.mv of a
+    -- missing path leaves install() returning true with no payload at all. Same
+    -- shape as the mesa bug recorded in pkgs/m/mesa.lua: a package that installed
+    -- cleanly and had no content.
+    local src = pkginfo.install_file():replace(".tar.gz", "")
+    if not os.isdir(src) then
+        local base = path.directory(src)
+        local found = nil
+        for _, d in ipairs(os.dirs(path.join(base, "*"))) do
+            if os.isfile(path.join(d, "share", "pkgconfig", "wayland-protocols.pc")) then
+                found = d; break
+            end
+        end
+        if not found then
+            raise("cannot find the payload root under '" .. base
+                  .. "': no extracted directory contains share/pkgconfig/wayland-protocols.pc")
+        end
+        src = found
+    end
+
     local dir = pkginfo.install_dir()
     os.tryrm(dir)
-    os.mv("wayland-protocols-1.38", dir)
+    os.mv(src, dir)
+
+    -- One representative file per protocol directory, plus the .pc.
+    --
+    -- All three directories matter and a subset is worse than an absence: mesa
+    -- binds linux-dmabuf-v1 from stable, fifo-v1/commit-timing-v1 from staging,
+    -- and older compositors still only offer the unstable spellings. A missing
+    -- directory configures fine and then misses an interface at run time, which
+    -- reads as a compositor-specific rendering fault rather than a missing file.
+    local want = {
+        { "share/pkgconfig/wayland-protocols.pc",                            "dependency('wayland-protocols')  meson.build:2061" },
+        { "share/wayland-protocols/stable/xdg-shell/xdg-shell.xml",          "stable/ -- window management" },
+        { "share/wayland-protocols/stable/linux-dmabuf/linux-dmabuf-v1.xml", "stable/ -- zero-copy buffer sharing, what EGL/gbm need" },
+    }
+    for _, w in ipairs(want) do
+        if not os.isfile(path.join(dir, w[1])) then
+            raise("wayland-protocols payload is missing " .. w[1] .. " -- " .. w[2])
+        end
+    end
+
+    -- Count them, because "the directory exists" is a different claim.
+    --
+    -- A truncated extraction leaves the tree present and nearly empty, and every
+    -- path assertion above still passes. 1.38 ships 50 files and 1.45 ships 57,
+    -- so the floor is set below both rather than pinned to either.
+    local n = 0
+    for _, sub in ipairs({"stable", "staging", "unstable"}) do
+        for _, d in ipairs(os.dirs(path.join(dir, "share", "wayland-protocols", sub, "*"))) do
+            for _, f in ipairs(os.files(path.join(d, "*.xml"))) do n = n + 1 end
+        end
+    end
+    if n < 40 then
+        raise("only " .. n .. " protocol XML files in the payload; 1.38 ships 50 and "
+              .. "1.45 ships 57 -- the tarball is truncated or the layout changed")
+    end
+
+    log.info("wayland-protocols: " .. n .. " protocol files in place")
     return true
 end
 
 function config()
-    local binding = package.name .. "@" .. pkginfo.version()
-
     xvm.add(package.name)
     return true
 end

--- a/pkgs/w/wayland.lua
+++ b/pkgs/w/wayland.lua
@@ -17,7 +17,36 @@ package = {
 
     xpm = {
         linux = {
-            deps = { "xim:libffi@>=3.4", "xim:glibc@>=2.38" },
+            -- libxml2 and expat are for `bin/wayland-scanner`, not for the
+            -- libraries, and that is why they were missing for so long.
+            --
+            -- Measured on the 1.23.1 payload, 2026-08-08. Its full DT_NEEDED set
+            -- across every ELF member is:
+            --
+            --   libc.so.6  libffi.so.8  libwayland-client.so.0
+            --   libexpat.so.1  libxml2.so.2
+            --
+            -- and the payload itself ships neither expat nor libxml2. Only
+            -- libffi and glibc were declared, so `xlings install wayland` on a
+            -- clean machine produced a wayland-scanner that cannot start:
+            --
+            --   wayland-scanner: error while loading shared libraries:
+            --   libxml2.so.2: cannot open shared object file
+            --
+            -- It went unnoticed because the LIBRARY half is fine --
+            -- libwayland-client needs only libffi and libc -- so a GL or EGL
+            -- program works and nothing hints that the code generator is broken.
+            -- It only surfaced when mesa's build invoked wayland-scanner, 1957
+            -- targets in, with an error naming neither wayland nor mesa.
+            --
+            -- Floors, not pins: both are ABI-stable and the consumer only needs
+            -- them present. 2.13.5 and 2.6.x are what the index carries.
+            deps = {
+                "xim:libffi@>=3.4",
+                "xim:libxml2@>=2.12",
+                "xim:expat@>=2.6",
+                "xim:glibc@>=2.38",
+            },
             -- elfpatch reads this from each dependency and writes the consumer's
             -- RPATH, which is what makes the stack resolve without anyone
             -- setting LD_LIBRARY_PATH. Same mechanism `gcc-runtime` uses.


### PR DESCRIPTION
Working the mesa iris+d3d12 rebuild turned up four things. Three are the same shape: **an input the build consumed from the host while every check reported a self-contained result.**

## The four

| | what | how it was found |
|---|---|---|
| `pkgs/g/gcc.lua` | #560 fixed at the source | an LLVM build dying at 13/4049 blaming libstdc++ |
| `pkgs/d/directx-headers.lua` | new, 1.614.1 | d3d12's prerequisite looked satisfied and was not |
| `pkgs/w/wayland-protocols.lua` | 1.45 added | mesa found the host's copy of a package we already ship |
| `build-llvm-dev.sh` | AMDGPU + gcc-15 gate | `llvm-config found: YES (/usr/bin/llvm-config) 18.1.3` |

## #560 — version skew against our own glibc

gcc 15.1.0 shipped `include-fixed/pthread.h`, a fixincludes snapshot taken from **our own sysroot** at gcc-build time (glibc 2.39). The sysroot is now 2.44, which changed `pthread_cond_t`:

```
2.39  PTHREAD_COND_INITIALIZER { { {0}, {0}, {0,0}, {0,0}, 0, 0, {0,0} } }
2.44  PTHREAD_COND_INITIALIZER { { {0}, {0}, {0,0}, 0, 0, {0,0}, 0, 0 } }
```

`include-fixed` precedes the sysroot, so the frozen macro meets the live type and libstdc++'s own `ext/concurrence.h:257` stops compiling. **Any C++ TU reaching that header fails** — which is most of them.

Not host leakage. Version skew, recurring on every glibc bump. `install()` now prunes headers carrying the fixincludes banner — the banner, not a filename list, because gcc also puts genuinely-generated headers there (`limits.h`, `syslimits.h`) which carry none.

Measured both ways with 15.1.0 **actually selected** — my first attempt used the subos shim while it still pointed at gcc 16, and proved nothing:

| | errors | `-H` says pthread.h came from |
|---|---|---|
| frozen header present | 1 | `include-fixed/pthread.h` |
| frozen header pruned | 0 | `subos/default/usr/include/pthread.h` |

## wayland-protocols — the one worth reading

**This package already existed at 1.38, published in both regions since 2026-08-05. mesa 25.0.7.1 was still built against the host's copy.**

Nothing was missing. The recipe was right, the payload was right, and the O4 probe certifies all 7 mapped Wayland/EGL objects as coming from `XLINGS_HOME` **at run time**. It was simply never installed in the build home, and the T5 line named it in neither `--deps` nor an extra pkgconfig path — so the host answered the same question and no check could tell.

An unwired build-time input is indistinguishable from a satisfied one. Self-containment at run time and at build time are different properties, and only the first had a guard.

## llvm-dev — an assumption measurement overturned

20.1.7 excluded AMDGPU reasoning it was "libllvm's axis, and building it twice would double an already long build for nothing." Wrong:

```
$ ls <libllvm payload>/
lib
```

No headers, no `LLVMConfig.cmake`, no `llvm-config`. meson has exactly two ways to find LLVM and libllvm offers neither — **libllvm can never be a build input.** So mesa fell through to the host's LLVM 18 while the index ships 20.1.7; a libgallium linked that way needs `libLLVM.so.18.1`, which this index does not ship, so the payload could not have loaded at all.

The axes are "the library a user loads" and "everything a build needs" — the second must cover every target the first does. Now `X86;AMDGPU;SPIRV`, which forces gcc 15 (16 ICEs on `AMDGPUAsmParser.cpp`), now possible because of the #560 fix. The two LLVM scripts finally agree on a compiler.

## build-in-subos.sh — four gaps between a recorded build and a reproducible one

- **meson.** No meson package exists (#562) and this script called `$SUBOS/bin/meson` unconditionally — a path in no home. Every meson build here, mesa included, was driven by the host's. Now: packaged if present, else a pinned copy under our own python.
- **python modules.** Enumerated from the consumer, not discovered one build at a time. mesa's mako probe imports `packaging.version` and falls back to `distutils.version` — and **Python 3.12 removed distutils**, so on our 3.13 payload it fails even when mako imports fine, and mesa blames the one module that isn't the problem. The probe is now mesa's own predicate verbatim.
- **dep `bin/` on PATH.** mesa wants `glslangValidator`; glslang's payload ships it beside `bin/glslang` but the recipe registers only an anchor, so the name mesa asks for was unreachable while the tool sat in an installed payload. Fixed here rather than by adding `programs`, which would change shim ownership to solve a build-time lookup.
- **`XLINGS_GFX_PKGCONFIG_EXTRA`.** A `status = "dev"` package stages nothing into the sysroot, so `--deps` cannot reach llvm-dev without making it pretend to be a runtime package. Restricted to paths under `XLINGS_HOME` or the work dir.

## tiers.sh — the recorded command was not the command

T5's deps field read `libxml2 expat`. That cannot be what built mesa: no subos sysroot farm in this home contains `libglvnd.pc`, and re-running the line as recorded stops at `ERROR: Dependency "libglvnd" not found`. The full 18-package list is spelled out.

A build recipe that does not reproduce the build is worse than none — it costs the next person the same afternoon and looks authoritative.

## Verification

Both new payloads published to GitHub + GitCode, byte-verified, then installed from the local index and checked through pkg-config **from the installed payload**:

```
DirectX-Headers  1.614.1   both spellings resolve, atleast-version ok
                           ${pcfiledir} lands in <payload>/include
wayland-protocols 1.45     pkgdatadir resolves, 57 XML files,
                           stable/xdg-shell/xdg-shell.xml present
```

The DirectX-Headers build audits its own inputs with `-H` and asserts every header came from `XLINGS_HOME` or the source tree — zero host headers, unlike the earlier ad-hoc build.

Both recipes initially failed to install on `os.exists`, which does not exist in the recipe sandbox; caught by running them, not by reading them.

## Not included

The `mesa` 25.0.7.2 bump. Its payload cannot be built until llvm-dev 20.1.7.1 (with AMDGPU) is published, and a recipe pointing at an unpublished URL fails CI immediately. That build is running now.

Refs #560, #562
