### PR TITLE
ci: bump the xlings client v2026.8.6.3 -> v2026.8.8.2

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Installation Xlings on Ubuntu
         run: |
           export XLINGS_NON_INTERACTIVE=1
-          export XLINGS_VERSION=v2026.8.6.3
+          export XLINGS_VERSION=v2026.8.8.2
           curl -fsSL https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.sh | bash
           echo "XLINGS_HOME=$HOME/.xlings" >> "$GITHUB_ENV"
           echo "PATH=$HOME/.xlings/subos/current/bin:$HOME/.xlings/bin:$PATH" >> "$GITHUB_ENV"
@@ -150,7 +150,7 @@ jobs:
         shell: pwsh
         run: |
           $env:XLINGS_NON_INTERACTIVE = "1"
-          $env:XLINGS_VERSION = "v2026.8.6.3"
+          $env:XLINGS_VERSION = "v2026.8.8.2"
           iex (Invoke-WebRequest `
             -Uri "https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.ps1" `
             -UseBasicParsing).Content
@@ -211,7 +211,7 @@ jobs:
       - name: Install xlings on Ubuntu
         run: |
           export XLINGS_NON_INTERACTIVE=1
-          export XLINGS_VERSION=v2026.8.6.3
+          export XLINGS_VERSION=v2026.8.8.2
           curl -fsSL https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.sh | bash
           echo "XLINGS_HOME=$HOME/.xlings" >> "$GITHUB_ENV"
           echo "$HOME/.xlings/bin"               >> "$GITHUB_PATH"
@@ -276,7 +276,7 @@ jobs:
       - name: Install xlings on macOS
         run: |
           export XLINGS_NON_INTERACTIVE=1
-          export XLINGS_VERSION=v2026.8.6.3
+          export XLINGS_VERSION=v2026.8.8.2
           curl -fsSL https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.sh | bash
           echo "XLINGS_HOME=$HOME/.xlings" >> "$GITHUB_ENV"
           echo "$HOME/.xlings/bin"               >> "$GITHUB_PATH"

--- a/.github/workflows/ci-xpkg-test.yml
+++ b/.github/workflows/ci-xpkg-test.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Install xlings
         run: |
           export XLINGS_NON_INTERACTIVE=1
-          export XLINGS_VERSION=v2026.8.6.3
+          export XLINGS_VERSION=v2026.8.8.2
           curl -fsSL https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.sh | bash
           echo "XLINGS_HOME=$HOME/.xlings" >> "$GITHUB_ENV"
           echo "PATH=$HOME/.xlings/subos/current/bin:$HOME/.xlings/bin:$PATH" >> "$GITHUB_ENV"


### PR DESCRIPTION
**只升 pin,不动测试。这是刻意的。**

这套 CI 通过 `quick_install` + 显式 `XLINGS_VERSION` 安装 xlings,所以**合并索引 bump 并不改变它实际跑的客户端**。这个 pin 已漂到比本索引若干测试所要验证的修复还老——最直接的是「没注册任何 xvm 版本的包能装不能删」(openxlings/xlings#506),该修复在 2026.8.8.2。

五处,不是四处:`ci-test.yml` 53、153(pwsh)、214、279,以及 `ci-xpkg-test.yml` 58。

## 预期会有行为变化,而这正是单独落它的理由

这一跳跨越 **2026.8.8.1**,那一版改了 `remove` 的语义(「remove 不再默默切断别人的依赖」)——而 `posix-test.sh` 基本就是一个大量跑 `remove` 的框架。所以**这里若红,是升级带来的,不是后续那个 PR**。

## 后续 PR(刻意不在这里)

删掉 `posix-test.sh` 的 `type = "config"` 容忍——它是 openxlings/xlings#506 **唯一真实的验收**。两个一起落的话,CI 一红就分不清是「升级回归」还是「修复没生效」,而这两者要做的事完全相反。

分析:openxlings/xlings `.agents/docs/2026-08-08-three-open-items-analysis-and-plan.md` §4