### PR TITLE
chore(xlings): 2026.8.10.3

### DIFF
--- a/pkgs/x/xlings.lua
+++ b/pkgs/x/xlings.lua
@@ -38,7 +38,14 @@ package = {
             -- res_versioned: version-bump bot tracks openxlings/xlings releases and
             -- appends new ["x.y.z"] = "XLINGS_RES" entries (see version-check.py).
             res_versioned = true,
-            ["latest"] = { ref = "2026.8.10.2" },
+            ["latest"] = { ref = "2026.8.10.3" },
+            ["2026.8.10.3"] = {
+                url = "XLINGS_RES",
+                sha256 = {
+                    aarch64 = "59327eceea46647eab1e092d05ba884c94818b7a5c6bda5a44c3baf3bfe4f7c6",
+                    x86_64 = "4e9b7ef18b50cb2f7dfe52ba30c09e7c4edd61fe39291017a3233abcbb5e1e1f",
+                },
+            },
             ["2026.8.10.2"] = {
                 url = "XLINGS_RES",
                 sha256 = {
@@ -492,7 +499,13 @@ package = {
             -- res_versioned: version-bump bot tracks openxlings/xlings releases and
             -- appends new ["x.y.z"] = "XLINGS_RES" entries (see version-check.py).
             res_versioned = true,
-            ["latest"] = { ref = "2026.8.10.2" },
+            ["latest"] = { ref = "2026.8.10.3" },
+            ["2026.8.10.3"] = {
+                url = "XLINGS_RES",
+                sha256 = {
+                    aarch64 = "73c12ffd40f65b0d1c4f6d9873bef67f8adad7ac01752d3baee66d94e0a6a762",
+                },
+            },
             ["2026.8.10.2"] = {
                 url = "XLINGS_RES",
                 sha256 = {
@@ -903,7 +916,13 @@ package = {
             -- res_versioned: version-bump bot tracks openxlings/xlings releases and
             -- appends new ["x.y.z"] = "XLINGS_RES" entries (see version-check.py).
             res_versioned = true,
-            ["latest"] = { ref = "2026.8.10.2" },
+            ["latest"] = { ref = "2026.8.10.3" },
+            ["2026.8.10.3"] = {
+                url = "XLINGS_RES",
+                sha256 = {
+                    x86_64 = "4ba68e08983737a931638882de5b178843a50479cfe1793cc978ef32fee2087a",
+                },
+            },
             ["2026.8.10.2"] = {
                 url = "XLINGS_RES",
                 sha256 = {


### PR DESCRIPTION
`xlings subos info` 现在会报出**这个索引的 `graphics` recipe 写下的**逐 vendor 接线判定(#594)。

实测表明这是那个判定**唯一的通道** —— config hook 的 log 在成功路径上根本不显示,
不只是新加的告警,连这个栈原有的 "GL renders on the GPU" 横幅也不显示。

真机(RTX 4080 / 550.144.03)上的效果:

```
    GL dispatch    <home>/data/xpkgs/xim-x-libglvnd/1.7.0.1
    mesa EGL       ok (built by xlings — no host driver behind it)
    mesa GLX       ok
  ⚠ nvidia EGL     BROKEN — it carries DT_RUNPATH, which is not transitive, …
    nvidia GLX     ok (the host driver behind it is reachable)
  ⚠ nvidia GLESv1  BROKEN — …
  ⚠ nvidia GLESv2  BROKEN — …
```

这六条判定与真实渲染矩阵(建上下文、问 `GL_RENDERER`)**逐条吻合** —— 静态 readelf
分析与真实渲染是两套毫不相干的方法。

## 检查方式

**三个平台段全部 bump,不是一个。** 部分 bump 在其他平台上表现为"找不到",两个索引仓库
都为此加过 CI。

**用解析验证,不是看 diff。** 对 .lua 的正则编辑可以应用干净却含义不同:

```
  linux    latest=2026.8.10.3  entry=yes  url=XLINGS_RES  arch=[aarch64,x86_64]  versions=97
  macosx   latest=2026.8.10.3  entry=yes  url=XLINGS_RES  arch=[aarch64]         versions=97
  windows  latest=2026.8.10.3  entry=yes  url=XLINGS_RES  arch=[x86_64]          versions=97
```

(顺带:正则数出 76 个版本,解析器数出 97 个。)

**哈希对的是 xlings-res 上的文件** —— 这个 recipe 的 `XLINGS_RES` 实际解析到的地方,
而不是它被镜像自的上游 release。

手工提交的原因:`version-bump` 是每日 cron,只开 PR,不由 release 触发。

上游:openxlings/xlings#530