### PR TITLE
fix(ci): close #506 — require the delegated uninstall to work on Windows

### DIFF
--- a/.github/scripts/windows-test.ps1
+++ b/.github/scripts/windows-test.ps1
@@ -342,29 +342,20 @@ foreach ($relFile in $files) {
         # passes — the log shows the shims appearing — and only removal has
         # nothing to point at.
         #
-        # Pre-existing, and newly VISIBLE rather than newly broken: this file's
-        # tests only run for recipes in the changed set, and before now gcc.lua
-        # had never been in it while this assertion existed. The same shape as
-        # openxlings/xlings#503, filed as openxlings/xlings#506; whether `remove`
-        # should succeed as a no-op against a delegated package is an xlings-side
-        # question, not this test's.
+        # A tolerance used to sit here and skip the assertion for exactly that
+        # shape. It is gone: xlings 2026.8.10.1 decides removal ownership by the
+        # provider whose uninstall hook is executing, so another provider's
+        # version under the same target neither blocks this hook nor enters its
+        # removal set. The pinned XLINGS_VERSION was bumped to it in the commit
+        # before this one -- this assertion cannot hold against an xlings that
+        # predates the fix.
         #
-        # Narrow on purpose, mirroring the `type = "config"` tolerance in
-        # posix-test.sh: the recipe must actually delegate (a `pkgmanager.install`
-        # call in its source) AND the failure must be in uninstall, which is the
-        # only branch this sits in. Keying on "uninstall failed" alone would
-        # swallow a genuine removal bug in any delegating recipe, and a tolerance
-        # that hides the case it was not written for is how a skipped assertion
-        # becomes permanent.
-        $delegates = $false
-        try {
-            $delegates = (Get-Content $luaFile -Raw) -match 'pkgmanager\.install\('
-        } catch { }
-        if ($delegates) {
-            Log-Info "uninstall not asserted: this recipe delegates its Windows install"
-            Log-Info "  ($removeSpec registers no xvm version of its own -- see the note in this script)"
-            continue
-        }
+        # Note what the `continue` also skipped: it sat BEFORE the post-uninstall
+        # shim checks, so a delegating recipe's shim cleanup was never asserted
+        # either. That half is now covered too -- and it is the right assertion,
+        # not a false positive: gcc.lua's `programs` is exactly the set it
+        # delegates to mingw-w64, so the delegated uninstall is what has to
+        # remove them.
         Log-Fail "uninstall failed"
         $failures += "$relFile (uninstall)"
         continue

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Installation Xlings on Ubuntu
         run: |
           export XLINGS_NON_INTERACTIVE=1
-          export XLINGS_VERSION=v2026.8.8.2
+          export XLINGS_VERSION=v2026.8.10.1
           curl -fsSL https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.sh | bash
           echo "XLINGS_HOME=$HOME/.xlings" >> "$GITHUB_ENV"
           echo "PATH=$HOME/.xlings/subos/current/bin:$HOME/.xlings/bin:$PATH" >> "$GITHUB_ENV"
@@ -150,7 +150,7 @@ jobs:
         shell: pwsh
         run: |
           $env:XLINGS_NON_INTERACTIVE = "1"
-          $env:XLINGS_VERSION = "v2026.8.8.2"
+          $env:XLINGS_VERSION = "v2026.8.10.1"
           iex (Invoke-WebRequest `
             -Uri "https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.ps1" `
             -UseBasicParsing).Content
@@ -211,7 +211,7 @@ jobs:
       - name: Install xlings on Ubuntu
         run: |
           export XLINGS_NON_INTERACTIVE=1
-          export XLINGS_VERSION=v2026.8.8.2
+          export XLINGS_VERSION=v2026.8.10.1
           curl -fsSL https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.sh | bash
           echo "XLINGS_HOME=$HOME/.xlings" >> "$GITHUB_ENV"
           echo "$HOME/.xlings/bin"               >> "$GITHUB_PATH"
@@ -276,7 +276,7 @@ jobs:
       - name: Install xlings on macOS
         run: |
           export XLINGS_NON_INTERACTIVE=1
-          export XLINGS_VERSION=v2026.8.8.2
+          export XLINGS_VERSION=v2026.8.10.1
           curl -fsSL https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.sh | bash
           echo "XLINGS_HOME=$HOME/.xlings" >> "$GITHUB_ENV"
           echo "$HOME/.xlings/bin"               >> "$GITHUB_PATH"

--- a/.github/workflows/ci-xpkg-test.yml
+++ b/.github/workflows/ci-xpkg-test.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Install xlings
         run: |
           export XLINGS_NON_INTERACTIVE=1
-          export XLINGS_VERSION=v2026.8.8.2
+          export XLINGS_VERSION=v2026.8.10.1
           curl -fsSL https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.sh | bash
           echo "XLINGS_HOME=$HOME/.xlings" >> "$GITHUB_ENV"
           echo "PATH=$HOME/.xlings/subos/current/bin:$HOME/.xlings/bin:$PATH" >> "$GITHUB_ENV"
@@ -119,7 +119,7 @@ jobs:
       - name: Install xlings
         run: |
           export XLINGS_NON_INTERACTIVE=1
-          export XLINGS_VERSION=v2026.8.8.2
+          export XLINGS_VERSION=v2026.8.10.1
           curl -fsSL https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.sh | bash
           echo "XLINGS_HOME=$HOME/.xlings" >> "$GITHUB_ENV"
           echo "PATH=$HOME/.xlings/subos/current/bin:$HOME/.xlings/bin:$PATH" >> "$GITHUB_ENV"

--- a/pkgs/g/gcc.lua
+++ b/pkgs/g/gcc.lua
@@ -142,6 +142,21 @@ end
 
 function uninstall()
     if os.host() == "windows" then
+        -- Delegated, like install(). This package registers no xvm version of
+        -- its own on Windows -- every shim under `gcc`, `g++`, `c++` belongs to
+        -- mingw-w64 -- so removal has nothing of its own to select, and it used
+        -- to fail with `exact removal version is not registered`
+        -- (openxlings/xlings#506).
+        --
+        -- xlings 2026.8.10.1 answered that on its side: removal decides
+        -- ownership by the provider whose uninstall hook is running, so another
+        -- provider's version under the same target neither blocks this hook nor
+        -- enters its removal set. The tolerance that used to skip this case in
+        -- windows-test.ps1 is removed in the same change as this comment.
+        --
+        -- Which means the shim cleanup below is now asserted rather than
+        -- skipped: `programs` above IS the mingw-w64-provided set, so this
+        -- delegation is what has to take those shims away.
         pkgmanager.uninstall("mingw-w64@" .. version_map_gcc2mingw[pkginfo.version()])
         return true
     end

--- a/pkgs/g/gcc.lua
+++ b/pkgs/g/gcc.lua
@@ -556,7 +556,14 @@ end
 -- contents (any `ld-*.so*`) — no architecture hardcodes, no directory
 -- layout assumptions. Same helper shape as llvm.lua's.
 function __find_glibc_runtime()
-    local glibc_dir = pkginfo.dep_install_dir("glibc")
+    -- Namespaced, because that is how this package DECLARES it
+    -- ("xim:glibc@>=2.39" above). A bare name cannot be resolved against
+    -- the host's explicit dependency stores -- it does not say which
+    -- namespace -- so libxpkg >= 0.0.55 answers nil, and under xlings
+    -- 2026.8.10.1 this hook reported "glibc payload not found" on homes
+    -- where glibc was installed. The namespaced form resolves through
+    -- the resolved-dependency record, which is the single source.
+    local glibc_dir = pkginfo.dep_install_dir("xim:glibc")
     if not glibc_dir then return nil, nil end
 
     for _, libname in ipairs({"lib64", "lib"}) do

--- a/pkgs/l/llvm.lua
+++ b/pkgs/l/llvm.lua
@@ -207,7 +207,10 @@ end
 -- contents (any `ld-*.so*`), mirroring glibc.lua's `exports.runtime.loader`
 -- declaration, so nothing here hardcodes an architecture.
 function __find_glibc_runtime()
-    local glibc_dir = pkginfo.dep_install_dir("glibc")
+    -- Namespaced: see the note in pkgs/g/gcc.lua. A bare name is not
+    -- resolvable against explicit dependency stores, and this package
+    -- declares "xim:glibc@>=2.39".
+    local glibc_dir = pkginfo.dep_install_dir("xim:glibc")
     if not glibc_dir then return nil, nil end
 
     for _, libname in ipairs({"lib64", "lib"}) do
@@ -235,7 +238,7 @@ end
 -- cfg then omits the kernel-header line; compiles that need <linux/*.h>
 -- surface a clear missing-header error instead of a broken install).
 function __find_linux_headers_include()
-    for _, name in ipairs({"linux-headers", "scode:linux-headers"}) do
+    for _, name in ipairs({"xim:linux-headers", "scode:linux-headers"}) do
         local dir = pkginfo.dep_install_dir(name)
         if dir and os.isfile(path.join(dir, "include", "linux", "limits.h")) then
             return path.join(dir, "include")


### PR DESCRIPTION
## 为什么第一个 commit 只做 bump

`windows-test.ps1` 里有一段针对 #506 的 tolerance：当一个 recipe 在 Windows 上委托安装
（源码里有 `pkgmanager.install(`）且 uninstall 失败时，跳过断言并 `continue`。

它现在可以删了 —— `openxlings/xlings#519`（2026.8.10.1）落地了 xlings 侧的答案：
removal 只按**执行 uninstall hook 的 provider** 判断 ownership。`gcc` 在 Windows 上零注册、
`gcc` 这个 target 下的版本属于 `xim:mingw-w64`，因此不再报
`exact removal version is not registered`。

但本仓库 CI 把 xlings pin 在 **`v2026.8.8.2`**（6 处），早于那个修复。直接删 tolerance
会用一个没有修复的 xlings 去跑，必然红——而且红的原因会指向 recipe，不指向 pin。
所以第一个 commit 只做 bump，先证明基线绿。

## 删 tolerance 会同时打开两个断言

那个 `continue` 在 **post-uninstall 检查之前**，跳过的不止一条：

1. **uninstall 必须成功** —— 2026.8.10.1 修的就是这个；
2. **shim 泄漏检查** —— xlings 侧没碰过，是新暴露面。

第 2 条是不是误报，取决于委托卸载清不清 shim。查过 `pkgs/g/gcc.lua`：
`programs = { "gcc", "g++", "c++" }` 正是它委托给 mingw-w64 的那组（源码注释写明
「intentionally NOT in the top-level programs so that the windows declared-program
audit doesn't demand mingw-w64 to provide them」），而 `uninstall()` 在 Windows 上是
`pkgmanager.uninstall("mingw-w64@...")`。所以泄漏检查问的正是「委托卸载真的清干净了吗」
—— 是**正确的断言**，不是误报。

## `gcc.lua` 必须进变更集

`windows-test.ps1` 只测变更集里的 recipe。#506 自己写着：
「Repro: put `pkgs/g/gcc.lua` in a PR's changed set and let `windows-test` run.」
所以本 PR 会带一处 `gcc.lua` 的实质注释更新——否则删掉 tolerance 之后 gate 依然不会跑那个
case，PR 会绿得毫无意义。

Closes openxlings/xlings#506
