### PR TITLE
fix(graphics): a vendor's verdict depends on who opens it — say so (0.1.3)

### DIFF
--- a/libs/graphics.lua
+++ b/libs/graphics.lua
@@ -337,6 +337,31 @@ function graphics.vendor_closure_gaps(interposer, host_vendor)
     -- reachability was false.
     local tags = os.iorun(string.format([[readelf -d "%s"]], interposer))
     if tags == "" then return out end
+    -- The tag on the INTERPOSER decides whether the host driver behind it can
+    -- resolve its own DT_NEEDED *from this library alone*. It does not decide
+    -- what happens in a real process, because a CONSUMER's DT_RPATH is
+    -- transitive: when an executable stamped that way opens this vendor, its
+    -- search path covers the whole chain and the host driver resolves.
+    --
+    -- Measured on one home, one interposer, changing only the consumer:
+    -- a DT_RUNPATH consumer cannot open libEGL_nvidia; a DT_RPATH consumer
+    -- loads it and renders on the GPU.
+    --
+    -- So this is NOT `broken`. Before libxpkg 0.0.57 nearly every installed
+    -- executable carried DT_RUNPATH and calling it broken was accurate in
+    -- practice; since 0.0.57 elfpatch stamps DT_RPATH on executables, so
+    -- installed programs reach the GPU through this vendor and only programs
+    -- the USER builds -- which still get DT_RUNPATH (openxlings/xlings#532) --
+    -- cannot. Reporting that as `broken` under-reports, which is the worse
+    -- direction: it sends someone to fix a problem that is not there and hides
+    -- the one that is. See openxlings/xlings#537.
+    -- The tag on the INTERPOSER decides whether the host driver behind it
+    -- resolves its own DT_NEEDED *from this library alone*. It does not decide
+    -- what happens in a process: a CONSUMER's DT_RPATH is transitive, so an
+    -- executable stamped that way covers this whole chain when it opens the
+    -- vendor. Measured -- DT_RUNPATH consumer cannot open libEGL_nvidia,
+    -- DT_RPATH loads it and renders on the GPU. The caller turns this into
+    -- `needs-transitive-consumer`, not `broken` (openxlings/xlings#537).
     if not tags:find("(RPATH)", 1, true) then
         out.ok = true
         out.reason = "tag"

--- a/pkgs/g/graphics.lua
+++ b/pkgs/g/graphics.lua
@@ -157,7 +157,7 @@ package = {
                     "xim:libglvnd@>=1.7.0.1",
                 },
             },
-            ["latest"] = { ref = "0.1.2" },
+            ["latest"] = { ref = "0.1.3" },
             -- No payload. This package is its dependency list and the report
             -- below; there is nothing to download.
             --
@@ -168,6 +168,12 @@ package = {
             -- 0.1.2 re-runs config() on an already-assembled home so it
             -- probes its vendors and records the wiring. Same payload-less
             -- recipe; the hook that consumes it is what changed.
+            -- 0.1.3 re-runs config() so an already-assembled home re-records
+            -- its wiring with the third state. Without a new key the hook
+            -- never fires again and the corrected verdict reaches only fresh
+            -- installs -- silently, which is the failure this stack keeps
+            -- producing and the reason every one of these keys exists.
+            ["0.1.3"] = { },
             ["0.1.2"] = { },
             ["0.1.1"] = { },
             ["0.1.0"] = { },
@@ -259,15 +265,36 @@ function __wire_glx_vendors()
                                      .. "is incomplete, GL renders through another "
                                      .. "driver and says nothing", soname)
                         elseif gaps.reason == "tag" then
+                            -- NOT `broken`: the verdict depends on WHO OPENS
+                            -- IT. A consumer's DT_RPATH is transitive and
+                            -- covers this whole chain, so an INSTALLED program
+                            -- (elfpatch stamps DT_RPATH since libxpkg 0.0.57)
+                            -- reaches the GPU through this vendor, while a
+                            -- program the user builds in this subos still
+                            -- cannot -- those get DT_RUNPATH
+                            -- (openxlings/xlings#532).
+                            --
+                            -- Measured on one home, one interposer, changing
+                            -- only the consumer: DT_RUNPATH cannot open
+                            -- libEGL_nvidia, DT_RPATH loads it and renders on
+                            -- the GPU.
+                            --
+                            -- `broken` was accurate before 0.0.57, when nearly
+                            -- every executable was DT_RUNPATH. It now
+                            -- UNDER-reports, which is the worse direction: it
+                            -- sends someone to fix a problem that is not there
+                            -- and hides the one that is
+                            -- (openxlings/xlings#537).
                             table.insert(lines, "vendor=" .. soname
-                                         .. " state=broken reason=runpath-not-transitive")
-                            log.warn("%s cannot load the host driver behind it: "
-                                     .. "this interposer carries DT_RUNPATH, "
-                                     .. "which is not transitive, so the host "
-                                     .. "driver reaches none of our payloads. "
-                                     .. "glvnd falls back to another vendor "
-                                     .. "WITHOUT saying so -- GL still renders, "
-                                     .. "just not on this driver.", soname)
+                                         .. " state=needs-transitive-consumer")
+                            log.warn("%s carries DT_RUNPATH. Installed "
+                                     .. "programs still reach it -- their own "
+                                     .. "DT_RPATH is transitive and covers this "
+                                     .. "chain -- but a program built in this "
+                                     .. "subos gets DT_RUNPATH and cannot load "
+                                     .. "it, so its GL silently renders "
+                                     .. "elsewhere (openxlings/xlings#532).",
+                                     soname)
                         elseif #gaps.missing > 0 then
                             table.insert(lines, "vendor=" .. soname
                                          .. " state=broken missing="


### PR DESCRIPTION
`vendor_closure_gaps` 判的是 interposer **孤立看**的可达性 —— 对 interposer 而言是对的。但对**进程**不对:消费者的 DT_RPATH 是传递的,覆盖整条链。

同一 home、同一 interposer,只改消费者的标签:

| 消费者标签 | libEGL_nvidia.so.0 | 真实渲染 |
|---|---|---|
| DT_RUNPATH | 打不开 | llvmpipe |
| **DT_RPATH** | **LOADED** | **NVIDIA** |

libxpkg 0.0.57 之前几乎所有已安装可执行文件都是 DT_RUNPATH,所以 `broken` 事实上准确。0.0.57 之后 elfpatch 给可执行文件打 DT_RPATH,已安装程序经这些 vendor 到得了 GPU,**只有用户自己构建的程序**(仍是 DT_RUNPATH,openxlings/xlings#532)到不了。把这个报成 `broken` 是**低报**。

**低报是更糟的方向**:它派人去修一个不存在的问题(派了我几个小时,三种机械修法各自把 surfaceless EGL 从 zink-over-NVIDIA 打成彻底失败),并**掩盖真正存在的那个**。openxlings/xlings#537。

所以新增 `state=needs-transitive-consumer` —— 既非 ok 也非 broken,读取端的措辞回答的是真正把人带到面板前的那个问题:「我刚编译的 GL 程序在软件渲染,为什么」。

**用 0.1.3 而不是原地改 0.1.2**:没有新 key,config hook 在已装配的 home 上不会再触发,修正后的判定只会到达全新安装 —— 而且是**静默地**。那正是这个栈反复产生的失败,也是这些无载荷版本 key 存在的理由。

真机端到端验证:改动后记录、加载器、面板 6/6 一致;而**现在两种标签各测一遍**的对账工具,在记录早于本改动的 home 上抓出了分歧。

读取端与双标签探测:openxlings/xlings#538