### PR TITLE
fix(binutils,graphics): let a subos link against its own farm, and expire a stale verdict

### DIFF
--- a/pkgs/b/binutils.lua
+++ b/pkgs/b/binutils.lua
@@ -31,7 +31,32 @@ package = {
     xpm = {
         linux = {
             deps = { "xim:glibc@>=2.39" },
-            ["latest"] = { ref = "2.42" },
+            ["latest"] = { ref = "2.42.1" },
+            -- SAME ARTIFACT, NEW KEY. The bytes are identical to 2.42 -- the
+            -- sha256 below is the 2.42 tarball's -- and the only thing that
+            -- changed is this recipe's config(), which now installs the `ld`
+            -- wrapper below.
+            --
+            -- config() runs only when a package INSTALLS. A home that already
+            -- has 2.42 would keep an `ld` that cannot see the subos library
+            -- farm, with nothing to say so; the fix would ship and those users
+            -- would never get it. A new key under the same artifact makes
+            -- `latest` pull it and the hook re-run. Same move as libglvnd
+            -- 1.7.0.1 and fontconfig 2.15.0.1.
+            --
+            -- Written as an explicit url rather than the XLINGS_RES sentinel
+            -- because that sentinel derives the filename from the VERSION, and
+            -- there is no `binutils-2.42.1-*` artifact -- there is no new
+            -- artifact at all. The install hook derives the extracted
+            -- directory from the downloaded FILENAME, so it still finds
+            -- `binutils-2.42-linux-x86_64/`.
+            ["2.42.1"] = {
+                url = {
+                    GLOBAL = "https://github.com/xlings-res/binutils/releases/download/2.42/binutils-2.42-linux-x86_64.tar.gz",
+                    CN     = "https://gitcode.com/xlings-res/binutils/releases/download/2.42/binutils-2.42-linux-x86_64.tar.gz",
+                },
+                sha256 = "32ec131327cd10624f70741fc553ad369f8f53ee4b79276a44f572c6d8190fd7",
+            },
             ["2.42"] = "XLINGS_RES",
         },
     },
@@ -41,6 +66,7 @@ import("xim.libxpkg.log")
 import("xim.libxpkg.pkginfo")
 import("xim.libxpkg.system")
 import("xim.libxpkg.xvm")
+import("xim.libxpkg.fs")
 -- elfpatch import removed: predicate-driven auto-patch (post 2026-05-02
 -- design) reads glibc.lua's exports.runtime.loader and rewrites our
 -- INTERP / RPATH automatically. No install-hook elfpatch call needed.
@@ -57,16 +83,123 @@ function install()
     return true
 end
 
+-- Where the `ld` wrapper lives. NOT `bin/` -- see write_ld_wrapper.
+local WRAPPER_SUBDIR = "xlings-wrappers"
+
+-- Single-quote for `sh`. NOT `string.format("%q")`, which is LUA quoting: it
+-- produces a double-quoted string, and a shell expands `$` and backticks
+-- inside those. libglvnd.lua records what that costs -- `$ORIGIN` went through
+-- `%q` into `os.exec`, the shell expanded it as an unset variable, and the
+-- resulting RPATH was a bare `/glx-vendor` that exists nowhere.
+function __shq(s)
+    return "'" .. tostring(s):gsub("'", "'\\''") .. "'"
+end
+
+-- Teach `ld` where this subos keeps its libraries.
+--
+-- THE PROBLEM (openxlings/xlings#532). A subos publishes every installed
+-- library into `<subos>/lib` and puts that on the compiler's search path, so
+-- `gcc t.c -lGL` finds `libGL.so`. But `libGL.so` has DT_NEEDED on
+-- `libGLdispatch.so.0` and `libGLX.so.0`, and `ld` does NOT search `-L`
+-- directories for a dependency's dependencies -- that is what `-rpath-link` is
+-- for. Measured, verbatim:
+--
+--   ld: warning: libGLdispatch.so.0, needed by <subos>/lib/libGL.so, not found
+--       (try using -rpath or -rpath-link)
+--   ld: <subos>/lib/libGL.so: undefined reference to `__glDispatchInit'
+--
+-- Both libraries are in the same directory as libGL.so. The linker's own
+-- message names the fix.
+--
+-- WHY HERE AND NOT IN EACH COMPILER'S ALIAS. Putting `-Wl,-rpath-link=...` in
+-- gcc's alias works and would need repeating for g++, clang, musl-gcc and
+-- every driver added later -- N answers to one question, which is the defect
+-- class this ecosystem keeps paying for. The linker is where the knowledge
+-- belongs: one place, and it also covers a direct `ld` call.
+--
+-- WHY NOT A SEPARATE PACKAGE. `binutils` already registers `ld` exclusively;
+-- a second package claiming that name meets the contested-name veto
+-- (2026.8.1.1), and it would need to re-derive where the real `ld` lives --
+-- a second answerer to that question too.
+--
+-- WHY `xlings-wrappers/` AND NOT `bin/ld`. Replacing the ELF at `bin/ld` with
+-- a shell script would put a non-ELF where the install-time ELF passes
+-- (elfpatch auto, closure_check rule E) expect a linker, and it would leave
+-- the real `ld` needing a new name that something else has to know. Instead
+-- `bin/` is untouched and only the xvm REGISTRATION moves: the shim for `ld`
+-- resolves here, and this file execs the untouched binary next door. A build
+-- that hardcodes `<payload>/bin/ld` behaves exactly as it does today.
+--
+-- WHY IT READS AN ENVIRONMENT VARIABLE. `XLINGS_SUBOS_LIB` (E2a, xlings
+-- 2026.8.11.1) is declared by whichever layer knows which subos this process
+-- is in -- the shell profile, `subos spawn`, `--sandbox`, and since
+-- 2026.8.11.2 the shim itself. So this file contains no home path, no subos
+-- path and no version: it is the same bytes in every home, `xlings use
+-- binutils <ver>` needs no rewrite, and there is no shared mutable state.
+--
+-- WHY THE VALUE IS TESTED AND NOT INTERPOLATED. An unset variable expands to
+-- the empty string, and `-rpath-link ""` is not "no option" -- it is an option
+-- naming the current directory. That exact confusion (empty vs absent) is what
+-- produced `--sysroot=` and cost this project five days. If there is no value,
+-- the flag does not appear at all.
+--
+-- POSIX ONLY, and that is not a gap: this recipe declares `xpm.linux` and
+-- nothing else, so there is no Windows payload for a `#!/bin/sh` file to be
+-- wrong on.
+function write_ld_wrapper()
+    local dir = path.join(pkginfo.install_dir(), WRAPPER_SUBDIR)
+    fs.mkdir_p(dir)
+    local wrapper = path.join(dir, "ld")
+    local real = path.join(pkginfo.install_dir(), "bin", "ld")
+
+    -- `$0` first, absolute second. The shim execs this by absolute path, so
+    -- `$0` is normally this file and the relative hop is correct even if the
+    -- home is moved or copied. The absolute fallback covers the case where it
+    -- is reached through something that rewrites `$0` -- belt and braces, two
+    -- lines, and the failure it prevents is "the linker vanished".
+    io.writefile(wrapper, table.concat({
+        "#!/bin/sh",
+        "# Generated by xlings: xim-pkgindex/pkgs/b/binutils.lua",
+        "# Adds the active subos library farm to the linker's",
+        "# dependency-of-a-dependency search path. See openxlings/xlings#532.",
+        'real="$(dirname "$0")/../bin/ld"',
+        '[ -x "$real" ] || real=' .. __shq(real),
+        'if [ -n "$XLINGS_SUBOS_LIB" ] && [ -d "$XLINGS_SUBOS_LIB" ]; then',
+        '    exec "$real" -rpath-link "$XLINGS_SUBOS_LIB" "$@"',
+        'fi',
+        'exec "$real" "$@"',
+        "",
+    }, "\n"))
+    os.exec("chmod +x " .. __shq(wrapper))
+
+    -- Assert, do not assume. A wrapper that was not written is
+    -- indistinguishable from one that works until someone tries to link a
+    -- library with cross-payload dependencies -- and then the error names
+    -- undefined symbols, not this file.
+    if not os.isfile(wrapper) then
+        log.error("could not write the ld wrapper at %s; `-l<lib in the subos "
+                  .. "farm>` will fail to link with undefined references",
+                  wrapper)
+        return nil
+    end
+    return dir
+end
+
 function config()
     xvm.add("binutils")
 
     local binutils_root_binding = "binutils@" .. pkginfo.version()
 
     local binutils_bindir = path.join(pkginfo.install_dir(), "bin")
+    local ld_bindir = write_ld_wrapper() or binutils_bindir
 
     for _, program in ipairs(package.programs) do
         xvm.add(program, {
-            bindir = binutils_bindir,
+            -- `ld` alone resolves through the wrapper. Everything else in this
+            -- payload is registered exactly as before: `as` and `gold` do not
+            -- resolve a dependency's dependencies, so there is nothing for the
+            -- flag to fix there and no reason to add a process to their path.
+            bindir = (program == "ld") and ld_bindir or binutils_bindir,
             binding = binutils_root_binding,
         })
     end

--- a/pkgs/b/binutils.lua
+++ b/pkgs/b/binutils.lua
@@ -30,7 +30,22 @@ package = {
 
     xpm = {
         linux = {
-            deps = { "xim:glibc@>=2.39" },
+            -- gcc-runtime is not decoration: `ld.gold` in this payload has
+            -- DT_NEEDED on libstdc++.so.6 and libgcc_s.so.1, and once the
+            -- payload uses OUR loader there is no host fallback behind it --
+            -- its ld.so.cache path exists on no machine. So those two sonames
+            -- were simply unresolvable and `ld.gold` could not run.
+            --
+            -- This was true before this change and invisible: the dependency
+            -- closure check (rule D) only runs on packages a PR touches, and
+            -- nothing had touched binutils since the check existed. Bumping to
+            -- 2.42.1 for the `ld` wrapper is what put it in front of the gate
+            -- -- which is the gate working, not the bump breaking anything.
+            --
+            -- elfpatch reads gcc-runtime's exports.runtime.libdirs and appends
+            -- it to this payload's RPATH at install time, so nothing here
+            -- hardcodes a path. No cycle: gcc-runtime depends only on glibc.
+            deps = { "xim:glibc@>=2.39", "xim:gcc-runtime@>=15" },
             ["latest"] = { ref = "2.42.1" },
             -- SAME ARTIFACT, NEW KEY. The bytes are identical to 2.42 -- the
             -- sha256 below is the 2.42 tarball's -- and the only thing that

--- a/pkgs/g/graphics.lua
+++ b/pkgs/g/graphics.lua
@@ -249,6 +249,33 @@ function __wire_glx_vendors()
         "libEGL_%s.so.0", "libGLX_%s.so.0",
         "libGLESv1_CM_%s.so.1", "libGLESv2_%s.so.2",
     }
+    -- PROVENANCE: which payload each verdict is about.
+    --
+    -- This record is written by `graphics` and every line in it describes a
+    -- DIFFERENT package -- mesa, libglvnd, nvidia-gl-host-link. Those packages
+    -- upgrade on their own schedule, and until now nothing could tell that a
+    -- record had outlived what it describes. Measured on a real home: the
+    -- record was written at 01:37:17 and the nvidia payload it speaks for at
+    -- 01:38:14 -- the verdict predated its subject by 57 seconds.
+    --
+    -- The dispatch layer already had this (`dispatch=` -> the reader compares
+    -- it against what the farm resolves to, and says `stale wiring`). The
+    -- vendor layer had nothing.
+    --
+    -- WHAT THE READER CAN DO WITH IT decided the shape. "Is this the current
+    -- version of that package" is unanswerable there: `subos info` answers
+    -- from local state by contract and must not parse the index. A PATH is
+    -- different -- the reader can follow `glx-vendor/<soname>` and see whether
+    -- it still lands inside this directory, which is precisely what changes
+    -- when a vendor is upgraded and the assembler is not re-run. Local, cheap,
+    -- and it needs nobody's cooperation.
+    --
+    -- LAST ON THE LINE, because it is a path and a path may contain a space;
+    -- the reader takes the whole remainder, exactly as it does for `dispatch=`.
+    local function vendor_line(soname, dir, rest)
+        return "vendor=" .. soname .. " " .. rest .. " payload=" .. dir
+    end
+
     local lines = { "dispatch=" .. dispatch }
     for _, v in ipairs(_GLX_VENDORS) do
         local dir = pkginfo.dep_install_dir(v.dep)
@@ -263,7 +290,7 @@ function __wire_glx_vendors()
                         -- library, and it used to be recorded as `native` --
                         -- which the panel shows as a PASS. An absent
                         -- observation must never be spent as a verdict.
-                        table.insert(lines, "vendor=" .. soname .. " state=unverified")
+                        table.insert(lines, vendor_line(soname, dir, "state=unverified"))
                         log.warn("%s: cannot read its dynamic section (readelf "
                                  .. "unavailable); its wiring is unknown, not "
                                  .. "healthy", soname)
@@ -272,11 +299,11 @@ function __wire_glx_vendors()
                         -- our store: this vendor is OURS, built against our
                         -- payloads. There is no host closure to check, which
                         -- is not the same as a failed check.
-                        table.insert(lines, "vendor=" .. soname .. " state=native")
+                        table.insert(lines, vendor_line(soname, dir, "state=native"))
                     else
                         local gaps = graphics.vendor_closure_gaps(lib, host)
                         if not gaps.ok then
-                            table.insert(lines, "vendor=" .. soname .. " state=unverified")
+                            table.insert(lines, vendor_line(soname, dir, "state=unverified"))
                             log.warn("%s: cannot verify its dependency closure "
                                      .. "(readelf or patchelf unavailable); if it "
                                      .. "is incomplete, GL renders through another "
@@ -302,8 +329,8 @@ function __wire_glx_vendors()
                             -- sends someone to fix a problem that is not there
                             -- and hides the one that is
                             -- (openxlings/xlings#537).
-                            table.insert(lines, "vendor=" .. soname
-                                         .. " state=needs-transitive-consumer")
+                            table.insert(lines, vendor_line(soname, dir,
+                                         "state=needs-transitive-consumer"))
                             log.warn("%s carries DT_RUNPATH. Installed "
                                      .. "programs still reach it -- their own "
                                      .. "DT_RPATH is transitive and covers this "
@@ -313,9 +340,9 @@ function __wire_glx_vendors()
                                      .. "elsewhere (openxlings/xlings#532).",
                                      soname)
                         elseif #gaps.missing > 0 then
-                            table.insert(lines, "vendor=" .. soname
-                                         .. " state=broken missing="
-                                         .. table.concat(gaps.missing, ","))
+                            table.insert(lines, vendor_line(soname, dir,
+                                         "state=broken missing="
+                                         .. table.concat(gaps.missing, ",")))
                             log.warn("%s cannot load: the host driver behind it "
                                      .. "needs %s, which nothing on its search "
                                      .. "path provides. glvnd falls back to "
@@ -323,7 +350,7 @@ function __wire_glx_vendors()
                                      .. "still renders, just not on this driver.",
                                      soname, table.concat(gaps.missing, ", "))
                         else
-                            table.insert(lines, "vendor=" .. soname .. " state=ok")
+                            table.insert(lines, vendor_line(soname, dir, "state=ok"))
                         end
                     end
                 end

--- a/tests/b/test_binutils_ld_wrapper.py
+++ b/tests/b/test_binutils_ld_wrapper.py
@@ -1,0 +1,219 @@
+"""binutils: the `ld` wrapper that lets a subos link against its own farm.
+
+WHAT IS BEING DEFENDED
+
+A subos publishes every installed library into `<subos>/lib` and puts that on
+the compiler's search path, so `gcc t.c -lGL` finds `libGL.so`. But `libGL.so`
+has DT_NEEDED on `libGLdispatch.so.0` and `libGLX.so.0`, and `ld` does NOT
+search `-L` directories for a dependency's dependencies. Measured on a real
+home, verbatim:
+
+    ld: warning: libGLdispatch.so.0, needed by <subos>/lib/libGL.so, not found
+        (try using -rpath or -rpath-link)
+    ld: <subos>/lib/libGL.so: undefined reference to `__glDispatchInit'
+
+Both libraries are in the same directory as libGL.so. The linker's own message
+names the fix (openxlings/xlings#532).
+
+WHY THESE TESTS RUN THE SHELL
+
+The wrapper is a `#!/bin/sh` file this recipe generates, and its failure mode
+is not "wrong output" -- it is a linker that vanishes, or one that appends
+`-rpath-link ""`, which is not "no option" but an option naming the current
+directory. That is the same empty-vs-absent confusion that produced
+`--sysroot=` and cost this project five days. So the wrapper text is lifted
+out of the recipe and actually executed against a stub linker, rather than
+matched against a pattern.
+"""
+
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+RECIPE = REPO / "pkgs" / "b" / "binutils.lua"
+
+
+def _recipe_text() -> str:
+    return RECIPE.read_text(encoding="utf-8")
+
+
+def _wrapper_body(real_path: str) -> str:
+    """The wrapper exactly as the recipe writes it, for a given real `ld`.
+
+    Lifted from the recipe rather than copied into this file: a copy is a
+    second source of truth, and the whole class of bug here is two things
+    that are supposed to agree and quietly stop agreeing.
+    """
+    text = _recipe_text()
+    start = text.index('io.writefile(wrapper, table.concat({')
+    end = text.index('}, "\\n"))', start)
+    block = text[start:end]
+
+    lines = []
+    for raw in block.splitlines()[1:]:
+        raw = raw.strip().rstrip(",")
+        if not raw:
+            continue
+        if raw.startswith("'") and raw.endswith("'"):
+            lines.append(raw[1:-1])
+        elif raw.startswith('"') and raw.endswith('"'):
+            lines.append(raw[1:-1])
+        elif ".. __shq(real)" in raw:
+            # `[ -x "$real" ] || real=` .. __shq(real)
+            prefix = raw.split(".. __shq(real)")[0].strip().rstrip()
+            prefix = prefix[1:-1] if prefix.startswith("'") else prefix
+            lines.append(prefix + "'" + real_path.replace("'", "'\\''") + "'")
+        else:
+            raise AssertionError(
+                f"unrecognised wrapper line in binutils.lua: {raw!r} -- the "
+                "generator changed shape and this test can no longer read it"
+            )
+    assert lines, "no wrapper lines were extracted from the recipe"
+    return "\n".join(lines) + "\n"
+
+
+@pytest.fixture()
+def wrapper(tmp_path):
+    """A materialised wrapper plus a stub `ld` that records its argv."""
+    payload = tmp_path / "payload"
+    (payload / "bin").mkdir(parents=True)
+    (payload / "xlings-wrappers").mkdir()
+
+    argv_log = tmp_path / "argv.txt"
+    real = payload / "bin" / "ld"
+    real.write_text(
+        "#!/bin/sh\n"
+        f'printf "%s\\n" "$@" > {argv_log}\n'
+        "exit 0\n",
+        encoding="utf-8",
+    )
+    real.chmod(0o755)
+
+    w = payload / "xlings-wrappers" / "ld"
+    w.write_text(_wrapper_body(str(real)), encoding="utf-8")
+    w.chmod(0o755)
+    return w, argv_log
+
+
+@pytest.mark.static
+def test_the_wrapper_is_valid_posix_sh(wrapper):
+    w, _ = wrapper
+    sh = shutil.which("sh")
+    if sh is None:
+        pytest.skip("no POSIX sh here; this wrapper is a linux-only payload")
+    r = subprocess.run([sh, "-n", str(w)], capture_output=True, text=True)
+    assert r.returncode == 0, (
+        "the generated wrapper does not parse; the linker would be replaced "
+        f"by a file that cannot run:\n{r.stderr}"
+    )
+
+
+@pytest.mark.static
+def test_the_farm_is_passed_when_the_variable_is_set(wrapper, tmp_path):
+    w, log = wrapper
+    farm = tmp_path / "subos" / "lib"
+    farm.mkdir(parents=True)
+    r = subprocess.run(
+        [str(w), "-o", "out", "obj.o"],
+        env={"PATH": "/usr/bin:/bin", "XLINGS_SUBOS_LIB": str(farm)},
+        capture_output=True, text=True,
+    )
+    assert r.returncode == 0, r.stderr
+    args = log.read_text().split()
+    assert "-rpath-link" in args, "the farm was not passed to the linker"
+    assert str(farm) in args
+    # The caller's own arguments must survive, in order and unmangled.
+    assert args[-3:] == ["-o", "out", "obj.o"]
+
+
+@pytest.mark.static
+def test_nothing_is_passed_when_the_variable_is_absent(wrapper):
+    w, log = wrapper
+    r = subprocess.run(
+        [str(w), "-o", "out"],
+        env={"PATH": "/usr/bin:/bin"},
+        capture_output=True, text=True,
+    )
+    assert r.returncode == 0, r.stderr
+    args = log.read_text().split()
+    assert "-rpath-link" not in args, (
+        "an absent variable must make the whole option disappear -- "
+        '`-rpath-link ""` is not "no option", it names the current directory'
+    )
+    assert args == ["-o", "out"]
+
+
+@pytest.mark.static
+def test_a_variable_pointing_nowhere_adds_nothing(wrapper, tmp_path):
+    w, log = wrapper
+    r = subprocess.run(
+        [str(w), "-o", "out"],
+        env={"PATH": "/usr/bin:/bin",
+             "XLINGS_SUBOS_LIB": str(tmp_path / "does-not-exist")},
+        capture_output=True, text=True,
+    )
+    assert r.returncode == 0, r.stderr
+    assert "-rpath-link" not in log.read_text().split()
+
+
+@pytest.mark.static
+def test_a_path_with_a_space_survives(tmp_path):
+    """A store under `/home/John Doe/...` must not split into two arguments."""
+    payload = tmp_path / "my payload"
+    (payload / "bin").mkdir(parents=True)
+    (payload / "xlings-wrappers").mkdir()
+    argv_log = tmp_path / "argv.txt"
+    real = payload / "bin" / "ld"
+    real.write_text(
+        "#!/bin/sh\n" f'printf "%s\\n" "$@" > "{argv_log}"\n' "exit 0\n",
+        encoding="utf-8")
+    real.chmod(0o755)
+    w = payload / "xlings-wrappers" / "ld"
+    w.write_text(_wrapper_body(str(real)), encoding="utf-8")
+    w.chmod(0o755)
+
+    farm = tmp_path / "a subos" / "lib"
+    farm.mkdir(parents=True)
+    r = subprocess.run([str(w), "-o", "out"],
+                       env={"PATH": "/usr/bin:/bin",
+                            "XLINGS_SUBOS_LIB": str(farm)},
+                       capture_output=True, text=True)
+    assert r.returncode == 0, r.stderr
+    lines = argv_log.read_text().splitlines()
+    assert str(farm) in lines, f"the farm path was split or mangled: {lines}"
+
+
+@pytest.mark.static
+def test_only_ld_is_registered_through_the_wrapper():
+    """`as` and `gold` resolve nothing transitively; routing them through a
+    shell process would be cost with no effect."""
+    text = _recipe_text()
+    assert 'bindir = (program == "ld") and ld_bindir or binutils_bindir' in text
+
+
+@pytest.mark.static
+def test_a_new_version_key_exists_so_installed_homes_re_run_config():
+    """config() runs only when a package INSTALLS.
+
+    Without a new key, every home that already has binutils keeps an `ld`
+    that cannot see the subos farm, with nothing to say so -- the fix ships
+    and those users never get it. Same move as libglvnd 1.7.0.1.
+    """
+    text = _recipe_text()
+    assert '["latest"] = { ref = "2.42.1" }' in text
+    assert '["2.42.1"] = {' in text
+    assert '["2.42"] = "XLINGS_RES"' in text, (
+        "the previous key must stay resolvable: homes pinned to it, and "
+        "removing a version key is not an upgrade path"
+    )
+    # Same artifact, so the sha256 must be the 2.42 tarball's and the URL must
+    # still name 2.42 -- there is no 2.42.1 artifact to fetch.
+    m = re.search(r'\["2\.42\.1"\] = \{(.*?)\n            \}', text, re.S)
+    assert m, "could not read the 2.42.1 entry"
+    entry = m.group(1)
+    assert "binutils-2.42-linux-x86_64.tar.gz" in entry
+    assert "sha256" in entry

--- a/tests/test_graphics_vendor_form.py
+++ b/tests/test_graphics_vendor_form.py
@@ -30,6 +30,7 @@ needing a compiler -- and the ABSENCE of the readelf sidecar is how the
 Design: xlings/.agents/docs/2026-08-11-five-issues-triage-and-plan.md §2.4
 """
 
+import re
 import shutil
 import subprocess
 from pathlib import Path
@@ -106,3 +107,55 @@ def test_vendor_form_is_distinguished(tmp_path):
         text=True,
     )
     assert proc.returncode == 0, proc.stdout + proc.stderr
+
+
+# ─── provenance: every recorded verdict names the payload it is about ───────
+#
+# The `.wiring` record is written by ONE package (`graphics`) and every line in
+# it is about ANOTHER (mesa, libglvnd, nvidia-gl-host-link). Those upgrade on
+# their own schedule and nothing made a verdict expire when its subject moved.
+# Measured on a real home: the record was written at 01:37:17 and the nvidia
+# payload it speaks for at 01:38:14 -- 57 seconds AFTER the verdict about it.
+#
+# The reader (xlings subos/graphics.cppm) compares the wired symlink against
+# `payload=` and reports STALE when it no longer lands inside. That check is
+# inert for any line missing the field, so the invariant that matters here is
+# that NO branch can emit a line without it.
+
+_GRAPHICS_RECIPE = Path(__file__).resolve().parents[1] / "pkgs" / "g" / "graphics.lua"
+
+
+def test_every_wiring_line_goes_through_the_single_builder():
+    """One writer, six branches.
+
+    There are six places that record a verdict (unverified x2, native,
+    needs-transitive-consumer, broken, ok). A regex-shaped edit that adds a
+    seventh by copying `"vendor=" .. soname` would parse fine, produce a
+    plausible record, and silently drop the provenance for exactly that state
+    -- and the reader would then never call it stale. Asserting the raw
+    construction does not appear is what keeps the builder singular.
+    """
+    text = _GRAPHICS_RECIPE.read_text(encoding="utf-8")
+    assert 'local function vendor_line(soname, dir, rest)' in text
+    assert 'payload=" .. dir' in text, "the builder no longer records provenance"
+    body = text[text.index("local function vendor_line"):]
+    # Inside the builder itself the literal is expected; anywhere after it, a
+    # raw `table.insert(lines, "vendor=` is a branch that bypassed it.
+    after_builder = body[body.index("local lines = {"):]
+    assert 'table.insert(lines, "vendor=' not in after_builder, (
+        "a wiring line is built without payload=; the reader cannot expire it"
+    )
+
+
+def test_provenance_is_last_on_the_line():
+    """A payload path may contain a space.
+
+    The reader tokenises a vendor line on spaces and takes everything after
+    ` payload=` as the remainder, exactly as it already does for `dispatch=`.
+    That only works while the field is last.
+    """
+    text = _GRAPHICS_RECIPE.read_text(encoding="utf-8")
+    m = re.search(r'return "vendor=" \.\. soname \.\. " " \.\. rest'
+                  r' \.\. " payload=" \.\. dir', text)
+    assert m, ("the builder's field order changed; the reader takes the rest "
+               "of the line after ` payload=` and would swallow later fields")


### PR DESCRIPTION
Pairs with openxlings/xlings#542 (2026.8.11.2). Both halves are cross-repository; the reader for `payload=` ships there.

## binutils: an `ld` wrapper

A subos publishes every installed library into `<subos>/lib` and puts that on the compiler's search path, so `gcc t.c -lGL` finds `libGL.so`. But `libGL.so` has DT_NEEDED on `libGLdispatch.so.0` and `libGLX.so.0`, and `ld` does **not** search `-L` directories for a dependency's dependencies. Measured, verbatim:

```
ld: warning: libGLdispatch.so.0, needed by <subos>/lib/libGL.so, not found
    (try using -rpath or -rpath-link)
ld: <subos>/lib/libGL.so: undefined reference to `__glDispatchInit'
```

Both libraries are in the same directory as `libGL.so`. The linker's own message names the fix; adding `-rpath-link <subos>/lib` links it (also measured). openxlings/xlings#532.

**Where, and why not the three alternatives.** Not each compiler's alias — gcc, g++, clang, musl-gcc and every driver added later would need their own copy, which is N answers to one question. Not a separate package — binutils already registers `ld` exclusively, so a second claimant meets the contested-name veto, and it would have to re-derive where the real `ld` lives. Not `bin/ld` replaced by a script — that puts a non-ELF where the install-time ELF passes expect a linker. Instead `bin/` is untouched and only the xvm registration for `ld` moves to `xlings-wrappers/`.

The wrapper contains no home path, no subos path and no version: it reads `XLINGS_SUBOS_LIB`. Same bytes in every home; `xlings use binutils <ver>` needs no rewrite. The value is **tested, not interpolated** — an unset variable expands to empty and `-rpath-link ""` is not "no option", it names the current directory. That is the same empty-vs-absent confusion that produced `--sysroot=`.

`2.42.1` is the 2.42 artifact under a new key, because `config()` runs only when a package installs. Without it, every home that already has binutils keeps an `ld` that cannot see its own farm and the fix ships to nobody. The libglvnd 1.7.0.1 / fontconfig 2.15.0.1 pattern; same URL, same sha256, no new artifact.

## graphics: `.wiring` records what each verdict is about

The record is written by `graphics` and every line in it describes another package. Measured on a real home: the record was written at `01:37:17` and the nvidia payload it speaks for at `01:38:14` — the verdict predated its subject by 57 seconds. The dispatch layer already had this (`dispatch=`); the vendor layer had nothing.

`payload=<dir>`, **last on the line** because a path may contain a space. The reader follows `glx-vendor/<soname>` and reports STALE when it no longer lands inside — a purely local test, which is what it had to be: `xlings subos info` answers from local state by contract and must not parse the index, so the obvious "is this the current version" form would have been unimplementable at the reader.

Every branch now builds its line through one helper, and a test asserts no branch bypasses it: a seventh state added by copy-paste would parse fine, produce a plausible record, and be silently unexpirable.

## Tests

`tests/b/test_binutils_ld_wrapper.py` lifts the wrapper out of the recipe and **executes** it against a stub linker — valid `sh`, farm passed when set, nothing added when unset or when it points nowhere, a path with a space survives, and the version key is present with the 2.42 artifact behind it. Plus two structural tests on `graphics.lua`'s single line-builder.
