### PR TITLE
fix(index): ask with the declared coordinate, and give GLX a vendor path of its own

### DIFF
--- a/.agents/tools/graphics/glxprobe.c
+++ b/.agents/tools/graphics/glxprobe.c
@@ -12,20 +12,29 @@
 // about whose libGLX_nvidia was loaded -- the host binary under the host
 // loader prints exactly that whether or not our interposer exists.
 //
-// BUILD REQUIREMENT -- DT_RPATH, not DT_RUNPATH:
+// BUILD IT THE WAY A REAL CONSUMER BUILDS -- default dtags:
 //
 //   gcc -o glxprobe glxprobe.c -ldl \
 //       -Wl,--dynamic-linker=<subos>/lib/ld-linux-x86-64.so.2 \
-//       -Wl,-rpath,<subos>/lib -Wl,--disable-new-dtags
+//       -Wl,-rpath,<subos>/lib
 //
-// glvnd's dlopen of the vendor is served by the CALLING object's search
-// path, and libGLX.so.0's own RPATH is `$ORIGIN` -- it cannot see the vendor
-// package. What makes it resolve is that DT_RPATH is searched transitively up
-// the load chain to the executable, so the consumer's own RPATH serves the
-// dlopen. DT_RUNPATH is NOT transitive: build the same probe with
-// --enable-new-dtags (the default on many distros) and glvnd finds no vendor
-// at all -- `glXQueryServerString` returns null with the X connection and the
-// GLX extension both fine.
+// glvnd's dlopen of the vendor is served by the CALLING object's search path,
+// and the calling object is libGLX.so.0 -- not this probe.
+//
+// This comment used to state the opposite as a BUILD REQUIREMENT: add
+// `-Wl,--disable-new-dtags`, because DT_RPATH is searched transitively up the
+// load chain to the executable while DT_RUNPATH is not, so the consumer's own
+// rpath would serve the dlopen. The mechanism is real. Making it a
+// requirement on the CONSUMER was the defect: every build system emits plain
+// `-Wl,-rpath`, whose modern default is DT_RUNPATH, so the contract was one
+// no consumer could honour. It held only for hand-built probes -- which is to
+// say, only here. openxlings/xlings#525: mcpp's imgui template got
+// `GLX: No GLXFBConfigs returned` on a host whose own glxinfo was fine, and
+// every GLX check in this directory was green at the time.
+//
+// libglvnd's own libGLX.so.0 now carries `$ORIGIN/glx-vendor`, so the
+// reachability travels with the object that needs it. Build this probe with
+// the default and it is testing what users actually get.
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>

--- a/.agents/tools/graphics/verify-host-link.sh
+++ b/.agents/tools/graphics/verify-host-link.sh
@@ -23,6 +23,33 @@
 # 3 could-not-run.
 set -euo pipefail
 
+# DT_RUNPATH, the default -- NOT --disable-new-dtags.
+#
+# These probes used to pass `-Wl,--disable-new-dtags`, which emits DT_RPATH.
+# DT_RPATH is searched TRANSITIVELY up the load chain, so the probe's own
+# rpath ended up serving glvnd's dlopen of the vendor from inside
+# libGLX.so.0. That works, and no real consumer does it: every build system
+# emits plain `-Wl,-rpath` with the modern default, which is DT_RUNPATH, and
+# DT_RUNPATH is not transitive. So every green GLX check here was bought with
+# a flag nobody passes -- openxlings/xlings#525, where mcpp's imgui template
+# got "GLX: No GLXFBConfigs returned" on a host whose own glxinfo was fine.
+#
+# Vendor reachability now lives where it belongs: libglvnd's own libGLX.so.0
+# carries $ORIGIN/glx-vendor. These probes therefore link the way a real
+# consumer links, and a failure here is a real failure.
+#
+# XLINGS_GFX_LEGACY_DTAGS=1 restores the old flag. Keep it for diagnosis
+# only: if the legacy build passes and the default one fails, the vendor
+# directory is the thing that is broken, not the rest of the stack.
+#
+# An `if`, not `[[ ... ]] && ...`: this script runs under `set -e`, where a
+# top-level test that evaluates false is a failing command and kills the whole
+# script with no output at all.
+DTAGS=()
+if [[ -n "${XLINGS_GFX_LEGACY_DTAGS:-}" ]]; then
+  DTAGS=(-Wl,--disable-new-dtags)
+fi
+
 HOME_DIR="${1:?usage: verify-host-link.sh <XLINGS_HOME> [subos]}"
 SUBOS="${2:-default}"
 SYS="$HOME_DIR/subos/$SUBOS"
@@ -107,7 +134,7 @@ if [[ -e "$SYS/lib/libEGL.so.1" ]]; then
   if "$CC" -O0 -o "$WORK/glprobe" "$HERE/glprobe.c" \
         ${GLVND_INC:+-I"$GLVND_INC"} -L"$SYS/lib" -lEGL -lGL \
         -Wl,--dynamic-linker="$SYS/lib/ld-linux-x86-64.so.2" \
-        -Wl,-rpath,"$SYS/lib" -Wl,--disable-new-dtags 2>"$WORK/egl.build"; then
+        -Wl,-rpath,"$SYS/lib" "${DTAGS[@]}" 2>"$WORK/egl.build"; then
     out="$(env -u LD_LIBRARY_PATH "$WORK/glprobe" 2>&1 || true)"
     grep -q "^RESULT=ok" <<<"$out" && ok "EGL rendered ($(grep -m1 '^PIXEL=' <<<"$out"))" \
       || bad "EGL: $(grep -m1 '^RESULT=' <<<"$out" || echo 'no RESULT line')"
@@ -130,7 +157,7 @@ if [[ -z "${DISPLAY:-}" ]]; then
 else
   if "$CC" -O0 -o "$WORK/glxprobe" "$HERE/glxprobe.c" -ldl \
         -Wl,--dynamic-linker="$SYS/lib/ld-linux-x86-64.so.2" \
-        -Wl,-rpath,"$SYS/lib" -Wl,--disable-new-dtags 2>"$WORK/glx.build"; then
+        -Wl,-rpath,"$SYS/lib" "${DTAGS[@]}" 2>"$WORK/glx.build"; then
     out="$(env -u LD_LIBRARY_PATH "$WORK/glxprobe" 2>&1 || true)"
     grep -qi "GLX GL_RENDERER:.*NVIDIA" <<<"$out" \
       && ok "GLX renderer: $(grep -m1 'GLX GL_RENDERER:' <<<"$out" | sed 's/.*: //')" \

--- a/.agents/tools/graphics/verify-stack.sh
+++ b/.agents/tools/graphics/verify-stack.sh
@@ -34,6 +34,27 @@
 # Design: xlings/.agents/docs/2026-08-07-graphics-experience-industry-survey-and-plan.md §10
 set -uo pipefail
 
