### PR TITLE
build-systems: xmake 追到 3.1.0、cmake 追到 4.4.2(均含 CN 镜像)

### DIFF
--- a/pkgs/c/cmake.lua
+++ b/pkgs/c/cmake.lua
@@ -20,24 +20,85 @@ package = {
     -- xvm: xlings version management
     xvm_enable = true,
 
+    -- Mirrored through the xlings-res resource service, so every version entry
+    -- below needs the SAME tag present on both legs before it can be referenced
+    -- here (xpkg-creater §1.2.1): github.com/xlings-res/cmake and
+    -- gitcode.com/xlings-res/cmake. Asset names follow the resource-service
+    -- convention `cmake-<ver>-<os>-<arch>.{tar.gz,zip}` (the installer appends
+    -- the host arch itself) plus a matching `.sha256` sidecar.
+    --
+    -- macosx-arm64 is upstream's `cmake-<ver>-macos-universal.tar.gz` REPACKED
+    -- so the top-level directory matches the asset name — install() derives the
+    -- extracted directory by stripping the extension off the download, so a
+    -- plain rename would leave it looking for a directory that isn't there.
+    -- linux-x86_64 and windows-x86_64 are upstream bytes verbatim.
+    --
+    -- No `ci = { update = true }` / `res_versioned = true` here: the auto-bump
+    -- path verifies mirrored assets but does not create them, so it would just
+    -- error on every upstream release until someone mirrors it by hand. That is
+    -- also why this recipe sat on 4.0.2 while upstream reached 4.4.2 — worth
+    -- automating (mirror-then-bump), but that is a tooling change, not a
+    -- recipe change.
     xpm = {
         linux = {
-            -- Runtime deps. cmake prebuilt is dynamically linked
-            -- (INTERP=/lib64/ld-linux-x86-64.so.2) and needs
-            -- libc/libdl/librt/libpthread/libm from glibc. No libstdc++
-            -- (statically linked into the binary).
+            -- Runtime deps, re-measured across the WHOLE 4.4.2 payload rather
+            -- than just bin/cmake (readelf on every ELF under bin/):
+            --
+            --   cmake, ctest, cpack, ccmake   libdl librt libpthread libm libc
+            --                                 + ld-linux  -> all glibc
+            --   cmake-gui                     the same, plus libxcb.so.1,
+            --                                 libfontconfig.so.1, libfreetype.so.6
+            --
+            -- No libstdc++ anywhere (statically linked in), and ccmake does NOT
+            -- need ncurses — also static.
+            --
+            -- The three GUI sonames are why fontconfig/freetype/libxcb are
+            -- declared even though most consumers only ever run `cmake`.
+            -- Because this recipe declares xim:glibc the payload gets our
+            -- loader, and behind our loader there is no host fallback — an
+            -- undeclared soname is simply not found (closure rules D1/D2).
+            -- Declaring them is also what puts their libdirs in this payload's
+            -- RPATH closure; a transitive dep would not.
+            --
+            -- bin/cmake's own floor is only GLIBC_2.17. The `>=2.39` below is
+            -- deliberately the index's glibc baseline (glibc.lua ships 2.39 and
+            -- 2.44), not the binary's requirement — don't "fix" it down to
+            -- 2.17, there is nothing older to resolve to.
             deps = {
-                runtime = { "xim:glibc@>=2.39" },
+                runtime = {
+                    "xim:glibc@>=2.39",
+                    "xim:fontconfig@>=2.15",
+                    "xim:freetype@>=2.13",
+                    "xim:libxcb@>=1.17",
+                },
             },
-            ["latest"] = { ref = "4.0.2" },
+            ["latest"] = { ref = "4.4.2" },
+            ["4.4.2"] = {
+                url = "XLINGS_RES",
+                sha256 = {
+                    x86_64 = "3ada9a3f5d8a85413579bdd0ea6aa8e8da86efdd6d15c91a1afa517f2021956c",
+                },
+            },
             ["4.0.2"] = "XLINGS_RES",
         },
         macosx = {
-            ["latest"] = { ref = "4.0.2" },
+            ["latest"] = { ref = "4.4.2" },
+            ["4.4.2"] = {
+                url = "XLINGS_RES",
+                sha256 = {
+                    aarch64 = "666abd8a375c61affdc68bdebfa2124aee9aa08cd795f7568aef4fcabb75f2db",
+                },
+            },
             ["4.0.2"] = "XLINGS_RES",
         },
         windows = {
-            ["latest"] = { ref = "4.0.2" },
+            ["latest"] = { ref = "4.4.2" },
+            ["4.4.2"] = {
+                url = "XLINGS_RES",
+                sha256 = {
+                    x86_64 = "e8139d85b3813bc38833142ae1940472e9a587e9b5d2718ac1804c60f4e57a64",
+                },
+            },
             ["4.0.2"] = "XLINGS_RES",
         },
     },

