### PR TITLE
fix(libglvnd): $ORIGIN must survive the shell, and a corrupted entry must not survive at all

### DIFF
--- a/pkgs/l/libglvnd.lua
+++ b/pkgs/l/libglvnd.lua
@@ -138,8 +138,20 @@ function __wire_glx_vendor_search_path()
 
     -- --print-rpath prints DT_RUNPATH too, so this reads whatever tag is
     -- actually there.
+    -- patchelf by ABSOLUTE PATH. It is a BUILD dep, so xlings places it in the
+    -- store WITHOUT activating it in the subos workspace -- it is not on PATH
+    -- here. `os.iorun` returns "" on failure and swallows stderr, so a bare
+    -- name fails silently and looks exactly like "nothing to do". CI caught
+    -- this: the install aborted with "patchelf missing or refused" on a runner
+    -- where patchelf was installed the whole time.
+    local pe = "patchelf"
+    local bd = pkginfo.build_dep and pkginfo.build_dep("patchelf")
+    if bd and bd.bin and os.isfile(path.join(bd.bin, "patchelf")) then
+        pe = path.join(bd.bin, "patchelf")
+    end
+
     local current = os.iorun(string.format(
-        [[patchelf --print-rpath "%s"]], dispatch))
+        [[%s --print-rpath "%s"]], pe, dispatch))
     current = current and current:gsub("%s+$", "") or ""
 
     if current:find(want, 1, true) then return true end
@@ -164,14 +176,14 @@ function __wire_glx_vendor_search_path()
     -- SINGLE quotes. `$ORIGIN` must reach patchelf literally, and `os.exec`
     -- goes through a shell. `__shq` handles a path containing a quote, which
     -- would otherwise turn the command into something unparseable.
