### PR TITLE
fix(nvidia-gl-host-link): 桩要的是 DT_RPATH,拿到的是 DT_RUNPATH

### DIFF
--- a/pkgs/n/nvidia-gl-host-link.lua
+++ b/pkgs/n/nvidia-gl-host-link.lua
@@ -409,11 +409,50 @@ function install()
         if os.isfile(vendor_real) then
             table.insert(present, name)
             if has_interposer then
+                local out = path.join(dir, "lib", name)
                 elfpatch.host_link_interposer{
                     vendor = vendor_real,
-                    out    = path.join(dir, "lib", name),
+                    out    = out,
                     soname = name,
                 }
+                -- DT_RPATH, not DT_RUNPATH. One word, and the whole package
+                -- turns on it.
+                --
+                -- The comment above already says why: RPATH is transitive
+                -- along the load chain, RUNPATH is not. The interposer NEEDs
+                -- the real vendor by absolute path, so the object that then
+                -- looks up libnvidia-glsi / libX11 / libc is the HOST's
+                -- vendor library -- which has no search path of its own
+                -- (`readelf -d` on it: zero RPATH/RUNPATH entries). With
+                -- RUNPATH the interposer's paths do not reach that lookup at
+                -- all, and glibc falls back to a cache baked with the build
+                -- machine's prefix plus an empty system path. Nothing is
+                -- found, glvnd swallows the dlopen error, and the only thing
+                -- a user sees is `GLX: No GLXFBConfigs returned`.
+                --
+                -- `elfpatch.host_link_interposer` emits RUNPATH today
+                -- (xlings), so this restores the tag the design calls for.
+                -- Measured on an NVIDIA 550.144.03 host, driving an imgui +
+                -- GLFW window through the hermetic stack:
+                --
+                --   RUNPATH (as emitted) : GLFW error 65542, exit 11
+                --   RPATH   (this line)  : exit 0, libGLX_nvidia initialised
+                --
+                -- Nothing else changed between those two runs.
+                -- `--print-rpath` prints DT_RUNPATH too, so this reads what
+                -- the interposer got and writes it back under the other tag.
+                -- Deliberately not a hand-built path list: the value is the
+                -- closure the RESOLVER computed, and a second copy of that
+                -- computation here would drift from it.
+                local rp = try { function()
+                    return os.iorun(string.format(
+                        [[patchelf --print-rpath "%s"]], out))
+                end }
+                rp = rp and rp:trim() or ""
+                if #rp > 0 then
+                    os.exec(string.format(
+                        [[patchelf --force-rpath --set-rpath %q %q]], rp, out))
+                end
                 table.insert(done, name)
             end
         end


### PR DESCRIPTION
修 mcpp-community/mcpp#352 —— NVIDIA 宿主上 GL 程序报 `GLX: No GLXFBConfigs returned`。

本文件注释早已写明设计要的是 **DT_RPATH**(沿加载链传递),而 `elfpatch.host_link_interposer` 今天发出的是 **DT_RUNPATH**。桩用绝对路径 NEED 宿主真 vendor,随后做查找的是**宿主的库**(自身 RPATH/RUNPATH 条目为 0)—— RUNPATH 不传递,于是桩算出的闭包对那次查找完全不可见,glibc 回落到用构建机前缀烙成的 cache 加一条空 system path。glvnd 吞掉 dlopen 错误,用户只看到 65542。

**NVIDIA 550.144.03 宿主实测,同一桩文件只换 tag:**

| | |
|---|---|
| RUNPATH(现状) | GLFW error 65542,exit 11 |
| RPATH(本改动) | **exit 0**,`libGLX_nvidia` 完成初始化 |

两次运行之间没有任何其它差别。

提交说明里记了排查中被否掉的两条路(软链缺库 / 补 DT_NEEDED),含一条安全教训:把载荷 glibc 软链进该目录会让宿主进程踩到 `__pointer_chk_guard, version GLIBC_PRIVATE`。

值不是手写的:`--print-rpath` 读出 resolver 算好的那份再写回另一个 tag,避免在此留下第二份会漂移的计算。

上游正解是让 `host_link_interposer` 直接发 RPATH(xlings);在那之前这里先纠正。