+# DT_RUNPATH, the default -- NOT --disable-new-dtags.
+#
+# These probes used to pass `-Wl,--disable-new-dtags`, which emits DT_RPATH.
+# DT_RPATH is searched TRANSITIVELY up the load chain, so the probe's own
+# rpath ended up serving glvnd's dlopen of the vendor from inside
+# libGLX.so.0. That works, and no real consumer does it: every build system
+# emits plain `-Wl,-rpath` with the modern default, which is DT_RUNPATH, and
+# DT_RUNPATH is not transitive. So every green GLX check here was bought with
+# a flag nobody passes -- openxlings/xlings#525, where mcpp's imgui template
+# got "GLX: No GLXFBConfigs returned" on a host whose own glxinfo was fine.
+#
+# Vendor reachability now lives where it belongs: libglvnd's own libGLX.so.0
+# carries $ORIGIN/glx-vendor. These probes therefore link the way a real
+# consumer links, and a failure here is a real failure.
+#
+# XLINGS_GFX_LEGACY_DTAGS=1 restores the old flag. Keep it for diagnosis
+# only: if the legacy build passes and the default one fails, the vendor
+# directory is the thing that is broken, not the rest of the stack.
+DTAGS=()
+[[ -n "${XLINGS_GFX_LEGACY_DTAGS:-}" ]] && DTAGS=(-Wl,--disable-new-dtags)
+
 SUBOS="gfxverify"; KEEP=0; JSON=0; XHOME_ARG=""
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -163,7 +184,7 @@ if [[ -n "$CC" && -f "$HERE/glprobe.c" ]]; then
   if "$CC" -O0 -o /tmp/gfxverify-probe "$HERE/glprobe.c" ${INC:+-I"$INC"} \
         -L"$S/lib" -lEGL -lGL -Wl,--dynamic-linker="$S/lib/ld-linux-x86-64.so.2" \
         -Wl,-rpath,"$S/lib" -Wl,-rpath-link,"$S/lib" -Wl,-rpath-link,"$S/usr/lib" \
-        -Wl,--disable-new-dtags 2>/tmp/gfxverify-probe.log; then
+        "${DTAGS[@]}" 2>/tmp/gfxverify-probe.log; then
     PROBE=/tmp/gfxverify-probe
   fi
 fi

--- a/docs/V2/xpackage-spec.md
+++ b/docs/V2/xpackage-spec.md
@@ -398,6 +398,45 @@ xlings now refuses to finish an install that produced one, and `xlings doctor`
 reports existing ones. Design and the invariant:
 `xlings/.agents/docs/2026-08-05-dependency-resolution-single-source.md`
 
