### PR TITLE
feat(dsh): add DeepSeek Harness 0.1.0-rc.6

### DIFF
--- a/pkgs/d/dsh.lua
+++ b/pkgs/d/dsh.lua
@@ -1,0 +1,135 @@
+-- DeepSeek Harness (`dsh`) — DeepSeek AI's open-source agent harness.
+--
+-- Distribution: **npm only**. `deepseek-ai/deepseek-harness` publishes no
+-- GitHub release and carries no git tag; the one shipping channel is the
+-- npm package `@deepseek-ai/dsh`, and upstream's own instruction is
+-- `npx @deepseek-ai/dsh web`. So this recipe goes through npm the same way
+-- openclaw.lua does, rather than downloading a platform asset like
+-- claude.lua / codex.lua — there is no asset to download.
+--
+-- No `package.ci`: version-check.py discovers versions from GitHub release
+-- tags (`github_releases()`), and this project has none. Bumps are read off
+-- registry.npmjs.org/@deepseek-ai/dsh (`dist-tags.latest`) by hand.
+--
+-- `--ignore-scripts` is safe here and is not a guess: the published
+-- package.json declares no `scripts` at all, and a full install with the
+-- flag (532 packages) yields a working `dsh --version` / `dsh --help`.
+-- Verified against 0.1.0-rc.6.
+--
+-- **pnpm is deliberately NOT in `deps`.** `dsh plugin --profile <p> add ...`
+-- shells out to `pnpm` off PATH — the CLI even says so when it is missing
+-- (`dsh: pnpm not found on PATH — install pnpm to manage profile plugins`),
+-- so it is tempting to declare it. But xim:pnpm ships only
+-- `pnpm-linux-x64` / `pnpm-win32-x64` / `pnpm-darwin-arm64`, i.e. it is
+-- `archs = {"x86_64"}` on Linux, while dsh itself is JavaScript and runs
+-- wherever node does. A hard dep would therefore make `xlings install dsh`
+-- fail outright on aarch64 Linux to enable one optional subcommand. Users
+-- who want profile plugin management run `xlings install pnpm` alongside;
+-- booting a profile, the web UI and headless runs need none of it.
+--
+-- Upstream is in *developer preview* and says so in capitals: "THERE WILL
+-- BE COMPATIBILITY-BREAKING CHANGES." Hence `status = "dev"` and the
+-- pre-release version keys — `0.1.0-rc.6` is the actual `latest` on npm,
+-- not a placeholder.
+--
+-- Two versions are tracked, not one, because a pre-1.0 harness that
+-- promises breaking changes is exactly the case `xvm use dsh@<ver>` exists
+-- for. The 0.1.0-rc.3 pin was installed and run before it was written down
+-- (`dsh --version` -> 0.1.0-rc.3): the `^0.1.0-rc.3` ranges its own
+-- @deepseek-ai/dsh-* dependencies carry are satisfiable within the 0.1.x
+-- line, so npm does not silently resolve an older root against newer
+-- bundle packages. Anything below 0.1.0 is a different line (0.0.1-rc.*)
+-- and is not tracked.
+
+package = {
+    spec = "2",
+
+    name = "dsh",
+    description = "DeepSeek Harness - an everything-is-a-plugin agent harness from DeepSeek AI",
+    homepage = "https://github.com/deepseek-ai/deepseek-harness",
+    licenses = {"MIT"},
+    repo = "https://github.com/deepseek-ai/deepseek-harness",
+    docs = "https://github.com/deepseek-ai/deepseek-harness/blob/master/docs/user/index.md",
+
+    type = "package",
+    archs = {"x86_64", "aarch64"},
+    status = "dev", -- upstream: developer preview, breaking changes expected
+    categories = {"ai", "cli", "tools"},
+    keywords = {"dsh", "deepseek", "deepseek-harness", "agent", "cli", "cordis"},
+
+    programs = {"dsh"},
+    xvm_enable = true,
+
+    xpm = {
+        linux = {
+            deps = {"xim:node", "xim:npm"},
+            ["latest"] = { ref = "0.1.0-rc.6" },
+            ["0.1.0-rc.6"] = {},
+            ["0.1.0-rc.3"] = {},
+        },
+        macosx = {
+            deps = {"xim:node", "xim:npm"},
+            ["latest"] = { ref = "0.1.0-rc.6" },
+            ["0.1.0-rc.6"] = {},
+            ["0.1.0-rc.3"] = {},
+        },
+        windows = {
+            deps = {"xim:node", "xim:npm"},
+            ["latest"] = { ref = "0.1.0-rc.6" },
+            ["0.1.0-rc.6"] = {},
+            ["0.1.0-rc.3"] = {},
+        },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+
+local function _bindir()
+    return path.join(pkginfo.install_dir(), "node_modules", ".bin")
+end
+
+-- The npm shim npm writes for `bin.dsh`. Windows gets the `.cmd` wrapper.
+local function _shim()
+    return path.join(_bindir(), is_host("windows") and "dsh.cmd" or "dsh")
+end
+
+function install()
+    os.tryrm(pkginfo.install_dir())
+    os.mkdir(pkginfo.install_dir())
+
+    -- Same proot warm-up as openclaw.lua, and for the same reason: the
+    -- first large fork+exec burst inside a fresh proot sandbox (npm
+    -- unpacking ~530 packages) trips `double free or corruption` in
+    -- proot's talloc pool. One PATH-traversing command primes proot's
+    -- path cache. Linux-only (proot is), harmless on native Linux.
+    if os.host() == "linux" then
+        os.execute("node --version > /dev/null 2>&1")
+    end
+
+    os.exec(string.format(
+        [[npm install --prefix "%s" --no-fund --no-audit --ignore-scripts "@deepseek-ai/dsh@%s"]],
+        pkginfo.install_dir(),
+        pkginfo.version()
+    ))
+
+    -- Assert the artifact, not the intent: a bare `return true` here gets
+    -- stamped as installed and leaves an xvm shim pointing at nothing.
+    return os.isfile(_shim())
+end
+
+function config()
+    xvm.add("dsh", {
+        bindir = _bindir(),
+        alias = is_host("windows") and "dsh.cmd" or "dsh",
+    })
+    return true
+end
+
+function uninstall()
+    -- Only the xpkg payload goes away. `$DSH_HOME` (default `~/.dsh`) holds
+    -- the user's profiles, their pnpm-managed plugins and their config
+    -- layer; it is user data this recipe never created and must not delete.
+    xvm.remove("dsh")
+    return true
+end

--- a/tests/d/test_dsh.py
+++ b/tests/d/test_dsh.py
@@ -1,0 +1,81 @@
+"""测试 dsh 包 (DeepSeek Harness)"""
+import pytest
+from tests.lib.xpkg_parser import parse_xpkg
+from tests.lib.assertions import (
+    assert_required_fields, assert_valid_spec, assert_valid_type,
+    assert_no_typos, assert_no_exec_xvm, assert_no_bashrc_modification,
+    assert_no_direct_path_modification, assert_uses_new_api,
+    assert_xim_add_succeeds, assert_install_succeeds,
+    assert_command_output, assert_xvm_registered,
+)
+from tests.lib.platform_utils import skip_if_not
+
+PKG = "dsh"
+PKG_FILE = "pkgs/d/dsh.lua"
+
+
+@pytest.fixture(scope='module')
+def meta():
+    return parse_xpkg(PKG_FILE)
+
+
+class TestStatic:
+    @pytest.mark.static
+    def test_required_fields(self, meta):
+        assert_required_fields(meta)
+
+    @pytest.mark.static
+    def test_valid_spec(self, meta):
+        assert_valid_spec(meta)
+
+    @pytest.mark.static
+    def test_valid_type(self, meta):
+        assert_valid_type(meta)
+
+    @pytest.mark.static
+    def test_no_typos(self):
+        assert_no_typos(PKG_FILE)
+
+
+class TestIndex:
+    @pytest.mark.index
+    def test_xim_add(self):
+        assert_xim_add_succeeds(PKG_FILE)
+
+
+class TestIsolation:
+    @pytest.mark.isolation
+    def test_no_exec_xvm(self):
+        assert_no_exec_xvm(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_no_bashrc(self):
+        assert_no_bashrc_modification(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_no_path_modification(self):
+        assert_no_direct_path_modification(PKG_FILE)
+
+    @pytest.mark.isolation
+    def test_new_api(self):
+        assert_uses_new_api(PKG_FILE)
+
+
+class TestLifecycle:
+    @pytest.mark.lifecycle
+    @skip_if_not('linux')
+    def test_install(self):
+        # ~530 npm packages; openclaw's 300s budget is not enough headroom.
+        assert_install_succeeds(PKG, timeout=900)
+
+
+class TestVerify:
+    @pytest.mark.verify
+    @skip_if_not('linux')
+    def test_dsh_version(self):
+        assert_command_output("dsh --version")
+
+    @pytest.mark.verify
+    @skip_if_not('linux')
+    def test_xvm_dsh(self):
+        assert_xvm_registered("dsh")


### PR DESCRIPTION
## Summary

新增 `xim:dsh` —— **DeepSeek Harness**（`deepseek-ai/deepseek-harness`），DeepSeek AI 的开源 agent harness，架构上"一切皆插件"，底层是 Cordis。

跟踪两个版本：`latest -> 0.1.0-rc.6`（npm `dist-tags.latest`，2026-08-13 发布），外加 `0.1.0-rc.3` 作为可切换的历史 pin。

### 为什么走 npm 而不是平台资产

上游**没有 GitHub release、也没有 git tag**，唯一发布渠道是 npm 包 `@deepseek-ai/dsh`（README 给的命令就是 `npx @deepseek-ai/dsh web`）。所以这份配方按 `openclaw.lua` 的形状走 npm，而不是像 `claude.lua` / `codex.lua` 那样下载平台二进制——没有二进制可下。

同样因为没有 release tag，**不声明 `package.ci`**：`version-check.py` 的 `github_releases()` 从 release tag 发现版本，这个项目一个都没有。版本跟进从 `registry.npmjs.org/@deepseek-ai/dsh` 手工读取，与 `claude.lua` / `codex.lua` 的处理一致。

### 关于 pnpm（**故意不进 `deps`**）

`dsh plugin --profile <p> add ...` 会 spawn PATH 上的 `pnpm`，缺失时 CLI 自己会说
`dsh: pnpm not found on PATH — install pnpm to manage profile plugins`。看起来该声明成依赖，但
`xim:pnpm` 只发 `pnpm-linux-x64` / `pnpm-win32-x64` / `pnpm-darwin-arm64`，在 Linux 上是 `archs = {"x86_64"}`；而 dsh 本身是 JavaScript，node 能跑的地方它都能跑。把它写成硬依赖等于**为了一个可选子命令让 aarch64 Linux 上的 `xlings install dsh` 直接失败**。需要 profile 插件管理的用户另外 `xlings install pnpm` 即可；启动 profile、web UI、headless 运行都用不到它。

理由已写进配方头部注释。

## 包行为

| 阶段 | 做了什么 |
|---|---|
| `install()` | `npm install --prefix <install_dir> --no-fund --no-audit --ignore-scripts "@deepseek-ai/dsh@<version>"`，结尾断言 `node_modules/.bin/dsh` 真的落地（不是裸 `return true`） |
| `config()` | `xvm.add("dsh", { bindir = <install_dir>/node_modules/.bin, alias = dsh / dsh.cmd })` |
| `uninstall()` | 只 `xvm.remove("dsh")`。**不动 `$DSH_HOME`（默认 `~/.dsh`）**——那里放的是用户的 profiles、pnpm 管理的插件和用户自己的 config layer，是本配方从未创建过的用户数据 |

不改系统配置、不写 `.bashrc`、不动 `PATH`、不调用系统包管理器。依赖只通过 `xpm.<platform>.deps` 声明。

`--ignore-scripts` 是查证过的，不是猜的：发布的 package.json **完全没有 `scripts` 字段**，带该 flag 的完整安装（532 个包）产出可用的 `dsh --version` / `dsh --help`。

`install()` 里的 proot 预热和 `openclaw.lua` 同源同因：新建 proot 沙箱里第一次大规模 fork+exec（npm 解包 ~530 个包）会踩到 proot talloc pool 的 `double free or corruption`，一条走 PATH 的命令先把路径缓存热起来即可。

## Test plan

**静态 / 隔离（全仓，不只本包）**

```
pytest tests/ -m static      → 1378 passed, 9 skipped
pytest tests/ -m isolation   → 375 passed, 4 xpassed
pytest tests/ -m "not lifecycle and not verify and not index"
                             → 1937 passed, 9 skipped, 4 xpassed
python3 .github/scripts/version-check.py --workspace .   → 无新增告警（dsh 无 ci 声明，不参与扫描）
```

**隔离 home 真装真卸（Linux x86_64）**

```bash
XLINGS_HOME=$TMP_HOME xlings update
XLINGS_HOME=$TMP_HOME xlings config --add-xpkg $PWD/pkgs/d/dsh.lua
XLINGS_HOME=$TMP_HOME xlings install local:dsh@0.1.0-rc.6 -y
```

- 依赖链解析并安装：`xim:glibc@2.44`、`xim:gcc-runtime@15.1.0`、`xim:node@24.19.0`、`xim:npm@11.2.0`，`✓ 5 package(s) installed`
- payload 落地确认：`data/xpkgs/local-x-dsh/0.1.0-rc.6/{node_modules,package.json,package-lock.json}`
- 用 xim 自己的 node payload 跑安装产物：`…/node_modules/.bin/dsh --version` → `0.1.0-rc.6`
- `xlings remove local:dsh -y` → `✓ local:dsh removed`，`data/xpkgs/local-x-dsh/` 整个消失
- 真实 `~/.xlings` 未被污染：`find ~/.xlings -maxdepth 4 -name dsh` 为空

**两个版本都实测过**（这是 `0.1.0-rc.3` 敢写进索引的依据，不是照抄版本号）：

| 版本 | `dsh --version` |
|---|---|
| 0.1.0-rc.6 | `0.1.0-rc.6` |
| 0.1.0-rc.3 | `0.1.0-rc.3` |

`0.1.0-rc.3` 自带的 `@deepseek-ai/dsh-*` 依赖是 `^0.1.0-rc.3` 区间，在 0.1.x 线内可解，npm 不会把旧 root 配上新 bundle 包。0.1.0 以下是另一条线（`0.0.1-rc.*`），不跟踪。

CI 需要验证的：多平台 install/uninstall（本地只覆盖了 Linux x86_64；macOS/Windows 路径靠 `is_host` 分支和 `dsh.cmd` alias）。
