### PR TITLE
chore(xlings): 2026.8.10.4

### DIFF
--- a/pkgs/x/xlings.lua
+++ b/pkgs/x/xlings.lua
@@ -38,7 +38,14 @@ package = {
             -- res_versioned: version-bump bot tracks openxlings/xlings releases and
             -- appends new ["x.y.z"] = "XLINGS_RES" entries (see version-check.py).
             res_versioned = true,
-            ["latest"] = { ref = "2026.8.10.3" },
+            ["latest"] = { ref = "2026.8.10.4" },
+            ["2026.8.10.4"] = {
+                url = "XLINGS_RES",
+                sha256 = {
+                    aarch64 = "938b215267740fc9048fc7e22ff574584904b55169a899de56212ea5f9a62a6a",
+                    x86_64 = "ab568737bfb176bd15cc194bc06e594082c17d2781b3632c3971386038d6c3e0",
+                },
+            },
             ["2026.8.10.3"] = {
                 url = "XLINGS_RES",
                 sha256 = {
@@ -499,7 +506,13 @@ package = {
             -- res_versioned: version-bump bot tracks openxlings/xlings releases and
             -- appends new ["x.y.z"] = "XLINGS_RES" entries (see version-check.py).
             res_versioned = true,
-            ["latest"] = { ref = "2026.8.10.3" },
+            ["latest"] = { ref = "2026.8.10.4" },
+            ["2026.8.10.4"] = {
+                url = "XLINGS_RES",
+                sha256 = {
+                    aarch64 = "10c5c44e573ab973e3da85a0f5dada74611c27681d3f2afed326ba6482014118",
+                },
+            },
             ["2026.8.10.3"] = {
                 url = "XLINGS_RES",
                 sha256 = {
@@ -916,7 +929,13 @@ package = {
             -- res_versioned: version-bump bot tracks openxlings/xlings releases and
             -- appends new ["x.y.z"] = "XLINGS_RES" entries (see version-check.py).
             res_versioned = true,
-            ["latest"] = { ref = "2026.8.10.3" },
+            ["latest"] = { ref = "2026.8.10.4" },
+            ["2026.8.10.4"] = {
+                url = "XLINGS_RES",
+                sha256 = {
+                    x86_64 = "186bdd8b112f70ef298bf9b99e5b1cf09645784bb8a7ff7598a1bdeaa218228c",
+                },
+            },
             ["2026.8.10.3"] = {
                 url = "XLINGS_RES",
                 sha256 = {


### PR DESCRIPTION
加载器标签现在有唯一的所有者。

elfpatch(libxpkg 0.0.57)给**可执行文件**打 DT_RPATH 而不是 DT_RUNPATH, 新增 rule E —— 当载荷带着旧标签到达时,**在用户机器上、安装时**说出来。

DT_RUNPATH 只对携带它的对象生效;DT_RPATH 对进程内任意深度的 dlopen 都生效。GL 程序要穿三层 dlopen 才够到驱动,所以**决定它在不在 GPU 上渲染的是标签,不是路径**。真机 73 个已安装可执行文件里 **1 个 DT_RPATH,而另外 68 个里有 55 个路径本来就是对的**。

另有两项可观测性:`subos info` 报宿主驱动漂移(检测器早就存在,缺的是通道),`subos use --sandbox` 不带 `--gpu` 时说明沙箱没有 GPU —— 三个条件,只在采取行动能改变结果时才响。

三个平台段全部 bump,用**解析**验证而非看 diff:

```
linux    latest=2026.8.10.4  arch=[aarch64,x86_64]
macosx   latest=2026.8.10.4  arch=[aarch64]
windows  latest=2026.8.10.4  arch=[x86_64]
```

哈希取自 **xlings-res** 上的文件(`XLINGS_RES` 实际解析到的地方),不是它镜像自的上游 release。

CN 镜像本地上传并**按大小**四平台核对通过 —— 上传前四个都返回 **127 字节**,所以只看状态码会对不存在的资源报 200。

上游:openxlings/xlings#536、openxlings/libxpkg#41、mcpplibs/mcpp-index#202