### PR TITLE
fix(dsh): build node-pty, pin node>=24, exec the dep's interpreter

### DIFF
--- a/pkgs/d/dsh.lua
+++ b/pkgs/d/dsh.lua
@@ -11,10 +11,46 @@
 -- tags (`github_releases()`), and this project has none. Bumps are read off
 -- registry.npmjs.org/@deepseek-ai/dsh (`dist-tags.latest`) by hand.
 --
--- `--ignore-scripts` is safe here and is not a guess: the published
--- package.json declares no `scripts` at all, and a full install with the
--- flag (532 packages) yields a working `dsh --version` / `dsh --help`.
--- Verified against 0.1.0-rc.6.
+-- **`--ignore-scripts` MUST NOT be used here, and the reason is Linux-only
+-- so it does not show up on a casual test.** The first version of this
+-- recipe carried it, on the argument that the published package.json
+-- declares no `scripts` of its own — which is true of the ROOT package and
+-- irrelevant, because the flag applies to the whole tree. Five packages in
+-- that tree have install lifecycle scripts (enumerated, not guessed):
+--
+--   node-pty@1.1.0                      install + postinstall
+--   koffi@3.1.4                         install
+--   protobufjs@7.6.5                    postinstall
+--   @deepseek-ai/dsh-subprocess-local   postinstall
+--   @google/genai@1.52.0                preinstall (a no-op echo)
+--
+-- node-pty is the one that breaks. Its install script is
+-- `node scripts/prebuild.js || node-gyp rebuild`, and prebuild.js downloads
+-- NOTHING — it only *checks* whether `prebuilds/<platform>-<arch>` exists
+-- and exits 1 when it does not. The npm tarball ships prebuilds for
+-- darwin-arm64, darwin-x64, win32-arm64 and win32-x64 **and no linux-x64**,
+-- so on Linux the `|| node-gyp rebuild` branch is the only thing that ever
+-- produces `pty.node`, into `build/Release/`.
+--
+-- Skip it and `dsh --version` / `dsh --help` still pass — neither loads the
+-- plugin tree — while every actual profile boot dies with
+--
+--   failed to import loader entry subprocess (@deepseek-ai/dsh-subprocess-local):
+--   Failed to load native module: pty.node, checked: build/Release, build/Debug,
+--   prebuilds/linux-x64
+--
+-- macOS and Windows are unaffected: their prebuilds are in the tarball.
+-- So verify a change to this line by BOOTING A PROFILE on Linux, never by
+-- `--version`. tests/d/test_dsh.py guards both directions.
+--
+-- Compiling from source means node-gyp, i.e. python3 + make + a C++
+-- toolchain on the host at install time. That cost is accepted rather than
+-- worked around: there is no prebuilt linux-x64 pty.node to fetch.
+--
+-- The compiled `pty.node` survives `xlings use node <other>`: node-pty
+-- builds against node-addon-api (N-API), which is ABI-stable across major
+-- versions. Measured, not assumed — a pty.node built under node 26.7.0
+-- loads under node 24.15.0.
 --
 -- **pnpm is deliberately NOT in `deps`.** `dsh plugin --profile <p> add ...`
 -- shells out to `pnpm` off PATH — the CLI even says so when it is missing
@@ -26,6 +62,15 @@
 -- fail outright on aarch64 Linux to enable one optional subcommand. Users
 -- who want profile plugin management run `xlings install pnpm` alongside;
 -- booting a profile, the web UI and headless runs need none of it.
+--
+-- `xim:node@>=24`, and that floor is upstream's own, not a round number.
+-- The repo root package.json declares
+-- `engines: { node: "^22.19.0 || >=24.0.0" }`. The 22.x arm is unreachable
+-- through this index: xim:node's 22 line stops at 22.17.1, which is BELOW
+-- 22.19.0, so no xim:node 22 satisfies upstream. `>=24` is therefore the
+-- only correct floor here, not a simplification of the disjunction. (The
+-- PUBLISHED @deepseek-ai/dsh package.json carries no `engines` at all, so
+-- npm will not enforce this for us — the dep constraint is the enforcement.)
 --
 -- Upstream is in *developer preview* and says so in capitals: "THERE WILL
 -- BE COMPATIBILITY-BREAKING CHANGES." Hence `status = "dev"` and the
