### PR TITLE
feat(meson): package it, with an xvm alias shim instead of a generated launcher

### DIFF
--- a/.agents/tools/graphics/build-in-subos.sh
+++ b/.agents/tools/graphics/build-in-subos.sh
@@ -742,13 +742,16 @@ export PKG_CONFIG_LIBDIR PKG_CONFIG_PATH="$PKG_CONFIG_LIBDIR" CPPFLAGS LDFLAGS
 
 # Resolve a meson to drive the build with.
 #
-# There is NO `meson` package in this index -- `xlings install meson` answers
-# "package 'meson' not found". This line used to read `"$SUBOS/bin/meson"`
-# unconditionally, which means every meson build here (mesa included) has in fact
-# been driven by whatever meson the developer's host happened to have on PATH,
-# usually a `pip --user` install. That is a build input nobody named or pinned,
-# and it is the same class of thing the host-leakage audit below exists to catch
-# -- the audit just never looked at the DRIVER, only at what the driver found.
+# `meson` IS a package now (pkgs/m/meson.lua, 1.8.2 -- #562), so branch 1 below is
+# the normal path and the vendored copy is the fallback for a home without it.
+#
+# The history is why this function exists at all: the line used to read
+# `"$SUBOS/bin/meson"` unconditionally while NO such package existed, so every
+# meson build here -- mesa included -- was driven by whatever meson the developer's
+# host happened to have on PATH, usually a `pip --user` install. That is a build
+# input nobody named or pinned, and it is the same class of thing the host-leakage
+# audit below exists to catch -- the audit just never looked at the DRIVER, only at
+# what the driver found.
 #
 # Order of preference:
 #   1. `$SUBOS/bin/meson` — if meson ever becomes a package, it wins with no
@@ -756,11 +759,10 @@ export PKG_CONFIG_LIBDIR PKG_CONFIG_PATH="$PKG_CONFIG_LIBDIR" CPPFLAGS LDFLAGS
 #   2. a pinned meson fetched into the work directory and run under the SUBOS's
 #      python. Reproducible and version-stated, which host meson is not.
 #
