### PR TITLE
fix(wsl-gl-host-link): force GALLIUM_DRIVER=d3d12 only when the driver is there

### DIFF
--- a/pkgs/m/mesa.lua
+++ b/pkgs/m/mesa.lua
@@ -211,7 +211,7 @@ function config()
 
     xvm.add(package.name)
 
-    -- Only `lib/*.so*`, so the twelve driver modules under `lib/dri/` stay
+    -- Only `lib/*.so*`, so the driver modules under `lib/dri/` stay
     -- out of `<subos>/lib`: those are loaded by path through
     -- LIBGL_DRIVERS_PATH below, and are not link targets.
     sysroot.declare_libs(dir, "lib", tag, pkginfo.version())

--- a/pkgs/n/nvidia-gl-host-link.lua
+++ b/pkgs/n/nvidia-gl-host-link.lua
@@ -409,11 +409,50 @@ function install()
         if os.isfile(vendor_real) then
             table.insert(present, name)
             if has_interposer then
+                local out = path.join(dir, "lib", name)
                 elfpatch.host_link_interposer{
                     vendor = vendor_real,
-                    out    = path.join(dir, "lib", name),
+                    out    = out,
                     soname = name,
                 }
+                -- DT_RPATH, not DT_RUNPATH. One word, and the whole package
+                -- turns on it.
+                --
+                -- The comment above already says why: RPATH is transitive
+                -- along the load chain, RUNPATH is not. The interposer NEEDs
+                -- the real vendor by absolute path, so the object that then
+                -- looks up libnvidia-glsi / libX11 / libc is the HOST's
+                -- vendor library -- which has no search path of its own
+                -- (`readelf -d` on it: zero RPATH/RUNPATH entries). With
+                -- RUNPATH the interposer's paths do not reach that lookup at
+                -- all, and glibc falls back to a cache baked with the build
+                -- machine's prefix plus an empty system path. Nothing is
+                -- found, glvnd swallows the dlopen error, and the only thing
+                -- a user sees is `GLX: No GLXFBConfigs returned`.
+                --
+                -- `elfpatch.host_link_interposer` emits RUNPATH today
+                -- (xlings), so this restores the tag the design calls for.
+                -- Measured on an NVIDIA 550.144.03 host, driving an imgui +
+                -- GLFW window through the hermetic stack:
+                --
+                --   RUNPATH (as emitted) : GLFW error 65542, exit 11
+                --   RPATH   (this line)  : exit 0, libGLX_nvidia initialised
+                --
+                -- Nothing else changed between those two runs.
+                -- `--print-rpath` prints DT_RUNPATH too, so this reads what
+                -- the interposer got and writes it back under the other tag.
+                -- Deliberately not a hand-built path list: the value is the
+                -- closure the RESOLVER computed, and a second copy of that
+                -- computation here would drift from it.
+                local rp = try { function()
+                    return os.iorun(string.format(
+                        [[patchelf --print-rpath "%s"]], out))
+                end }
+                rp = rp and rp:trim() or ""
+                if #rp > 0 then
+                    os.exec(string.format(
+                        [[patchelf --force-rpath --set-rpath %q %q]], rp, out))
+                end
                 table.insert(done, name)
             end
         end