@@ -62,19 +107,19 @@ package = {
 
     xpm = {
         linux = {
-            deps = {"xim:node", "xim:npm"},
+            deps = {"xim:node@>=24", "xim:npm"},
             ["latest"] = { ref = "0.1.0-rc.6" },
             ["0.1.0-rc.6"] = {},
             ["0.1.0-rc.3"] = {},
         },
         macosx = {
-            deps = {"xim:node", "xim:npm"},
+            deps = {"xim:node@>=24", "xim:npm"},
             ["latest"] = { ref = "0.1.0-rc.6" },
             ["0.1.0-rc.6"] = {},
             ["0.1.0-rc.3"] = {},
         },
         windows = {
-            deps = {"xim:node", "xim:npm"},
+            deps = {"xim:node@>=24", "xim:npm"},
             ["latest"] = { ref = "0.1.0-rc.6" },
             ["0.1.0-rc.6"] = {},
             ["0.1.0-rc.3"] = {},
@@ -84,14 +129,23 @@ package = {
 
 import("xim.libxpkg.pkginfo")
 import("xim.libxpkg.xvm")
+import("xim.libxpkg.log")
 
 local function _bindir()
     return path.join(pkginfo.install_dir(), "node_modules", ".bin")
 end
 
--- The npm shim npm writes for `bin.dsh`. Windows gets the `.cmd` wrapper.
+-- npm's own shim for `bin.dsh`. Used ONLY as install()'s artifact assertion;
+-- the xvm shim deliberately does not go through it — see config().
 local function _shim()
     return path.join(_bindir(), is_host("windows") and "dsh.cmd" or "dsh")
+end
+
+-- The real entry point, i.e. what `bin.dsh` in the published package.json
+-- points at. config() execs this with an explicit interpreter.
+local function _entry()
+    return path.join(pkginfo.install_dir(), "node_modules",
+                     "@deepseek-ai", "dsh", "lib", "bin.js")
 end
 
 function install()
@@ -107,22 +161,77 @@ function install()
         os.execute("node --version > /dev/null 2>&1")
     end
 
+    -- Lifecycle scripts run on purpose. See the header: node-pty's install
+    -- script is the only thing that produces pty.node on Linux.
     os.exec(string.format(
-        [[npm install --prefix "%s" --no-fund --no-audit --ignore-scripts "@deepseek-ai/dsh@%s"]],
+        [[npm install --prefix "%s" --no-fund --no-audit "@deepseek-ai/dsh@%s"]],
         pkginfo.install_dir(),
         pkginfo.version()
     ))
 
     -- Assert the artifact, not the intent: a bare `return true` here gets
     -- stamped as installed and leaves an xvm shim pointing at nothing.
-    return os.isfile(_shim())
+    if not os.isfile(_shim()) then
+        return false
+    end
+    if not os.isfile(_entry()) then
+        raise("dsh: npm tree has no @deepseek-ai/dsh/lib/bin.js after install")
+    end
+
+    -- The whole point of not passing --ignore-scripts. On Linux this file
+    -- only exists if node-pty's install script actually ran; without it
+    -- every profile boot dies and only `--version` keeps working, which is
+    -- exactly the failure this recipe shipped once already.
+    if os.host() == "linux" then
+        local pty = path.join(pkginfo.install_dir(), "node_modules", "node-pty",
+                              "build", "Release", "pty.node")
+        if not os.isfile(pty) then
+            raise("dsh: node-pty was not built (no build/Release/pty.node); "
+                  .. "profile boot would fail. node-gyp needs python3, make "
+                  .. "and a C++ toolchain on this host.")
+        end
+    end
+
+    return true
 end
 
+-- Pin the interpreter to the node payload this package resolved against,
+-- rather than shipping npm's `node_modules/.bin/dsh` shim — that shim starts
+-- with `#!/usr/bin/env node` and therefore follows whatever `xlings use node`
+-- last selected. This is meson.lua's pattern (it execs its OWN python payload
+-- for the same reason) and R6 of the V2 spec: an internal consumer binds the
+-- payload, not the subos view.
+--
+-- Concretely, without this `xlings use node 26` silently changes which
+-- runtime boots dsh. That is survivable today — node-pty is N-API and its
+-- pty.node loads across majors (measured) — but "survivable" is not
+-- "chosen", and upstream's floor is `>=24`, which a bare shim cannot enforce.
+--
+-- Stated trade-off, same as meson's: node is resolved once, at dsh-install
+-- time. `xlings use node <other>` afterwards does not move dsh, and removing
+-- the node payload leaves this shim pointing at a gone interpreter. For an
+-- agent runtime with a native module compiled into its own tree, not moving
+-- is the safer direction.
 function config()
+    local nodedir = pkginfo.dep_install_dir("xim:node")
+    if not nodedir then
+        raise("dsh: cannot locate the xim:node payload; the shim would have "
+              .. "no interpreter to exec")
+    end
+
+    -- node.lua puts the binary in <payload>/bin on unix and at the payload
+    -- root on windows; mirror that rather than guessing one shape.
+    local nodebin = is_host("windows") and nodedir or path.join(nodedir, "bin")
+    local exe = is_host("windows") and "node.exe" or "node"
+    if not os.isfile(path.join(nodebin, exe)) then
+        raise("dsh: xim:node payload at " .. nodebin .. " has no " .. exe)
+    end
+
     xvm.add("dsh", {
-        bindir = _bindir(),
-        alias = is_host("windows") and "dsh.cmd" or "dsh",
+        bindir = nodebin,
+        alias  = exe .. " " .. _entry(),
     })
+    log.info("dsh: shim execs " .. path.join(nodebin, exe) .. " " .. _entry())
     return true
 end
 

--- a/tests/d/test_dsh.py
+++ b/tests/d/test_dsh.py
@@ -1,4 +1,5 @@
 """测试 dsh 包 (DeepSeek Harness)"""
+import pathlib
 import pytest
 from tests.lib.xpkg_parser import parse_xpkg
 from tests.lib.assertions import (
@@ -35,6 +36,40 @@ class TestStatic:
     @pytest.mark.static
     def test_no_typos(self):
         assert_no_typos(PKG_FILE)
+
+    @pytest.mark.static
+    def test_no_ignore_scripts(self):
+        """`--ignore-scripts` must never come back to this recipe.
+
+        node-pty ships prebuilds for darwin/win32 only. On Linux its install
+        script (`node scripts/prebuild.js || node-gyp rebuild`) is the ONLY
+        thing that produces build/Release/pty.node, and prebuild.js downloads
+        nothing — it just checks and exits 1. Skip it and `dsh --version`
+        still passes while every profile boot dies on
+        `Failed to load native module: pty.node`.
+
+        This is a static guard because the runtime symptom is Linux-only and
+        invisible to --version, which is exactly how it shipped once.
+        """
+        # The header discusses the flag on purpose, so only executable lines
+        # are checked — a comment saying "never use --ignore-scripts" must not
+        # be what trips the guard.
+        code = [ln for ln in pathlib.Path(PKG_FILE).read_text(encoding="utf-8").splitlines()
+                if not ln.lstrip().startswith("--")]
+        assert "--ignore-scripts" not in "\n".join(code), (
+            "npm install must run lifecycle scripts: node-pty has no linux-x64 "
+            "prebuild and only its install script builds pty.node"
+        )
+
+    @pytest.mark.static
+    def test_node_floor_declared(self):
+        """Upstream requires `^22.19.0 || >=24.0.0`, and xim:node's 22 line
+        tops out at 22.17.1 — below that floor — so >=24 is the only
+        satisfiable constraint here, not a rounded-off simplification."""
+        body = pathlib.Path(PKG_FILE).read_text(encoding="utf-8")
+        assert body.count('"xim:node@>=24"') == 3, (
+            "every platform section must pin the node floor upstream declares"
+        )
 
 
 class TestIndex:
@@ -74,6 +109,19 @@ class TestVerify:
     @skip_if_not('linux')
     def test_dsh_version(self):
         assert_command_output("dsh --version")
+
+    @pytest.mark.verify
+    @skip_if_not('linux')
+    def test_dsh_loads_plugin_tree(self):
+        """`--version` is NOT an acceptance test for this package.
+
+        It never loads the plugin tree, so it passes even when the native
+        modules the tree needs are missing. `--dump-config` composes the
+        whole profile — it is the cheapest command that actually exercises
+        what a user hits on `dsh --profile web`.
+        """
+        assert_command_output("dsh --profile web --dump-config",
+                              contains="@deepseek-ai/dsh-base")
 
     @pytest.mark.verify
     @skip_if_not('linux')


### PR DESCRIPTION
## Summary

修 #617 引入的一个**只在 Linux 上出现、且 `--version` 看不见**的缺陷，并按上游声明补上 node 版本下限与解释器绑定。

用户实际报错（`dsh --profile web`）：

```
Error: dsh: plugin tree failed to load: failed to apply loader entry include (cordis:include):
failed to import loader entry subprocess (@deepseek-ai/dsh-subprocess-local):
Failed to load native module: pty.node, checked: build/Release, build/Debug, prebuilds/linux-x64
```

### 1. 去掉 `--ignore-scripts`（根因）

#617 带了 `--ignore-scripts`，理由写的是"发布的 package.json 没有 `scripts` 字段"。这句话对**根包**成立，但**与该 flag 无关**——flag 作用于整棵依赖树。树里有 5 个包带 install 生命周期脚本（枚举出来的，不是猜的）：

| 包 | 脚本 |
|---|---|
| `node-pty@1.1.0` | `install` + `postinstall` |
| `koffi@3.1.4` | `install` |
| `protobufjs@7.6.5` | `postinstall` |
| `@deepseek-ai/dsh-subprocess-local` | `postinstall` |
| `@google/genai@1.52.0` | `preinstall`（空 echo） |

出事的是 `node-pty`。它的 install 脚本是 `node scripts/prebuild.js || node-gyp rebuild`，而 **`prebuild.js` 不下载任何东西**——它只检查 `prebuilds/<platform>-<arch>` 存在与否，不存在就 exit 1。npm tarball 里的 prebuilds 只有 `darwin-arm64` / `darwin-x64` / `win32-arm64` / `win32-x64`，**没有 `linux-x64`**。所以在 Linux 上，`|| node-gyp rebuild` 是 `pty.node` 唯一的来源。

**为什么 #617 的验证没抓到**：`dsh --version` 和 `dsh --help` 都不加载 plugin tree，跳过 `--ignore-scripts` 后它们照样通过；而任何一次真实的 profile boot 都会死。macOS/Windows 因为 tarball 里有 prebuild，完全不受影响——**这是个纯 Linux 缺陷**，`linux-install-test` 也没覆盖到，因为它只跑安装/卸载，不 boot profile。

代价是安装期要 node-gyp（python3 + make + C++ 工具链）。这个代价是**接受**而不是绕开的：没有 linux-x64 的预编译产物可拉。

### 2. `deps` 补 `xim:node@>=24`

上游仓库根 `package.json` 声明 `engines: { node: "^22.19.0 || >=24.0.0" }`。

22.x 那一支在本索引里**够不着**：`xim:node` 的 22 线最高到 `22.17.1`，低于 `22.19.0`。所以 `>=24` 不是把析取式"简化"了，而是这里**唯一可满足**的下限。

另外，**发布到 npm 的 `@deepseek-ai/dsh` 根本没有 `engines` 字段**（`engines: None`），npm 不会替我们把关——dep 约束就是唯一的把关点。

### 3. `config()` 绑定 node payload，不再跟着 `xlings use node` 漂

原来注册的是 npm 写的 `node_modules/.bin/dsh`，它的 shebang 是 `#!/usr/bin/env node`，于是**谁 `xlings use node 26`，dsh 就换谁跑**。

改成 meson.lua 的做法（它 exec 自己的 python payload，同一个理由），也就是 V2 spec 的 R6——内部消费者绑 payload，不绑 subos view：

```lua
local nodedir = pkginfo.dep_install_dir("xim:node")
xvm.add("dsh", { bindir = <nodedir>/bin, alias = "node <install_dir>/.../dsh/lib/bin.js" })
```

trade-off 照 meson 那样**写在注释里而不是留给以后发现**：node 在 dsh 安装时解析一次，之后 `xlings use node <other>` 不会移动 dsh；node payload 被删则 shim 指向空。对一个把原生模块编译进自己树里的 agent runtime，"不跟着动"是更安全的方向。

> N-API 顺带澄清：`pty.node` 走 node-addon-api，跨大版本 ABI 稳定。**实测**——node 26.7.0 下编出来的 `pty.node`，在 node 24.15.0 下能正常 load。所以 #2/#3 不是为了修 ABI，是为了让"用哪个 node"变成一个**被选择**的事实。

## 回归防护

`--version` 从此不再是这个包的验收标准。新增：

- `test_no_ignore_scripts`（static）：扫描非注释行，`--ignore-scripts` 不得出现。**验证过它真的会 fire**——手动把 flag 加回去，该用例立刻失败。header 里成段讨论这个 flag 的注释不会误触发。
- `test_node_floor_declared`（static）：三个平台段都必须写 `xim:node@>=24`。
- `test_dsh_loads_plugin_tree`（verify）：跑 `dsh --profile web --dump-config` 并断言输出里有 `@deepseek-ai/dsh-base`——这是最便宜的、**真正会加载 plugin tree** 的命令。
- `install()` 里增加产物断言：Linux 上 `build/Release/pty.node` 不存在就 `raise`，而不是把一个只能跑 `--version` 的安装标记成成功。

## Test plan

**静态 / 隔离（全仓）**

```
pytest tests/d/test_dsh.py -m "static or isolation"  → 10 passed
pytest tests/ -m "static or isolation"               → 1755 passed, 9 skipped, 4 xpassed
```

**隔离 home 真装 + 真 boot（Linux x86_64）**

```bash
XLINGS_HOME=$TMP xlings update
XLINGS_HOME=$TMP xlings config --add-xpkg $PWD/pkgs/d/dsh.lua
XLINGS_HOME=$TMP xlings install local:dsh@0.1.0-rc.6 -y
```

- 依赖解析出 `xim:node@24.19.0`（`>=24` 生效），`✓ 6 package(s) installed`
- **`node_modules/node-pty/build/Release/pty.node` 存在**（68648 bytes）——修复前这个文件根本不产生
- `subos/default/.xlings.json` 里 `"dsh": {"active": "local:0.1.0-rc.6"}`，证明 `config()` 跑到了尾部，即 `pkginfo.dep_install_dir("xim:node")` 解析成功（失败会在 `xvm.add` 之前 `raise`）
- `dsh --profile web --dump-config` → exit 0
- `dsh --profile headless "hi"` → 唯一报错是
  `MISSING_CREDENTIAL: no API key for provider route "deepseek-official"`
  —— 即**整棵 plugin tree（含 dsh-subprocess-local / node-pty、dsh-attachment-local / sharp）已全部挂载成功**，这是正确的"健康失败"

**修复前后对照（同一台机器）**

| 命令 | 修复前 | 修复后 |
|---|---|---|
| `dsh --version` | ✅ 通过（所以没抓到） | ✅ |
| `dsh --profile web --dump-config` | ❌ `Failed to load native module: pty.node` | ✅ exit 0 |
| `dsh --profile headless` | ❌ 同上 | ✅ 走到缺 API key |

CI 需要覆盖的：macOS / Windows 安装路径（本地只验了 Linux x86_64；这两个平台本来就不受该缺陷影响，但 `config()` 的 `is_host` 分支和 node payload 布局是新代码）。