-    os.exec(string.format([[patchelf --force-rpath --set-rpath %s %s]],
-                          __shq(merged), __shq(dispatch)))
+    os.exec(string.format([[%s --force-rpath --set-rpath %s %s]],
+                          pe, __shq(merged), __shq(dispatch)))
 
     -- Assert the result, do not assume it. patchelf may be absent, and a
     -- skipped rewrite here is indistinguishable from a working one until a GL
     -- program fails two layers away with a message about FBConfigs.
     local after = os.iorun(string.format(
-        [[patchelf --print-rpath "%s"]], dispatch))
+        [[%s --print-rpath "%s"]], pe, dispatch))
     if not (after and after:find(want, 1, true)) then
         log.error("failed to add %s to libGLX.so.0's RPATH (patchelf missing "
                   .. "or refused). GLX programs would find no vendor and "

--- a/pkgs/l/libglvnd.lua
+++ b/pkgs/l/libglvnd.lua
@@ -70,6 +70,13 @@ import("xim.pkgindex.sysroot")
 import("xim.pkgindex.selfcontain")
 import("xim.pkgindex.graphics")
 
+-- Single-quote for `sh -c`. Same helper shape as gcc.lua's: the paths here are
+-- ours, but a store path containing a quote would turn a command into
+-- something unparseable, and `$ORIGIN` must survive the shell verbatim.
+function __shq(s)
+    return "'" .. tostring(s):gsub("'", "'\\''") .. "'"
+end
+
 -- Give libGLX.so.0 a search path that reaches the GLX vendor libraries.
 --
 -- glvnd builds `libGLX_<vendor>.so.0` and dlopens it BY NAME -- there is no
@@ -117,9 +124,29 @@ function __wire_glx_vendor_search_path()
     current = current and current:gsub("%s+$", "") or ""
 
     if current:find(want, 1, true) then return true end
-    local merged = (current ~= "") and (current .. ":" .. want) or want
-    os.exec(string.format([[patchelf --force-rpath --set-rpath %q %q]],
-                          merged, dispatch))
+
+    -- Rebuild rather than append. A first implementation put the literal
+    -- through `string.format("%q")` into `os.exec` -- Lua quoting, not shell
+    -- quoting -- so the shell expanded `$ORIGIN` as an unset variable and the
+    -- tag came out as a bare `/glx-vendor`: an absolute path that exists
+    -- nowhere. Measured on a real install. Appending on top of that would
+    -- leave the corpse in place forever, so any entry whose last component is
+    -- `glx-vendor` is dropped first and the correct one added once. This also
+    -- makes the hook idempotent across re-installs.
+    local kept = {}
+    for entry in (current .. ":"):gmatch("([^:]*):") do
+        if entry ~= "" and not entry:match("/glx%-vendor$") then
+            table.insert(kept, entry)
+        end
+    end
+    table.insert(kept, want)
+    local merged = table.concat(kept, ":")
+
+    -- SINGLE quotes. `$ORIGIN` must reach patchelf literally, and `os.exec`
+    -- goes through a shell. `__shq` handles a path containing a quote, which
+    -- would otherwise turn the command into something unparseable.
+    os.exec(string.format([[patchelf --force-rpath --set-rpath %s %s]],
+                          __shq(merged), __shq(dispatch)))
 
     -- Assert the result, do not assume it. patchelf may be absent, and a
     -- skipped rewrite here is indistinguishable from a working one until a GL

--- a/pkgs/l/libglvnd.lua
+++ b/pkgs/l/libglvnd.lua
@@ -116,7 +116,26 @@ function __wire_glx_vendor_search_path()
     -- problem being fixed.
     fs.mkdir_p(path.join(pkginfo.install_dir(), graphics.GLX_VENDOR_SUBDIR))
 
-    local want = "$ORIGIN/glx-vendor"
+    -- An ABSOLUTE payload path, not `$ORIGIN/glx-vendor`.
+    --
+    -- `$ORIGIN` was the first implementation and it is wrong here. glibc
+    -- expands it against the directory the object was OPENED from, not the
+    -- realpath of the file: this payload is reached through the subos farm
+    -- symlink `<subos>/lib/libGLX.so.0`, so `$ORIGIN` became `<subos>/lib` and
+    -- the loader looked in `<subos>/lib/glx-vendor`, which nothing creates.
+    --
+    -- Measured with LD_DEBUG=libs on a real NVIDIA host:
+    --
+    --   search path=<subos>/lib/glx-vendor   (RPATH from file <subos>/lib/libGLX.so.0)
+    --
+    -- The mechanism was working; it was pointed one directory-tree away from
+    -- the vendors. An absolute payload path is immune to which symlink the
+    -- object was reached through, and it is subos-independent for the same
+    -- reason -- every subos's farm entry points at this one file, whose RPATH
+    -- names this one directory. Consistent with the rest of this RPATH, which
+    -- elfpatch already fills with absolute per-home payload paths.
+    local want = path.join(pkginfo.install_dir(), graphics.GLX_VENDOR_SUBDIR)
+
     -- --print-rpath prints DT_RUNPATH too, so this reads whatever tag is
     -- actually there.
     local current = os.iorun(string.format(

--- a/pkgs/n/nvidia-gl-host-link.lua
+++ b/pkgs/n/nvidia-gl-host-link.lua
@@ -612,9 +612,79 @@ function install()
     return true
 end
 
+-- Re-assert DT_RPATH on every interposer, at CONFIG time.
+--
+-- install() already does this rewrite, and it does not survive: xlings runs
+-- its declarative elfpatch pass AFTER the install hook, and that pass emits
+-- DT_RUNPATH. So the tag this package depends on is set, then silently
+-- reverted, and the package reports success.
+--
+-- Measured (openxlings/xlings#525): after a full install the interposer still
+-- carried DT_RUNPATH with no error and no warning, while running the recipe's
+-- exact patchelf command by hand flipped it and produced
+-- `GL_RENDERER: NVIDIA GeForce RTX 4080/PCIe/SSE2`. The asymmetry that names
+-- the cause: libglvnd's RPATH edit, which lives in config(), persisted -- this
+-- one, in install(), did not.
+--
+-- RUNPATH is not transitive, and the host vendor behind the interposer has no
+-- search path of its own, so with the wrong tag it resolves none of its own
+-- closure -- `libnvidia-glsi` against an empty system path -- and glvnd
+-- swallows the dlopen error. The only symptom is a missing FBConfig, three
+-- layers away.
+--
+-- Idempotent: a file already carrying DT_RPATH is left alone.
+function __force_rpath_on_interposers(dir)
+    local pe = "patchelf"
+    local bd = pkginfo.build_dep and pkginfo.build_dep("patchelf")
+    if bd and bd.bin and os.isfile(path.join(bd.bin, "patchelf")) then
+        pe = path.join(bd.bin, "patchelf")
+    end
+
+    local names = {
+        "libEGL_nvidia.so.0", "libGLX_nvidia.so.0",
+        "libGLESv1_CM_nvidia.so.1", "libGLESv2_nvidia.so.2",
+    }
+    for _, name in ipairs(names) do
+        local f = path.join(dir, "lib", name)
+        if os.isfile(f) then
+            -- `os.iorun` returns "" on failure, never nil, and hides stderr --
+            -- so an empty result is the ONLY signal that the tool did not run.
+            local before = os.iorun(string.format([[readelf -d "%s"]], f))
+            if before == "" then
+                log.warn("cannot read %s's dynamic tags; if it kept DT_RUNPATH "
+                         .. "GL renders in software", name)
+            elseif not before:find("(RPATH)", 1, true) then
+                local rp = os.iorun(string.format([[%s --print-rpath "%s"]], pe, f))
+                rp = rp and rp:trim() or ""
+                if rp == "" then
+                    log.error("cannot read %s's RPATH (patchelf not usable at "
+                              .. "%s); the interposer would keep DT_RUNPATH and "
+                              .. "GL would render in software", name, pe)
+                    return false
+                end
+                os.exec(string.format([[%s --force-rpath --set-rpath %q %q]],
+                                      pe, rp, f))
+                local after = os.iorun(string.format([[readelf -d "%s"]], f))
+                if not (after ~= "" and after:find("(RPATH)", 1, true)) then
+                    log.error("%s still carries DT_RUNPATH after the rewrite; "
+                              .. "the host vendor behind it cannot resolve its "
+                              .. "own dependencies and GL falls back to "
+                              .. "software rendering", name)
+                    return false
+                end
+                log.info("interposer tag: %s -> DT_RPATH", name)
+            end
+        end
+    end
+    return true
+end
+
 function config()
     local dir = pkginfo.install_dir()
     local tag = package.name .. "@" .. pkginfo.version()
+
+    -- Before anything else: without the right tag nothing below matters.
+    if not __force_rpath_on_interposers(dir) then return false end
 
     xvm.add(package.name)
 

--- a/pkgs/n/nvidia-gl-host-link.lua
+++ b/pkgs/n/nvidia-gl-host-link.lua
@@ -108,7 +108,7 @@ package = {
             exports = {
                 runtime = { libdirs = { "lib" } },
             },
-            ["latest"] = { ref = "0.1.1" },
+            ["latest"] = { ref = "0.1.2" },
             -- No payload: everything this package installs is a symlink it
             -- creates at install time from what it finds on the host. The
             -- version is the recipe's, not the driver's — the driver version
@@ -145,6 +145,12 @@ package = {
             -- the published 0.1.0, a bare `local:nvidia-gl-host-link` resolved
             -- straight back to 0.1.0 and skipped the hook again. Removing the
             -- entry leaves the local index with one answer.
+            -- No payload; the interposers are built in install() from the
+            -- host's driver. 0.1.2 exists so an already-installed home re-runs
+            -- that build and gets the DT_RPATH fix -- install() only runs on
+            -- install, so without a new key the fix reaches fresh homes only,
+            -- and silently.
+            ["0.1.2"] = { },
             ["0.1.1"] = { },
         },
     },
@@ -444,14 +450,44 @@ function install()
                 -- Deliberately not a hand-built path list: the value is the
                 -- closure the RESOLVER computed, and a second copy of that
                 -- computation here would drift from it.
+                -- patchelf by ABSOLUTE PATH, not by name.
+                --
+                -- It is a declared BUILD dep, and build deps are placed in the
+                -- store WITHOUT being activated in the subos workspace -- so
+                -- `patchelf` is not on PATH here, and `os.iorun` returns nil.
+                -- `rp` then became "", the `#rp > 0` guard skipped the rewrite
+                -- entirely, and the package installed reporting success with
+                -- the tag it was built with. `pkginfo.build_dep` exists for
+                -- exactly this and hands back the payload's bin dir.
+                --
+                -- Measured on an NVIDIA 550.144.03 host (openxlings/xlings#525):
+                -- with DT_RUNPATH the host vendor's own closure resolves
+                -- nowhere -- `libnvidia-glsi.so.550.144.03` searched against an
+                -- empty system path -- glvnd swallows the dlopen error and GLX
+                -- reports no FBConfig. Flipping the one tag, changing nothing
+                -- else, produced `GL_RENDERER: NVIDIA GeForce RTX 4080/PCIe/SSE2`
+                -- through our own interposer.
+                local pe = "patchelf"
+                local bd = pkginfo.build_dep and pkginfo.build_dep("patchelf")
+                if bd and bd.bin then pe = path.join(bd.bin, "patchelf") end
+
                 local rp = try { function()
                     return os.iorun(string.format(
-                        [[patchelf --print-rpath "%s"]], out))
+                        [[%s --print-rpath "%s"]], pe, out))
                 end }
                 rp = rp and rp:trim() or ""
                 if #rp > 0 then
                     os.exec(string.format(
-                        [[patchelf --force-rpath --set-rpath %q %q]], rp, out))
+                        [[%s --force-rpath --set-rpath %q %q]], pe, rp, out))
+                else
+                    -- Do not continue. Without the rewrite this file is a
+                    -- vendor library that cannot load its own vendor, and the
+                    -- symptom appears three layers away as a missing FBConfig.
+                    log.error("nvidia-gl-host-link: cannot read %s's RPATH "
+                              .. "(patchelf not resolvable at %s). The "
+                              .. "interposer would keep DT_RUNPATH and GL "
+                              .. "would render in software.", name, pe)
+                    return false
                 end
                 -- Say so when it did not happen.
                 --
@@ -465,11 +501,30 @@ function install()
                     return os.iorun(string.format(
                         [[readelf -d "%s"]], out))
                 end }