--- a/pkgs/w/wsl-gl-host-link.lua
+++ b/pkgs/w/wsl-gl-host-link.lua
@@ -44,6 +44,14 @@ package = {
     --   chain. So a symlink in the subos lib directory is enough: no interposer,
     --   no LD_LIBRARY_PATH.
     --
+    --   The RPATH half is measured and holds: `d3d12_dri.so` is a symlink to
+    --   `libdril_dri.so`, whose RPATH ends in `<subos>/lib` -- checked on both
+    --   25.0.7.1 and 25.0.7.2. The FILE half did not hold until 25.0.7.2:
+    --   25.0.7.1 shipped no `d3d12_dri.so` at all, so "verified on the shipped
+    --   payload" was never true of the very driver this package exists to feed.
+    --   config() now checks for the file rather than assuming it
+    --   (mcpp-community/mcpp#382).
+    --
     -- WHY THE LINKS MUST BE OURS AND NOT THE HOST'S ld.so.cache
     --   WSL makes /usr/lib/wsl/lib visible to the HOST loader through
     --   /etc/ld.so.conf.d. Our processes run on our own glibc with its own
@@ -245,13 +253,51 @@ function config()
     -- host needs no conditional syntax in the consumer, only a package that is
     -- a no-op elsewhere.
     --
-    -- `set`, not `prepend`: this is a single value, not a list. A user who
-    -- exported GALLIUM_DRIVER themselves keeps it (UC-1), so
-    -- `GALLIUM_DRIVER=llvmpipe` remains the escape hatch when the GPU path
-    -- misbehaves -- and that escape is why forcing the value here is safe.
+    -- ONLY if the driver module is actually there.
+    --
+    -- This used to force the value unconditionally, on the reasoning that
+    -- "`GALLIUM_DRIVER=llvmpipe` remains the escape hatch ... and that escape is
+    -- why forcing the value here is safe". **Both halves were wrong**, and an
+    -- external report (mcpp-community/mcpp#382) is what showed it.
+    --
+    -- Wrong half one: mesa 25.0.7.1 shipped no d3d12 driver at all. Not in
+    -- `lib/dri/`, and not in libgallium's GALLIUM_DRIVER selector table either --
+    -- `strings libgallium-25.0.7.so` gives `iris llvmpipe radeonsi softpipe`.
+    -- Forcing a driver that does not exist does not degrade, it hard-fails:
+    --
+    --   glx: failed to create drisw screen      (exit 255)
+    --
+    -- and the message names neither this package nor mesa. mesa 25.0.7.2 adds
+    -- d3d12, but a sentinel must not assume the version of a dep it declares as a
+    -- bare `xim:mesa` -- which is exactly what "whatever mesa this home has" means.
+    --
+    -- Wrong half two: the escape hatch does not exist. `subos.env` has two ops,
+    -- `set` and `prepend` (xlings src/core/subos/manifest.cppm:45-46), and neither
+    -- is conditional -- `set` overwrites a value the user exported. Verified in the
+    -- report: `export GALLIUM_DRIVER=llvmpipe; mcpp run` still failed. So the
+    -- safety argument rested on a capability that was never implemented, and an
+    -- `if-unset` op is filed separately (openxlings/xlings#508).
+    --
+    -- The check reads the SUBOS view, not mesa's payload, and that is deliberate:
+    -- `usr/lib/dri` is an `xvm.files` symlink to the ACTIVE mesa, so this asks
+    -- "what will actually be loaded" rather than "what some installed payload
+    -- contains". mesa is a dep, so it is configured before this runs.
+    local dri_d3d12 = path.join(system.subos_sysrootdir(), "usr", "lib", "dri", "d3d12_dri.so")
+    if not os.isfile(dri_d3d12) then
+        log.warn("wsl-gl-host-link: this is a WSL host, but the active mesa has no "
+                 .. "d3d12_dri.so -- NOT forcing GALLIUM_DRIVER=d3d12")
+        log.warn("  forcing it would turn a missing driver into "
+                 .. "`glx: failed to create drisw screen` (mcpp-community/mcpp#382);")
+        log.warn("  GL still works through llvmpipe. For GPU acceleration install "
+                 .. "mesa >= 25.0.7.2, which ships the d3d12 driver.")
+        return true
+    end
+
+    -- `set`, not `prepend`: this is a single value, not a list.
     if type(subos.env) == "function" then
         subos.env{ var = "GALLIUM_DRIVER", op = "set",
                    value = "d3d12", binding = tag }
+        log.info("wsl-gl-host-link: GALLIUM_DRIVER=d3d12 (d3d12_dri.so present)")
     end
     return true
 end


### PR DESCRIPTION
Fixes the user-facing half of **mcpp-community/mcpp#382**, which is a good report.

## The failure

On WSL2, any GL program died:

```
glx: failed to create drisw screen      (exit 255)
```

This package forced `GALLIUM_DRIVER=d3d12` while the active mesa had no d3d12 driver. Verified against both payloads — the `GALLIUM_DRIVER` selector table inside libgallium (symbols are hidden, so the name table is the right probe):

| | selector table | `d3d12_dri.so` |
|---|---|---|
| mesa 25.0.7.1 | `iris llvmpipe radeonsi softpipe` | ✗ |
| mesa 25.0.7.2 | **`d3d12`** `iris llvmpipe radeonsi softpipe` | ✓ |

So forcing it on 25.0.7.1 could only hard-fail. 25.0.7.2 (#563) adds it — but this package declares a **bare** `xim:mesa`, meaning "whatever mesa this home resolves", so it must not assume a version. Shipping the new mesa is not a fix for the sentinel.

## Two claims in the old code, both wrong

**1. The escape hatch does not exist.**

> `set`, not `prepend` … A user who exported GALLIUM_DRIVER themselves keeps it (UC-1) … **and that escape is why forcing the value here is safe.**

`subos.env` has exactly two ops (`xlings src/core/subos/manifest.cppm:45-46`):

```cpp
inline constexpr std::string_view OP_SET     = "set";
inline constexpr std::string_view OP_PREPEND = "prepend";
```

Neither is conditional — `set` overwrites the user's value. The reporter measured it: `export GALLIUM_DRIVER=llvmpipe; mcpp run` still failed. **The safety argument rested on a capability that was never implemented**, and the comment was the only place the escape hatch existed. Filed as openxlings/xlings#508.

Until there is a `default` op, a package cannot offer "the user's value wins" — so the honest move is to force *less*, not to promise an override it cannot deliver.

**2. "verified on the shipped payload".**

> `d3d12_dri.so` … carries a DT_RPATH ending in the subos lib directory (verified on the shipped payload)

The RPATH half is true, and I re-checked it: `d3d12_dri.so` is a symlink to `libdril_dri.so`, whose RPATH ends in `<subos>/lib` on **both** payloads. The FILE half was never true of 25.0.7.1 — there was no `d3d12_dri.so` to verify anything about. A claim about a file that does not exist reads as evidence, which is worse than no comment at all.

## The fix

`config()` checks the **subos view**, not mesa's payload:

```lua
local dri_d3d12 = path.join(system.subos_sysrootdir(), "usr", "lib", "dri", "d3d12_dri.so")
if not os.isfile(dri_d3d12) then  -- warn with the remedy, do not force
```

That is deliberate: `<subos>/usr/lib/dri` is an `xvm.files` symlink to the **active** mesa, so it asks "what will actually be loaded" rather than "does some installed payload contain it". mesa is a dep, so it is configured before this runs.

When the driver is absent, GL stays on llvmpipe and the warning names the remedy (`install mesa >= 25.0.7.2`) — the same outcome as a non-WSL host, which is what the sentinel contract already promises everywhere else.

## Also

`mesa.lua` said "the twelve driver modules under `lib/dri/`". 25.0.7.1 ships 6 entries, 25.0.7.2 ships 8. Dropped the number rather than correcting it, since it moves with the driver set.

## Not fixed here

The reporter's secondary observation — that a user's pre-exported `GALLIUM_DRIVER` is clobbered — is xlings#508 and needs a new env op. This PR removes the breakage it caused; it does not restore the override.

Refs mcpp-community/mcpp#382, openxlings/xlings#508
