### PR TITLE
feat(node): track 24.19.0/26.7.0 and give every version a CN mirror

### DIFF
--- a/pkgs/n/node.lua
+++ b/pkgs/n/node.lua
@@ -1,23 +1,146 @@
+-- SHA256 for every asset this recipe can hand out, transcribed from the
+-- upstream https://nodejs.org/dist/v<ver>/SHASUMS256.txt.
+--
+-- These are what make the CN mirror below safe to use. GLOBAL and CN are only
+-- interchangeable if they carry identical bytes, and a checksum is the only
+-- thing that proves it at install time: a CN copy that ever diverges from
+-- nodejs.org fails the install loudly instead of installing a different node.
+-- Every version listed in `xpm` must appear here (windows-only keys are absent
+-- for versions no windows section lists; 18.20.8 has no win-arm64 build at all).
+local _sha256 = {
+    ["26.7.0"] = {
+        linux_x64     = "982aa24dd8be4c889c6a8ab337ddff3b0896645b20f4239356e80552c16277ee",
+        linux_arm64   = "afc7a004018485092ac8985b817b0d5684472bd9472e0b57d2ab88737e50090d",
+        darwin_x64    = "f279d1ed28ce57f7788bf23435d2ad7fdd7438904ad5c4d8a1081a7cde3d4b96",
+        darwin_arm64  = "7ee659a7768e641bbfd5360940660b8e8fd0052f77488f365562bac522fc15d4",
+        win_x64       = "d3bd72755141ed32bbcd841228ee81897c8a98d50dfa7dae2179399a0a7c90f8",
+        win_arm64     = "be8775204cfceca5a73c30f91bf0de5e85274c01b776dc13f16b91aa251ebb01",
+    },
+    ["25.9.0"] = {
+        linux_x64     = "1d8db7d6e291d167e8c467ae4094be175e1a0b3969c7ae1f8955b9f7824f7b2e",
+        linux_arm64   = "bf007bf0dcc2fddd90888fde374a1ad33c1ab2ca2ad324c645dd7aed0f9f1460",
+        darwin_x64    = "7d737b53ce191142bfa1c17cfa5b070d96e84eebf76b8dd06d84981cbdc3f7e3",
+        darwin_arm64  = "e479f3c469d3d9303a44f00a8ea37a3788395d171bb8059c48a4bbbd2e371b59",
+        win_x64       = "929552b8305effac843ba7b4270c437aefb702fc3fbd73fcd1bffd35d4ac284e",
+        win_arm64     = "6b499bcaf16c86fe1a98c8e2874fd1980b23b5c90ea412983db4392d7e08c36b",
+    },
+    ["24.19.0"] = {
+        linux_x64     = "14b342e71204f811bde6153be8e04b62aef63c236fef92b55f9c83154b409647",
+        linux_arm64   = "01443c1e1a29e531ccad5a46fefa6df490d2189c49f7955904aecdbb0fe86fdc",
+        darwin_x64    = "d1b5e999db158c62fe8f7267a4476b035d8bd93b1a605bac24a3f0dd166e3316",
+        darwin_arm64  = "8294b7aa9b03997481c06babf1e8b270c859358f27da57a11509afe537ac381d",
+        win_x64       = "57f71ab3652e797d84acddc79c81cc9ff1c6ddb2a1974cdb83f00fee9bff4c73",
+        win_arm64     = "8502f4a50b458d4cc38ed8f2001556c2cd239d464920f74017926ccb1e1c157f",
+    },
+    ["24.15.0"] = {
+        linux_x64     = "472655581fb851559730c48763e0c9d3bc25975c59d518003fc0849d3e4ba0f6",
+        linux_arm64   = "f3d5a797b5d210ce8e2cb265544c8e482eaedcb8aa409a8b46da7e8595d0dda0",
+        darwin_x64    = "ffd5ee293467927f3ee731a553eb88fd1f48cf74eebc2d74a6babe4af228673b",
+        darwin_arm64  = "372331b969779ab5d15b949884fc6eaf88d5afe87bde8ba881d6400b9100ffc4",
+        win_x64       = "cc5149eabd53779ce1e7bdc5401643622d0c7e6800ade18928a767e940bb0e62",
+        win_arm64     = "c9eb7402eda26e2ba7e44b6727fc85a8de56c5095b1f71ebd3062892211aa116",
+    },
+    ["24.4.1"] = {
+        linux_x64     = "7e067b13cd0dc7ee8b239f4ebe1ae54f3bba3a6e904553fcb5f581530eb8306d",
+        linux_arm64   = "555659c36fc72d0617e278b5d26ffcaebc3760a3de354926b1e5f1b0bfd66083",
+        darwin_x64    = "59fbad953a0705e78d220079fb6d10d341d0a61afd3aeb4db2a87207fddd8944",
+        darwin_arm64  = "55a772a600b7bdafb4b35945b3935090e27aff9934b4c11b281220fcd99139d7",
+        win_x64       = "0428a6ca7544df310de4ed12c10e84c0bc7c9022945dc16de22f7c0dc4893dd2",
+        win_arm64     = "8cb993d89d13119f582c77a4c734be5bdfeee5557e6cfe850ea1a2f23fa94686",
+    },
+    ["23.11.0"] = {
+        linux_x64     = "fa9ae28d8796a6cfb7057397e1eea30ca1c61002b42b8897f354563a254e7cf5",
+        linux_arm64   = "85915f885fe7eab2be4a6e3de840cb83db4fc53749274d31383a0e1721a883c6",
+        darwin_x64    = "a5782655748d4602c1ee1ee62732e0a16d29d3e4faac844db395b0fbb1c9dab8",
+        darwin_arm64  = "635990b46610238e3c008cd01480c296e0c2bfe7ec59ea9a8cd789d5ac621bb0",
+    },
+    ["23.6.0"] = {
+        linux_x64     = "90e3c96e2464978e8309db2e8bb7c5c1b606f85afa80314195f01c30eccf4ffc",
+        linux_arm64   = "7554f6ed6171d0e25938978a67868cadb6eed6f0393ed72b6aaf8f1195028ec2",
+        darwin_x64    = "009f4b4955ddbebaad86e306ad4c65b568f06fd76d855e7fd617eb2748cd5f2d",
+        darwin_arm64  = "93e84485e41e7f35246e11329ea920ee5a8e7e12e90bfcea2f8205953c869bc2",
+        win_x64       = "9daeb5894273b820fb3bf2485aa433ff9653feb2c1a3daebd1a06b0e4fbe4309",
+        win_arm64     = "e553f0841582570875b667aaa0bd9b94c37e558c909cab9505a85db23f3a7c65",
+    },
+    ["22.17.1"] = {
+        linux_x64     = "ff04bc7c3ed7699ceb708dbaaf3580d899ff8bf67f17114f979e83aa74fc5a49",
+        linux_arm64   = "a5bb879af2fe70e7b5dc5e0bbadecba88e87f45bd8e62c0c57b5c815a4cbbaa6",
+        darwin_x64    = "b925103150fac0d23a44a45b2d88a01b73e5fff101e5dcfbae98d32c08d4bee3",
+        darwin_arm64  = "a983f4f2a7b71512b78d7935b9ccf6b72120a255810070afd635c4146bca7b31",
+        win_x64       = "b1fdb5635ba860f6bf71474f2ca882459a582de49b1d869451e3ad188e3943eb",
+        win_arm64     = "588d42c7c90eecf14ed4fc126a64cc70993e3a002f93e26be9c979cdc516b0d3",
+    },
+    ["22.14.0"] = {
+        linux_x64     = "69b09dba5c8dcb05c4e4273a4340db1005abeafe3927efda2bc5b249e80437ec",
+        linux_arm64   = "08bfbf538bad0e8cbb0269f0173cca28d705874a67a22f60b57d99dc99e30050",
+        darwin_x64    = "6698587713ab565a94a360e091df9f6d91c8fadda6d00f0cf6526e9b40bed250",
+        darwin_arm64  = "e9404633bc02a5162c5c573b1e2490f5fb44648345d64a958b17e325729a5e42",
+    },
+    ["22.12.0"] = {
+        linux_x64     = "22982235e1b71fa8850f82edd09cdae7e3f32df1764a9ec298c72d25ef2c164f",
+        linux_arm64   = "8cfd5a8b9afae5a2e0bd86b0148ca31d2589c0ea669c2d0b11c132e35d90ed68",
+        darwin_x64    = "52bc25dd026db7247c3c00439afdb83e95087248267f02d6c1a7250d1f896173",
+        darwin_arm64  = "293dcc6c2408da21562d135b0412525e381bb6fe150d688edb58fe850d0f3e13",
+        win_x64       = "2b8f2256382f97ad51e29ff71f702961af466c4616393f767455501e6aece9b8",
+        win_arm64     = "17401720af48976e3f67c41e8968a135fb49ca1f88103a92e0e8c70605763854",
+    },
+    ["20.19.0"] = {
+        linux_x64     = "b4e336584d62abefad31baecff7af167268be9bb7dd11f1297112e6eed3ca0d5",
+        linux_arm64   = "dbe339e55eb393955a213e6b872066880bb9feceaa494f4d44c7aac205ec2ab9",
+        darwin_x64    = "a8554af97d6491fdbdabe63d3a1cfb9571228d25a3ad9aed2df856facb131b20",
+        darwin_arm64  = "c016cd1975a264a29dc1b07c6fbe60d5df0a0c2beb4113c0450e3d998d1a0d9c",
+    },
+    ["18.20.8"] = {
+        linux_x64     = "5467ee62d6af1411d46b6a10e3fb5cacc92734dbcef465fea14e7b90993001c9",
+        linux_arm64   = "224e569dbe7b0ea4628ce383d9d482494b57ee040566583f1c54072c86d1116b",
+        darwin_x64    = "ed2554677188f4afc0d050ecd8bd56effb2572d6518f8da6d40321ede6698509",
+        darwin_arm64  = "bae4965d29d29bd32f96364eefbe3bca576a03e917ddbb70b9330d75f2cacd76",
+    },
+}
+
+-- One asset = one {GLOBAL, CN} mirror pair plus its checksum.
+--
+--   GLOBAL  https://nodejs.org/dist/v<ver>/<file>              (authoritative)
+--   CN      https://cdn.npmmirror.com/binaries/node/v<ver>/<file>
+--
+-- npmmirror is Alibaba's full rsync copy of the whole `nodejs.org/dist` tree --
+-- the host `nvm`/`fnm`/`nrm` already point NODEJS_ORG_MIRROR at in mainland
+-- China. Mirroring node into xlings-res the way most packages here do would
+-- mean re-hosting 2.45 GB of tarballs (64 assets across 12 versions) and then
+-- re-uploading on every bump, for a tree upstream already publishes a CN copy
+-- of. So CN points at npmmirror directly and every version -- not just the
+-- newest -- gets a CN path for free.
+local function _asset(ver, os_token, arch_token, ext)
+    local file = string.format("node-v%s-%s-%s.%s", ver, os_token, arch_token, ext)
+    return {
+        url = {
+            GLOBAL = "https://nodejs.org/dist/v" .. ver .. "/" .. file,
+            CN     = "https://cdn.npmmirror.com/binaries/node/v" .. ver .. "/" .. file,
+        },
+        sha256 = (_sha256[ver] or {})[os_token .. "_" .. arch_token],
+    }
+end
+
 -- V2 Scheme B per-arch builders: each returns a { x86_64 = {...}, aarch64 = {...} }
