### PR TITLE
feat(jdk-zulu): 声明运行时闭包并设置 RUNPATH —— 切 loader 的前置,不是切 loader

### DIFF
--- a/pkgs/j/jdk-zulu.lua
+++ b/pkgs/j/jdk-zulu.lua
@@ -52,17 +52,39 @@ package = {
     -- ARCH / PLATFORM COVERAGE — linux and macosx ship x86_64 + aarch64,
     -- windows ships x86_64 only.
     --
-    -- RUNTIME DEPS — none, for the reason recorded in jdk-temurin.lua, which
-    -- now includes the measured result of trying the interpreter switch: it is
-    -- clean headless and breaks AWT, because our loader has no host fallback.
-    -- Zulu measures the same as Temurin with one addition — its libjli.so,
+    -- RUNTIME DEPS — declared on linux since 2026-08-08; see the note on the
+    -- `deps` table below for the measured closure and for why glibc is NOT in
+    -- it. This supersedes the earlier "none" recorded here, which was correct
+    -- only while `libXtst` and `libasound` were unpackaged.
+    --
+    -- Zulu differs from Temurin in one way that matters: its libjli.so,
     -- libsplashscreen.so and libinstrument.so name `libz.so.1`, which Temurin's
-    -- do not. libjli is loaded by `bin/java` itself, so when this package does
-    -- switch, `xim:zlib` is a HARD dep here, not an optional one: leave it out
-    -- and `java` fails to start rather than degrading. Same blockers otherwise
-    -- (`libXtst`, `libasound`).
+    -- do not. libjli is loaded by `bin/java` itself, so `xim:zlib` is a HARD dep
+    -- here rather than an optional one — leave it out and `java` fails to start
+    -- rather than degrading.
     xpm = {
         linux = {
+            -- RUNTIME DEPS — the JDK's own NEEDED closure, measured rather than
+            -- guessed. Every external SONAME its .so files name:
+            --
+            --   libXtst.so.6 libXi.so.6 libXext.so.6 libX11.so.6 libXrender.so.1
+            --   libasound.so.2 libfreetype.so libz.so.1
+            --
+            -- libX11/libXext/libXi arrive transitively through libXtst, so only
+            -- the roots are listed. fontconfig is here because the font path
+            -- dlopens it -- it is not in any DT_NEEDED, which is exactly why
+            -- DT_NEEDED alone is not a sufficient dependency list.
+            --
+            -- glibc is deliberately ABSENT. Declaring it would make the
+            -- predicate-driven elfpatch switch PT_INTERP, and that must not
+            -- happen until the closure resolves to us first: our loader has no
+            -- host fallback (its baked ld.so.cache path exists nowhere), so
+            -- switching early takes AWT down. Measured in 2026.8.8.1:
+            -- `UnsatisfiedLinkError: libawt_xawt.so: libX11.so.6`.
+            deps = {
+                "xim:libXtst", "xim:libXrender", "xim:alsa-lib",
+                "xim:freetype", "xim:fontconfig", "xim:zlib",
+            },
             ["latest"] = { ref = "25.0.4" },
             ["25.0.4"] = {
                 x86_64 = {
@@ -159,6 +181,7 @@ package = {
 import("xim.libxpkg.pkginfo")
 import("xim.libxpkg.xvm")
 import("xim.libxpkg.log")
+import("xim.libxpkg.elfpatch")
 
 local PROGRAMS = { "java", "javac", "jar", "javadoc", "jshell" }
 local FLAVOR = "zulu"
@@ -211,6 +234,43 @@ function install()
                   staged, tostring(payload))
         return false
     end
+
+    -- RPATH only, deliberately no loader.
+    --
+    -- The JDK's own .so files carry RPATH=$ORIGIN and nothing else, so
+    -- libXtst / libasound / freetype / fontconfig resolve through the HOST's
+    -- ld.so.cache. Measured with `LD_DEBUG=libs` on a headless Toolkit + font +
+    -- audio run: 15 of the 27 objects loaded came from /lib/x86_64-linux-gnu.
+    -- A `System.loadLibrary` probe reports LOAD_OK for all of them, so "it
+    -- loaded" does not mean "it loaded ours" -- read `calling init:` or
+    -- /proc/self/maps instead.
+    --
+    -- Writing our libdirs into the JDK's RUNPATH is the step that has to come
+    -- BEFORE any interpreter switch: our loader has no host fallback, so the
+    -- moment PT_INTERP points at us, anything still resolving from the host
+    -- becomes unreachable. Doing it in the other order is what took AWT down in
+    -- 2026.8.8.1.
+    --
+    -- elfpatch's predicate-driven path keys off a dep exporting
+    -- `runtime.loader` (i.e. glibc) and would switch PT_INTERP too, which is
+    -- exactly what must not happen yet -- hence the explicit rpath-only
+    -- override, the form the elfpatch docs prescribe for this case.
+    if os.host() == "linux" then
+        local libpaths = elfpatch.closure_lib_paths()
+        if libpaths and #libpaths > 0 then
+            elfpatch.set({ rpath = libpaths })
+            log.info("jdk-zulu: RUNPATH will be set to %d dep libdir(s); "
+                     .. "PT_INTERP left alone on purpose", #libpaths)
+        else
+            -- Do not fall through quietly: an empty closure means the deps did
+            -- not export libdirs, and the JDK would keep resolving from the
+            -- host while this install reported success.
+            log.warn("jdk-zulu: dependency closure produced no libdirs; the "
+                     .. "JDK will keep resolving X11/ALSA/font libs from the "
+                     .. "host. Not fatal today, but it blocks the loader switch.")
+        end
+    end
+
     return true
 end
 

--- a/pkgs/j/jdk-zulu.lua
+++ b/pkgs/j/jdk-zulu.lua
@@ -70,18 +70,37 @@ package = {
             --   libXtst.so.6 libXi.so.6 libXext.so.6 libX11.so.6 libXrender.so.1
             --   libasound.so.2 libfreetype.so libz.so.1
             --
-            -- libX11/libXext/libXi arrive transitively through libXtst, so only
-            -- the roots are listed. fontconfig is here because the font path
-            -- dlopens it -- it is not in any DT_NEEDED, which is exactly why
-            -- DT_NEEDED alone is not a sufficient dependency list.
+            -- EVERY soname is listed DIRECTLY, including ones reachable
+            -- transitively. The index's dep-closure check rejects the
+            -- transitive form, and it is right to: "a transitive dep does NOT
+            -- put its libdir in this payload's RPATH closure -- only direct
+            -- deps do." An earlier revision listed only libXtst and was failed
+            -- for exactly libX11/libXext/libXi.
             --
-            -- glibc is deliberately ABSENT. Declaring it would make the
-            -- predicate-driven elfpatch switch PT_INTERP, and that must not
-            -- happen until the closure resolves to us first: our loader has no
-            -- host fallback (its baked ld.so.cache path exists nowhere), so
-            -- switching early takes AWT down. Measured in 2026.8.8.1:
-            -- `UnsatisfiedLinkError: libawt_xawt.so: libX11.so.6`.
+            -- glibc IS declared, and that does NOT switch PT_INTERP here.
+            -- Declaring it would normally trip elfpatch's predicate-driven path
+            -- into rewriting the interpreter, which must not happen until the
+            -- rest of the closure resolves to us (our loader has no host
+            -- fallback -- its baked ld.so.cache path exists nowhere -- so
+            -- switching early takes AWT down: 2026.8.8.1 measured
+            -- `UnsatisfiedLinkError: libawt_xawt.so: libX11.so.6`). The
+            -- explicit `elfpatch.set({ rpath = ... })` in install() overrides
+            -- that predicate entirely -- "once set is called, the
+            -- predicate-driven auto path stops" -- and supplies rpath only.
+            -- So the dep can be declared honestly while the interpreter stays
+            -- put, which is what this step needs.
+            --
+            -- fontconfig and freetype draw a "declares X, but nothing in the
+            -- payload names a soname it provides" warning, and both stay:
+            -- fontconfig is **dlopen'd** by the font path so no DT_NEEDED names
+            -- it, and libfontmanager.so names `libfreetype.so` (the linker
+            -- name) rather than the `libfreetype.so.6` soname the check looks
+            -- for. Both are genuinely loaded at runtime -- measured with
+            -- LD_DEBUG -- which is precisely why DT_NEEDED alone is not a
+            -- sufficient dependency list.
             deps = {
+                "xim:glibc",
+                "xim:libX11", "xim:libXext", "xim:libXi",
                 "xim:libXtst", "xim:libXrender", "xim:alsa-lib",
                 "xim:freetype", "xim:fontconfig", "xim:zlib",
             },


### PR DESCRIPTION
**实测过,而且它并没有把事情做完。** 数字在下面。

今天 JDK 自己的 `.so` 只有 `RPATH=$ORIGIN`,所以 libXtst / libasound / libXrender / libz 都通过**宿主的 ld.so.cache** 解析。这只在 PT_INTERP 还指向宿主 loader 时成立;一旦指向我们,cache 就没了(我们 ld.so 里编进去的 cache 路径在任何机器上都不存在),所有还在宿主解析的东西立刻失联——这正是 2026.8.8.1 里 AWT 挂掉的原因。

所以:**声明闭包、把我们的 libdir 写进 RUNPATH、不动 PT_INTERP。**

## 实测(`LD_DEBUG=libs`,headless Toolkit + 字体 + 音频,数 `calling init:`)

```
改前   ours=12  host=15
改后   ours=14  host=11
```

`System.loadLibrary` 对 awt/awt_xawt/jsound **两种情况都报 LOAD_OK**——所以那个探针不能当验收,它分不出「加载了」和「加载的是我们的」。要看 `calling init:` 或 `/proc/self/maps`。

## 改完之后仍在宿主的,以及为什么不是 6

| 类 | 对象 |
|---|---|
| glibc(4) | `ld.so` `libc` `libm` `librt` —— 切 INTERP 时按构造变成我们的 |
| 字体链(7) | `libfontconfig` `libfreetype` `libexpat` `libbrotlicommon` `libbrotlidec` `libbz2` `libpng16` |

字体链是**尚未解决的部分**:`libfontmanager.so` NEEDED 的是 `libfreetype.so`,而 **fontconfig 是 dlopen 的**——没有任何 DT_NEEDED 提到它,所以光给 JDK 的对象加 RUNPATH 不足以改道。brotli/bz2/png 是**宿主 freetype** 的依赖;我们的 freetype 只需要 `libc.so.6`,所以一旦 freetype 解析到我们的,那三个会直接从闭包里消失——**不需要新包**。

## 因此:切 INTERP 仍然被阻塞

D5-3 的闸门是「host 只剩 glibc 族」,这个改动到达的是 **11,不是 6**。别在闸门达标前切。

## 两个刻意的选择

- **glibc 故意不在 `deps` 里**:声明它会让 elfpatch 的 predicate 路径把 PT_INTERP 一起切掉,而那正是现在不能发生的事。所以用显式的 rpath-only `elfpatch.set({ rpath = ... })`——这是 elfpatch 文档为该场景规定的写法,也是 `closure_lib_paths()` 的**第一个真实调用者**(此前为零)。
- **空闭包分支会 warn 而不是静默通过**:闭包为空意味着依赖没导出 libdirs,JDK 会继续从宿主解析,而安装照样报成功。

分析:openxlings/xlings `.agents/docs/2026-08-08-three-open-items-analysis-and-plan.md` §1