### PR TITLE
feat(slang): add Slang shader compiler package

### DIFF
--- a/pkgs/s/slang.lua
+++ b/pkgs/s/slang.lua
@@ -41,7 +41,20 @@ package = {
             -- once the interpreter moves there is no host fallback — so
             -- gcc-runtime is not an optional extra, it is the rest of the
             -- closure.
-            deps = { "xim:glibc@>=2.38", "xim:gcc-runtime@>=13" },
+            --
+            -- zlib and libX11 are NOT optional extras either -- they are the
+            -- rest of the DT_NEEDED closure, measured over every ELF in the
+            -- payload rather than assumed:
+            --
+            --   libz.so.1    <- lib/libslang-llvm.so   (the LLVM downstream)
+            --   libX11.so.6  <- lib/libgfx.so.*        (slang's graphics layer)
+            --
+            -- libgfx is a leaf here (nothing in bin/ links it), but it is not
+            -- dropped from the payload: it is what upstream ships, and a
+            -- consumer that links or dlopens it has to find libX11 or it fails
+            -- to load. Behind our loader there is no host fallback.
+            deps = { "xim:glibc@>=2.38", "xim:gcc-runtime@>=13",
+                     "xim:zlib@>=1.3", "xim:libX11@>=1.8" },
             source = "https://github.com/shader-slang/slang/releases/download/v${version}/slang-${version}-linux-${arch}.${ext}",
             ["latest"] = { ref = "2026.14.1" },
             ["2026.14.1"] = {

--- a/pkgs/s/slang.lua
+++ b/pkgs/s/slang.lua
@@ -1,0 +1,168 @@
+package = {
+    spec = "2",
+    homepage = "https://shader-slang.org",
+
+    name = "slang",
+    description = "Slang shading language compiler — HLSL-like source to SPIR-V / DXIL / Metal / WGSL",
+
+    maintainers = {"https://github.com/shader-slang/slang/graphs/contributors"},
+    licenses = {"Apache-2.0 WITH LLVM-exception"},
+    repo = "https://github.com/shader-slang/slang",
+    docs = "https://shader-slang.org/slang/user-guide/",
+
+    type = "package",
+    archs = {"x86_64", "aarch64"},
+    status = "stable",
+    categories = {"graphics", "shader", "compiler"},
+    keywords = {"slang", "slangc", "shader", "spirv", "hlsl", "vulkan", "dxil", "metal", "wgsl"},
+
+    -- slangc  — the shader compiler (the reason most people install this)
+    -- slangd  — the language server (editor integration)
+    -- slangi  — the interpreter
+    -- slang   — the reflection/introspection driver
+    programs = {"slangc", "slangd", "slangi", "slang"},
+    xvm_enable = true,
+
+    -- Upstream ships prebuilt archives for every platform/arch pair under a
+    -- regular naming scheme, so one template per platform covers everything.
+    -- Two irregularities are handled by platform-scope `source` overrides
+    -- rather than by an `arch_alias`:
+    --   * the release TAG carries a `v` prefix (`v2026.14.1`) while the FILE
+    --     name does not (`slang-2026.14.1-...`);
+    --   * xlings spells macOS `macosx`, upstream spells it `macos`.
+    -- `${ext}` already resolves to `zip` on windows and `tar.gz` elsewhere,
+    -- which matches upstream exactly.
+    xpm = {
+        linux = {
+            -- The Linux archives are dynamically linked against glibc and
+            -- libstdc++: `bin/slangc` carries DT_NEEDED on libm/libdl/libpthread
+            -- /libc (glibc) and libstdc++/libgcc_s (gcc-runtime). Declaring
+            -- glibc is also what moves PT_INTERP into the xlings sandbox, and
+            -- once the interpreter moves there is no host fallback — so
+            -- gcc-runtime is not an optional extra, it is the rest of the
+            -- closure.
+            deps = { "xim:glibc@>=2.38", "xim:gcc-runtime@>=13" },
+            source = "https://github.com/shader-slang/slang/releases/download/v${version}/slang-${version}-linux-${arch}.${ext}",
+            ["latest"] = { ref = "2026.14.1" },
+            ["2026.14.1"] = {
+                sha256 = {
+                    x86_64  = "21f2d7847385a770e569fb61b1507a7794d742d97850bce0432bff0032ca005f",
+                    aarch64 = "438325c6529ba658f571614d9d551cdff09e730836d29c26c290afc8ed996985",
+                },
+            },
+        },
+        macosx = {
+            source = "https://github.com/shader-slang/slang/releases/download/v${version}/slang-${version}-macos-${arch}.${ext}",
+            ["latest"] = { ref = "2026.14.1" },
+            ["2026.14.1"] = {
+                sha256 = {
+                    aarch64 = "92da7ab6226dd951037cd85397f830ae78fe40fbbb8928882e0b2654e468fdd4",
+                    x86_64  = "adc5e179f5584ca572293e93612df9f0b6be8a46dcb53622238efc7a62b1da2f",
+                },
+            },
+        },
+        windows = {
+            source = "https://github.com/shader-slang/slang/releases/download/v${version}/slang-${version}-windows-${arch}.${ext}",
+            ["latest"] = { ref = "2026.14.1" },
+            ["2026.14.1"] = {
+                sha256 = {
+                    x86_64  = "5ed0a59d650a0af0aca45d5db4e083b3d8fb5cea05748747dd95dfbe9c580658",
+                    aarch64 = "5067047bb35ae5675b06a3467d0b302d9816727450a803cb3770660bef684f37",
+                },
+            },
+        },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+
+-- The upstream archive extracts FLAT — `bin/`, `include/`, `lib/`, `share/`,
+-- `docs/`, `LICENSE` at top level with no `slang-<ver>-<os>-<arch>/` wrapper —
+-- so the stock `os.mv(<archive-basename>, install_dir)` idiom finds nothing.
+--
+-- Rather than mirroring a repackaged tarball (patchelf.lua's route), the payload
+-- root is located BY CONTENT: `bin/slangc*` is the marker. That covers both
+-- shapes without guessing, so if upstream ever adds a top-level directory this
+-- recipe keeps working unchanged.
+local function payload_root()
+    local named = pkginfo.install_file()
+        :replace(".tar.gz", "")
+        :replace(".zip", "")
+    if os.isdir(named) then
+        return named
+    end
+
+    -- Flat archive: the contents landed beside the downloaded file.
+    local base = path.directory(pkginfo.install_file())
+    local exe  = is_host("windows") and "slangc.exe" or "slangc"
+    if os.isfile(path.join(base, "bin", exe)) then
+        return base
+    end
+
+    -- Defensive: the extraction directory can be shared, so also look one level
+    -- down for whichever sibling actually carries bin/slangc.
+    for _, d in ipairs(os.dirs(path.join(base, "*"))) do
+        if os.isfile(path.join(d, "bin", exe)) then
+            return d
+        end
+    end
+
+    raise("cannot find the slang payload under '" .. base
+          .. "': no directory contains bin/" .. exe)
+end
+
+function install()
+    local src = payload_root()
+    local dir = pkginfo.install_dir()
+    os.tryrm(dir)
+
+    if src == path.directory(pkginfo.install_file()) then
+        -- Flat: move the known payload entries rather than the whole extraction
+        -- directory, which also holds the archive itself (and possibly other
+        -- packages' files).
+        -- os.exists / os.files / os.filedirs are NOT available in the recipe
+        -- sandbox (see spirv-tools.lua, which hit the same wall); os.isdir and
+        -- os.isfile are.
+        os.mkdir(dir)
+        for _, name in ipairs({"bin", "include", "lib", "share", "docs",
+                               "LICENSE", "LICENSES", "README.md"}) do
+            local p = path.join(src, name)
+            if os.isdir(p) or os.isfile(p) then
+                os.mv(p, path.join(dir, name))
+            end
+        end
+    else
+        os.mv(src, dir)
+    end
+
+    -- Assert the payload is what the `programs` list promises. A silently
+    -- half-extracted archive would otherwise register shims for binaries that
+    -- do not exist, and the failure would surface much later as "command not
+    -- found" with no hint about which package is at fault.
+    local exe = is_host("windows") and ".exe" or ""
+    for _, prog in ipairs({"slangc", "slangd"}) do
+        if not os.isfile(path.join(dir, "bin", prog .. exe)) then
+            raise("slang payload is missing bin/" .. prog .. exe)
+        end
+    end
+
+    return true
+end
+
+function config()
+    local bindir = path.join(pkginfo.install_dir(), "bin")
+    xvm.add("slangc", { bindir = bindir })
+    xvm.add("slangd", { bindir = bindir })
+    xvm.add("slangi", { bindir = bindir })
+    xvm.add("slang",  { bindir = bindir })
+    return true
+end
+
+function uninstall()
+    xvm.remove("slangc")
+    xvm.remove("slangd")
+    xvm.remove("slangi")
+    xvm.remove("slang")
+    return true
+end

--- a/tests/s/test_slang.py
+++ b/tests/s/test_slang.py
@@ -1,0 +1,153 @@
+"""测试 slang 包"""
+import re
+import pytest
+from tests.lib.xpkg_parser import parse_xpkg
+from tests.lib.assertions import (
+    assert_required_fields, assert_valid_spec, assert_valid_type,
+    assert_no_typos, assert_no_exec_xvm, assert_no_bashrc_modification,
+    assert_no_direct_path_modification, assert_uses_new_api,
+    assert_no_direct_pkg_manager, assert_platform_supported,
+    assert_xim_add_succeeds, assert_install_succeeds,
+    assert_command_output, assert_xvm_registered,
+)
+from tests.lib.platform_utils import skip_if_not
+
+PKG = "slang"
+PKG_FILE = "pkgs/s/slang.lua"
+VERSION = "2026.14.1"
+
+# 每个平台的资源 URL 都由 platform-scope `source` 模板展开。三平台各有一处
+# 不规则，所以三个模板都要断言，而不是只测宿主平台那一个：
+#   * release tag 带 v 前缀（v2026.14.1），文件名不带；
+#   * xlings 把 macOS 拼作 macosx，上游拼作 macos；
+#   * ${ext} 在 windows 上是 zip，其余是 tar.gz —— 与上游一致。
+EXPECTED_SOURCES = {
+    "linux":   "slang-${version}-linux-${arch}.${ext}",
+    "macosx":  "slang-${version}-macos-${arch}.${ext}",
+    "windows": "slang-${version}-windows-${arch}.${ext}",
+}
+
+EXPECTED_ARCHES = ("x86_64", "aarch64")
+
+
+@pytest.fixture(scope='module')
+def meta():
+    return parse_xpkg(PKG_FILE)
+
+
+@pytest.fixture(scope='module')
+def content(meta):
+    return meta.raw_content
+
+
+class TestStatic:
+    @pytest.mark.static
+    def test_required_fields(self, meta):
+        assert_required_fields(meta)
+
+    @pytest.mark.static
+    def test_valid_spec(self, meta):
+        assert_valid_spec(meta)
+
+    @pytest.mark.static
+    def test_valid_type(self, meta):
+        assert_valid_type(meta)
+
+    @pytest.mark.static
+    def test_no_typos(self):
+        assert_no_typos(PKG_FILE)
+
+    @pytest.mark.static
+    @pytest.mark.parametrize("platform", sorted(EXPECTED_SOURCES))
+    def test_platform_supported(self, meta, platform):
+        assert_platform_supported(meta, platform)
+
+    @pytest.mark.static
+    def test_programs_declared(self, meta):
+        # xvm 为这四个名字注册 shim；programs 与 config() 必须一致，
+        # 否则装完会出现「注册了但不存在」或「存在但没 shim」。
+        assert set(meta.programs) == {"slangc", "slangd", "slangi", "slang"}
+
+
+class TestResources:
+    @pytest.mark.static
+    @pytest.mark.parametrize("platform", sorted(EXPECTED_SOURCES))
+    def test_platform_source_template(self, content, platform):
+        assert EXPECTED_SOURCES[platform] in content, (
+            f"{platform} 的 source 模板缺失或不匹配: {EXPECTED_SOURCES[platform]}"
+        )
+
+    @pytest.mark.static
+    def test_per_arch_sha256(self, content):
+        # spec=2 要求每个架构都有校验和：缺一个就是 fail-closed 的安装失败，
+        # 而不是静默装上另一个架构的二进制（正是 V2 要消灭的 V1 缺陷）。
+        digests = re.findall(r'(x86_64|aarch64)\s*=\s*"([0-9a-f]{64})"', content)
+        assert len(digests) == len(EXPECTED_SOURCES) * len(EXPECTED_ARCHES), (
+            f"期望 {len(EXPECTED_SOURCES) * len(EXPECTED_ARCHES)} 个 per-arch 摘要，"
+            f"实得 {len(digests)}"
+        )
+        for arch in EXPECTED_ARCHES:
+            got = [d for a, d in digests if a == arch]
+            assert len(got) == len(EXPECTED_SOURCES), f"{arch} 缺少某个平台的摘要"
+            assert len(set(got)) == len(got), (
+                f"{arch} 在不同平台上出现了重复摘要——多半是复制粘贴错误"
+            )
+
+    @pytest.mark.static
+    def test_latest_ref(self, content):
+        refs = re.findall(r'\["latest"\]\s*=\s*\{\s*ref\s*=\s*"([^"]+)"\s*\}', content)
+        assert len(refs) == len(EXPECTED_SOURCES), "每个平台都要有 latest -> 具体版本"
+        assert set(refs) == {VERSION}
+
+
+class TestIndex:
+    @pytest.mark.index
+    def test_xim_add(self):
+        assert_xim_add_succeeds(PKG_FILE)
+
+
+class TestIsolation:
+    @pytest.mark.isolation
+    def test_no_exec_xvm(self):
+        assert_no_exec_xvm(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_no_bashrc(self):
+        assert_no_bashrc_modification(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_no_path_modification(self):
+        assert_no_direct_path_modification(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_new_api(self):
+        assert_uses_new_api(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_no_direct_pkg_manager(self):
+        assert_no_direct_pkg_manager(PKG_FILE)
+
+
+class TestLifecycle:
+    @pytest.mark.lifecycle
+    @skip_if_not('linux')
+    def test_install(self):
+        # 上游 Linux 归档约 77 MiB，默认 180s 在慢网络上不够。
+        assert_install_succeeds(PKG, timeout=600)
+
+
+class TestVerify:
+    @pytest.mark.verify
+    @skip_if_not('linux')
+    def test_slangc(self):
+        assert_command_output("slangc -v", regex=re.escape(VERSION))
+
+    @pytest.mark.verify
+    @skip_if_not('linux')
+    def test_xvm_slangc(self):
+        assert_xvm_registered("slangc")
+
+    @pytest.mark.verify
+    @skip_if_not('linux')
+    def test_xvm_slangd(self):
+        assert_xvm_registered("slangd")


### PR DESCRIPTION
## 包用途

[Slang](https://github.com/shader-slang/slang) 是 Khronos 托管的着色语言与编译器，把 HLSL 风格源码编译到 SPIR-V / DXIL / Metal / WGSL。任何用 `.slang` 写 shader 的 Vulkan 项目在**资产生成期**都需要 `slangc`。

直接动机：给 [xrgui](https://github.com/Sunrisepeak/xrgui) 做 mcpp 适配时发现，它的 shader 管线依赖 `slangc`，而目前索引里没有 —— 上游 CI 只能手写一段「打 GitHub API 取 latest tag → 下 zip → 解压 → 塞 PATH」的脚本，且只覆盖 Windows。装成 xpkg 之后这段脚本可以整体删掉，四个平台统一 `xlings install slang -y`。

## 平台与架构

六个归档全部来自上游 release，逐个下载并计算了 SHA256：

| 平台 | 架构 | 归档 |
|---|---|---|
| linux | x86_64 / aarch64 | `slang-2026.14.1-linux-<arch>.tar.gz` |
| macosx | x86_64 / aarch64 | `slang-2026.14.1-macos-<arch>.tar.gz` |
| windows | x86_64 / aarch64 | `slang-2026.14.1-windows-<arch>.zip` |

资源来源：上游 `https://github.com/shader-slang/slang/releases/download/v2026.14.1/`，无镜像 release/tag（未走 xlings-res）。

## 三处命名不规则

用 platform-scope `source` 覆写处理，而不是 `arch_alias`：

- release **tag** 带 `v` 前缀（`v2026.14.1`），**文件名**不带（`slang-2026.14.1-…`）；
- xlings 把 macOS 拼作 `macosx`，上游拼作 `macos`；
- `${ext}` 本身就在 windows 上解析为 `zip`、其余为 `tar.gz` —— 与上游发布方式恰好一致，不需要额外处理。

## 归档是扁平的

上游归档解压后是 `bin/` `include/` `lib/` `share/` `LICENSE` 直接在顶层，**没有** `slang-<ver>-<os>-<arch>/` 包裹目录，所以 `os.mv(<归档 basename>, install_dir)` 这个惯用法找不到东西（与 `patchelf.lua` 撞到的是同一堵墙）。

这里没有走「镜像一份重新打包的 tarball」那条路，而是**按内容**定位 payload 根目录 —— 以 `bin/slangc` 为标记，同时覆盖扁平与带包裹目录两种形态。上游哪天加了包裹目录，这份配方不用改。

`install()` 另外断言 `bin/slangc` 与 `bin/slangd` 确实存在：半解压的归档否则会注册一堆指向不存在文件的 shim，报错要等到很久以后的「command not found」，且不会指向是哪个包的问题。

## install / config / uninstall 对用户环境的影响

- `install()` 只写 `pkginfo.install_dir()`；
- `config()` 用 `xvm.add` 注册 4 个 shim（`slangc` / `slangd` / `slangi` / `slang`），与 `programs` 声明一一对应；
- `uninstall()` 逐个 `xvm.remove`；
- 不碰 bashrc、不改 PATH、不调 `os.exec("xvm ...")`。

Linux 侧声明了 `xim:glibc@>=2.38` 与 `xim:gcc-runtime@>=13`：归档是动态链接的，声明 glibc 会把 PT_INTERP 移进 xlings 沙箱，移进去之后就没有 host 回退，所以 gcc-runtime 不是可选附加项而是闭包的其余部分。

## 验证

静态与隔离检查：

```
$ pytest tests/s/test_slang.py -m "static or isolation"
18 passed
```

按 `docs/contributing.md` §4 用隔离 home 跑了完整安装：

```
$ export XLINGS_HOME="$(mktemp -d)"
$ xlings update && xlings config --add-xpkg pkgs/s/slang.lua
$ xlings install slang -y
  ✓ 3 package(s) installed
$ .../data/xpkgs/local-x-slang/2026.14.1/bin/slangc -v
2026.14.1
```

这一轮还抓到了一个真 bug：初版 `install()` 用了 `os.exists`，而它在配方沙箱里是 nil（`spirv-tools.lua` 的注释里已记过这件事），已改用 `os.isdir` / `os.isfile`。

## 未做

- 未发 xlings-res 镜像，因此 `source` 直指上游 GitHub，没有 CN 镜像。若需要我可以补一个 `xlings-res/slang` 的镜像 release 再改成 source map。
- 未声明 `ci = { mirror = true, update = true }` —— 等镜像就位再开更合适。
- macOS 与 Windows 的安装只做了静态校验，没有在真机上跑过（手头只有 Linux x86_64）。