--- map so x86_64 AND aarch64 both resolve to the correct nodejs.org asset.
+-- map so x86_64 AND aarch64 both resolve to the correct asset.
 -- (V1 previously shipped only x64 on linux/windows and only darwin-arm64 on
 -- macOS, contradicting its own archs declaration.)
 local function _win_url(ver)
     return {
-        x86_64  = { url = string.format("https://nodejs.org/dist/v%s/node-v%s-win-x64.zip",   ver, ver) },
-        aarch64 = { url = string.format("https://nodejs.org/dist/v%s/node-v%s-win-arm64.zip", ver, ver) },
+        x86_64  = _asset(ver, "win", "x64",   "zip"),
+        aarch64 = _asset(ver, "win", "arm64", "zip"),
     }
 end
 local function _linux_url(ver)
     return {
-        x86_64  = { url = string.format("https://nodejs.org/dist/v%s/node-v%s-linux-x64.tar.xz",   ver, ver) },
-        aarch64 = { url = string.format("https://nodejs.org/dist/v%s/node-v%s-linux-arm64.tar.xz", ver, ver) },
+        x86_64  = _asset(ver, "linux", "x64",   "tar.xz"),
+        aarch64 = _asset(ver, "linux", "arm64", "tar.xz"),
     }
 end
 local function _mac_url(ver)
     return {
-        x86_64  = { url = string.format("https://nodejs.org/dist/v%s/node-v%s-darwin-x64.tar.gz",   ver, ver) },
-        aarch64 = { url = string.format("https://nodejs.org/dist/v%s/node-v%s-darwin-arm64.tar.gz", ver, ver) },
+        x86_64  = _asset(ver, "darwin", "x64",   "tar.gz"),
+        aarch64 = _asset(ver, "darwin", "arm64", "tar.gz"),
     }
 end
 
