### PR TITLE
fix(graphics): ask for patchelf by the coordinate as declared

### DIFF
--- a/pkgs/l/libglvnd.lua
+++ b/pkgs/l/libglvnd.lua
@@ -144,8 +144,20 @@ function __wire_glx_vendor_search_path()
     -- name fails silently and looks exactly like "nothing to do". CI caught
     -- this: the install aborted with "patchelf missing or refused" on a runner
     -- where patchelf was installed the whole time.
+    -- Asked for BY THE COORDINATE AS DECLARED (`xim:patchelf@0.18.0` above),
+    -- with the bare name as a fallback for clients older than libxpkg 0.0.57.
+    -- That version refuses a bare name against explicit dependency stores --
+    -- it does not say which namespace -- and the refusal reaches this recipe
+    -- as a config hook that returns false, which is the same "looks like
+    -- nothing to do" shape the comment above already warns about, one layer up.
     local pe = "patchelf"
-    local bd = pkginfo.build_dep and pkginfo.build_dep("patchelf")
+    local bd = nil
+    if pkginfo.build_dep then
+        bd = try { function() return pkginfo.build_dep("xim:patchelf") end }
+        if not (bd and bd.bin) then
+            bd = try { function() return pkginfo.build_dep("patchelf") end }
+        end
+    end
     if bd and bd.bin and os.isfile(path.join(bd.bin, "patchelf")) then
         pe = path.join(bd.bin, "patchelf")
     end

--- a/pkgs/n/nvidia-gl-host-link.lua
+++ b/pkgs/n/nvidia-gl-host-link.lua
@@ -467,8 +467,28 @@ function install()
                 -- reports no FBConfig. Flipping the one tag, changing nothing
                 -- else, produced `GL_RENDERER: NVIDIA GeForce RTX 4080/PCIe/SSE2`
                 -- through our own interposer.
+                -- Asked for BY THE COORDINATE AS DECLARED, with the bare name
+                -- as a fallback.
+                --
+                -- libxpkg 0.0.57 refuses a bare name against explicit
+                -- dependency stores -- it does not say which namespace -- and
+                -- the refusal surfaced here as `config hook returned false`
+                -- with the interposer left at DT_RUNPATH, i.e. the exact
+                -- silent-software-rendering failure the block below exists to
+                -- prevent, arriving through the code meant to prevent it.
+                --
+                -- Both spellings are tried because this recipe is served to
+                -- clients older than that change too, and those resolve the
+                -- bare name and nothing else. Order matters: qualified first,
+                -- so a current client never depends on the legacy path.
                 local pe = "patchelf"
-                local bd = pkginfo.build_dep and pkginfo.build_dep("patchelf")
+                local bd = nil
+                if pkginfo.build_dep then
+                    bd = try { function() return pkginfo.build_dep("xim:patchelf") end }
+                    if not (bd and bd.bin) then
+                        bd = try { function() return pkginfo.build_dep("patchelf") end }
+                    end
+                end
                 if bd and bd.bin then pe = path.join(bd.bin, "patchelf") end
 
                 local rp = try { function()


### PR DESCRIPTION
## What

`pkginfo.build_dep("patchelf")` passes a **bare name** while the dependency is declared `xim:patchelf@0.18.0`. libxpkg 0.0.57 refuses a bare name against explicit dependency stores — it does not say which namespace — and the refusal reaches these recipes as `config hook returned false`.

## Measured

Installing `graphics@0.1.4` on a real NVIDIA host (xlings 2026.8.11.1):

```
[ERROR] dep_install_dir(patchelf): a bare name cannot be resolved against
        explicit dependency stores -- it does not say which namespace.
[ERROR] cannot read libGLX_nvidia.so.0's RPATH (patchelf not usable at patchelf);
        the interposer would keep DT_RUNPATH and GL would render in software
nvidia-gl-host-link installed but registered none of the programs it declares:
        xlings-gl-doctor
install failed: nvidia-gl-host-link installed but registered none of its declared programs
```

So **the guard that exists to prevent silent software rendering was itself disabled by this**, and the whole graphics stack could not install.

## The fix

Both spellings are tried, **qualified first** — these recipes are served to clients older than 0.0.57 too, and those resolve the bare name and nothing else. Order matters so a current client never takes the legacy path.

`libglvnd` had the identical call and would fail the same way. Its own comment already warns that getting this wrong *"fails silently and looks exactly like nothing to do"* — which is the shape this arrived in, one layer up.

## No version bump

The recipe text is fetched fresh from the index, and the half-installed payload is now marked **incomplete** by xlings 2026.8.11.1, so the hook re-runs against the corrected code on the next install. (That marker is itself new in this release — this failure is the first real-world exercise of it.)

Refs: openxlings/xlings#541