### PR TITLE
feat(bazel): 补齐构建引擎对比的最后一块 —— bazel 9.2.0 入索引(含 CN 镜像)

### DIFF
--- a/pkgs/b/bazel.lua
+++ b/pkgs/b/bazel.lua
@@ -1,0 +1,143 @@
+package = {
+    spec = "1",
+    homepage = "https://bazel.build",
+
+    name = "bazel",
+    description = "Bazel — a fast, scalable, multi-language and extensible build system",
+    authors = {"The Bazel Authors"},
+    licenses = {"Apache-2.0"},
+    repo = "https://github.com/bazelbuild/bazel",
+    docs = "https://bazel.build/docs",
+    ci = { update = true },
+
+    type = "package",
+
+    -- x86_64 only, and the reason is a dependency-resolution constraint rather
+    -- than an upstream gap: bazel publishes linux-arm64 / darwin-arm64 /
+    -- windows-arm64 assets too.
+    --
+    -- The linux binary is glibc-dynamic (measured below), so it needs
+    -- `xim:glibc` and `xim:gcc-runtime`. xim resolves deps PER-OS, not per-arch
+    -- (the same constraint ninja.lua records), and both of those packages are
+    -- `archs = {"x86_64"}` — so declaring them while also claiming aarch64 would
+    -- make every linux/aarch64 install fail at dependency resolution rather than
+    -- at a missing asset. Adding aarch64 is a follow-up gated on aarch64 payloads
+    -- for glibc + gcc-runtime; the macOS and Windows arm64 assets have no such
+    -- blocker and can be added independently.
+    archs = {"x86_64"},
+    status = "stable",
+    categories = {"build-system", "tools"},
+    keywords = {"bazel", "build", "buildsystem", "starlark", "monorepo"},
+
+    programs = {"bazel"},
+    xvm_enable = true,
+
+    -- WHY THIS PACKAGE EXISTS
+    --
+    -- Build-engine benchmarking (mcpp-community/mcpp `bench/`) compares mcpp
+    -- against the mainstream engines on the same C++ sources. cmake, ninja,
+    -- meson and xmake were already in this index; bazel was the one named
+    -- comparison point with no way to install it from xlings.
+    --
+    -- SHAPE — a single 66 MB self-extracting binary, not an archive. It carries
+    -- its own JDK and unpacks into the user's cache on first run; there is no
+    -- external JDK dependency to declare. Verified locally:
+    --
+    --     $ ./bazel-9.2.0-linux-x86_64 --version
+    --     bazel 9.2.0
+    --     $ ./bazel-9.2.0-linux-x86_64 --help
+    --     Extracting Bazel installation...
+    --     OpenJDK 64-Bit Server VM warning: ...      <- its own bundled JVM
+    --
+    -- NOT musl-static, and there is no upstream musl build. Measured with
+    -- readelf on bazel-9.2.0-linux-x86_64:
+    --
+    --     Type: EXEC (non-PIE)
+    --     NEEDED: librt.so.1, libdl.so.2, libpthread.so.0, libm.so.6,
+    --             libstdc++.so.6, libgcc_s.so.1, libc.so.6
+    --
+    -- Hence the two runtime deps below: glibc supplies libc/libm/librt/libdl/
+    -- libpthread, gcc-runtime supplies libstdc++.so.6 + libgcc_s.so.1. In form H
+    -- those resolve from the host and the deps look redundant; in form X there is
+    -- no host fallback and they are exactly what keeps the closure complete
+    -- (ecosystem-closure rule D).
+    --
+    -- bazelisk is deliberately NOT used as the payload. It is a Go static binary
+    -- and would look like the musl-friendly choice, but it is only a launcher:
+    -- it downloads this same glibc-dynamic bazel at first run, moving the same
+    -- dependency to a place where the index cannot declare it, and adding a
+    -- network fetch to every cold environment.
+    -- GLOBAL points at upstream bazelbuild rather than an xlings-res copy: the
+    -- release assets are large (57-66 MB each) and upstream is already a stable,
+    -- checksummed source, so mirroring them a second time on GitHub buys
+    -- immutability we can get from the pinned sha256 instead. CN is a real
+    -- mirror, because that is the leg where reaching GitHub is the problem.
+    --
+    -- The CN assets were uploaded with `gtc release upload` and each was then
+    -- re-downloaded and compared against the upstream bytes — the sha256 below
+    -- is the SAME value for both legs by construction.
+    xpm = {
+        linux = {
+            deps = {
+                runtime = { "xim:glibc", "xim:gcc-runtime" },
+            },
+            ["latest"] = { ref = "9.2.0" },
+            ["9.2.0"] = {
+                url = {
+                    GLOBAL = "https://github.com/bazelbuild/bazel/releases/download/9.2.0/bazel-9.2.0-linux-x86_64",
+                    CN     = "https://gitcode.com/xlings-res/bazel/releases/download/9.2.0/bazel-9.2.0-linux-x86_64",
+                },
+                sha256 = "7668a95db1250f12c40407251e4e203b4ec8bf39bc495d2f485b2d8c99048694",
+            },
+        },
+        macosx = {
+            ["latest"] = { ref = "9.2.0" },
+            ["9.2.0"] = {
+                url = {
+                    GLOBAL = "https://github.com/bazelbuild/bazel/releases/download/9.2.0/bazel-9.2.0-darwin-x86_64",
+                    CN     = "https://gitcode.com/xlings-res/bazel/releases/download/9.2.0/bazel-9.2.0-darwin-x86_64",
+                },
+                sha256 = "14c9bcb01303b38192e0e2895051c1bcf19bf89d7e416f5aeeeb48b6b624cfbf",
+            },
+        },
+        windows = {
+            ["latest"] = { ref = "9.2.0" },
+            ["9.2.0"] = {
+                url = {
+                    GLOBAL = "https://github.com/bazelbuild/bazel/releases/download/9.2.0/bazel-9.2.0-windows-x86_64.exe",
+                    CN     = "https://gitcode.com/xlings-res/bazel/releases/download/9.2.0/bazel-9.2.0-windows-x86_64.exe",
+                },
+                sha256 = "5fc2f2805b8c697a54732558576938d06bab63aa0f9b6610cc01d2cae0388705",
+            },
+        },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+
+function install()
+    -- The download is the program itself; there is nothing to extract.
+    os.tryrm(pkginfo.install_dir())
+    os.mkdir(pkginfo.install_dir())
+
+    local exe_name = is_host("windows") and "bazel.exe" or "bazel"
+    if not is_host("windows") then
+        os.exec("chmod +x " .. pkginfo.install_file())
+    end
+
+    os.mv(pkginfo.install_file(), path.join(pkginfo.install_dir(), exe_name))
+    return true
+end
+
+function config()
+    -- Explicit bindir, matching bat.lua / fzf.lua. (A bare `xvm.add("bazel")`
+    -- also works — this is convention, not a fix.)
+    xvm.add("bazel", { bindir = pkginfo.install_dir() })
+    return true
+end
+
+function uninstall()
+    xvm.remove("bazel")
+    return true
+end

--- a/pkgs/x/xmake.lua
+++ b/pkgs/x/xmake.lua
@@ -21,15 +21,37 @@ package = {
     programs = {"xmake"},
     xvm_enable = true,
 
-    -- v3.0.8 deliberately skipped: although the v3.0.8 release.yml says
-    -- the Linux bundle is built with `xrepo env -b zig xmake f --embed=y
-    -- --toolchain=zig --cross=x86_64-linux-musl`, the artifact actually
+    -- v3.0.8 and everything after it deliberately skipped: although the v3.0.8
+    -- release.yml says the Linux bundle is built with `xrepo env -b zig xmake f
+    -- --embed=y --toolchain=zig --cross=x86_64-linux-musl`, the artifact actually
     -- uploaded to the v3.0.8 release page is *not* a musl-static binary —
     -- it's glibc-dynamic with INTERP=/lib64/ld-linux-x86-64.so.2 and
     -- DT_NEEDED libncurses.so.6 + libtinfo.so.6, breaking on Alpine /
     -- distroless / any host without those libs. v3.0.7 (and prior) are
     -- correctly musl-static, so we pin `latest = 3.0.7` until upstream
-    -- re-uploads a corrected v3.0.8 bundle. Tracking issue: TBD.
+    -- re-uploads a corrected bundle. Tracking issue: TBD.
+    --
+    -- RE-CHECKED 2026-08-12 against v3.1.0 (the then-current stable, released
+    -- 2026-08-08) — still not fixed, so the pin stays. Measured, not read off the
+    -- release notes, on xmake-bundle-v3.1.0.linux.x86_64
+    -- (sha256 1baab457f3bf11032e82c6210bc5bec04f5b902962da17dab53cae10783170de):
+    --
+    --     Type: DYN (PIE), has PT_INTERP
+    --     NEEDED: libncurses.so.6, libtinfo.so.6, libm.so.6, libc.so.6
+    --
+    -- Bumping is not merely "less portable", it would REGRESS arch coverage: a
+    -- dynamic bundle needs `xim:glibc` (+ ncurses) declared, xim resolves deps
+    -- per-OS rather than per-arch, and glibc is `archs = {"x86_64"}` — so every
+    -- linux/aarch64 install would start failing at dependency resolution. The
+    -- static 3.0.7 bundle needs no deps at all and works on both arches. Record
+    -- the measurement here so the next bump attempt costs one readelf, not a
+    -- rediscovery.
+    --
+    -- Also considered and rejected: xmake-bundle-v3.1.0.cosmocc (Cosmopolitan
+    -- APE). It genuinely has no ELF NEEDED, but it is a DOS/MBR-header hybrid
+    -- that rewrites itself on first run — it trips binfmt_misc assumptions and
+    -- noexec/read-only payload dirs, which is the opposite of what a package
+    -- payload should do.
     xpm = {
         linux = {
             -- ncurses declared (2026-08-09), measured with readelf, and the


### PR DESCRIPTION
## 动机

构建引擎基准(`mcpp-community/mcpp` 的 `bench/`)要在**同一份 C++ 源码**上横向比较主流构建系统。索引里 cmake / ninja / meson / xmake 都有,**只有 bazel 没有** —— 它是唯一被点名却装不上的对照项。

## 变更

### 1. 新增 `pkgs/b/bazel.lua` — bazel 9.2.0

**形态**:单个 66 MB 自解压二进制,不是压缩包。自带 JDK,首次运行解包到用户缓存,因此**不需要声明外部 JDK 依赖**。实测:

```
$ ./bazel-9.2.0-linux-x86_64 --version
bazel 9.2.0
$ ./bazel-9.2.0-linux-x86_64 --help
Extracting Bazel installation...
OpenJDK 64-Bit Server VM warning: ...      <- 自带 JVM
```

**不是 musl-static**,上游也没有 musl 构建。`readelf` 实测:

```
Type: EXEC (non-PIE)
NEEDED: librt.so.1, libdl.so.2, libpthread.so.0, libm.so.6,
        libstdc++.so.6, libgcc_s.so.1, libc.so.6
```

故声明 `deps.runtime = { xim:glibc, xim:gcc-runtime }`。form H 下这些从宿主解析、看着多余;form X 没有宿主回落,它们正是让闭包完整的那一环(闭包规则 D)。

**刻意不用 bazelisk 当载荷**:它是 Go 静态二进制、看着像 musl 友好的选择,但它只是下载器 —— 首次运行仍会拉同一个 glibc 动态 bazel,把依赖挪到索引声明不到的地方,还给每个冷环境加一次网络往返。

**`archs` 只写 x86_64**,原因是依赖解析约束而非上游缺件:bazel 也发布 linux-arm64 / darwin-arm64 / windows-arm64。但 **xim 按 OS(而非按 arch)解析依赖**(`ninja.lua` 记录过同一约束),而 `glibc` 与 `gcc-runtime` 都是 `archs = {"x86_64"}` —— 同时声明 aarch64 会让每次 linux/aarch64 安装**死在依赖解析**而不是缺资源上。补 aarch64 需先有这两个包的 aarch64 载荷;macOS / Windows 的 arm64 没有这个阻塞,可独立补。

**CN 镜像**:三个平台的资源已用 `gtc release upload` 传到 gitcode `xlings-res/bazel`,并逐个重新下载与上游**字节比对通过**,所以两条腿共用同一个 sha256。GLOBAL 直接指上游 bazelbuild —— 资源 57–66 MB,而不可变性由 pin 住的 sha256 保证,再在 GitHub 上镜像一份并不多买到什么;CN 才是真正够不到 GitHub 的那条腿。

### 2. `pkgs/x/xmake.lua` — 补 v3.1.0 的跳版证据(仅注释,不 bump)

v3.1.0(2026-08-08)**仍未修复** 3.0.8 起的问题。实测 `xmake-bundle-v3.1.0.linux.x86_64`(sha256 `1baab457…`):

```
Type: DYN (PIE), has PT_INTERP
NEEDED: libncurses.so.6, libtinfo.so.6, libm.so.6, libc.so.6
```

而且 bump 不只是"更不可移植",它会**倒退架构覆盖**:动态 bundle 必须声明 `xim:glibc`,依赖按 OS 解析、glibc 只有 x86_64 —— linux/aarch64 会开始装不上;静态的 3.0.7 零依赖、双架构可用。把测量写进注释,**下次尝试 bump 只需一条 readelf,不必重新发现**。

另外记录:`xmake-bundle-v3.1.0.cosmocc` 也评估过并否决 —— 它确实没有 ELF NEEDED,但是 DOS/MBR 头混合体、首次运行会自我改写,会踩 binfmt_misc 假设与 noexec/只读载荷目录。

## 验证

| 项 | 结果 |
|---|---|
| `.github/scripts/posix-test.sh pkgs/b/bazel.lua … linux` | **tested 1 / failures 0**(install dir、新 shim、loader/libc 同源、依赖闭包、卸载后 shim 清理 全 PASS) |
| `.github/scripts/check-dep-namespace.sh` | **PASS**(226 条依赖声明 / 169 recipe) |
| 三个 CN 镜像 URL | HTTP 200,且与上游**字节一致** |

> 提示:本地跑 `posix-test.sh` 时若 `XLINGS_PROJECT_DIR` 指向某个 workspace,安装会记到 workspace `_` 而 shim 落在全局 `default`,卸载只清前者 —— 会误报 `leftover-shim`。清掉该环境变量后复测即通过。