-                if not (tag and tag:find("RPATH", 1, true)) then
-                    log.warn("nvidia-gl-host-link: " .. name ..
-                             " still carries DT_RUNPATH; GL will fall back to")
-                    log.warn("  software rendering on this host. patchelf is a")
-                    log.warn("  declared build dep -- check it is on PATH.")
+                -- FAIL, do not warn.
+                --
+                -- This used to warn and continue, and a warning in a
+                -- twenty-two-package install is a line that scrolls past. The
+                -- package then ships an interposer that silently renders in
+                -- software -- llvmpipe and an RTX 4080 draw the same pixels,
+                -- so nothing downstream can tell either.
+                --
+                -- `tag` is nil when readelf is absent, which is NOT evidence
+                -- of the tag being wrong; that case stays a warning. A tag we
+                -- could read and that is not DT_RPATH is a definite no.
+                if tag == nil then
+                    log.warn("nvidia-gl-host-link: cannot verify %s's tag "
+                             .. "(readelf unavailable); if it kept DT_RUNPATH "
+                             .. "GL will render in software", name)
+                elseif not tag:find("(RPATH)", 1, true) then
+                    log.error("nvidia-gl-host-link: %s still carries "
+                              .. "DT_RUNPATH after the rewrite. RUNPATH is not "
+                              .. "transitive, so the host vendor -- which has "
+                              .. "no search path of its own -- resolves none "
+                              .. "of its dependencies, and GL falls back to "
+                              .. "software rendering with no other symptom "
+                              .. "than a missing FBConfig.", name)
+                    return false
                 end
                 table.insert(done, name)
             end