@@ -57,17 +180,23 @@ package = {
     categories = {"node", "javascript"},
 
     xpm = {
+        -- `latest` tracks the ACTIVE LTS line (24.x "Krypton"), not the newest
+        -- release: an unpinned `xlings install node` should get the line node
+        -- itself recommends for production. 26.x is Current until it enters LTS
+        -- in Oct 2026; it is listed so `node@26.7.0` resolves, but it is not the
+        -- default. Same rule the 24.15.0 bump followed.
         windows = {
-            ["latest"] = { ref = "24.15.0" },
+            ["latest"] = { ref = "24.19.0" },
+            ["26.7.0"] = _win_url("26.7.0"),
             ["25.9.0"] = _win_url("25.9.0"),
+            ["24.19.0"] = _win_url("24.19.0"),
             ["24.15.0"] = _win_url("24.15.0"),
             ["24.4.1"] = _win_url("24.4.1"),
             ["23.6.0"] = _win_url("23.6.0"),
             ["22.17.1"] = _win_url("22.17.1"),
-            ["22.12.0"] = {
-                url = "https://nodejs.org/dist/v22.12.0/node-v22.12.0-win-x64.zip",
-                sha256 = "2b8f2256382f97ad51e29ff71f702961af466c4616393f767455501e6aece9b8",
-            },
+            -- was a bare x86_64 url+sha256; the builder keeps that same asset
+            -- and hash and adds the win-arm64 half this version does publish.
+            ["22.12.0"] = _win_url("22.12.0"),
         },
         linux = {
             -- Runtime deps. The upstream node prebuilt is dynamically linked
@@ -84,24 +213,26 @@ package = {
             deps = {
                 runtime = { "xim:glibc@>=2.39", "xim:gcc-runtime@15.1.0" },
             },
-            ["latest"] = { ref = "24.15.0" },
+            ["latest"] = { ref = "24.19.0" },
+            ["26.7.0"] = _linux_url("26.7.0"),
             ["25.9.0"] = _linux_url("25.9.0"),
+            ["24.19.0"] = _linux_url("24.19.0"),
             ["24.15.0"] = _linux_url("24.15.0"),
             ["24.4.1"] = _linux_url("24.4.1"),
             ["23.11.0"] = _linux_url("23.11.0"),
             ["23.6.0"] = _linux_url("23.6.0"),
             ["22.17.1"] = _linux_url("22.17.1"),
             ["22.14.0"] = _linux_url("22.14.0"),
-            ["22.12.0"] = {
-                url = "https://nodejs.org/dist/v22.12.0/node-v22.12.0-linux-x64.tar.xz",
-                sha256 = "22982235e1b71fa8850f82edd09cdae7e3f32df1764a9ec298c72d25ef2c164f",
-            },
+            -- see the windows note: same x86_64 asset + hash, plus linux-arm64.
+            ["22.12.0"] = _linux_url("22.12.0"),
             ["20.19.0"] = _linux_url("20.19.0"),
             ["18.20.8"] = _linux_url("18.20.8"),
         },
         macosx = {
-            ["latest"] = { ref = "24.15.0" },
+            ["latest"] = { ref = "24.19.0" },
+            ["26.7.0"] = _mac_url("26.7.0"),
             ["25.9.0"] = _mac_url("25.9.0"),
+            ["24.19.0"] = _mac_url("24.19.0"),
             ["24.15.0"] = _mac_url("24.15.0"),
             ["24.4.1"] = _mac_url("24.4.1"),
             ["23.11.0"] = _mac_url("23.11.0"),

--- a/tests/lua/node_resources_harness.lua
+++ b/tests/lua/node_resources_harness.lua
@@ -1,0 +1,52 @@
+-- Load a recipe as a plain Lua chunk and print every resource it RESOLVES.
+--
+-- node.lua builds its resources with `_asset()` rather than writing URLs out,
+-- so grepping the file cannot tell you what a version actually points at --
+-- only evaluating it can. `import()` is stubbed and no hook is called, so this
+-- reads exactly the `package` table the index would.
+--
+-- Output, one asset per line, tab separated:
+--     ASSET <platform> <version> <arch> <global-url> <cn-url> <sha256>
+-- plus one line per platform:
+--     LATEST <platform> <ref>
+-- Missing pieces are spelled NO-CN / NO-SHA / NOT-A-MIRROR-TABLE so the
+-- caller asserts on them instead of on a nil that vanished from the output.
+
+local recipe = ...
+assert(recipe, "usage: lua node_resources_harness.lua <recipe.lua>")
+
+local env = setmetatable({}, { __index = _G })
+env.import = function() return {} end
+assert(loadfile(recipe, "t", env))()
+
+local pkg = assert(env.package, "recipe defines no `package` table")
+local out = {}
+
+for _, platform in ipairs({ "linux", "macosx", "windows" }) do
+    local versions = pkg.xpm and pkg.xpm[platform]
+    if versions then
+        local latest = versions["latest"]
+        print(string.format("LATEST\t%s\t%s", platform,
+            (type(latest) == "table" and latest.ref) or "NO-LATEST"))
+
+        for version, entry in pairs(versions) do
+            -- skip `latest`/aliases (`{ref=...}`) and non-version keys (`deps`)
+            if type(entry) == "table" and entry.ref == nil and version:match("^%d") then
+                for _, arch in ipairs({ "x86_64", "aarch64" }) do
+                    local res = entry[arch]
+                    if res then
+                        local url, cn = res.url, "NOT-A-MIRROR-TABLE"
+                        if type(url) == "table" then
+                            cn, url = url.CN or "NO-CN", url.GLOBAL or "NO-GLOBAL"
+                        end
+                        out[#out + 1] = string.format("ASSET\t%s\t%s\t%s\t%s\t%s\t%s",
+                            platform, version, arch, url, cn, res.sha256 or "NO-SHA")
+                    end
+                end
+            end
+        end
+    end
+end
+
+table.sort(out)
+for _, line in ipairs(out) do print(line) end

--- a/tests/n/test_node.py
+++ b/tests/n/test_node.py
@@ -1,4 +1,21 @@
-"""测试 node 包"""
+"""测试 node 包
+
+node 的资源没有一条 URL 字面量: 每个资产由 `_asset()` 拼出一对
+`{GLOBAL = nodejs.org/dist, CN = cdn.npmmirror.com}` 再配上 `_sha256` 表里的
+per-arch 校验和。所以静态断言看两样东西 ——
+
+* 那个构造器是唯一的 URL 来源 (谁也没法绕过 CN 单写一个 GLOBAL);
+* `_sha256` 覆盖每一个被列出来的版本 (漏一个不会报错, 只会静默变成
+  `sha256 = nil`, 那样 CN 镜像就没有任何东西证明它和上游同字节)。
+
+再加一条真正求值配方的检查 (需要 lua, 没有就 skip, 同 tests/test_hostlib.py):
+逐架构解析出来的 URL/hash 必须成对齐全。
+"""
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
 import pytest
 from tests.lib.xpkg_parser import parse_xpkg
 from tests.lib.assertions import (
@@ -13,6 +30,52 @@ from tests.lib.platform_utils import skip_if_not
 PKG = "node"
 PKG_FILE = "pkgs/n/node.lua"
 
+REPO = Path(__file__).resolve().parent.parent.parent
+HARNESS = REPO / "tests" / "lua" / "node_resources_harness.lua"
+
+GLOBAL_HOST = "https://nodejs.org/dist"
+CN_HOST = "https://cdn.npmmirror.com/binaries/node"
+
+# builder -> (platform, the two `_sha256` keys that builder consumes)
+BUILDERS = {
+    "_win_url":   ("windows", ("win_x64", "win_arm64")),
+    "_linux_url": ("linux",   ("linux_x64", "linux_arm64")),
+    "_mac_url":   ("macosx",  ("darwin_x64", "darwin_arm64")),
+}
+
+
+def _code(content: str) -> str:
+    """去掉 lua 行注释 — 注释里也写了这些 host 和版本号"""
+    return "\n".join(
+        line for line in content.splitlines() if not line.lstrip().startswith("--")
+    )
+
+
+def _listed_versions(content: str) -> dict:
+    """{platform: {version, ...}}, 读的是 `["24.19.0"] = _linux_url("24.19.0")` 这种行"""
+    listed = {plat: set() for plat, _ in BUILDERS.values()}
+    for key, builder, arg in re.findall(
+            r'\["([^"]+)"\]\s*=\s*(_\w+_url)\("([^"]+)"\)', _code(content)):
+        assert key == arg, f"版本键 {key} 用的却是 {builder}({arg}) 的资源"
+        listed[BUILDERS[builder][0]].add(key)
+    return listed
+
+
+def _sha_table(content: str) -> dict:
+    """{version: {key: sha256}} — 解析 `local _sha256 = { ... }`"""
+    body = re.search(r'local _sha256 = \{\n(.*?)\n\}\n', content, re.S)
+    assert body, "找不到 _sha256 表"
+    table, current = {}, None
+    for line in body.group(1).splitlines():
+        head = re.match(r'\s*\["([^"]+)"\]\s*=\s*\{', line)
+        if head:
+            current = table.setdefault(head.group(1), {})
+            continue
+        entry = re.match(r'\s*(\w+)\s*=\s*"([0-9a-f]{64})",', line)
+        if entry and current is not None:
+            current[entry.group(1)] = entry.group(2)
+    return table
+
 
 @pytest.fixture(scope='module')
 def meta():
@@ -20,4 +83,142 @@ def meta():
 
 
 class TestStatic:
-    pass
+    @pytest.mark.static
+    def test_required_fields(self, meta):
+        assert_required_fields(meta)
+
+    @pytest.mark.static
+    def test_valid_spec(self, meta):
+        assert_valid_spec(meta)
+
+    @pytest.mark.static
+    def test_valid_type(self, meta):
+        assert_valid_type(meta)
+
+    @pytest.mark.static
+    def test_no_typos(self):
+        assert_no_typos(PKG_FILE)
+
+    @pytest.mark.static
+    def test_asset_builder_is_the_only_url_source(self, meta):
+        """两个 host 各只能出现一次, 都在 `_asset()` 里
+
+        写死一条 URL 的版本块会拿到 GLOBAL 而没有 CN, 国内用户就还是走
+        nodejs.org —— 而且这种块不会报错, 只是安静地少一个镜像。
+        """
+        code = _code(meta.raw_content)
+        assert code.count(GLOBAL_HOST) == 1, "GLOBAL URL 只应由 _asset() 拼出"
+        assert code.count(CN_HOST) == 1, "CN URL 只应由 _asset() 拼出"
+        builder = re.search(r'local function _asset\(.*?\nend\n', code, re.S)
+        assert builder, "找不到 _asset()"
+        assert GLOBAL_HOST in builder.group(0) and CN_HOST in builder.group(0), \
+            "两个 host 必须都在 _asset() 里, 才能保证每个资产成对"
+
+    @pytest.mark.static
+    def test_sha256_covers_every_listed_version(self, meta):
+        """每个列出来的版本, 在它那个平台需要的两个 arch 上都要有 hash
+
+        `_asset()` 查不到就返回 `sha256 = nil` —— 装得上, 但没有任何东西
+        保证 CN 那份和 nodejs.org 同字节。
+        """
+        shas = _sha_table(meta.raw_content)
+        missing = [
+            f"{plat}/{ver}/{key}"
+            for builder, (plat, keys) in BUILDERS.items()
+            for ver in _listed_versions(meta.raw_content)[plat]
+            for key in keys
+            if key not in shas.get(ver, {})
+        ]
+        assert not missing, f"缺少 sha256: {missing}"
+
+    @pytest.mark.static
+    def test_latest_agrees_across_platforms(self, meta):
+        """三个平台的 latest 必须指向同一个版本, 且那个版本在各自表里列着"""
+        refs = set(re.findall(r'\["latest"\]\s*=\s*\{\s*ref\s*=\s*"([^"]+)"\s*\}',
+                              _code(meta.raw_content)))
+        assert len(refs) == 1, f"latest 指向了多个版本: {sorted(refs)}"
+        ref = refs.pop()
+        for plat, versions in _listed_versions(meta.raw_content).items():
+            assert ref in versions, f"{plat} 的 latest -> {ref} 在该平台没有版本块"
+
+
+@pytest.mark.skipif(
+    shutil.which("lua5.4") is None and shutil.which("lua") is None,
+    reason="no lua interpreter on this machine",
+)
+@pytest.mark.static
+def test_every_resolved_asset_is_a_complete_mirror_pair():
+    """求值配方, 逐平台逐架构检查解析结果 (静态断言看不到 `_asset()` 的输出)"""
+    lua = shutil.which("lua5.4") or shutil.which("lua")
+    out = subprocess.run([lua, str(HARNESS), str(REPO / PKG_FILE)],
+                         capture_output=True, text=True, check=True).stdout
+
+    assets = [line.split("\t")[1:] for line in out.splitlines() if line.startswith("ASSET")]
+    listed = _listed_versions((REPO / PKG_FILE).read_text(encoding="utf-8"))
+    expected = sum(len(v) for v in listed.values()) * 2  # 每个版本两个 arch
+    assert len(assets) == expected, f"解析出 {len(assets)} 个资产, 期望 {expected}"
+
+    for platform, version, arch, global_url, cn_url, sha in assets:
+        where = f"{platform}/{version}/{arch}"
+        assert global_url.startswith(GLOBAL_HOST + "/v" + version + "/"), \
+            f"{where}: GLOBAL 不是 nodejs.org 上这个版本的目录 ({global_url})"
+        assert cn_url.startswith(CN_HOST + "/v" + version + "/"), \
+            f"{where}: 没有 CN 镜像 ({cn_url})"
+        assert cn_url.rsplit("/", 1)[1] == global_url.rsplit("/", 1)[1], \
+            f"{where}: CN 和 GLOBAL 指向不同文件名"
+        assert re.fullmatch(r"[0-9a-f]{64}", sha), f"{where}: sha256 缺失或不合法 ({sha})"
+
+    # 每个版本必须两个 arch 都在 —— archs 声明了 x86_64 + aarch64
+    per_version = {}
+    for platform, version, arch, *_ in assets:
+        per_version.setdefault((platform, version), set()).add(arch)
+    for key, arches in sorted(per_version.items()):
+        assert arches == {"x86_64", "aarch64"}, f"{key} 只解析出 {sorted(arches)}"
+
+
+class TestIndex:
+    @pytest.mark.index
+    def test_xim_add(self):
+        assert_xim_add_succeeds(PKG_FILE)
+
+
+class TestIsolation:
+    @pytest.mark.isolation
+    def test_no_exec_xvm(self):
+        assert_no_exec_xvm(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_no_bashrc(self):
+        assert_no_bashrc_modification(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_no_path_modification(self):
+        assert_no_direct_path_modification(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_new_api(self):
+        assert_uses_new_api(PKG_FILE)
+
+
+class TestLifecycle:
+    @pytest.mark.lifecycle
+    @skip_if_not('linux')
+    def test_install(self):
+        assert_install_succeeds(PKG)
+
+
+class TestVerify:
+    @pytest.mark.verify
+    @skip_if_not('linux')
+    def test_node_version(self):
+        assert_command_output("node --version", contains="v24.19.0")
+
+    @pytest.mark.verify
+    @skip_if_not('linux')
+    def test_npm_runs(self):
+        assert_command_output("npm --version", regex=r"^\d+\.\d+\.\d+")
+
+    @pytest.mark.verify
+    @skip_if_not('linux')
+    def test_xvm_node(self):
+        assert_xvm_registered("node")


### PR DESCRIPTION
`node` was the only widely-used runtime in this index with **no CN path at all** — every version, every arch resolved to `nodejs.org/dist`, the one host a mainland-China install cannot rely on. It was also four LTS patch releases behind (`latest -> 24.15.0`, released before 24.16…24.19) and carried no 26.x line.

Both land together because the mirror fix is what makes the version adds cheap.

## The mirror: npmmirror, not `xlings-res`

Every asset is now a `{GLOBAL, CN}` pair built by a single `_asset()` helper:

```
GLOBAL  https://nodejs.org/dist/v<ver>/<file>
CN      https://cdn.npmmirror.com/binaries/node/v<ver>/<file>
```

The usual route here is `gitcode.com/xlings-res/<pkg>`. Node is the case where that is the wrong shape. npmmirror is Alibaba's full rsync copy of the **whole** `dist` tree — the host `nvm`/`fnm`/`nrm` already point `NODEJS_ORG_MIRROR` at — so **all 12 listed versions get a CN path today**, and every future bump gets one for free with no publish step. Re-hosting under `xlings-res` would mean **2.45 GB** across 64 assets (measured, not estimated), re-uploaded on every bump, to duplicate a CN copy upstream already publishes. This is also why `node` sat in the mirror rollout's deferred pile for a year.

The tradeoff is that CN is now a third party, which is exactly what the next section pays for.

## SHA256 for all 64 assets

Recorded for every asset — 12 versions × the arches each platform publishes — transcribed from each version's `nodejs.org/dist/v<ver>/SHASUMS256.txt`. Before this PR only two version blocks carried a hash at all.

With a third-party mirror in the resolution path the checksum is not bookkeeping, it is the whole safety argument: `GLOBAL` and `CN` are interchangeable **only** if they carry identical bytes, and the hash is what proves it at install time. A CN copy that ever diverges fails the install loudly instead of quietly installing a different node.

## Versions

- **+24.19.0** — newest Active LTS ("Krypton"), all three platforms
- **+26.7.0** — newest Current, all three platforms
- `latest` **24.15.0 -> 24.19.0** on windows/linux/macosx

`latest` stays on the LTS line rather than jumping to 26.x — the same rule the 24.15.0 bump used. 26 is Current until it enters LTS in Oct 2026; it is listed so `node@26.7.0` resolves, without becoming the unpinned default.

Also folds the two hand-written `22.12.0` blocks (windows, linux) into the builders: same x86_64 asset, same hash, plus the `win-arm64` / `linux-arm64` halves that version does publish and that `archs = {x86_64, aarch64}` already promised.

## Tests

`tests/n/test_node.py` was `class TestStatic: pass` — node had no tests. It now covers what this change introduces (contributing §5: 资源表达变更必须覆盖 mirror 和 per-arch hash):

- `_asset()` is the **only** URL source — a hand-written version block would get `GLOBAL` and no `CN`, and nothing would complain;
- `_sha256` covers every listed version — a gap does not error, it degrades silently to `sha256 = nil`, i.e. an unverified mirror;
- a version key matches its builder's argument — `["24.19.0"] = _win_url("24.15.0")` is the shape a hurried bump produces;
- `latest` agrees across platforms and is listed on each;
- and, by **evaluating** the recipe through `tests/lua/node_resources_harness.lua`, that every resolved asset is a complete `GLOBAL` + `CN` + 64-hex-`sha256` triple on both arches. Static grep cannot check this — the file contains no URL literals.

Each assertion was mutation-checked against the regression it names (dropped hash, stale builder arg, unmirrored block) and confirmed to fail.

## Verified

- all 64 `GLOBAL` and 64 `CN` URLs live, `Content-Length` matching pairwise
- 5 assets downloaded **in full from npmmirror** and hashed to the upstream value: 26.7.0 linux-x64, 24.19.0 win-arm64 + darwin-x64, 22.12.0 linux-x64, 18.20.8 darwin-arm64
- recipe-resolved sha256 cross-checked against `SHASUMS256.txt` for all 64
- isolated `XLINGS_HOME`, linux x86_64: `local:node` → 24.19.0 installs, `node --version` `v24.19.0`, `npm --version` `11.17.0`, uninstall leaves no `node`/`npm`/`npx` shim
- **the CN leg is proved, not assumed**: with `xlings config --mirror CN` and `GLOBAL` rewritten to an unresolvable host, `local:node@25.9.0` still installed and ran (`v25.9.0`) — so the CN URL is genuinely what a CN home fetches, and those bytes passed the sha256 gate
- `pytest -m "static or isolation"`: 1735 passed, 9 skipped
- `version-check.py`, `check-no-direct-ld-libpath.sh`, `check-no-blocking-input.sh`, `check-dep-namespace.sh`: all PASS

`install()` / `config()` / `uninstall()` are unchanged and touch nothing outside the xpkg store and xvm registrations — no shell rc file, no `PATH` edit.

Not verifiable on this machine: `xvm info` prints no `Program:`/`Version:` fields for **any** package here, so `assert_xvm_registered` is left to CI.
