### PR TITLE
fix(dsh): separate npm's output from xlings' own with a blank line

### DIFF
--- a/pkgs/d/dsh.lua
+++ b/pkgs/d/dsh.lua
@@ -161,6 +161,11 @@ function install()
         os.execute("node --version > /dev/null 2>&1")
     end
 
+    -- npm writes straight to the terminal, and its first line lands flush
+    -- against whatever xlings printed last, so the two read as one message.
+    -- One blank line separates them.
+    print("")
+
     -- Lifecycle scripts run on purpose. See the header: node-pty's install
     -- script is the only thing that produces pty.node on Linux.
     os.exec(string.format(


### PR DESCRIPTION
## Summary

`npm install` writes straight to the terminal, so its first line lands flush
against whatever xlings printed last:

```
    ✓ xim:node@24.19.0             done
npm warn deprecated node-domexception@1.0.0: ...
```

The two read as one message. A single blank line before the install separates
them.

Same change is going into `Sunrisepeak/dsh-index`'s `template.lua`, where pnpm
does the same thing on `dsh plugin add`.

## Test plan

```
pytest tests/d/test_dsh.py -m "static or isolation"  → 10 passed
```

Output-only change: no resource, dependency, version or hook-behaviour edit.
CI's install lanes cover that the recipe still installs.