-# A vendored copy rather than a new package because meson contributes no code and
-# no linkage to the payload: it reads meson.build and writes build.ninja. ninja
-# and the compiler, which do touch the output, are already packages. Packaging
-# meson is still worth doing (openxlings/xim-pkgindex#562) -- this makes the
-# build honest in the meantime instead of silently depending on the host.
+# The fallback stays now that the package exists: `MESON_PIN` and the package track
+# the same version (1.8.2) deliberately, so which COPY a build uses cannot change
+# which VERSION it uses -- and a home that has not installed meson still gets a
+# reproducible driver instead of the host's.
 MESON_PIN="${MESON_PIN:-1.8.2}"
 __resolve_meson() {
     if [[ -x "$SUBOS/bin/meson" ]]; then

--- a/.agents/tools/graphics/build-meson.sh
+++ b/.agents/tools/graphics/build-meson.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Repack `meson` as an xlings payload — closes openxlings/xim-pkgindex#562.
+#
+# WHY THIS EXISTS
+#
+# There was no meson package, and `build-in-subos.sh` called `$SUBOS/bin/meson`
+# unconditionally — a path that exists in no home. So every meson build in this
+# tree, mesa included, was driven by whatever meson the developer's host had
+# (`pip --user`, usually). The G2 input audit never caught it because it inspects
+# what the driver FOUND, never the driver itself.
+#
+# NO COMPILER RUNS
+#
+# meson is pure Python. This script downloads upstream's release tarball and
+# repacks it under the naming publish.sh expects; there is nothing to build, and
+# the payload is byte-identical content to upstream's.
+#
+# `-linux-x86_64` in the asset name is a convention of this index, not a claim:
+# the content is architecture-independent, exactly like wayland-protocols. If a
+# second arch is ever published it should get this same tarball.
+#
+# THE LAUNCHER IS NOT HERE
+#
+# `bin/meson` cannot be shipped: it has to name an absolute path inside the
+# install directory, which is only known at install time. pkgs/m/meson.lua either
+# registers an `alias` shim (xvm runs `python3 <payload>/meson.py`) or writes a
+# launcher — see that recipe for which, and why.
+#
+# Exit codes follow .agents/tools/README.md:
+#   0 packaged · 1 it broke · 3 it never started
+set -uo pipefail
+
+VERSION="${1:-1.8.2}"
+WORK="${XLINGS_GFX_WORK:-${TMPDIR:-/tmp}/xlings-gfx}"
+
+log()  { echo "[meson] $*"; }
+fail() { echo "[meson] FAIL: $*" >&2; exit 1; }
+skip() { echo "[meson] SKIP: $*" >&2; exit 3; }
+
+command -v curl >/dev/null || skip "no curl"
+mkdir -p "$WORK/src" "$WORK/dist"
+
+SRC="$WORK/src/meson-$VERSION"
+TB="$WORK/src/meson-$VERSION.tar.gz"
+if [[ ! -d "$SRC" ]]; then
+    [[ -f "$TB" ]] || {
+        log "fetching meson $VERSION"
+        curl -fsSL --retry 3 -o "$TB" \
+          "https://github.com/mesonbuild/meson/releases/download/$VERSION/meson-$VERSION.tar.gz" \
+          || fail "download failed"
+    }
+    tar -C "$WORK/src" -xzf "$TB" || fail "extract failed"
+fi
+[[ -f "$SRC/meson.py" ]] || fail "$SRC has no meson.py -- wrong tarball layout"
+
+PREFIX="$WORK/dist/meson-$VERSION"
+rm -rf "$PREFIX"; mkdir -p "$PREFIX"
+
+# meson.py plus the package it imports. Everything else in the tarball is
+# packaging metadata, tests and docs, and a build driver has no use for them.
+cp "$SRC/meson.py" "$PREFIX/meson.py"        || fail "copying meson.py"
+cp -r "$SRC/mesonbuild" "$PREFIX/mesonbuild" || fail "copying mesonbuild/"
+cp "$SRC/COPYING" "$PREFIX/COPYING" 2>/dev/null || true
+
+# Assertions naming what each file is for.
+for f in meson.py mesonbuild/mesonmain.py mesonbuild/__init__.py; do
+    [[ -f "$PREFIX/$f" ]] || fail "payload is missing $f"
+done
+
+# No object code. A pure-Python package that grows an ELF has become something
+# else, and the recipe's (empty) dep list would silently stop being true.
+elves=$(find "$PREFIX" -type f -exec sh -c 'head -c4 "$1" | od -An -tx1 | grep -q "7f 45 4c 46" && echo "$1"' _ {} \; 2>/dev/null)
+[[ -z "$elves" ]] || { echo "$elves" >&2; fail "payload contains ELF objects"; }
+
+# Prove it runs, and that it reports the version we think we packaged.
+#
+# Any python3 will do for this check -- it is asking whether the payload is
+# complete, not which interpreter the shim will use.
+if command -v python3 >/dev/null 2>&1; then
+    got=$(cd "$PREFIX" && python3 meson.py --version 2>&1 | tail -1)
+    [[ "$got" == "$VERSION" ]] || fail "payload reports version '$got', expected $VERSION"
+    log "acceptance: meson.py --version -> $got"
+else
+    log "note: no python3 here, so the run check was skipped (the recipe asserts the files)"
+fi
+
+TAR="$WORK/dist/meson-$VERSION-linux-x86_64.tar.gz"
+rm -f "$TAR"
+tar -C "$WORK/dist" -czf "$TAR" "meson-$VERSION" || fail "packaging"
+log "packaged $TAR"
+log "sha256 $(sha256sum "$TAR" | awk '{print $1}')"
+log "size   $(du -h "$TAR" | awk '{print $1}')"

--- a/.agents/tools/graphics/tiers.sh
+++ b/.agents/tools/graphics/tiers.sh
@@ -78,9 +78,11 @@ T4=(
 #   spirv-tools        build-spirv-tools.sh        SPIRV-Headers at the revision
 #                                                  SPIRV-Tools' own DEPS pins,
 #                                                  then SPIRV-Tools; static only
-#   directx-headers    build-directx-headers.sh    no meson in this index (#562),
-#                                                  and its whole Linux install is
-#                                                  two static_library() calls
+#   directx-headers    build-directx-headers.sh    its whole Linux install is two
+#                                                  static_library() calls, so meson
+#                                                  buys nothing here
+#   meson              build-meson.sh              pure Python; a repack, not a
+#                                                  build (#562)
 #   wayland-protocols  build-wayland-protocols.sh  data only; no compiler runs
 #
 # llvm-dev, spirv-tools and directx-headers are `status = "dev"`; wayland-protocols

--- a/pkgs/m/meson.lua
+++ b/pkgs/m/meson.lua
@@ -1,0 +1,145 @@
+package = {
+    spec = "1",
+    homepage = "https://mesonbuild.com",
+
+    name = "meson",
+    description = "The Meson build system",
+    authors = {"The Meson development team"},
+    licenses = {"Apache-2.0"},
+    repo = "https://github.com/mesonbuild/meson",
+    docs = "https://mesonbuild.com/Manual.html",
+
+    type = "package",
+    -- Architecture-independent content. `x86_64` is what this index publishes
+    -- for; a second arch should be given this same tarball.
+    archs = {"x86_64"},
+    status = "stable",
+    categories = {"build", "tool"},
+    keywords = {"meson", "build", "ninja", "buildsystem"},
+
+    programs = {"meson"},
+    xvm_enable = true,
+
+    -- WHY THIS PACKAGE EXISTS
+    --
+    -- There was no meson in this index, while
+    -- `.agents/tools/graphics/build-in-subos.sh` called `$SUBOS/bin/meson`
+    -- unconditionally -- a path present in no home. So every meson build in this
+    -- tree, **mesa included**, was driven by whatever meson the developer's host
+    -- happened to have, usually a `pip --user` install (#562).
+    --
+    -- The host-leakage audit could not catch it: that audit inspects what the
+    -- build driver FOUND (meson-log.txt, build.ninja) and never the driver.
+
+    xpm = {
+        linux = {
+            -- python, and nothing else. meson is pure Python -- the build script
+            -- asserts no payload member has an ELF magic number -- so there is no
+            -- loader, no libc and no C++ runtime in the picture.
+            --
+            -- A floor rather than a pin: meson 1.8 supports python >= 3.7, and
+            -- pinning would make this package refuse a home that upgraded python
+            -- for unrelated reasons.
+            deps = { "xim:python@>=3.9" },
+            ["latest"] = { ref = "1.8.2" },
+            -- 1.8.2 is the version `build-in-subos.sh` already pins as its
+            -- vendored fallback (MESON_PIN), so packaging it changes which COPY a
+            -- build uses and not which VERSION -- one variable at a time.
+            ["1.8.2"] = {
+                url = {
+                    GLOBAL = "https://github.com/xlings-res/meson/releases/download/1.8.2/meson-1.8.2-linux-x86_64.tar.gz",
+                    CN     = "https://gitcode.com/xlings-res/meson/releases/download/1.8.2/meson-1.8.2-linux-x86_64.tar.gz",
+                },
+                sha256 = "6afe6e96f53771b2c3810a7861e5b80de034ee306242877846de470f520b44e6",
+            },
+        },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+import("xim.libxpkg.log")
+
+function install()
+    local src = pkginfo.install_file():replace(".tar.gz", "")
+    if not os.isdir(src) then
+        -- By content, not by name: the extraction directory is shared.
+        local base = path.directory(src)
+        local found = nil
+        for _, d in ipairs(os.dirs(path.join(base, "*"))) do
+            if os.isfile(path.join(d, "meson.py")) then found = d; break end
+        end
+        if not found then
+            raise("cannot find the payload root under '" .. base
+                  .. "': no extracted directory contains meson.py")
+        end
+        src = found
+    end
+
+    os.tryrm(pkginfo.install_dir())
+    os.mv(src, pkginfo.install_dir())
+
+    for _, f in ipairs({"meson.py", "mesonbuild/mesonmain.py"}) do
+        if not os.isfile(path.join(pkginfo.install_dir(), f)) then
+            raise("meson payload is missing " .. f)
+        end
+    end
+
+    log.info("meson: " .. pkginfo.version() .. " in place (pure Python)")
+    return true
+end
+
+-- An `alias` shim, not a generated launcher.
+--
+-- `alias` is a COMMAND LINE, not merely another name for the binary -- gcc.lua
+-- appends `--sysroot=...` straight into it (`config.alias = prog .. alias_args`).
+-- So `meson` can be a shim that execs python with meson.py as its first argument,
+-- and this package ships no wrapper script at all.
+--
+-- The alternative, writing `bin/meson` at install time (the media-crawler
+-- pattern), works too and is strictly worse here: a generated shell script is one
+-- more artifact whose interpreter lookup nobody audits, and it would resolve
+-- `python3` through the ambient PATH -- which is how a build ends up using the
+-- host's interpreter, the very thing #562 is about.
+--
+-- `bindir` is python's OWN payload, found through pkginfo.dep_install_dir -- the
+-- same helper gcc.lua uses to locate glibc's loader. That makes the interpreter
+-- explicit and hermetic.
+--
+-- The trade-off, stated rather than discovered later: this resolves python once,
+-- at meson-install time. Switch python afterwards and meson keeps using the
+-- interpreter it was configured with. For a build driver that is the safer
+-- direction -- a build should not change interpreter under you because something
+-- else was switched -- but it does mean `xlings use python <other>` does not move
+-- meson, and a python REMOVAL leaves this shim pointing at a gone payload.
+function config()
+    local py = pkginfo.dep_install_dir("python")
+    if not py then
+        raise("meson: cannot locate the python dependency's payload; "
+              .. "the shim would have no interpreter to exec")
+    end
+
+    local bindir = path.join(py, "bin")
+    -- Named explicitly, because the two spellings are not interchangeable on
+    -- every payload and a missing one must fail here rather than at first use.
+    local interp = nil
+    for _, cand in ipairs({"python3", "python"}) do
+        if os.isfile(path.join(bindir, cand)) then interp = cand; break end
+    end
+    if not interp then
+        raise("meson: python payload at " .. bindir
+              .. " has neither bin/python3 nor bin/python")
+    end
+
+    xvm.add("meson", {
+        bindir = bindir,
+        alias  = interp .. " " .. path.join(pkginfo.install_dir(), "meson.py"),
+    })
+    log.info("meson: shim execs " .. interp .. " " .. path.join(pkginfo.install_dir(), "meson.py"))
+    return true
+end
+
+function uninstall()
+    xvm.remove("meson")
+    return true
+end


### PR DESCRIPTION
Closes #562. meson **1.8.2** published to both regions — 1.8M, sha256 `6afe6e96…`.

## The gap it closes

`build-in-subos.sh` called `$SUBOS/bin/meson` unconditionally while **no such package existed**. So every meson build in this tree — mesa included — was driven by whatever meson the developer's host happened to have, usually a `pip --user` install.

The host-leakage audit could not catch it: that audit inspects what the build driver *found* (`meson-log.txt`, `build.ninja`) and never the driver itself.

## Nothing is compiled

meson is pure Python. `build-meson.sh` fetches upstream's release tarball and repacks `meson.py` + `mesonbuild/`. It asserts **no payload member has an ELF magic number** — a pure-Python package that grows object code has become something else, and this recipe's one-line dep list would silently stop being true.

Acceptance is a run, not a file listing: `python3 meson.py --version` must report the version being packaged.

## The shim is an `alias`, not a wrapper script

`alias` is a **command line**, not merely another name for a binary — gcc.lua appends `--sysroot=…` straight into it (`config.alias = prog .. alias_args`). So `meson` is a shim that execs python with `meson.py` as its first argument, and this package ships no generated file:

```lua
xvm.add("meson", { bindir = <python payload>/bin,
                   alias  = "python3 <meson payload>/meson.py" })
```

Verified end to end in an isolated home:

```
$ meson --version
1.8.2
```

and `[[ -x $SUBOS/bin/meson ]]` is now true, so `build-in-subos.sh` reports `meson: 1.8.2 (packaged)` instead of vendoring.

The alternative — writing `bin/meson` at install time (the `media-crawler` pattern) — works and is strictly worse here: a generated shell script is one more artifact whose interpreter lookup nobody audits, and it resolves `python3` through the ambient PATH. Ending up on the host's interpreter is the exact thing #562 is about.

`bindir` is python's own payload via `pkginfo.dep_install_dir("python")`, the same helper gcc.lua uses to find glibc's loader.

**Trade-off, stated in the recipe rather than discovered later:** this resolves python once, at meson-install time. Switching python afterwards does not move meson — safer for a build driver, but a python *removal* leaves the shim pointing at a gone payload.

## The vendored fallback stays

`MESON_PIN` and the package track the same version (1.8.2) deliberately, so which **copy** a build uses cannot change which **version** it uses — and a home that has not installed meson still gets a reproducible driver rather than the host's.

## Note on #566

While this was in progress, `build-meson.sh` sat untracked in the shared worktree and PR #566's `git add -A` swept it into an unrelated nvidia commit (`2da22940`). That was my file left in the way, not a mistake in #566. I restored #566's branch to its own tip, but **the script is still inside that commit** — it should be dropped from #566, since it belongs here. Say the word and I'll do it, or it can just be resolved when one of the two merges.

Closes #562
