### PR TITLE
fix(graphics): stop recording `native` about vendors nothing examined (0.1.4)

### DIFF
--- a/libs/graphics.lua
+++ b/libs/graphics.lua
@@ -395,13 +395,52 @@ end
 -- The interposer names it by ABSOLUTE path in its own DT_NEEDED -- that is the
 -- whole design: we do not copy the host's driver, which must stay paired with
 -- the running kernel module. So the absolute entry IS the host vendor.
+--
+-- Returns `host_path, form` where form is one of:
+--
+--   "interposed"  a stub of ours with the host driver named absolutely
+--   "direct"      the host's own driver, symlinked into the payload with no
+--                 stub in front of it
+--   "native"      our own build; there is no host closure to complete
+--   "unreadable"  readelf did not run. NOT a verdict about the library.
+--
+-- WHY THIS RETURNS FOUR THINGS AND NOT A POINTER-OR-NIL
+--
+-- It used to return nil for three of these, and the caller turned every nil
+-- into `state=native` -- which the panel reports as a PASS. Measured on a real
+-- home, ALL SIX vendors were recorded `native`, including an EGL interposer
+-- that plainly has an absolute DT_NEEDED and three GLX/GLES entries that are
+-- bare symlinks to `/lib/x86_64-linux-gnu/`. The stack was wired to nothing
+-- and four independent channels said it was fine.
+--
+-- Two distinct conflations produced that:
+--
+--   * `os.iorun` returns "" when the tool is missing, and "the tool did not
+--     run" became "this is ours, nothing to check". The sibling function
+--     `vendor_closure_gaps` guards exactly this case and says so in its own
+--     comment -- the guard existed, one function away.
+--   * since 0.1.2 the GLX and GLES vendors are DIRECT SYMLINKS to the host
+--     driver. A host library has no absolute DT_NEEDED (it names its
+--     siblings by soname), so the old test read "no absolute entry" as "our
+--     own build". It is literally the host driver. The verdict was inverted
+--     for precisely the vendors that most needed checking.
 function graphics.host_vendor_behind(interposer)
     local dyn = os.iorun(string.format([[readelf -d "%s"]], interposer))
-    if dyn == "" then return nil end
+    -- "" is the ONLY signal os.iorun gives for a tool that did not run, and
+    -- it is not evidence about the library.
+    if dyn == "" then return nil, "unreadable" end
     for soname in dyn:gmatch("Shared library:%s*%[([^%]]+)%]") do
-        if soname:sub(1, 1) == "/" then return soname end
+        if soname:sub(1, 1) == "/" then return soname, "interposed" end
     end
-    return nil
+    -- No stub in front of it. Follow the file: a vendor that resolves outside
+    -- our store is the host's driver wearing our filename, and its closure is
+    -- every bit as unchecked as an interposer's.
+    local real = os.iorun(string.format([[readlink -f "%s"]], interposer))
+    real = (real or ""):gsub("%s+$", "")
+    if real ~= "" and not real:find("xpkgs", 1, true) then
+        return real, "direct"
+    end
+    return nil, "native"
 end
 
 -- Record what was wired, next to what was wired.

--- a/pkgs/g/graphics.lua
+++ b/pkgs/g/graphics.lua
@@ -157,7 +157,7 @@ package = {
                     "xim:libglvnd@>=1.7.0.1",
                 },
             },
-            ["latest"] = { ref = "0.1.3" },
+            ["latest"] = { ref = "0.1.4" },
             -- No payload. This package is its dependency list and the report
             -- below; there is nothing to download.
             --
