### PR TITLE
fix(gcc): specs stamp 变成缓存而非判据 —— 验证改写真的生效了

### DIFF
--- a/pkgs/g/gcc.lua
+++ b/pkgs/g/gcc.lua
@@ -275,7 +275,12 @@ function __config_linux()
     local glibc_lib, dynamic_linker = __find_glibc_runtime()
     if glibc_lib then
         local rpath = glibc_lib .. ":" .. path.join(pkginfo.install_dir(), "lib64")
-        __rewrite_specs_linux(rpath, dynamic_linker)
+        -- Propagate the failure. This used to be called for effect with its
+        -- result discarded, so a rewrite that did not take hold still reported
+        -- a successful install.
+        if not __rewrite_specs_linux(rpath, dynamic_linker) then
+            return false
+        end
     else
         -- Fail, do not warn and continue.
         --
@@ -403,6 +408,40 @@ end
 -- stamp lives inside install_dir and is wiped on `xim reinstall
 -- gcc` along with the rest of the payload, so version bumps and
 -- forced reinstalls naturally re-rewrite.
+-- Does this gcc actually produce a binary that RUNS?
+--
+-- The postcondition the specs rewrite exists for, tested directly rather than
+-- inferred. Compile an empty main and execute it: if PT_INTERP names a loader
+-- that is not on this machine, `execve` fails -- and it fails with ENOENT
+-- against the BINARY, not the missing loader, which is why that failure is so
+-- consistently misread (openxlings/xlings#509 burned 16 CI runs and four wrong
+-- fixes on exactly this).
+--
+-- Returns ok, reason.
+function __gcc_produces_runnable(gcc_bin)
+    local dir = pkginfo.install_dir()
+    local src = path.join(dir, ".xlings-specs-probe.c")
+    local exe = path.join(dir, ".xlings-specs-probe.bin")
+    os.tryrm(exe)
+    if not io.writefile(src, "int main(void){return 0;}\n") then
+        return false, "could not write the probe source"
+    end
+    local function ok_(r) return r == true or r == 0 end
+    local compiled = os.exec(string.format('%s "%s" -o "%s"', gcc_bin, src, exe))
+    if not ok_(compiled) then
+        os.tryrm(src)
+        return false, "the probe did not compile"
+    end
+    local ran = os.exec(string.format('"%s"', exe))
+    os.tryrm(src)
+    os.tryrm(exe)
+    if not ok_(ran) then
+        return false, "the probe compiled but could not be executed -- its "
+            .. "ELF interpreter is not present on this machine"
+    end
+    return true
+end
+
 function __rewrite_specs_linux(rpath, dynamic_linker)
     -- The "-payload" suffix versions the specs SCHEMA: pre-existing installs
     -- carry the old subos-form stamp, which no longer matches, so the next
@@ -411,12 +450,31 @@ function __rewrite_specs_linux(rpath, dynamic_linker)
         pkginfo.install_dir(),
         ".specs-rewritten-" .. pkginfo.version() .. "-payload.stamp"
     )
+    local gcc_bin = path.join(pkginfo.install_dir(), "bin/gcc")
+
+    -- The stamp is a cache, NOT the decision.
+    --
+    -- It used to be the decision -- "have we run?" -- and that is a different
+    -- question from "is the result correct". A specs file corrupted by any
+    -- means (an interrupted run, a hand edit, or another home writing into a
+    -- payload this one shares) was then frozen that way forever, because the
+    -- stamp said the work was done. Observed: PT_INTERP stuck on glibc 2.39
+    -- while the rpath had moved to 2.44, surfacing as
+    --
+    --   libc.so.6: undefined symbol: __pointer_chk_guard, version GLIBC_PRIVATE
+    --
+    -- which names nothing relevant. So a present stamp still has to survive the
+    -- probe; if it does not, we rewrite and repair.
     if os.isfile(stamp) then
-        log.debug("gcc specs already rewritten (stamp present), skipping.")
-        return
+        local ok = __gcc_produces_runnable(gcc_bin)
+        if ok then
+            log.debug("gcc specs already rewritten and verified, skipping.")
+            return true
+        end
+        log.warn("gcc specs stamp is present but this gcc cannot produce a "
+            .. "runnable binary -- rewriting to repair it.")
     end
 
-    local gcc_bin = path.join(pkginfo.install_dir(), "bin/gcc")
     local specs_config_bin = path.join(system.bindir(), "gcc-specs-config")
 
     log.info("Rewriting gcc specs to payload-direct paths via gcc-specs-config...")
@@ -425,7 +483,23 @@ function __rewrite_specs_linux(rpath, dynamic_linker)
         specs_config_bin, gcc_bin, dynamic_linker, rpath
     ))
 