--- a/pkgs/x/xmake.lua
+++ b/pkgs/x/xmake.lua
@@ -108,11 +108,15 @@ package = {
             ["3.1.0"] = {
                 sha256 = "1baab457f3bf11032e82c6210bc5bec04f5b902962da17dab53cae10783170de",
             },
-            -- Last musl-static bundle. Kept for Alpine / distroless form-H
-            -- hosts; see the header comment.
+            -- Last musl-static bundle (verified: `statically linked`, zero
+            -- DT_NEEDED). Kept for Alpine / distroless form-H hosts; see the
+            -- header comment. Its sha256 used to be nil — on the one package
+            -- whose whole story is "upstream shipped something other than what
+            -- the release notes claimed", an unpinned fallback was the wrong
+            -- gap to leave open. Resolves through the `source` map above, so it
+            -- gets the CN leg too.
             ["3.0.7"] = {
-                url = "https://github.com/xmake-io/xmake/releases/download/v3.0.7/xmake-bundle-v3.0.7.linux.x86_64",
-                sha256 = nil,
+                sha256 = "59371d344722fd7f2883d1d5ce347a3bac0493d3e80e85a8e438603eaee9b958",
             },
         },
         macosx = {
@@ -125,8 +129,7 @@ package = {
                 sha256 = "296ee53b26e17adc2de5533e3695234c843089712c372db611293ad96ba8ab45",
             },
             ["3.0.7"] = {
-                url = "https://github.com/xmake-io/xmake/releases/download/v3.0.7/xmake-bundle-v3.0.7.macos.arm64",
-                sha256 = nil,
+                sha256 = "999093c3455d3537d6012a5d51a05d736275d55dfb43e59a4b84d519f3e97966",
             },
         },
         windows = {
@@ -139,8 +142,7 @@ package = {
                 sha256 = "41f497ed71f076a9ecf14100e77af5509656a5e41dfd4da8d068b1319a8ef895",
             },
             ["3.0.7"] = {
-                url = "https://github.com/xmake-io/xmake/releases/download/v3.0.7/xmake-bundle-v3.0.7.win64.exe",
-                sha256 = nil,
+                sha256 = "beb282f889357c7a6125ccf334c2476aebf26119a12e0cb86cf4e7d272192f68",
             },
         },
     },