@@ -173,6 +173,13 @@ package = {
             -- never fires again and the corrected verdict reaches only fresh
             -- installs -- silently, which is the failure this stack keeps
             -- producing and the reason every one of these keys exists.
+            -- 0.1.4 re-runs config() so an already-assembled home re-records
+            -- wiring that no longer says `native` about two things it never
+            -- examined: a vendor whose dynamic section could not be read, and
+            -- a vendor that is a bare symlink to the host driver. Measured on
+            -- a real home, ALL SIX vendors were recorded `native` -- a pass --
+            -- while the stack was wired to nothing.
+            ["0.1.4"] = { },
             ["0.1.3"] = { },
             ["0.1.2"] = { },
             ["0.1.1"] = { },
@@ -250,11 +257,21 @@ function __wire_glx_vendors()
                 local soname = string.format(pat, v.vendor)
                 local lib = path.join(dir, "lib", soname)
                 if os.isfile(lib) then
-                    local host = graphics.host_vendor_behind(lib)
-                    if not host then
-                        -- No absolute DT_NEEDED: this vendor is OURS, built
-                        -- against our payloads. There is no host closure to
-                        -- check, which is not the same as a failed check.
+                    local host, form = graphics.host_vendor_behind(lib)
+                    if form == "unreadable" then
+                        -- The tool did not run. That is not a fact about this
+                        -- library, and it used to be recorded as `native` --
+                        -- which the panel shows as a PASS. An absent
+                        -- observation must never be spent as a verdict.
+                        table.insert(lines, "vendor=" .. soname .. " state=unverified")
+                        log.warn("%s: cannot read its dynamic section (readelf "
+                                 .. "unavailable); its wiring is unknown, not "
+                                 .. "healthy", soname)
+                    elseif form == "native" then
+                        -- No absolute DT_NEEDED and the file resolves inside
+                        -- our store: this vendor is OURS, built against our
+                        -- payloads. There is no host closure to check, which
+                        -- is not the same as a failed check.
                         table.insert(lines, "vendor=" .. soname .. " state=native")
                     else
                         local gaps = graphics.vendor_closure_gaps(lib, host)

--- a/tests/lua/graphics_vendor_form_harness.lua
+++ b/tests/lua/graphics_vendor_form_harness.lua
@@ -1,0 +1,109 @@
+-- Exercise graphics.host_vendor_behind in a plain-Lua sandbox, the way libxpkg
+-- runs a hook: no xmake, only the globals the prelude provides.
+--
+-- WHAT THIS IS DEFENDING
+--
+-- The function used to return nil for three unrelated situations and the
+-- caller turned every nil into `state=native`, which the panel reports as a
+-- PASS. Measured on a real NVIDIA home, ALL SIX vendors were recorded native
+-- while the graphics stack was wired to nothing at all.
+--
+-- The two conflations, each reproduced below as its own case:
+--
+--   * readelf missing -> "" -> "this is ours, nothing to check"
+--   * a bare symlink to the host driver has no absolute DT_NEEDED (a host
+--     library names its siblings by soname), so "no absolute entry" read as
+--     "our own build". It IS the host driver.
+--
+-- Every case here asserts the FORM, not the verdict, because the form is what
+-- was wrong. The verdict is the caller's job and has its own test surface.
+
+local ROOT = assert(os.getenv("FAKE_ROOT"), "FAKE_ROOT required")
+
+-- ── the sandbox ────────────────────────────────────────────────────────
+path = {}
+function path.join(...)
+    local parts = {...}
+    local out = parts[1] or ""
+    for i = 2, #parts do
+        if out:sub(-1) == "/" then out = out .. parts[i]
+        else out = out .. "/" .. parts[i] end
+    end
+    return out
+end
+function path.directory(p) return (p:gsub("/[^/]*$", "")) end
+function path.filename(p) return (p:match("[^/]+$")) end
+
+os.isfile = function(p)
+    local f = io.open(p, "rb")
+    if f then f:close(); return true end
+    return false
+end
+
+-- `readelf` is answered from a sidecar file so the harness needs no ELF
+-- objects and no toolchain: `<lib>.readelf` holds what readelf would print,
+-- and its ABSENCE is how the "tool did not run" case is reproduced -- which is
+-- the case the real bug turned into a pass.
+os.iorun = function(cmd)
+    local target = cmd:match('"([^"]+)"')
+    if cmd:match("^readelf") then
+        local f = io.open(target .. ".readelf", "rb")
+        if not f then return "" end
+        local out = f:read("*a"); f:close(); return out
+    end
+    if cmd:match("^readlink") then
+        local f = io.popen(string.format('readlink -f "%s"', target))
+        if not f then return "" end
+        local out = f:read("*a"); f:close(); return out
+    end
+    return ""
+end
+
+-- `import` is a libxpkg-sandbox global. The modules it pulls in are used by
+-- other functions in the file, not by the one under test, so a stub that
+-- yields an inert table is enough -- and it is the same reason the real
+-- sandbox can stub an unknown module without the recipe noticing.
+function import(_) return setmetatable({}, {__index = function() return function() end end}) end
+log = {warn = function() end, info = function() end}
+
+local graphics = dofile(ROOT .. "/libs/graphics.lua")
+assert(type(graphics) == "table", "libs/graphics.lua must return its module table")
+
+local failures = 0
+local function check(name, got, want)
+    if got ~= want then
+        failures = failures + 1
+        print(string.format("FAIL %-34s got=%s want=%s",
+                            name, tostring(got), tostring(want)))
+    else
+        print(string.format("ok   %-34s %s", name, tostring(got)))
+    end
+end
+
+local FIX = os.getenv("FIXTURE_DIR")
+assert(FIX, "FIXTURE_DIR required")
+
+-- 1. A stub of ours naming the host driver absolutely.
+local _, form = graphics.host_vendor_behind(FIX .. "/interposed.so")
+check("interposer -> interposed", form, "interposed")
+
+-- 2. readelf produced nothing. NOT a verdict about the library: this is the
+--    one that used to be recorded as a pass.
+local _, form2 = graphics.host_vendor_behind(FIX .. "/unreadable.so")
+check("no readelf -> unreadable", form2, "unreadable")
+
+-- 3. A bare symlink to a host path. The vendor IS the host driver, and its
+--    closure is every bit as unchecked as an interposer's.
+local host3, form3 = graphics.host_vendor_behind(FIX .. "/direct.so")
+check("host symlink -> direct", form3, "direct")
+check("direct names the host lib", (host3 or ""):find("xpkgs", 1, true) == nil, true)
+
+-- 4. Our own build: no absolute DT_NEEDED and it resolves inside the store.
+local _, form4 = graphics.host_vendor_behind(FIX .. "/xpkgs/ours.so")
+check("our build -> native", form4, "native")
+
+if failures > 0 then
+    print(string.format("%d case(s) failed", failures))
+    os.exit(1)
+end
+print("all cases passed")

--- a/tests/test_graphics_vendor_form.py
+++ b/tests/test_graphics_vendor_form.py
@@ -1,0 +1,108 @@
+"""graphics: telling apart the four things a vendor library can be.
+
+`graphics.host_vendor_behind` used to return nil for three unrelated
+situations, and `pkgs/g/graphics.lua` turned every nil into `state=native` --
+which `xlings subos info` renders as a PASS.
+
+Measured on a real NVIDIA home (2026-08-11): all six vendors were recorded
+`native` while the graphics stack was wired into no subos at all, `<subos>/lib`
+held zero GL libraries, and GL rendered in software. Four independent channels
+reported health for a stack that could not work.
+
+Two conflations produced that, and each has a case here:
+
+* `os.iorun` returns "" when the tool is missing, so "readelf did not run"
+  became "this is our own build, nothing to check". The sibling function
+  `vendor_closure_gaps` guards exactly this and says so in its own comment --
+  the guard existed, one function away.
+
+* since nvidia-gl-host-link 0.1.2 the GLX and GLES vendors are DIRECT SYMLINKS
+  to the host driver. A host library has no absolute DT_NEEDED (it names its
+  siblings by soname), so "no absolute entry" read as "our own build". It is
+  literally the host driver, and the verdict was inverted for precisely the
+  vendors that most needed checking.
+
+The fixtures are text, not ELF: the function reads `readelf -d` output and a
+`readlink -f` result, so forging those directly tests the logic without
+needing a compiler -- and the ABSENCE of the readelf sidecar is how the
+"tool did not run" case is reproduced, which is the case that mattered.
+
+Design: xlings/.agents/docs/2026-08-11-five-issues-triage-and-plan.md §2.4
+"""
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+HARNESS = REPO / "tests" / "lua" / "graphics_vendor_form_harness.lua"
+GRAPHICS = REPO / "libs" / "graphics.lua"
+
+
+def test_graphics_lib_exists():
+    assert GRAPHICS.is_file(), "libs/graphics.lua is the shared wiring probe"
+
+
+def test_caller_never_maps_a_missing_tool_to_a_pass():
+    """An INVARIANT, in pure Python, that always runs.
+
+    `state=native` is a pass. It may only be written where the recipe has
+    established the vendor is our own build -- never on the path where a tool
+    failed to run. Grepping for the pairing is crude, but it is the shape that
+    regressed, and it regresses by someone reintroducing `if not host then`.
+    """
+    text = (REPO / "pkgs" / "g" / "graphics.lua").read_text(encoding="utf-8")
+    assert 'form == "native"' in text, (
+        "the native verdict must be gated on the explicit form, not on a "
+        "nil that also means 'readelf did not run'"
+    )
+    assert "if not host then" not in text, (
+        "a bare nil test is the conflation this file exists to prevent: it "
+        "maps 'tool missing' and 'host driver symlinked in' onto a pass"
+    )
+
+
+@pytest.mark.skipif(
+    shutil.which("lua5.4") is None and shutil.which("lua") is None,
+    reason="no lua interpreter on this machine",
+)
+def test_vendor_form_is_distinguished(tmp_path):
+    lua = shutil.which("lua5.4") or shutil.which("lua")
+
+    fix = tmp_path / "fixtures"
+    (fix / "xpkgs").mkdir(parents=True)
+    host_dir = tmp_path / "hostlib"
+    host_dir.mkdir()
+    (host_dir / "libGLX_nvidia.so.0").write_text("host driver")
+
+    # 1. interposed: a stub of ours naming the host driver ABSOLUTELY.
+    (fix / "interposed.so").write_text("stub")
+    (fix / "interposed.so.readelf").write_text(
+        " 0x0000000000000001 (NEEDED) Shared library: "
+        f"[{host_dir}/libGLX_nvidia.so.0]\n"
+    )
+
+    # 2. unreadable: no sidecar, so `readelf` yields "". The tool did not run.
+    (fix / "unreadable.so").write_text("something")
+
+    # 3. direct: no absolute DT_NEEDED, and the file resolves to a host path.
+    (fix / "direct.so").symlink_to(host_dir / "libGLX_nvidia.so.0")
+    (fix / "direct.so.readelf").write_text(
+        " 0x0000000000000001 (NEEDED) Shared library: [libnvidia-glcore.so.550]\n"
+    )
+
+    # 4. native: no absolute DT_NEEDED and it resolves inside a store.
+    (fix / "xpkgs" / "ours.so").write_text("our build")
+    (fix / "xpkgs" / "ours.so.readelf").write_text(
+        " 0x0000000000000001 (NEEDED) Shared library: [libc.so.6]\n"
+    )
+
+    proc = subprocess.run(
+        [lua, str(HARNESS)],
+        env={"FAKE_ROOT": str(REPO), "FIXTURE_DIR": str(fix), "PATH": "/usr/bin:/bin"},
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr


### PR DESCRIPTION
## What

`native` is a **pass** on `xlings subos info`: "this vendor is our own build, there is no host closure to complete". `graphics.host_vendor_behind` returned `nil` for three unrelated situations and the caller turned every `nil` into that pass.

Measured on a real NVIDIA home (2026-08-11): **all six vendors recorded `native`** while the graphics stack was wired into no subos at all, `<subos>/lib` held zero GL libraries, and GL rendered in software. Four independent channels reported health for a stack that could not work.

## The two conflations

- **`os.iorun` returns `""` when the tool is missing**, so "readelf did not run" became "this is ours, nothing to check". The sibling `vendor_closure_gaps` guards exactly this and says so in its own comment — the guard existed one function away.
- **Since `nvidia-gl-host-link` 0.1.2, GLX and GLES vendors are direct symlinks to the host driver.** A host library has no absolute `DT_NEEDED` (it names siblings by soname), so "no absolute entry" read as "our own build". It *is* the host driver — the verdict was inverted for precisely the vendors that most needed checking.

## The change

`host_vendor_behind` returns a **form**: `interposed` / `direct` / `native` / `unreadable`.

Verified against the real payload:

| vendor | form | verdict |
|---|---|---|
| `libEGL_nvidia.so.0` | interposed | real closure check |
| `libGLX_nvidia.so.0` | **direct** | `needs-transitive-consumer` |
| `libGLESv1_CM_nvidia.so.1` | **direct** | `needs-transitive-consumer` |
| `libGLESv2_nvidia.so.2` | **direct** | `needs-transitive-consumer` |

All four were `native` before. `needs-transitive-consumer` is exactly right for a host library carrying no search path of its own.

`unreadable` records `state=unverified`, which already exists and already means "we could not look".

## Version

`0.1.4` rather than editing `0.1.3` — without a new key the config hook never re-fires on an assembled home and the correction reaches only fresh installs, silently.

## Tests

`tests/test_graphics_vendor_form.py` + a plain-Lua harness. **Falsified**: restoring the old function turns exactly the two conflation cases red, both reporting `native`.

Full suite: 121 failed / 2021 passed vs. `origin/main` baseline 122 failed / 2017 passed — no regressions (the failures are pre-existing environment-dependent lifecycle tests).

Refs: openxlings/xlings#537, openxlings/xlings#541