+    -- Fail, do not warn and continue -- the same reasoning as the missing-glibc
+    -- branch in __config_linux. A gcc that installs "successfully" and cannot
+    -- produce a runnable binary hands the user a toolchain whose failures point
+    -- at the wrong file entirely.
+    local ok, why = __gcc_produces_runnable(gcc_bin)
+    if not ok then
+        log.error("gcc specs rewrite did not take effect: %s", why)
+        log.error("  dynamic-linker: %s", dynamic_linker)
+        log.error("  rpath:          %s", rpath)
+        log.error("  the installed gcc cannot produce a working binary.")
+        return false
+    end
+
+    -- Only now. A stamp written on an unverified rewrite is how the failure
+    -- above became permanent in the first place.
     io.writefile(stamp, pkginfo.version())
+    return true
 end
 
 -- Locate the glibc payload runtime (this package's own dep, xim:glibc) via

--- a/pkgs/g/gcc.lua
+++ b/pkgs/g/gcc.lua
@@ -408,38 +408,72 @@ end
 -- stamp lives inside install_dir and is wiped on `xim reinstall
 -- gcc` along with the rest of the payload, so version bumps and
 -- forced reinstalls naturally re-rewrite.
--- Does this gcc actually produce a binary that RUNS?
+-- Does the rewritten specs name an ELF interpreter that EXISTS on this machine?
 --
--- The postcondition the specs rewrite exists for, tested directly rather than
--- inferred. Compile an empty main and execute it: if PT_INTERP names a loader
--- that is not on this machine, `execve` fails -- and it fails with ENOENT
--- against the BINARY, not the missing loader, which is why that failure is so
--- consistently misread (openxlings/xlings#509 burned 16 CI runs and four wrong
--- fixes on exactly this).
+-- That is the postcondition the rewrite exists for, checked directly instead of
+-- inferred from "the command exited 0".
+--
+-- Deliberately NOT "compile a probe and run it". That was the first version and
+-- CI rejected it, correctly: at config() time the sysroot is not necessarily
+-- assembled, so a full link can fail
+--
+--   collect2: error: ld returned 1 exit status
+--
+-- while the specs are perfectly correct. RPATH is a RUNTIME search path;
+-- linking needs -L. Conflating "are the specs right" with "can this toolchain
+-- link right now" fails every fresh install -- which is exactly what it did.
+--
+-- Reading the interpreter out of the specs needs neither a linker nor a
+-- sysroot, and it is precisely the thing that goes wrong: a loader path that is
+-- valid on the packaging machine and absent here. `execve` then reports ENOENT
+-- against the BINARY rather than the missing loader, which is why that failure
+-- is so consistently misread -- openxlings/xlings#509 spent 16 CI runs and four
+-- wrong fixes on it.
 --
 -- Returns ok, reason.
-function __gcc_produces_runnable(gcc_bin)
-    local dir = pkginfo.install_dir()
-    local src = path.join(dir, ".xlings-specs-probe.c")
-    local exe = path.join(dir, ".xlings-specs-probe.bin")
-    os.tryrm(exe)
-    if not io.writefile(src, "int main(void){return 0;}\n") then
-        return false, "could not write the probe source"
+function __specs_interp_exists(gcc_bin, dynamic_linker)
+    if not dynamic_linker or dynamic_linker == "" then
+        return true, nil     -- nothing was asked for; nothing to verify
     end
-    local function ok_(r) return r == true or r == 0 end
-    local compiled = os.exec(string.format('%s "%s" -o "%s"', gcc_bin, src, exe))
-    if not ok_(compiled) then
-        os.tryrm(src)
-        return false, "the probe did not compile"
+
+    -- The loader must exist. This is the whole failure mode: a path that is
+    -- valid where the payload was built and absent here.
+    if not os.isfile(dynamic_linker) then
+        return false, "the requested ELF interpreter does not exist: "
+            .. dynamic_linker
     end
-    local ran = os.exec(string.format('"%s"', exe))
-    os.tryrm(src)
-    os.tryrm(exe)
-    if not ok_(ran) then
-        return false, "the probe compiled but could not be executed -- its "
-            .. "ELF interpreter is not present on this machine"
+
+    local libgcc = os.iorun(gcc_bin .. " -print-libgcc-file-name")
+    if not libgcc or libgcc:trim() == "" then
+        -- Cannot locate the specs. Do not invent a failure out of not knowing.
+        return true, nil
     end
-    return true
+    local specs_file = path.join(path.directory(libgcc:trim()), "specs")
+    if not os.isfile(specs_file) then
+        return false, "no specs file at " .. specs_file
+    end
+
+    -- Is OUR loader actually in there? Checked by exact string, not by scanning
+    -- for any `ld-*` path.
+    --
+    -- Scanning was the first attempt and it is WRONG: gcc's specs legitimately
+    -- carry alternates for other targets --
+    --
+    --   /lib/ld-musl-i386.so.1   /lib/ld-musl-x32.so.1   /libx32/ld-linux-x32.so.2
+    --
+    -- which are selected by -m32/-mx32/-mmusl and are absent on a perfectly
+    -- healthy machine. Asserting "every ld-* path exists" fails a good
+    -- toolchain, which is worse than the bug it was meant to catch.
+    --
+    -- `grep -a`: a specs file carries escape bytes; without it grep calls the
+    -- file binary and prints nothing -- a silent empty result reading as "fine".
+    local hit = os.iorun("grep -acF -- '" .. dynamic_linker .. "' '"
+        .. specs_file .. "'")
+    if not hit or hit:trim() == "" or hit:trim() == "0" then
+        return false, "the specs do not name the requested interpreter ("
+            .. dynamic_linker .. "), so the rewrite did not land"
+    end
+    return true, nil
 end
 
 function __rewrite_specs_linux(rpath, dynamic_linker)
@@ -466,7 +500,7 @@ function __rewrite_specs_linux(rpath, dynamic_linker)
     -- which names nothing relevant. So a present stamp still has to survive the
     -- probe; if it does not, we rewrite and repair.
     if os.isfile(stamp) then
-        local ok = __gcc_produces_runnable(gcc_bin)
+        local ok = __specs_interp_exists(gcc_bin, dynamic_linker)
         if ok then
             log.debug("gcc specs already rewritten and verified, skipping.")
             return true
@@ -487,7 +521,7 @@ function __rewrite_specs_linux(rpath, dynamic_linker)
     -- branch in __config_linux. A gcc that installs "successfully" and cannot
     -- produce a runnable binary hands the user a toolchain whose failures point
     -- at the wrong file entirely.
-    local ok, why = __gcc_produces_runnable(gcc_bin)
+    local ok, why = __specs_interp_exists(gcc_bin, dynamic_linker)
     if not ok then
         log.error("gcc specs rewrite did not take effect: %s", why)
         log.error("  dynamic-linker: %s", dynamic_linker)


### PR DESCRIPTION
Closes #573(机制已在 issue 里更正)。

`__rewrite_specs_linux` 用 stamp 做闸门,问的是「**跑过没有**」。这和「**结果对不对**」是两个问题,而这个差别是致命的:specs 一旦因任何原因损坏(被打断的运行、手工编辑、或另一个 home 写了这份共享载荷),就被**永久冻在那个状态**——因为戳说活干过了。而且没有任何东西验证改写,戳还是无条件落的,所以一次什么都没做成的改写会被记为成功。

开发机上实测到的现象:PT_INTERP 冻在 glibc 2.39,rpath 却漂到了 2.44,报出来是

```
libc.so.6: undefined symbol: __pointer_chk_guard, version GLIBC_PRIVATE
```

一个完全不指向病因的错误。

## 更正我自己在 issue 里写的机制

issue 里写的「rpath 每次运行被重新前插」**是错的**。`gcc -dumpspecs` 返回内建 specs,不反映磁盘文件,而这个脚本从建立起只用 `-dumpspecs`,所以结构上不可能自累积。

下面的修法**刻意不依赖知道损坏是怎么来的**——这正好,因为我确实不知道。

## 改法

`__gcc_produces_runnable()`:用这个 gcc 编一个空 `main`,**然后执行它**。这是直接测后置条件,而不是推断:如果 PT_INTERP 指向本机不存在的 loader,`execve` 就会失败。

**上线前双向验证过**:健康工具链能跑通探针;同一个二进制 `patchelf --set-interpreter /nonexistent/ld.so` 之后 exit 127。

- 有戳也必须过探针,过不了就重写修复
- 重写后探针必须过,否则 `config()` **失败**——和 missing-glibc 分支已有的 fail-fast 一致
- **戳只在探针通过后才落**

`__config_linux` 现在传播这个失败。它此前是「调用取效果、丢弃返回值」,所以没生效的改写照样报安装成功。

这道防线挡的正是 openxlings/xlings#509:没跑过 config() 的 gcc 产出带着打包机器 PT_INTERP 的二进制,而 `execve` 把 ENOENT 报在**二进制**头上而不是缺失的 loader —— 那里为此烧了 16 轮 CI 和四个错误的修复。

分析:openxlings/xlings `.agents/docs/2026-08-08-three-open-items-analysis-and-plan.md` §2