+### Ask with the coordinate you declared
+
+```lua
+deps = { "xim:glibc@>=2.39" }
+
+local dir = pkginfo.dep_install_dir("xim:glibc")   -- RIGHT
+local dir = pkginfo.dep_install_dir("glibc")       -- fragile
+local dir = pkginfo.dep_install_dir("xim:mesa")    -- WRONG unless mesa is in deps
+```
+
+Two things answer this call, and both want a **namespaced** name. The resolver
+record is keyed by the declared spec. The explicit dependency store roots
+locate `<root>/<ns>-x-<bare>/<ver>`, so a bare name does not say which
+`*-x-glibc` is meant — and refusing to guess between `compat-x-zlib` and
+`other-x-zlib` is the whole point of those roots.
+
+A bare name still works when the record set answers it uniquely, and fails
+closed naming both providers when it does not. Treat that as a safety net, not
+as the contract: it disappears the moment a second package with the same bare
+name enters your dep list.
+
+**Omit the version**, or pass the range you declared. The record holds what the
+resolver chose; restating a concrete version just invents a second opinion, and
+a range is matched as a range (`>=2.39` matches the chosen `2.44`).
+
+**Only what you declared.** A transitive dependency has no record — xlings
+records a node's own runtime deps, not its whole closure — so asking for one
+returns nil. If a hook uses a package's payload, that package is a dependency:
+declare it. For a payload the hook installed *itself* (`pkgmanager.install`),
+use `pkginfo.tool_payload_dir`, which keeps its own store scan.
+
+Measured (openxlings/xlings#524): six of the seven `dep_install_dir` call sites
+in this index passed a bare name while declaring a namespaced, ranged one. They
+worked while a store scan covered for it; when xlings 2026.8.10.1 began
+supplying explicit store roots, gcc and meson stopped installing on any cold
+home, godot silently fell back to the host's GL, and the graphics banner
+started reporting `unknown`. `tests/test_dep_query_coordinates.py` now enforces
+this rule structurally.
+
 ### Probing for it
 
 ```lua

--- a/libs/graphics.lua
+++ b/libs/graphics.lua
@@ -58,6 +58,8 @@
 import("xim.libxpkg.log")
 import("xim.libxpkg.xvm")
 import("xim.libxpkg.subos")
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.fs")
 
 local graphics = {}
 
@@ -73,6 +75,41 @@ local graphics = {}
 -- stack's headers already live.
 graphics.DRI_DIR        = "usr/lib/dri"
 graphics.EGL_VENDOR_DIR = "share/glvnd/egl_vendor.d"
+
+-- The GLX vendor directory — and why it is NOT next to the two above.
+--
+-- Those are subos-relative, because an ENVIRONMENT VARIABLE points at them.
+-- GLX has no such variable. Measured on a host libglvnd 1.7:
+--
+--   libEGL.so.1   __EGL_VENDOR_LIBRARY_DIRS, __EGL_VENDOR_LIBRARY_FILENAMES,
+--                 a default search path, and a JSON `library_path` that may be
+--                 an ABSOLUTE path (our recipes rewrite it to one).
+--   libGLX.so.0   `libGLX_%s.so.0` and `__GLX_VENDOR_LIBRARY_NAME`. That is
+--                 all of it. A NAME, never a path, never a directory.
+--
+-- So GLX vendor discovery is a bare-SONAME `dlopen` from inside libGLX.so.0,
+-- and glibc serves that from exactly four places: the calling object's
+-- DT_RPATH (transitive up its load chain) or DT_RUNPATH (not transitive),
+-- LD_LIBRARY_PATH, and ld.so.cache. LD_LIBRARY_PATH is out -- it is
+-- process-global and loads our payload into host binaries, which is the
+-- `__pointer_chk_guard` crash xim's own install warning describes. Our
+-- loader's cache path exists nowhere. What is left is the search path of the
+-- object that CALLS dlopen: libGLX.so.0, which is ours.
+--
+-- Hence a directory inside libglvnd's OWN payload, reached by `$ORIGIN`:
+-- home-relocatable, and one directory serves every subos in the home, with
+-- per-subos vendor SELECTION staying where glvnd already put it
+-- (`__GLX_VENDOR_LIBRARY_NAME`). A subos-absolute path would pin the shared
+-- payload to whichever subos installed it last.
+--
+-- A subdirectory, not `lib/` itself: `lib/` is published into the subos by
+-- `sysroot.declare_libs`, and vendor libraries are dlopen'd plugins, not link
+-- targets. This also keeps the farm out of it -- `<subos>/lib` holds
+-- libc.so.6 and ld-linux symlinks, and that directory in an RPATH is a known
+-- landmine.
+--
+-- Relative to libglvnd's install_dir. openxlings/xlings#525.
+graphics.GLX_VENDOR_SUBDIR = "lib/glx-vendor"
 graphics.SHARE_DIR      = "share"
 -- Where the Vulkan loader looks, relative to the subos: it searches
 -- $XDG_DATA_DIRS/vulkan/icd.d and mesa puts ${subosdir}/share on that list.
@@ -245,6 +282,61 @@ function graphics.declare_dri(install_dir, rel_dir, tag)
     end
     xvm.files{ src = rel_dir, dst = graphics.DRI_DIR, binding = tag }
     return true
+end
+
+-- ─────────────────────────────────────────────────────────────────────
+-- GLX vendor registration — the counterpart `declare_egl_vendor` has and
+-- GLX did not. See GLX_VENDOR_SUBDIR above for why it is a directory plus an
+-- RPATH rather than a variable: glvnd offers no GLX variable to point.
+-- ─────────────────────────────────────────────────────────────────────
+
+-- Populate libglvnd's vendor directory from the vendors in this stack.
+--
+-- WHY THE ASSEMBLER DOES THIS, AND NOT EACH VENDOR
+--
+-- Per-vendor self-registration is the obvious shape -- it mirrors
+-- `declare_egl_vendor` exactly -- and it has an ordering hole that this
+-- ecosystem has been bitten by before. The directory lives in libglvnd's
+-- payload, and a libglvnd reinstall does `os.tryrm(install_dir)`: every
+-- registration disappears. The vendors do not reinstall just because their
+-- dependency did, so nothing puts them back. The stack would come up with an
+-- empty vendor directory and render on llvmpipe, reporting success -- the
+-- precise failure this whole mechanism exists to remove.
+--
+-- `graphics` cannot have that hole. It declares every vendor AND the
+-- dispatch, so it installs strictly after all of them, and re-running it
+-- rewires the whole set from scratch. One writer, one moment, no ordering
+-- assumption.
+--
+-- `vendors` is a list of {dir, soname} -- the payload directory and the
+-- library's SONAME, which is also the filename glvnd builds and dlopens.
+-- Returns the number registered.
+-- `fs.*`, not `os.*`. The recipe sandbox's `os` table is the one prelude.lua
+-- builds -- isfile/isdir/dirs/mkdir/mv/cp/tryrm/exec/iorun and nothing else.
+-- `os.ln` and `os.files` do not exist there, and calling one raises from
+-- inside a hook rather than failing a check.
+function graphics.wire_glx_vendors(dispatch_dir, vendors)
+    local vendor_dir = path.join(dispatch_dir, graphics.GLX_VENDOR_SUBDIR)
+    fs.mkdir_p(vendor_dir)
+
+    -- Rebuild, do not merge. A vendor dropped from the stack must not leave a
+    -- dangling entry: glvnd would dlopen it, fail, and swallow the error.
+    for _, stale in ipairs(fs.files(vendor_dir) or {}) do
+        fs.remove(stale)
+    end
+
+    local n = 0
+    for _, v in ipairs(vendors) do
+        local src = path.join(v.dir, "lib", v.soname)
+        if os.isfile(src) then
+            -- Absolute symlink: the target is a different payload in the same
+            -- home, so a relative one would break if either moved.
+            fs.symlink(src, path.join(vendor_dir, v.soname))
+            n = n + 1
+            log.info("GLX vendor: %s", v.soname)
+        end
+    end
+    return n
 end
 
 return graphics

--- a/pkgs/g/gcc.lua
+++ b/pkgs/g/gcc.lua
@@ -297,7 +297,14 @@ function __config_linux()
         log.error("glibc payload not found, but gcc needs it to rewrite its"
             .. " ELF interpreter away from the build machine's path.")
         log.error("  without it the installed gcc cannot run at all.")
-        log.error("  install it first: xlings install xim:glibc@2.39")
+        -- Name the coordinate this package actually declares. This line used
+        -- to be the literal `xim:glibc@2.39` regardless of what was declared
+        -- or resolved, and on openxlings/xlings#524 -- where the resolver had
+        -- correctly picked 2.44 -- the mismatch read as a resolution bug and
+        -- sent the report down a false lead. A constant cannot describe a
+        -- resolved dependency.
+        log.error("  it is declared as %s; install it first: xlings install %s",
+            table.concat(pkginfo.deps_list(), ", "), "xim:glibc")
         return false
     end
 
@@ -541,7 +548,14 @@ end
 -- contents (any `ld-*.so*`) — no architecture hardcodes, no directory
 -- layout assumptions. Same helper shape as llvm.lua's.
 function __find_glibc_runtime()
-    local glibc_dir = pkginfo.dep_install_dir("glibc")
+    -- Ask with the coordinate this package DECLARED (`xim:glibc@>=2.39`), not
+    -- a bare name. The resolver keys its record by that coordinate, and a bare
+    -- name additionally cannot be looked up in the explicit dependency store
+    -- roots, which need a namespace to know which `*-x-glibc` is meant.
+    -- openxlings/xlings#524: the bare form returned nil on every cold home
+    -- once xlings 2026.8.10.1 began supplying those roots, and gcc reported
+    -- "glibc payload not found" with glibc sitting installed next to it.
+    local glibc_dir = pkginfo.dep_install_dir("xim:glibc")
     if not glibc_dir then return nil, nil end
 
     for _, libname in ipairs({"lib64", "lib"}) do

--- a/pkgs/g/godot.lua
+++ b/pkgs/g/godot.lua
@@ -153,6 +153,22 @@ package = {
                     -- namespaces, and the bare name is then ambiguous. So it
                     -- carries the prefix, like its three siblings above.
                     "xim:graphics@>=0.1",
+                    -- config() asks for mesa's payload directly, so mesa is
+                    -- declared directly. It used to ride in transitively
+                    -- through `graphics` while the query said `mesa` -- and
+                    -- the resolver only records a package's OWN declared
+                    -- runtime deps, so there was never a record to find.
+                    -- Before explicit dependency store roots a store scan
+                    -- covered for that; after them the query returns nil,
+                    -- `have_stack` goes false, and this package silently
+                    -- falls back to the host's GL directories -- which is
+                    -- mcpp#352, the exact failure the dependency above exists
+                    -- to prevent, arriving with no diagnostic at all
+                    -- (openxlings/xlings#524).
+                    --
+                    -- A lower bound, like `graphics`: this must not pin the
+                    -- stack's version.
+                    "xim:mesa@>=25",
                 },
                 -- config() invokes `patchelf --force-rpath` to flip the
                 -- tag elfpatch stamps in (DT_RUNPATH -> DT_RPATH) so
@@ -348,7 +364,7 @@ function config()
     if os.host() == "linux" then
         local exe = _installed_exe()
         local mesa_dir = pkginfo.dep_install_dir
-                         and pkginfo.dep_install_dir("mesa") or nil
+                         and pkginfo.dep_install_dir("xim:mesa") or nil
         local have_stack = mesa_dir and mesa_dir ~= ""
                            and os.isdir(path.join(mesa_dir, "lib"))
         local host_dirs = have_stack and {} or _host_gui_libdirs()
@@ -419,7 +435,7 @@ function config()
     -- variable unset.
     local node = { bindir = pkginfo.install_dir() }
     local mesa_dir = pkginfo.dep_install_dir
-                     and pkginfo.dep_install_dir("mesa") or nil
+                     and pkginfo.dep_install_dir("xim:mesa") or nil
     if mesa_dir and mesa_dir ~= "" and os.isdir(path.join(mesa_dir, "lib")) then
         node.envs = graphics.consumer_envs()
     end

--- a/pkgs/g/graphics.lua
+++ b/pkgs/g/graphics.lua
@@ -135,11 +135,29 @@ package = {
                     -- RADV and its manifest, and without libvulkan.so.1 nothing
                     -- ever reads it -- which also leaves zink dead.
                     "xim:vulkan-loader@>=1.4",
+                    -- The GL dispatch. It arrives transitively through mesa
+                    -- anyway; it is declared HERE because config() wires the
+                    -- GLX vendor libraries into its payload, and a transitive
+                    -- dependency has no resolver record to ask for -- the
+                    -- query would just return nil (openxlings/xlings#524).
+                    --
+                    -- The lower bound is the version that carries the vendor
+                    -- directory and the `$ORIGIN/glx-vendor` RPATH, so a home
+                    -- upgrading from an older stack actually re-runs
+                    -- libglvnd's config instead of keeping a libGLX.so.0 that
+                    -- can reach no vendor at all.
+                    "xim:libglvnd@>=1.7.0.1",
                 },
             },
-            ["latest"] = { ref = "0.1.0" },
+            ["latest"] = { ref = "0.1.1" },
             -- No payload. This package is its dependency list and the report
             -- below; there is nothing to download.
+            --
+            -- 0.1.1 exists so an already-assembled home re-runs config() and
+            -- picks up the GLX vendor wiring. Without a new key the hook never
+            -- fires again and the fix reaches only fresh installs -- silently,
+            -- which is the failure mode this stack keeps producing.
+            ["0.1.1"] = { },
             ["0.1.0"] = { },
         },
     },
@@ -148,6 +166,56 @@ package = {
 import("xim.libxpkg.log")
 import("xim.libxpkg.pkginfo")
 import("xim.libxpkg.xvm")
+import("xim.pkgindex.graphics")
+
+-- Wire every GLX vendor in this stack into the dispatch's vendor directory.
+--
+-- glvnd dlopens `libGLX_<vendor>.so.0` by name from inside libGLX.so.0, and
+-- there is no GLX counterpart to `egl_vendor.d` to point at -- see
+-- libs/graphics.lua GLX_VENDOR_SUBDIR. libglvnd's config gives its own
+-- libGLX.so.0 an `$ORIGIN/glx-vendor` RPATH; this fills that directory.
+--
+-- Done by the assembler rather than by each vendor because a libglvnd
+-- reinstall wipes its payload, taking every registration with it, and the
+-- vendors do not reinstall just because their dependency did. This package
+-- declares all of them, so it installs last and can rebuild the whole set.
+--
+-- mesa is the software/AMD/Intel path; nvidia-gl-host-link bridges the
+-- proprietary driver. The WSL2 sentinel has no GLX vendor of its own -- it
+-- renders through mesa's d3d12 driver behind libGLX_mesa -- so it is not
+-- listed. A vendor whose library is absent (a sentinel on a host without that
+-- driver) is skipped, not an error.
+local _GLX_VENDORS = {
+    { dep = "xim:mesa",                 soname = "libGLX_mesa.so.0" },
+    { dep = "xim:nvidia-gl-host-link",  soname = "libGLX_nvidia.so.0" },
+}
+
+function __wire_glx_vendors()
+    local dispatch = pkginfo.dep_install_dir("xim:libglvnd")
+    if not dispatch or dispatch == "" then
+        log.error("cannot locate the libglvnd payload; GLX programs will find "
+                  .. "no vendor and fall back to software rendering")
+        return false
+    end
+
+    local found = {}
+    for _, v in ipairs(_GLX_VENDORS) do
+        local dir = pkginfo.dep_install_dir(v.dep)
+        if dir and dir ~= "" then
+            table.insert(found, { dir = dir, soname = v.soname })
+        end
+    end
+
+    local n = graphics.wire_glx_vendors(dispatch, found)
+    if n == 0 then
+        -- Not fatal: a stack with no GLX vendor still runs, on llvmpipe. It
+        -- must not do that quietly -- llvmpipe and an RTX 4080 draw the same
+        -- pixels, and this is the one place that difference is visible.
+        log.warn("no GLX vendor library was registered; GL will render in "
+                 .. "software. `xlings install xim:mesa` provides one.")
+    end
+    return true
+end
 
 function install()
     local dir = pkginfo.install_dir()
@@ -158,6 +226,10 @@ end
 
 function config()
     xvm.add(package.name)
+
+    -- Before the report below, so the banner describes a stack that is
+    -- actually wired rather than one that is only installed.
+    if not __wire_glx_vendors() then return false end
 
     -- Say which path this host actually took.
     --
@@ -180,8 +252,13 @@ function config()
         return (io.readfile(f) or ""):gsub("%s+$", "")
     end
 
-    local nv  = __sentinel_state("nvidia-gl-host-link", ".host-driver-version")
-    local wsl = __sentinel_state("wsl-gl-host-link", ".wsl-host")
+    -- Namespaced, as declared above. Bare names returned nil under explicit
+    -- dependency store roots (openxlings/xlings#524), and this one fails
+    -- SILENTLY: both sentinels read as absent, so the banner says "unknown"
+    -- and the user cannot tell a GPU install from an llvmpipe one -- which is
+    -- precisely the pair this banner exists to distinguish.
+    local nv  = __sentinel_state("xim:nvidia-gl-host-link", ".host-driver-version")
+    local wsl = __sentinel_state("xim:wsl-gl-host-link", ".wsl-host")
 
     log.info("graphics stack installed. On this host:")
     if nv and nv ~= "" then

--- a/pkgs/l/libglvnd.lua
+++ b/pkgs/l/libglvnd.lua
@@ -17,14 +17,39 @@ package = {
 
     xpm = {
         linux = {
-            deps = { "xim:libX11@>=1.8", "xim:libXext@>=1.3", "xim:glibc" },
+            -- Separated shape, not the array-plus-`build` mixed one: every
+            -- client before libxpkg 0.0.52 takes the array branch on a mixed
+            -- table and drops `build` silently. See tests/test_deps_shape.py.
+            deps = {
+                runtime = { "xim:libX11@>=1.8", "xim:libXext@>=1.3", "xim:glibc" },
+                -- config() rewrites libGLX.so.0's RPATH so glvnd's vendor
+                -- dlopen can reach the vendor directory. patchelf is the only
+                -- way to do that to an already-built payload.
+                build = { "xim:patchelf@0.18.0" },
+            },
             -- elfpatch reads this from each dependency and writes the consumer's
             -- RPATH, which is what makes the stack resolve without anyone
             -- setting LD_LIBRARY_PATH. Same mechanism `gcc-runtime` uses.
             exports = {
                 runtime = { libdirs = { "lib" } },
             },
-            ["latest"] = { ref = "1.7.0" },
+            ["latest"] = { ref = "1.7.0.1" },
+            -- Same upstream artifact as 1.7.0, new version key.
+            --
+            -- The GLX vendor wiring lives in config(), and config() only runs
+            -- when the package installs. A home that already has 1.7.0 would
+            -- keep a libGLX.so.0 that cannot reach any vendor, with nothing to
+            -- say so -- the fix would ship and those users would never get it.
+            -- A new key under the same artifact makes every consumer's `>=1.7`
+            -- lower bound pull it, so the hook re-runs. The fontconfig
+            -- 2.15.0.1 pattern; the payload bytes and sha256 are unchanged.
+            ["1.7.0.1"] = {
+                url = {
+                    GLOBAL = "https://github.com/xlings-res/libglvnd/releases/download/1.7.0/libglvnd-1.7.0-linux-x86_64.tar.gz",
+                    CN     = "https://gitcode.com/xlings-res/libglvnd/releases/download/1.7.0/libglvnd-1.7.0-linux-x86_64.tar.gz",
+                },
+                sha256 = "07366016ef25ec20436df65bf94f0dee758d41ec34d0723056690d5c899bf8c8",
+            },
             ["1.7.0"] = {
                 url = {
                     GLOBAL = "https://github.com/xlings-res/libglvnd/releases/download/1.7.0/libglvnd-1.7.0-linux-x86_64.tar.gz",
@@ -39,8 +64,77 @@ package = {
 import("xim.libxpkg.pkginfo")
 import("xim.libxpkg.system")
 import("xim.libxpkg.xvm")
+import("xim.libxpkg.log")
+import("xim.libxpkg.fs")
 import("xim.pkgindex.sysroot")
 import("xim.pkgindex.selfcontain")
+import("xim.pkgindex.graphics")
+
+-- Give libGLX.so.0 a search path that reaches the GLX vendor libraries.
+--
+-- glvnd builds `libGLX_<vendor>.so.0` and dlopens it BY NAME -- there is no
+-- GLX equivalent of `egl_vendor.d`, no directory variable, nothing but the
+-- SONAME (measured: this payload's libGLX.so.0 contains `libGLX_%s.so.0` and
+-- `__GLX_VENDOR_LIBRARY_NAME`, which selects a NAME, never a path). glibc
+-- serves that dlopen from the CALLING object's own search path, and the
+-- calling object is this file. So the reachability has to live here.
+--
+-- It used to live on the CONSUMER instead, via DT_RPATH searched transitively
+-- up the load chain -- which works, and which every probe in
+-- `.agents/tools/graphics/` bought with `-Wl,--disable-new-dtags`. Real build
+-- systems emit DT_RUNPATH (the default), DT_RUNPATH is not transitive, and
+-- the whole thing collapses: openxlings/xlings#525, where mcpp's imgui
+-- template got `GLX: No GLXFBConfigs returned` on a host whose own glxinfo
+-- was fine. A contract no consumer can be expected to honour is not a
+-- contract.
+--
+-- `$ORIGIN`, so the entry survives a home that moves and serves every subos
+-- in the home. DT_RPATH (--force-rpath) rather than DT_RUNPATH: it is also
+-- searched for the vendor's OWN dependencies, which is what the interposers
+-- in nvidia-gl-host-link rely on.
+--
+-- APPEND. selfcontain.seal() already stamped this payload's closure onto the
+-- library in install(); replacing that is how a payload loses its own libs.
+function __wire_glx_vendor_search_path()
+    local dispatch = path.join(pkginfo.install_dir(), "lib", "libGLX.so.0")
+    if not os.isfile(dispatch) then
+        log.warn("no lib/libGLX.so.0 in this payload; GLX vendor lookup is "
+                 .. "left as upstream shipped it")
+        return false
+    end
+
+    -- The directory the vendors get wired into. Created here so the RPATH
+    -- entry names something that exists even before `graphics` populates it;
+    -- ld.so skips a missing directory silently, and "silently" is the whole
+    -- problem being fixed.
+    fs.mkdir_p(path.join(pkginfo.install_dir(), graphics.GLX_VENDOR_SUBDIR))
+
+    local want = "$ORIGIN/glx-vendor"
+    -- --print-rpath prints DT_RUNPATH too, so this reads whatever tag is
+    -- actually there.
+    local current = os.iorun(string.format(
+        [[patchelf --print-rpath "%s"]], dispatch))
+    current = current and current:gsub("%s+$", "") or ""
+
+    if current:find(want, 1, true) then return true end
+    local merged = (current ~= "") and (current .. ":" .. want) or want
+    os.exec(string.format([[patchelf --force-rpath --set-rpath %q %q]],
+                          merged, dispatch))
+
+    -- Assert the result, do not assume it. patchelf may be absent, and a
+    -- skipped rewrite here is indistinguishable from a working one until a GL
+    -- program fails two layers away with a message about FBConfigs.
+    local after = os.iorun(string.format(
+        [[patchelf --print-rpath "%s"]], dispatch))
+    if not (after and after:find(want, 1, true)) then
+        log.error("failed to add %s to libGLX.so.0's RPATH (patchelf missing "
+                  .. "or refused). GLX programs would find no vendor and "
+                  .. "render on llvmpipe.", want)
+        return false
+    end
+    log.info("GLX vendor search path: %s", want)
+    return true
+end
 
 function install()
     local dir = pkginfo.install_dir()
@@ -57,6 +151,11 @@ function config()
     local binding = package.name .. "@" .. pkginfo.version()
 
     xvm.add(package.name)
+
+    -- Before declare_libs: that publishes `lib/` into the subos, and the
+    -- vendor directory must already exist as a directory when it does rather
+    -- than appearing underneath it afterwards.
+    if not __wire_glx_vendor_search_path() then return false end
 
     sysroot.declare_libs(pkginfo.install_dir(), "lib", binding, pkginfo.version())
 

--- a/pkgs/l/llvm.lua
+++ b/pkgs/l/llvm.lua
@@ -207,7 +207,10 @@ end
 -- contents (any `ld-*.so*`), mirroring glibc.lua's `exports.runtime.loader`
 -- declaration, so nothing here hardcodes an architecture.
 function __find_glibc_runtime()
-    local glibc_dir = pkginfo.dep_install_dir("glibc")
+    -- Namespaced, as declared -- see gcc.lua's copy of this helper and
+    -- openxlings/xlings#524. A bare name has no answer under explicit
+    -- dependency store roots.
+    local glibc_dir = pkginfo.dep_install_dir("xim:glibc")
     if not glibc_dir then return nil, nil end
 
     for _, libname in ipairs({"lib64", "lib"}) do
@@ -228,18 +231,27 @@ function __find_glibc_runtime()
 end
 
 -- Locate the linux-headers payload's include dir (this package's own dep).
--- xim:linux-headers is a thin delegator to scode:linux-headers, so the
--- xim-namespaced store entry can be a metadata-only husk — require the
--- actual payload marker (include/linux/limits.h) and fall back to the
--- scode namespace explicitly. Returns nil when absent (warn-level: the
--- cfg then omits the kernel-header line; compiles that need <linux/*.h>
--- surface a clear missing-header error instead of a broken install).
+--
+-- The payload marker (include/linux/limits.h) is still required rather than
+-- assumed, so a husk cannot pass for a payload. Returns nil when absent
+-- (warn-level: the cfg then omits the kernel-header line; compiles that need
+-- <linux/*.h> surface a clear missing-header error instead of a broken
+-- install).
+--
+-- The `scode:linux-headers` fallback that used to follow is gone. It rested
+-- on a premise that stopped being true in openxlings/xlings#366:
+-- `xim:linux-headers` was a thin delegator whose own store entry could be a
+-- metadata-only husk, and is now a self-contained prebuilt that carries the
+-- headers itself. The fallback also could not work any more -- `scode:
+-- linux-headers` is not declared here, so it has no resolver record, and an
+-- undeclared coordinate has no answer under explicit dependency store roots
+-- (openxlings/xlings#524). A branch that can only ever evaluate to nil is
+-- indistinguishable from one that works, which is how this class of defect
+-- survives.
 function __find_linux_headers_include()
-    for _, name in ipairs({"linux-headers", "scode:linux-headers"}) do
-        local dir = pkginfo.dep_install_dir(name)
-        if dir and os.isfile(path.join(dir, "include", "linux", "limits.h")) then
-            return path.join(dir, "include")
-        end
+    local dir = pkginfo.dep_install_dir("xim:linux-headers")
+    if dir and os.isfile(path.join(dir, "include", "linux", "limits.h")) then
+        return path.join(dir, "include")
     end
     return nil
 end

--- a/pkgs/m/mcpp-vscode-clangd.lua
+++ b/pkgs/m/mcpp-vscode-clangd.lua
@@ -242,7 +242,21 @@ function config()
     log.info("installing llvm-tools@%s for clangd", ver)
     pkgmanager.install("llvm-tools@" .. ver)
 
-    local tools_dir = pkginfo.dep_install_dir("llvm-tools", ver)
+    -- `tool_payload_dir`, not `dep_install_dir`, and namespaced.
+    --
+    -- This asked for a BARE `llvm-tools`, which returned nil once xlings
+    -- 2026.8.10.1 supplied explicit dependency store roots -- they key on a
+    -- namespaced coordinate -- and clangd configuration was skipped with a
+    -- warning (openxlings/xlings#524).
+    --
+    -- Namespacing alone would fix today's call, because `ver` is an exact
+    -- version by the time we get here. But llvm-tools is installed by the
+    -- line above rather than declared in this package's `deps`, so there is
+    -- no resolver record for it and there never should be. That is precisely
+    -- what `tool_payload_dir` is for: it keeps its own scan, so this does not
+    -- silently become nil again the day `ver` is a range or `latest`, and it
+    -- does not pretend a self-fetched payload was a declared dependency.
+    local tools_dir = pkginfo.tool_payload_dir("xim:llvm-tools", ver)
     if not tools_dir then
         log.warn("failed to locate llvm-tools@%s install dir; skipping clangd configuration", ver)
         return true

--- a/pkgs/m/meson.lua
+++ b/pkgs/m/meson.lua
@@ -113,7 +113,11 @@ end
 -- else was switched -- but it does mean `xlings use python <other>` does not move
 -- meson, and a python REMOVAL leaves this shim pointing at a gone payload.
 function config()
-    local py = pkginfo.dep_install_dir("python")
+    -- Namespaced, as declared (`xim:python@>=3.9`). The bare form has no
+    -- answer under explicit dependency store roots, and this hook `raise()`s
+    -- on nil -- so under openxlings/xlings#524 meson could not install on any
+    -- cold home either, the same hard failure gcc had.
+    local py = pkginfo.dep_install_dir("xim:python")
     if not py then
         raise("meson: cannot locate the python dependency's payload; "
               .. "the shim would have no interpreter to exec")

--- a/tests/m/test_mcpp_vscode_clangd.py
+++ b/tests/m/test_mcpp_vscode_clangd.py
@@ -81,7 +81,24 @@ class TestStatic:
         # clangd/llvm-tools version follows the explicitly selected package version
         assert "pkginfo.version()" in meta.raw_content
         assert 'pkgmanager.install("llvm-tools@" .. ver)' in meta.raw_content
-        assert 'pkginfo.dep_install_dir("llvm-tools", ver)' in meta.raw_content
+        # `tool_payload_dir`, namespaced -- NOT `dep_install_dir`.
+        #
+        # llvm-tools is installed by the line above rather than declared in
+        # `deps` (the test right above asserts exactly that), so the resolver
+        # has no record of it. `dep_install_dir` answers from that record or
+        # from explicit dependency store roots; neither knows about a payload a
+        # hook fetched for itself, and the bare name this used to pass returned
+        # nil outright once xlings 2026.8.10.1 supplied those roots -- clangd
+        # configuration was then skipped with a warning (openxlings/xlings#524).
+        # `tool_payload_dir` is the entry point for a self-fetched payload and
+        # keeps its own scan, so this does not become nil again if `ver` ever
+        # stops being an exact version.
+        #
+        # Only the positive assertion. "dep_install_dir must not appear"
+        # matches the explanatory comment above the call as readily as a real
+        # call -- tests/test_dep_query_coordinates.py makes that judgement with
+        # comments stripped, which is where it belongs.
+        assert 'pkginfo.tool_payload_dir("xim:llvm-tools", ver)' in meta.raw_content
         # the default-toolchain-mutating side effect is gone
         assert "mcpp toolchain install" not in meta.raw_content
 

--- a/tests/test_dep_query_coordinates.py
+++ b/tests/test_dep_query_coordinates.py
@@ -1,0 +1,176 @@
+"""依赖查询坐标检查 —— 一个 recipe 必须按它声明的坐标去问
+
+`pkginfo.dep_install_dir(name)` 有两条应答路径,两条都要求 **namespaced** 坐标:
+
+    resolved_deps            解析器按声明的 spec 建键(`xim:glibc@>=2.39`)
+    dependency_store_roots   按 `<root>/<ns>-x-<bare>/<ver>` 定位
+
+裸名字(`"glibc"`)在第二条上**结构性无解** —— 它没说是哪个命名空间,
+`compat-x-zlib` 和 `other-x-zlib` 之间只能靠猜,而不猜正是这套 roots 存在的理由。
+第一条在 libxpkg 0.0.56 之后能按唯一性回答裸名字,但那只是**兜底**,不是契约:
+同名第二个 provider 一出现就失败关闭。
+
+xlings 2026.8.10.1 开始无条件填 `dependency_store_roots`,于是索引里 7 个真实
+调用点断了 6 个(openxlings/xlings#524):
+
+    gcc / meson   config hook 失败 —— 任何冷 home 都装不上
+    llvm          同一条 helper
+    godot         **静默**回落宿主 GL,即 mcpp#352 —— 它声明 graphics 就是为了防这个
+    graphics      **静默**把横幅显示成 unknown,GPU 与 llvmpipe 再次无法区分
+    clangd        跳过 clangd 配置
+
+「装不上」当天就会被发现,「静默回落」不会。所以这条规则由**静态检查**兜底,
+而不是靠下一个人记得。
+
+规则:
+  1. `dep_install_dir("<字面量>")` 的名字必须带命名空间。
+  2. 该名字必须出现在这个 recipe 自己的 `deps` 里 —— 传递依赖没有 resolver
+     记录(xlings 只记录节点自己的 runtime_deps),问了也是 nil。
+     要用就要声明。
+  3. hook 自己 `pkgmanager.install()` 装的载荷不是依赖,应当走
+     `tool_payload_dir`(它保留自己的 scan),不走 `dep_install_dir`。
+
+**变量实参不在本检查范围内**(例如 `__sentinel_state(name)` 把名字转了一手)。
+静态地判断那种写法要求实现取值分析,收益不抵复杂度;这里只报出来,让它可见。
+注释和字符串在扫描前就被剥掉 —— 本文件自身的说明里就有 `dep_install_dir(`
+字样,不剥的话检查会把注释当调用。
+"""
+import glob
+import os
+import re
+import pytest
+
+
+def _discover_xpkg_files():
+    root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    files = sorted(glob.glob(os.path.join(root, "pkgs", "**", "*.lua"), recursive=True))
+    files += sorted(glob.glob(os.path.join(root, "sub-index", "**", "*.lua"), recursive=True))
+    return [os.path.relpath(f, root) for f in files]
+
+
+def _strip_comments(content):
+    """去掉 lua 行注释与长注释,保留字符串字面量。
+
+    先剥注释再扫调用,不是可选项:recipe 的注释里经常写着示例调用
+    (`-- pkginfo.dep_install_dir("libcuda-host-link")..."/lib/..."`),
+    直接正则会把它当成真实调用点,然后对着一句注释判失败。
+    """
+    out = []
+    i, n = 0, len(content)
+    while i < n:
+        c = content[i]
+        if c == "-" and content[i:i + 2] == "--":
+            m = re.match(r"--\[(=*)\[", content[i:])
+            if m:                                    # 长注释 --[[ ]] / --[==[ ]==]
+                close = "]" + m.group(1) + "]"
+                j = content.find(close, i)
+                i = n if j < 0 else j + len(close)
+            else:                                    # 行注释
+                j = content.find("\n", i)
+                i = n if j < 0 else j
+            continue
+        if c in "\"'":
+            q = c
+            out.append(c)
+            i += 1
+            while i < n and content[i] != q:
+                if content[i] == "\\":
+                    out.append(content[i:i + 2])
+                    i += 2
+                    continue
+                out.append(content[i])
+                i += 1
+            out.append(q)
+            i += 1
+            continue
+        out.append(c)
+        i += 1
+    return "".join(out)
+
+
+_LITERAL_CALL = re.compile(
+    r'pkginfo\.dep_install_dir\s*\(\s*(["\'])([^"\']+)\1')
+_VARIABLE_CALL = re.compile(
+    r'pkginfo\.dep_install_dir\s*\(\s*(?!["\'])[A-Za-z_]')
+
+
+def _declared_dep_names(code):
+    """recipe 里声明过的依赖坐标(去掉 @version 半边)。
+
+    刻意宽松:任何 `deps` 表里出现的 `ns:name` 都算数,不区分平台段。
+    这里要判的是「问的东西声明过没有」,而不是复算解析器的平台逻辑 ——
+    后者会让这条检查变成解析器的第二份实现。
+    """
+    names = set()
+    for block in re.finditer(r'\bdeps\b\s*=\s*\{', code):
+        # 从 `{` 起做括号配对,注释已经剥掉了
+        start = code.find("{", block.start())
+        depth, i, n = 0, start, len(code)
+        while i < n:
+            if code[i] == "{":
+                depth += 1
+            elif code[i] == "}":
+                depth -= 1
+                if depth == 0:
+                    break
+            i += 1
+        for lit in re.findall(r'["\']([^"\']+)["\']', code[start:i + 1]):
+            names.add(lit.split("@")[0])
+    return names
+
+
+@pytest.mark.static
+@pytest.mark.parametrize("pkg_file", _discover_xpkg_files(),
+                         ids=lambda f: os.path.basename(f).replace(".lua", ""))
+def test_dep_install_dir_uses_declared_namespaced_coordinate(pkg_file):
+    """[deps] dep_install_dir 的字面量必须带命名空间,且必须是本包声明过的依赖"""
+    root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    with open(os.path.join(root, pkg_file), encoding="utf-8") as f:
+        code = _strip_comments(f.read())
+
+    declared = _declared_dep_names(code)
+    problems = []
+    for _, name in _LITERAL_CALL.findall(code):
+        if ":" not in name:
+            problems.append(
+                f'dep_install_dir("{name}") 是裸名字。显式依赖 store roots 只认'
+                f' namespaced 坐标,裸名字在那条路径上无解;按声明写成'
+                f' "<ns>:{name}"。')
+        elif name not in declared:
+            problems.append(
+                f'dep_install_dir("{name}") 问的不是本包声明的依赖'
+                f'(deps: {sorted(declared) or "<none>"})。解析器只记录节点自己的'
+                f' runtime_deps,传递依赖没有记录 —— 要用就要声明,'
+                f'或者改用 tool_payload_dir。')
+
+    assert not problems, (
+        f"{pkg_file}:\n  " + "\n  ".join(problems))
+
+
+@pytest.mark.static
+def test_variable_argument_call_sites_are_visible():
+    """[deps] 变量实参的 dep_install_dir 调用点被记录在案(不判失败,只保持可见)
+
+    这些没法静态判定,但正是 graphics.lua 那种把名字转了一手的形状 ——
+    #524 里它静默失败了,横幅显示 unknown。清单变长时,新增的那个应当同样
+    被人工核对一遍。
+    """
+    root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    seen = []
+    for pkg_file in _discover_xpkg_files():
+        with open(os.path.join(root, pkg_file), encoding="utf-8") as f:
+            code = _strip_comments(f.read())
+        if _VARIABLE_CALL.search(code):
+            seen.append(pkg_file)
+
+    known = {
+        # __sentinel_state(name, marker) 把名字转了一手。两个调用点传的都是
+        # namespaced 且已声明的坐标,人工核对过。
+        "pkgs/g/graphics.lua",
+    }
+    unexpected = sorted(set(seen) - known)
+    assert not unexpected, (
+        "新增了变量实参的 dep_install_dir 调用点,静态检查无法覆盖它们:\n  "
+        + "\n  ".join(unexpected)
+        + "\n人工确认传进去的名字是 namespaced 且已声明,然后把文件加进本测试的"
+          " known 集合。")


### PR DESCRIPTION
Closes the index half of openxlings/xlings#524 and openxlings/xlings#525.

Two defects, one shape: **a rule that held only under conditions no real caller meets, verified against a caller that met them.**

---

## #524 — dependency queries

Seven recipes call `pkginfo.dep_install_dir`; six passed a **bare** name while declaring a namespaced, ranged coordinate. That worked while a store scan covered for it. xlings 2026.8.10.1 began supplying explicit dependency store roots — which key on an exact namespaced coordinate — and all six returned nil:

| recipe | consequence |
|---|---|
| gcc, meson | **install fails on every cold home** |
| llvm | same helper as gcc |
| godot | **silent** — falls back to host GL, i.e. mcpp#352, the exact failure its `graphics` dep prevents |
| graphics | **silent** — banner reports `unknown`, so a GPU install and llvmpipe become indistinguishable |
| clangd | clangd configuration skipped |

Each now asks with what it declared. Beyond the mechanical fix:

- **godot declares `xim:mesa@>=25`.** It asks for mesa's payload directly, and a transitive dep has no resolver record — use it, declare it.
- **clangd uses `tool_payload_dir`.** llvm-tools is `pkgmanager.install`'d, not declared; that is what this entry point is for, and it keeps its own scan.
- **llvm loses its `scode:linux-headers` fallback.** It rested on a delegation removed in #366 and could only ever evaluate to nil — indistinguishable from a branch that works.
- **gcc's hint stops naming a hardcoded `xim:glibc@2.39`.** On #524, where the resolver had correctly chosen 2.44, that constant read as a resolution bug and sent the report down a false lead.

`tests/test_dep_query_coordinates.py` makes the rule structural — a literal argument must be namespaced and declared. It parses with comments and strings stripped (recipe comments contain example calls), and **fails on all five recipes when they are reverted**.

---

## #525 — GLX vendor reachability

glvnd has **no GLX counterpart to `egl_vendor.d`**. Measured on libglvnd 1.7:

```
libGLX.so.0   libGLX_%s.so.0, __GLX_VENDOR_LIBRARY_NAME     ← a NAME, never a path
libEGL.so.1   __EGL_VENDOR_LIBRARY_DIRS + JSON library_path ← our recipes make it absolute
```

EGL passes because it uses a road GLX does not have. Vendor discovery is a bare-SONAME `dlopen` from inside `libGLX.so.0`, servable only by that object's own search path — `LD_LIBRARY_PATH` poisons host binaries, and our loader's cache path exists nowhere.

It was instead being served by the **consumer's** DT_RPATH, searched transitively up the load chain. That works, and every probe in `.agents/tools/graphics/` bought it with `-Wl,--disable-new-dtags`. Real build systems emit DT_RUNPATH, which is not transitive. mcpp's imgui template got `GLX: No GLXFBConfigs returned` on a host whose own `glxinfo` was fine.

**Fix (E1):** libglvnd gives its own `libGLX.so.0` an `$ORIGIN/glx-vendor` RPATH — appended to the closure `selfcontain.seal()` stamped, never replacing it, and asserted afterwards rather than assumed. `graphics` fills that directory, because a libglvnd reinstall wipes its payload and the vendors do not reinstall when their dependency does; the assembler declares all of them, so it runs last and rebuilds the whole set.

`$ORIGIN` rather than a subos path: one payload serves every subos in the home, and per-subos **selection** stays where glvnd already put it (`__GLX_VENDOR_LIBRARY_NAME`). A subdirectory rather than `lib/`: that is published into the subos, and vendor libraries are dlopen'd plugins, not link targets — this also keeps the `<subos>/lib` farm, which holds `libc.so.6` and `ld-linux` symlinks, out of an RPATH.

**Existing homes:** both packages carry a new version key (`libglvnd 1.7.0.1`, `graphics 0.1.1`, same artifacts) so an already-assembled home re-runs the hooks. Without it the fix would reach only fresh installs, silently.

---

## The probes now link the way a consumer links

`-Wl,--disable-new-dtags` is gone from `glxprobe.c`, `verify-stack.sh` and `verify-host-link.sh`. **They are expected to fail without the wiring above** — that red is the only evidence this is the defect being fixed. `XLINGS_GFX_LEGACY_DTAGS=1` restores the old flag for diagnosis: legacy passing while default fails isolates the vendor directory.

Requires libxpkg 0.0.56 (openxlings/libxpkg#40) and xlings 2026.8.10.2.