--- a/pkgs/x/xmake.lua
+++ b/pkgs/x/xmake.lua
@@ -21,87 +21,123 @@ package = {
     programs = {"xmake"},
     xvm_enable = true,
 
-    -- v3.0.8 and everything after it deliberately skipped: although the v3.0.8
-    -- release.yml says the Linux bundle is built with `xrepo env -b zig xmake f
-    -- --embed=y --toolchain=zig --cross=x86_64-linux-musl`, the artifact actually
-    -- uploaded to the v3.0.8 release page is *not* a musl-static binary —
-    -- it's glibc-dynamic with INTERP=/lib64/ld-linux-x86-64.so.2 and
-    -- DT_NEEDED libncurses.so.6 + libtinfo.so.6, breaking on Alpine /
-    -- distroless / any host without those libs. v3.0.7 (and prior) are
-    -- correctly musl-static, so we pin `latest = 3.0.7` until upstream
-    -- re-uploads a corrected bundle. Tracking issue: TBD.
+    -- WHY `latest` TRACKS A GLIBC-DYNAMIC BUNDLE, AND WHY 3.0.7 IS KEPT
     --
-    -- RE-CHECKED 2026-08-12 against v3.1.0 (the then-current stable, released
-    -- 2026-08-08) — still not fixed, so the pin stays. Measured, not read off the
-    -- release notes, on xmake-bundle-v3.1.0.linux.x86_64
-    -- (sha256 1baab457f3bf11032e82c6210bc5bec04f5b902962da17dab53cae10783170de):
+    -- Upstream stopped shipping a musl-static Linux bundle at v3.0.8. The
+    -- v3.0.8 release.yml says it is cross-built with `xrepo env -b zig xmake f
+    -- --embed=y --toolchain=zig --cross=x86_64-linux-musl`, but the artifact
+    -- actually uploaded is glibc-dynamic, and that has not been corrected
+    -- since. RE-MEASURED 2026-08-13 on xmake-bundle-v3.1.0.linux.x86_64
+    -- (sha256 1baab457f3bf11032e82c6210bc5bec04f5b902962da17dab53cae10783170de)
+    -- with readelf, not read off the release notes:
     --
-    --     Type: DYN (PIE), has PT_INTERP
-    --     NEEDED: libncurses.so.6, libtinfo.so.6, libm.so.6, libc.so.6
+    --     Type:        DYN (PIE), has PT_INTERP
+    --     NEEDED:      libncurses.so.6, libtinfo.so.6, libm.so.6, libc.so.6
+    --     max GLIBC_:  2.38          <- the floor declared in linux deps below
     --
-    -- Bumping is not merely "less portable", it would REGRESS arch coverage: a
-    -- dynamic bundle needs `xim:glibc` (+ ncurses) declared, xim resolves deps
-    -- per-OS rather than per-arch, and glibc is `archs = {"x86_64"}` — so every
-    -- linux/aarch64 install would start failing at dependency resolution. The
-    -- static 3.0.7 bundle needs no deps at all and works on both arches. Record
-    -- the measurement here so the next bump attempt costs one readelf, not a
-    -- rediscovery.
+    -- The index pinned `latest = 3.0.7` over this until 2026-08-13, on the
+    -- argument that a bump would REGRESS arch coverage: a dynamic bundle must
+    -- declare `xim:glibc`, xim resolves deps per-OS rather than per-arch, and
+    -- glibc is `archs = {"x86_64"}`, so linux/aarch64 would start failing at
+    -- dependency resolution. That argument does not survive contact with this
+    -- file, on two counts:
+    --
+    --   * this recipe ALREADY carries an x86_64-only linux dep. `ncurses` is
+    --     `archs = {"x86_64"}` and has been in the linux block since
+    --     2026-08-09, so adding glibc spends no coverage that is still unspent.
+    --   * upstream publishes no linux-aarch64 bundle at all. The v3.1.0 assets
+    --     are linux.x86_64, macos.arm64, macos.x86_64, win32/win64/arm64.exe
+    --     and cosmocc — and the linux URL below is hardcoded `.linux.x86_64`.
+    --     "3.0.7 is zero-dep and works on both arches" was never true of linux;
+    --     the aarch64 in `archs` above is the macOS bundle.
+    --
+    -- So the dependency is declarable and xlings resolves it: in form X the
+    -- closure installs glibc + ncurses from the index, in form H they come from
+    -- the host. That is the same trade bazel.lua and cmake.lua already make, and
+    -- it is why `latest` now tracks 3.1.0.
+    --
+    -- 3.0.7 is KEPT rather than deleted: it is the last musl-static bundle and
+    -- the only entry that still runs on Alpine / distroless in form H, where
+    -- 3.1.0 will not. Pin it explicitly (`xmake@3.0.7`) on such hosts.
     --
     -- Also considered and rejected: xmake-bundle-v3.1.0.cosmocc (Cosmopolitan
     -- APE). It genuinely has no ELF NEEDED, but it is a DOS/MBR-header hybrid
     -- that rewrites itself on first run — it trips binfmt_misc assumptions and
     -- noexec/read-only payload dirs, which is the opposite of what a package
     -- payload should do.
+    --
+    -- NEXT BUMP costs one readelf on the new linux bundle: if NEEDED or the max
+    -- GLIBC_ reference move, update the linux deps; if upstream ever restores a
+    -- musl-static bundle, the deps can be dropped entirely.
     xpm = {
         linux = {
-            -- ncurses declared (2026-08-09), measured with readelf, and the
-            -- measurement is version-split:
+            -- Both deps are read straight off the readelf measurement above,
+            -- and as of `latest = 3.1.0` they are live requirements rather
+            -- than anticipatory ones: glibc supplies libc.so.6 + libm.so.6 at
+            -- GLIBC_2.38, ncurses supplies libncurses.so.6 + libtinfo.so.6.
+            -- (While `latest` was the static 3.0.7 this block drew the D1
+            -- "declares X, but nothing in the payload names a soname it
+            -- provides" warning; the bump is what clears it.)
             --
-            --   3.0.7 (the pinned latest)  static, no INTERP, no NEEDED —
-            --                              needs nothing at runtime
-            --   3.0.8 (skipped, see above) glibc-dynamic, NEEDED
-            --                              libncurses.so.6 + libtinfo.so.6
+            -- They bite in form X / subos, where there is no host fallback and
+            -- libtinfo must come from the index — mcpp#392 is exactly an
+            -- xmake-adjacent binary crashing on that gap. In form H both
+            -- resolve from host SONAMEs and look redundant.
             --
-            -- So today this dep draws the D1 "declares X, but nothing in the
-            -- payload names a soname it provides" WARNING against 3.0.7, and
-            -- that is the accurate state: the declaration is for the moment
-            -- the pin moves to any dynamic bundle (3.0.8's shape), and for
-            -- form-X/subos consumers, where libtinfo must come from the index
-            -- because our loader has no host fallback — mcpp#392 is exactly
-            -- an xmake-adjacent binary crashing on that gap. The ecosystem-
-            -- side fix is this edge (ncurses provides the sonames); the
-            -- host-glibc side is C1's version floor in glibc.lua. Form H
-            -- resolution today is unchanged either way: host SONAMEs keep
-            -- working.
-            --
-            -- Bare name, not `xim:ncurses`, deliberately: ncurses is NEW in
-            -- the index, and a new name cannot be served by CI's overlay
-            -- (the compiled catalog has no entry; a miss triggers the
-            -- auto-refresh that clobbers the overlay). The harness registers
-            -- new packages under local:, and bare names prefer primary repos
+            -- Bare name for ncurses, not `xim:ncurses`, deliberately: ncurses
+            -- entered the index recently enough that check-dep-namespace.lua
+            -- still carries it as a not-yet-published exemption, and a name the
+            -- compiled catalog lacks cannot be served by CI's overlay (a miss
+            -- triggers the auto-refresh that clobbers the overlay). The harness
+            -- registers new packages under local:, and bare names prefer primary repos
             -- (local: in CI, xim: once published) over the scode sub-index —
             -- so the bare form resolves correctly in every state this recipe
             -- meets. posix-test.sh records the same rule: "a new package is
-            -- referenced bare, a changed published one with xim:".
-            deps = { "ncurses" },
-            url_template = "https://github.com/xmake-io/xmake/releases/download/v{version}/xmake-bundle-v{version}.linux.x86_64",
-            ["latest"] = { ref = "3.0.7" },
+            -- referenced bare, a changed published one with xim:". glibc is
+            -- long-published, so it takes the `xim:` form.
+            deps = { "ncurses", "xim:glibc@>=2.38" },
+            -- `source` map rather than `url_template`: it carries the CN leg,
+            -- and version-check.py's bump appends `["<ver>"] = { sha256 }`
+            -- against it, so the mirror survives future auto-bumps instead of
+            -- being flattened back to a single GitHub URL.
+            source = {
+                GLOBAL = "https://github.com/xmake-io/xmake/releases/download/v${version}/xmake-bundle-v${version}.linux.x86_64",
+                CN = "https://gitcode.com/xlings-res/xmake/releases/download/${version}/xmake-bundle-v${version}.linux.x86_64",
+            },
+            ["latest"] = { ref = "3.1.0" },
+            ["3.1.0"] = {
+                sha256 = "1baab457f3bf11032e82c6210bc5bec04f5b902962da17dab53cae10783170de",
+            },
+            -- Last musl-static bundle. Kept for Alpine / distroless form-H
+            -- hosts; see the header comment.
             ["3.0.7"] = {
                 url = "https://github.com/xmake-io/xmake/releases/download/v3.0.7/xmake-bundle-v3.0.7.linux.x86_64",
                 sha256 = nil,
             },
         },
         macosx = {
-            url_template = "https://github.com/xmake-io/xmake/releases/download/v{version}/xmake-bundle-v{version}.macos.arm64",
-            ["latest"] = { ref = "3.0.7" },
+            source = {
+                GLOBAL = "https://github.com/xmake-io/xmake/releases/download/v${version}/xmake-bundle-v${version}.macos.arm64",
+                CN = "https://gitcode.com/xlings-res/xmake/releases/download/${version}/xmake-bundle-v${version}.macos.arm64",
+            },
+            ["latest"] = { ref = "3.1.0" },
+            ["3.1.0"] = {
+                sha256 = "296ee53b26e17adc2de5533e3695234c843089712c372db611293ad96ba8ab45",
+            },
             ["3.0.7"] = {
                 url = "https://github.com/xmake-io/xmake/releases/download/v3.0.7/xmake-bundle-v3.0.7.macos.arm64",
                 sha256 = nil,
             },
         },
         windows = {
-            url_template = "https://github.com/xmake-io/xmake/releases/download/v{version}/xmake-bundle-v{version}.win64.exe",
-            ["latest"] = { ref = "3.0.7" },
+            source = {
+                GLOBAL = "https://github.com/xmake-io/xmake/releases/download/v${version}/xmake-bundle-v${version}.win64.exe",
+                CN = "https://gitcode.com/xlings-res/xmake/releases/download/${version}/xmake-bundle-v${version}.win64.exe",
+            },
+            ["latest"] = { ref = "3.1.0" },
+            ["3.1.0"] = {
+                sha256 = "41f497ed71f076a9ecf14100e77af5509656a5e41dfd4da8d068b1319a8ef895",
+            },
             ["3.0.7"] = {
                 url = "https://github.com/xmake-io/xmake/releases/download/v3.0.7/xmake-bundle-v3.0.7.win64.exe",
                 sha256 = nil,


### PR DESCRIPTION
把索引里的构建引擎对齐到上游当前稳定版,并给两者都补上 CN 镜像腿。

| 包 | 之前 | 之后 | GLOBAL | CN |
|---|---|---|---|---|
| xmake | 3.0.7 | 3.1.0 | 上游 xmake-io | gitcode `xlings-res/xmake@3.1.0`(3.0.7 也补了) |
| cmake | 4.0.2 | 4.4.2 | github `xlings-res/cmake@4.4.2` | gitcode `xlings-res/cmake@4.4.2` |

bazel 已随 #613 入索引,其 9.2.0 就是上游当前 stable(8.8.0rc1 是 prerelease,不取),本轮无需再动。本分支已 rebase 到 main,重复的 bazel 提交被跳过。

## xmake —— 跳版论据不成立,latest 追到 3.1.0

先把实测钉死。v3.1.0 仍未修复 v3.0.8 起的回归,readelf 实测 `xmake-bundle-v3.1.0.linux.x86_64`:

    Type:        DYN (PIE), has PT_INTERP
    NEEDED:      libncurses.so.6, libtinfo.so.6, libm.so.6, libc.so.6
    max GLIBC_:  2.38

但据此"继续钉 3.0.7"的论据 —— **bump 会倒退架构覆盖** —— 对着文件本身站不住:

* 这份 recipe **今天已经**带着一个 x86_64-only 的 linux 依赖:`ncurses` 就是 `archs = {"x86_64"}`,2026-08-09 起就在 linux 块里。再加 glibc 没有多花掉任何还没花掉的覆盖。
* 上游根本不发 linux-aarch64 bundle(v3.1.0 资产:linux.x86_64 / macos.arm64 / macos.x86_64 / win32,win64,arm64.exe / cosmocc),而 linux URL 一直硬编码 `.linux.x86_64`。"3.0.7 零依赖、双架构可用"对 linux 从来不成立 —— `archs` 里的 aarch64 指的是 macOS 那个 bundle。

也就是说依赖是可声明的、xlings 也解析得了,这正是 bazel.lua / cmake.lua 已经在做的同一笔交易。故 latest 追到 3.1.0,linux deps 补上 `xim:glibc@>=2.38`(按实测的 GLIBC_2.38 上限,不是照抄别处的 2.39)。

**3.0.7 保留而非删除**:它是最后一个 musl-static bundle(实测 `statically linked`、零 DT_NEEDED),Alpine / distroless 的 form H 上显式 pin `xmake@3.0.7` 即可。顺带给它钉上此前缺失的 sha256 并补了 CN 腿 —— 在这个包上让唯一的回落版本没有完整性校验,恰恰是最不该留的口子。

URL 形态从 `url_template` 换成 `source` 映射(GLOBAL/CN):version-check.py 对 source 映射的 bump 只追加 `["<ver>"] = { sha256 }`,镜像腿能活过将来的自动 bump;留在 url_template 上会被拍回单条 GitHub URL。

## cmake —— 4.4.2,并补齐 cmake-gui 的依赖闭包

索引落后四个小版本,原因不是疏忽:这份 recipe 既没有 `ci.update` 也没有 `res_versioned`,压根没有自动更新通道 —— 而 XLINGS_RES 的自动 bump 只**校验**镜像资产、不**创建**它们,打开也会在每个上游版本上报错直到有人手工镜像。已写进注释。

顺带修掉一个此前潜伏、被这次改动照出来的闭包缺口。逐个 readelf 整个载荷(不只 bin/cmake):

    cmake, ctest, cpack, ccmake   libdl librt libpthread libm libc + ld-linux
    cmake-gui                     以上,再加 libxcb.so.1、libfontconfig.so.1、libfreetype.so.6

因为本包声明了 `xim:glibc`,载荷会换成我们的 loader,而其背后没有宿主回落 —— 未声明的 soname 就是找不到(D1/D2)。故补上 fontconfig / freetype / libxcb 三条**直接**依赖(传递依赖不会把 libdir 放进本载荷的 RPATH 闭包)。

macosx-arm64 资产是上游 macos-universal 重打包,只改顶层目录名 —— `install()` 是把下载文件名去掉扩展名来推算解压目录的,单纯改名会让它去找一个不存在的目录(4.0.2 当年也是这么做的)。linux / windows 是上游字节原样。

另记一笔:bin/cmake 自身的 glibc 下限实测只有 GLIBC_2.17,而声明的 `>=2.39` 是索引里 glibc 的基线(glibc.lua 只有 2.39 和 2.44),不是二进制的要求 —— 别"顺手修"成 2.17。

## 验证

镜像:每条腿的每个资产都回下一次比对 sha256 —— 与上游/本地逐字节一致;cmake 两条腿另有 `.sha256` sidecar,内容相符。

本机端到端(xlings 2026.8.11.2):

* `xlings install local:xmake@3.1.0` → 装上,`xmake --version` 报 v3.1.0,`xlings use` 在 3.1.0/3.0.7 间来回切正常
* `xlings install local:cmake@4.4.2` → 装上并拉起 9 个包(三条新依赖及其传递依赖),`cmake --version` 报 4.4.2
* `dep-closure-check.sh`:xmake 3.1.0 载荷 1 ELF / 4 sonames rc=0;cmake 4.4.2 载荷 5 ELF / 9 sonames rc=0(**补依赖之前是 D1 FAIL**,列出的正是那三个 GUI soname)

静态:`check-dep-namespace.sh` PASS(234 条声明)、`check-no-direct-ld-libpath.sh` PASS、`check-no-blocking-input.sh` PASS、`test_version_check.py` All tests passed、`pytest -m "static or index"` 10 passed。

已知噪声,非缺陷:本机直接装 `local:xmake@3.0.7` 会得到空载荷,那是 `local:`/`xim:` 同 (name,version) 的既有冲突 —— 拿 main 上未修改的 recipe 做对照结果一模一样,与本次改动无关。`posix-test.sh` 跑 xmake 时报的 uninstall 失败同理,是本机残留的 `xpkgs/xim-x-xmake/3.0.8` 目录所致,干净的 CI 机器上不存在。
