### PR TITLE
feat(jdk): package libXtst + alsa-lib — the two libraries blocking the loader switch

### DIFF
--- a/.agents/tools/graphics/tiers.sh
+++ b/.agents/tools/graphics/tiers.sh
@@ -29,7 +29,18 @@ T1=(
   "libxshmfence|1.3.2|https://xorg.freedesktop.org/archive/individual/lib/libxshmfence-1.3.2.tar.xz|autotools|"
 )
 
+# libXtst and alsa-lib are here for the JDK, not for graphics: `libawt_xawt.so`
+# has a hard DT_NEEDED on libXtst.so.6 and `libjsound.so` on libasound.so.2, and a
+# PT_INTERP switch to our loader removes all host fallback -- so the JDK cannot be
+# switched until its whole closure is ours (openxlings/xim-pkgindex#568).
+#
+# libXtst needs libXfixes AT BUILD TIME ONLY: `xi.pc` carries `Requires: xfixes`,
+# and leaving it out of --deps fails configure with `Package 'xfixes', required by
+# 'xi', not found` -- an error naming neither libXtst nor libXi. The payload does
+# not link it, so the recipe does not declare it.
 T2=(
+  "libXtst|1.2.5|https://xorg.freedesktop.org/archive/individual/lib/libXtst-1.2.5.tar.xz|autotools||xorgproto libX11 libXext libXi libXfixes libXau libXdmcp libxcb libXrender"
+  "alsa-lib|1.2.11|https://www.alsa-project.org/files/pub/lib/alsa-lib-1.2.11.tar.bz2|autotools|--disable-python --disable-topology --disable-ucm"
   "libXau|1.0.11|https://xorg.freedesktop.org/archive/individual/lib/libXau-1.0.11.tar.xz|autotools|"
   "libXdmcp|1.1.5|https://xorg.freedesktop.org/archive/individual/lib/libXdmcp-1.1.5.tar.xz|autotools|"
   "libxcb|1.17.0|https://xorg.freedesktop.org/archive/individual/lib/libxcb-1.17.0.tar.xz|autotools|"

--- a/pkgs/a/alsa-lib.lua
+++ b/pkgs/a/alsa-lib.lua
@@ -1,0 +1,109 @@
+package = {
+    spec = "2",
+
+    homepage = "https://www.alsa-project.org",
+    name = "alsa-lib",
+    description = "ALSA userspace library (libasound) — required by the JDK's javax.sound",
+
+    authors = {"ALSA project"},
+    licenses = {"LGPL-2.1"},
+    repo = "https://github.com/alsa-project/alsa-lib",
+
+    type = "package",
+    archs = {"x86_64"},
+    status = "stable",
+    categories = {"audio", "lib"},
+    keywords = {"alsa", "libasound", "audio", "sound", "jdk"},
+
+    -- WHY THIS IS PACKAGED
+    --
+    -- The other half of what blocks the JDK loader migration:
+    --
+    --   libjsound.so NEEDED: libasound.so.2 libc.so.6
+    --
+    -- Switching a JDK's PT_INTERP to our loader removes all host fallback (our
+    -- glibc's compiled-in cache path exists on no machine), so every library in
+    -- the JDK's closure has to be ours before the switch can happen. `libXtst`
+    -- covers AWT; this covers javax.sound.sampled.
+    --
+    -- See openxlings/xim-pkgindex#568.
+
+    xpm = {
+        linux = {
+            -- Just glibc, and measured rather than assumed:
+            --
+            --   objdump -p lib/libasound.so.2.0.0 | grep NEEDED
+            --     libm.so.6  libc.so.6  ld-linux-x86-64.so.2
+            --
+            -- All three are glibc's. There is no second-level dependency here
+            -- despite alsa-lib's reputation, because the parts that would bring
+            -- one (python bindings, topology, UCM) are configured out.
+            deps = { "xim:glibc@>=2.38" },
+            exports = {
+                runtime = { libdirs = { "lib" } },
+            },
+            ["latest"] = { ref = "1.2.11" },
+            ["1.2.11"] = {
+                url = {
+                    GLOBAL = "https://github.com/xlings-res/alsa-lib/releases/download/1.2.11/alsa-lib-1.2.11-linux-x86_64.tar.gz",
+                    CN     = "https://gitcode.com/xlings-res/alsa-lib/releases/download/1.2.11/alsa-lib-1.2.11-linux-x86_64.tar.gz",
+                },
+                sha256 = "c95f1535f267608378d115a820e6b4aa29df408df0f8a1d45a866371957fb4e8",
+            },
+        },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.system")
+import("xim.libxpkg.xvm")
+import("xim.libxpkg.log")
+import("xim.pkgindex.sysroot")
+import("xim.pkgindex.selfcontain")
+
+function install()
+    local dir = pkginfo.install_dir()
+    os.tryrm(dir)
+    os.mv("alsa-lib-1.2.11", dir)
+
+    -- The SONAME libjsound.so asks for. The `.so` dev symlink existing says
+    -- nothing about whether the runtime name resolves.
+    if not os.isfile(path.join(dir, "lib", "libasound.so.2")) then
+        raise("alsa-lib payload has no lib/libasound.so.2 -- that is the SONAME "
+              .. "libjsound.so has a DT_NEEDED on")
+    end
+
+    -- Built with --disable-python --disable-topology --disable-ucm: only the ELF
+    -- is wanted here. The Python bindings, the topology parser and the UCM
+    -- configuration manager are separate concerns that would enlarge both the
+    -- payload and its closure for something the JDK never calls.
+    --
+    -- Consequence worth stating: this package is NOT a general-purpose alsa-lib.
+    -- A consumer that needs UCM (PulseAudio/PipeWire config, embedded audio
+    -- profiles) needs a differently-configured build, and should get its own
+    -- version rather than silently inheriting this one.
+    selfcontain.seal(dir)
+    log.info("alsa-lib: libasound in place (no python/topology/ucm)")
+    return true
+end
+
+function config()
+    local binding = package.name .. "@" .. pkginfo.version()
+
+    xvm.add(package.name)
+
+    sysroot.declare_libs(pkginfo.install_dir(), "lib", binding, pkginfo.version())
+
+    if not sysroot.declare_headers_tree(pkginfo.install_dir(), "include",
+                                        "usr/include", binding) then
+        sysroot.install_headers_tree(
+            path.join(pkginfo.install_dir(), "include"),
+            path.join(system.subos_sysrootdir(), "usr", "include"))
+    end
+    return true
+end
+
+function uninstall()
+    xvm.remove(package.name)
+    return true
+end

--- a/pkgs/l/libXtst.lua
+++ b/pkgs/l/libXtst.lua
@@ -1,0 +1,118 @@
+package = {
+    spec = "2",
+
+    homepage = "https://www.x.org",
+    name = "libXtst",
+    description = "X11 Testing/Record extension client library — required by the JDK's AWT",
+
+    authors = {"X.Org Foundation"},
+    licenses = {"MIT"},
+    repo = "https://gitlab.freedesktop.org/xorg/lib/libXtst",
+
+    type = "package",
+    archs = {"x86_64"},
+    status = "stable",
+    categories = {"graphics", "lib"},
+    keywords = {"libxtst", "xtest", "record", "x11", "awt", "jdk"},
+
+    -- WHY THIS IS PACKAGED
+    --
+    -- Half of what blocks the JDK loader migration. Every JDK's
+    -- `libawt_xawt.so` has a hard DT_NEEDED on it:
+    --
+    --   libawt_xawt.so NEEDED: libawt.so libjava.so libdl.so.2 libm.so.6
+    --                          libX11.so.6 libXext.so.6 libXi.so.6
+    --                          libXrender.so.1 libXtst.so.6 ...
+    --
+    -- Switching a JDK's PT_INTERP to our loader REMOVES ALL HOST FALLBACK: our
+    -- glibc's compiled-in cache path exists on no machine, and on a multiarch
+    -- distro the host's libraries are reachable only through that cache. So the
+    -- JDK cannot be switched until its whole closure is ours -- and AWT is the
+    -- first thing to die, with an error naming `libawt_xawt.so` rather than the
+    -- dependency that is actually missing.
+    --
+    -- `alsa-lib` (libasound) is the other half. See openxlings/xim-pkgindex#568.
+
+    xpm = {
+        linux = {
+            -- Exactly the payload's runtime closure, measured:
+            --
+            --   objdump -p lib/libXtst.so.6.1.0 | grep NEEDED
+            --     libX11.so.6  libXext.so.6  libXi.so.6  libc.so.6
+            --
+            -- `libXfixes` is deliberately NOT here. It is needed to BUILD this --
+            -- `xi.pc` carries `Requires: xfixes`, and omitting it fails configure
+            -- with `Package 'xfixes', required by 'xi', not found`, an error
+            -- naming neither libXtst nor libXi -- but nothing in the payload
+            -- links it. libXi declares it, so it arrives transitively at runtime.
+            -- Declaring a build-time need as a runtime dep would make this
+            -- package's closure claim something the ELF does not.
+            deps = {
+                "xim:libX11", "xim:libXext@>=1.3", "xim:libXi@>=1.8", "xim:glibc",
+            },
+            -- elfpatch reads this from each dependency and writes the consumer's
+            -- RPATH, which is what makes the stack resolve without anyone
+            -- setting LD_LIBRARY_PATH.
+            exports = {
+                runtime = { libdirs = { "lib" } },
+            },
+            ["latest"] = { ref = "1.2.5" },
+            ["1.2.5"] = {
+                url = {
+                    GLOBAL = "https://github.com/xlings-res/libXtst/releases/download/1.2.5/libXtst-1.2.5-linux-x86_64.tar.gz",
+                    CN     = "https://gitcode.com/xlings-res/libXtst/releases/download/1.2.5/libXtst-1.2.5-linux-x86_64.tar.gz",
+                },
+                sha256 = "5974d03284fd77e379f7790d635ff4b9950c40c1a4b17397444c0431dd13680c",
+            },
+        },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.system")
+import("xim.libxpkg.xvm")
+import("xim.pkgindex.sysroot")
+import("xim.pkgindex.selfcontain")
+
+function install()
+    local dir = pkginfo.install_dir()
+    os.tryrm(dir)
+    os.mv("libXtst-1.2.5", dir)
+
+    -- The one file the JDK actually opens, asserted by the SONAME it asks for.
+    -- `libXtst.so` (the dev symlink) being present says nothing about whether
+    -- the runtime name resolves.
+    if not os.isfile(path.join(dir, "lib", "libXtst.so.6")) then
+        raise("libXtst payload has no lib/libXtst.so.6 -- that is the SONAME "
+              .. "libawt_xawt.so has a DT_NEEDED on")
+    end
+
+    -- Stamp this payload's own dependency closure onto its libraries, so they
+    -- resolve from our payloads and not from the host's ld.so.cache.
+    selfcontain.seal(dir)
+    return true
+end
+
+function config()
+    local binding = package.name .. "@" .. pkginfo.version()
+
+    xvm.add(package.name)
+
+    sysroot.declare_libs(pkginfo.install_dir(), "lib", binding, pkginfo.version())
+
+    -- _tree, not declare_headers: several packages contribute to one `X11/`,
+    -- and declaring that directory places it as a single asset -- rename(2)
+    -- over the sysroot's copy, so the last install wins and the others vanish.
+    if not sysroot.declare_headers_tree(pkginfo.install_dir(), "include",
+                                        "usr/include", binding) then
+        sysroot.install_headers_tree(
+            path.join(pkginfo.install_dir(), "include"),
+            path.join(system.subos_sysrootdir(), "usr", "include"))
+    end
+    return true
+end
+
+function uninstall()
+    xvm.remove(package.name)
+    return true
+end


### PR DESCRIPTION
Closes #568. Both published to GitHub + GitCode, byte-verified.

| | size | sha256 |
|---|---|---|
| `libXtst` 1.2.5 | 72K | `5974d032…` |
| `alsa-lib` 1.2.11 | 1.8M | `c95f1535…` |

## Why exactly these two

Switching a JDK's `PT_INTERP` to our loader **removes all host fallback** — our glibc's compiled-in cache path exists on no machine, and on a multiarch distro the host's libraries are reachable only through that cache. So the JDK cannot be switched until every library in its closure is ours. These were the last two:

```
libawt_xawt.so NEEDED: ... libXtst.so.6 ...       → AWT dies first
libjsound.so   NEEDED: libasound.so.2 libc.so.6   → javax.sound.sampled
```

AWT is also the misleading one: the failure names `libawt_xawt.so`, not the dependency that is actually absent.

## Deps are the measured closure, not the build requirement

```
objdump -p lib/libXtst.so.6.1.0   → libX11.so.6 libXext.so.6 libXi.so.6 libc.so.6
objdump -p lib/libasound.so.2.0.0 → libm.so.6 libc.so.6 ld-linux-x86-64.so.2
```

**`libXfixes` is deliberately not a dep of libXtst**, even though the build needs it: `xi.pc` carries `Requires: xfixes`, and omitting it from `--deps` fails configure with `Package 'xfixes', required by 'xi', not found` — an error naming neither libXtst nor libXi. But nothing in the payload links it, and libXi declares it, so it arrives transitively. Declaring a build-time need as a runtime dep would make the package's closure claim something its ELF does not.

`alsa-lib` is `--disable-python --disable-topology --disable-ucm`: only the ELF is wanted. The recipe says so explicitly, because the consequence is real — **this is not a general-purpose alsa-lib**, and a consumer needing UCM should get its own version rather than silently inheriting this one.

## Verified at the level that matters

Both build with `all N resolved input path(s) are ours` and no host references. Then, installed and checked against the actual consumer — every external dependency of the JDK's two libraries now resolves from our tree:

```
libjsound.so    libasound.so.2 OK   libc.so.6 OK
libawt_xawt.so  libdl libm libX11 libXext libXi libXrender libXtst libpthread libc
                → all OK (ours)
```

That is the **closure precondition** for the switch. The switch itself, with headless `Toolkit.getDefaultToolkit()` as its acceptance, is separate work and not claimed here.

## Note for reviewers install-testing these

The lib nodes only register once the local index can load `xim.pkgindex.*`, which needs openxlings/xlings#510. On 2026.8.8.1, an `--add-xpkg` install of either recipe registers the anchor and nothing else — that is the bug #510 fixes, not a problem with these recipes.

Closes #568
