### PR TITLE
test: loader/libc 守卫恰好跳过了会段错误的那一格

### DIFF
--- a/.github/scripts/posix-test.sh
+++ b/.github/scripts/posix-test.sh
@@ -498,7 +498,43 @@ for rel_file in "${files[@]}"; do
             [[ -n "$interp" ]] || continue
             payload_of() { sed -E 's#(.*/xpkgs/[^/]+/[^/]+)/.*#\1#' <<<"$1"; }
             iroot="$(payload_of "$interp")"
-            [[ "$iroot" == *"/xpkgs/"* ]] || continue
+
+            # HOST interpreter + one of OUR libcs in RPATH.
+            #
+            # This used to `continue` here, which skipped every binary still on
+            # the host loader -- and that is precisely the combination that
+            # segfaults. The host's ld.so resolves libc.so.6 through this
+            # RPATH, gets ours, and the process dies before main:
+            #
+            #   $ java -version
+            #   __vdso_gettimeofdaySegmentation fault (core dumped)
+            #
+            # Shipped and reverted on 2026-08-09 (openxlings/xim-pkgindex#578,
+            # reverted by #580): declaring `xim:glibc` as a runtime dep put
+            # glibc's lib64 into the JDK's RPATH while PT_INTERP stayed the
+            # host's. The install reported success and this very step printed
+            # "loader and libc come from one payload".
+            #
+            # The old check only asked "if you use OUR loader, is the libc from
+            # the same payload". The converse -- "if you use the HOST loader,
+            # you must not pull in our libc" -- is the half that actually
+            # crashes, and it was the one being skipped.
+            if [[ "$iroot" != *"/xpkgs/"* ]]; then
+                rp_host="$(patchelf --print-rpath "$elf" 2>/dev/null)"
+                IFS=: read -ra hparts <<<"$rp_host"
+                for hp in "${hparts[@]}"; do
+                    case "$hp" in *"/xpkgs/"*)
+                        # Only a libc-providing payload matters here; pulling
+                        # our libX11 under the host loader is fine and common.
+                        if compgen -G "$hp/libc.so.6" >/dev/null 2>&1 \
+                           || compgen -G "$hp/ld-linux-*.so.*" >/dev/null 2>&1; then
+                            log_fail "host loader + our libc: ${elf##*/} interp=$interp rpath=$hp"
+                            split_found=1
+                        fi ;;
+                    esac
+                done
+                continue
+            fi
             provider="$(sed -E 's#.*/xpkgs/([^/]+)/[^/]+$#\1#' <<<"$iroot")"
             rp="$(patchelf --print-rpath "$elf" 2>/dev/null)"
             same=0; other=""


### PR DESCRIPTION
`loader/libc same-source` 这一步原本是:

```bash
iroot="$(payload_of "$interp")"
[[ "$iroot" == *"/xpkgs/"* ]] || continue
```

**任何还在宿主 loader 上的二进制,整个被跳过。** 而那恰好就是会崩的组合:宿主的 ld.so 通过该二进制的 RPATH 解析 `libc.so.6`,拿到我们的,进程在 main 之前就死。

不是假设。**#578 正好造出了这个状态**——把 `xim:glibc` 声明成运行时依赖,glibc 的 lib64 进了 JDK 的 RPATH,而 PT_INTERP 仍是宿主的:

```
$ java -version
__vdso_gettimeofdaySegmentation fault (core dumped)
```

安装报成功,**而且这一步还打印了「loader and libc come from one payload」**。已由 #580 回滚。

## 洞在哪

旧检查只问「**用了我们的 loader** 时,libc 是否同源」。反过来那半——「**用宿主 loader** 时,不许拉进我们的 libc」——才是真正会崩的,而它正是被跳过的那半。

**一条形状像覆盖、而洞恰好开在 bug 所在位置的守卫。**

## 改法

宿主 interpreter 分支不再 `continue`,而是检查 RPATH 里有没有**提供 libc 的载荷**(`libc.so.6` 或 `ld-linux-*.so.*`)。

**刻意只针对 libc 提供者**:宿主 loader 的二进制 RPATH 里带我们的 libX11/libXtst 是合法且极常见的,绝不能误报。

## 上线前双向验证过(用真实二进制)

```
宿主 interp + .../xim-x-glibc/2.39/lib64  在 RPATH  ->  FAIL(抓到)
宿主 interp + .../xim-x-libX11/1.8.10/lib 在 RPATH  ->  pass(不误报)
```

## 这个 PR 没有解决的

install-test **仍然从不执行装好的程序**。它装完后的断言只有:安装目录、新 shim、本检查、deps-vs-DT_NEEDED。**没有任何一步跑 `java`。** 一个本守卫谓词没覆盖到的崩溃仍然会发布出去。那是另一个缺口,值得单独补。