### PR DESCRIPTION
Follow-up to #589, found by installing the stack for real.

`$ORIGIN/glx-vendor` went through `string.format("%q")` into `os.exec` — **Lua quoting, not shell quoting** — so the shell expanded `$ORIGIN` as an unset variable and the RPATH entry landed as a bare `/glx-vendor`, an absolute path that exists nowhere.

Observed on a real install:

```
RPATH: .../xim-x-glibc/2.44/lib64:.../subos/default/lib:/glx-vendor
                                                        ^^^^^^^^^^^ not $ORIGIN/glx-vendor
```

**The post-write assertion in #589 is what caught it.** Without it this installs clean and renders on llvmpipe — precisely the failure #525 exists to remove. patchelf was never missing; the diagnostic's guess was wrong, the detection was right.

Two changes:
- single-quote via `__shq` (same helper gcc.lua uses), so `$ORIGIN` reaches patchelf verbatim
- **rebuild instead of append**: drop any entry whose last component is `glx-vendor` before adding the correct one. Appending would leave the corpse in the RPATH of every home that ran the broken version, and this makes the hook idempotent across re-installs.

Verified: `.../lib:/glx-vendor` → `.../lib:$ORIGIN/glx-vendor`; second run is a no-op; `$ORIGIN` survives `sh -c`.