### PR TITLE
fix(graphics): raise the nvidia bound to >=0.1.2 so an upgrade actually pulls the fix

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Installation Xlings on Ubuntu
         run: |
           export XLINGS_NON_INTERACTIVE=1
-          export XLINGS_VERSION=v2026.8.8.2
+          export XLINGS_VERSION=v2026.8.10.1
           curl -fsSL https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.sh | bash
           echo "XLINGS_HOME=$HOME/.xlings" >> "$GITHUB_ENV"
           echo "PATH=$HOME/.xlings/subos/current/bin:$HOME/.xlings/bin:$PATH" >> "$GITHUB_ENV"
@@ -150,7 +150,7 @@ jobs:
         shell: pwsh
         run: |
           $env:XLINGS_NON_INTERACTIVE = "1"
-          $env:XLINGS_VERSION = "v2026.8.8.2"
+          $env:XLINGS_VERSION = "v2026.8.10.1"
           iex (Invoke-WebRequest `
             -Uri "https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.ps1" `
             -UseBasicParsing).Content
@@ -211,7 +211,7 @@ jobs:
       - name: Install xlings on Ubuntu
         run: |
           export XLINGS_NON_INTERACTIVE=1
-          export XLINGS_VERSION=v2026.8.8.2
+          export XLINGS_VERSION=v2026.8.10.1
           curl -fsSL https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.sh | bash
           echo "XLINGS_HOME=$HOME/.xlings" >> "$GITHUB_ENV"
           echo "$HOME/.xlings/bin"               >> "$GITHUB_PATH"
@@ -276,7 +276,7 @@ jobs:
       - name: Install xlings on macOS
         run: |
           export XLINGS_NON_INTERACTIVE=1
-          export XLINGS_VERSION=v2026.8.8.2
+          export XLINGS_VERSION=v2026.8.10.1
           curl -fsSL https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.sh | bash
           echo "XLINGS_HOME=$HOME/.xlings" >> "$GITHUB_ENV"
           echo "$HOME/.xlings/bin"               >> "$GITHUB_PATH"

--- a/pkgs/g/graphics.lua
+++ b/pkgs/g/graphics.lua
@@ -75,7 +75,15 @@ package = {
                     "xim:mesa",
                     -- Sentinel: the host's proprietary NVIDIA GL userspace.
                     -- A no-op on a machine without that driver.
-                    "xim:nvidia-gl-host-link@>=0.1",
+                    -- >=0.1.2, not >=0.1. The interposer's DT_RPATH fix is in
+                    -- 0.1.2, and 0.1.1 already satisfies `>=0.1` -- so an
+                    -- already-installed home would keep the broken build and
+                    -- stay on software rendering with nothing to say so.
+                    -- Measured: after bumping the recipe, the home reported
+                    -- "installed, but 'nvidia-gl-host-link' still resolves to
+                    -- 0.1.1" and needed a manual `xlings use` to switch. A
+                    -- lower bound only pulls what it excludes.
+                    "xim:nvidia-gl-host-link@>=0.1.2",
                     -- Sentinel: WSL2's Windows-side D3D12 userspace.
                     -- A no-op anywhere that is not WSL2.
                     --


### PR DESCRIPTION
Follow-up to #590. The interposer's DT_RPATH fix ships in `nvidia-gl-host-link@0.1.2`, but `graphics` asked for `>=0.1` — which **0.1.1 already satisfies**. An already-assembled home keeps the broken interposer and stays on software rendering, silently.

Measured on the verification home: after the recipe bump it reported

```
xim:nvidia-gl-host-link@0.1.2 installed, but 'nvidia-gl-host-link' still resolves to 0.1.1
```

and GLX kept failing until a manual `xlings use`. **A lower bound only pulls what it excludes.**

`libglvnd` already carries `>=1.7.0.1` for exactly this reason — this is the sibling that was missed. This is the A8 acceptance criterion in the design doc (existing-home upgrade path), which is the one most likely to be skipped because fresh installs pass either way.