### PR TITLE
feat(dsh): declare pnpm, drop redundant npm

### DIFF
--- a/pkgs/d/dsh.lua
+++ b/pkgs/d/dsh.lua
@@ -68,6 +68,21 @@
 -- manage plugins is a worse default than one that says what it needs, and the
 -- gap closes on its own the moment xim:pnpm gains an arm64 asset.
 --
+-- **No `xim:npm`.** node.lua's config() already does
+-- `xvm.add("npm", ...)` and `xvm.add("npx", ...)` off the node payload's own
+-- bin directory, so npm arrives with node — verified: the node payload ships
+-- `bin/npm`. Declaring xim:npm as well is not merely redundant, it puts a
+-- SECOND OWNER on the xvm name `npm` with a different version string
+-- (`11.2.0` from xim:npm vs `node-24.19.0` from xim:node). Two owners with
+-- different versions is the case the spec calls out as the dangerous one:
+-- it is accepted silently at install time and only bites later, when an
+-- `xvm use` on one side rewrites what the other side pointed at. Measured on
+-- a live machine: `npm` already showed three actives across 19 subos in both
+-- naming schemes at once.
+--
+-- (bun.lua and openclaw.lua declare the same redundant pair; out of scope
+-- here, worth a follow-up.)
+--
 -- `xim:node@>=24`, and that floor is upstream's own, not a round number.
 -- The repo root package.json declares
 -- `engines: { node: "^22.19.0 || >=24.0.0" }`. The 22.x arm is unreachable
@@ -118,19 +133,19 @@ package = {
 
     xpm = {
         linux = {
-            deps = {"xim:node@>=24", "xim:npm", "xim:pnpm"},
+            deps = {"xim:node@>=24", "xim:pnpm"},
             ["latest"] = { ref = "0.1.0-rc.6" },
             ["0.1.0-rc.6"] = {},
             ["0.1.0-rc.3"] = {},
         },
         macosx = {
-            deps = {"xim:node@>=24", "xim:npm", "xim:pnpm"},
+            deps = {"xim:node@>=24", "xim:pnpm"},
             ["latest"] = { ref = "0.1.0-rc.6" },
             ["0.1.0-rc.6"] = {},
             ["0.1.0-rc.3"] = {},
         },
         windows = {
-            deps = {"xim:node@>=24", "xim:npm", "xim:pnpm"},
+            deps = {"xim:node@>=24", "xim:pnpm"},
             ["latest"] = { ref = "0.1.0-rc.6" },
             ["0.1.0-rc.6"] = {},
             ["0.1.0-rc.3"] = {},

--- a/pkgs/d/dsh.lua
+++ b/pkgs/d/dsh.lua
@@ -52,16 +52,21 @@
 -- versions. Measured, not assumed — a pty.node built under node 26.7.0
 -- loads under node 24.15.0.
 --
--- **pnpm is deliberately NOT in `deps`.** `dsh plugin --profile <p> add ...`
--- shells out to `pnpm` off PATH — the CLI even says so when it is missing
--- (`dsh: pnpm not found on PATH — install pnpm to manage profile plugins`),
--- so it is tempting to declare it. But xim:pnpm ships only
--- `pnpm-linux-x64` / `pnpm-win32-x64` / `pnpm-darwin-arm64`, i.e. it is
--- `archs = {"x86_64"}` on Linux, while dsh itself is JavaScript and runs
--- wherever node does. A hard dep would therefore make `xlings install dsh`
--- fail outright on aarch64 Linux to enable one optional subcommand. Users
--- who want profile plugin management run `xlings install pnpm` alongside;
--- booting a profile, the web UI and headless runs need none of it.
+-- **pnpm IS a dependency**, and it belongs here rather than in every install
+-- command a user is told to type. `dsh plugin --profile <p> add ...` shells
+-- out to `pnpm` off PATH — the CLI says so itself when it is missing
+-- (`dsh: pnpm not found on PATH — install pnpm to manage profile plugins`) —
+-- and upstream's own removal note is explicit: "Profile installation requires
+-- `pnpm` on the host `PATH`."
+--
+-- The cost, stated rather than discovered later: xim:pnpm ships only
+-- `pnpm-linux-x64` / `pnpm-win32-x64` / `pnpm-darwin-arm64`, so it is
+-- `archs = {"x86_64"}` on Linux while dsh itself is JavaScript and runs
+-- wherever node does. Declaring it therefore makes `xlings install dsh` fail
+-- on aarch64 Linux, where it previously succeeded with plugin management
+-- broken. That trade was made deliberately: an install that works but cannot
+-- manage plugins is a worse default than one that says what it needs, and the
+-- gap closes on its own the moment xim:pnpm gains an arm64 asset.
 --
 -- `xim:node@>=24`, and that floor is upstream's own, not a round number.
 -- The repo root package.json declares
@@ -97,7 +102,13 @@ package = {
     docs = "https://github.com/deepseek-ai/deepseek-harness/blob/master/docs/user/index.md",
 
     type = "package",
-    archs = {"x86_64", "aarch64"},
+    -- x86_64 only, and that is a consequence of the pnpm dep above rather
+    -- than a property of dsh: dsh is JavaScript and runs wherever node does,
+    -- but xim:pnpm has no aarch64 asset, so the dependency closure cannot
+    -- resolve there. Declaring aarch64 while the install cannot succeed would
+    -- be a claim the index cannot honour. Restore it the moment xim:pnpm
+    -- ships arm64.
+    archs = {"x86_64"},
     status = "dev", -- upstream: developer preview, breaking changes expected
     categories = {"ai", "cli", "tools"},
     keywords = {"dsh", "deepseek", "deepseek-harness", "agent", "cli", "cordis"},
@@ -107,19 +118,19 @@ package = {
 
     xpm = {
         linux = {
-            deps = {"xim:node@>=24", "xim:npm"},
+            deps = {"xim:node@>=24", "xim:npm", "xim:pnpm"},
             ["latest"] = { ref = "0.1.0-rc.6" },
             ["0.1.0-rc.6"] = {},
             ["0.1.0-rc.3"] = {},
         },
         macosx = {
-            deps = {"xim:node@>=24", "xim:npm"},
+            deps = {"xim:node@>=24", "xim:npm", "xim:pnpm"},
             ["latest"] = { ref = "0.1.0-rc.6" },
             ["0.1.0-rc.6"] = {},
             ["0.1.0-rc.3"] = {},
         },
         windows = {
-            deps = {"xim:node@>=24", "xim:npm"},
+            deps = {"xim:node@>=24", "xim:npm", "xim:pnpm"},
             ["latest"] = { ref = "0.1.0-rc.6" },
             ["0.1.0-rc.6"] = {},
             ["0.1.0-rc.3"] = {},


### PR DESCRIPTION
## Summary

`dsh plugin` is a pnpm forwarder. Without pnpm on `PATH` it fails with
`dsh: pnpm not found on PATH — install pnpm to manage profile plugins`, and
upstream's own removal note states it outright:

> Profile installation requires `pnpm` on the host `PATH`.

So it belongs in this package's deps, not in every install command a reader is
told to type (`xlings install dsh pnpm -y` → `xlings install dsh -y`).

## This reverses a call made in #617

The original recipe deliberately left pnpm out, because `xim:pnpm` ships only
`pnpm-linux-x64` / `pnpm-win32-x64` / `pnpm-darwin-arm64` — it is
`archs = {"x86_64"}` on Linux, while dsh is JavaScript and runs wherever node
does. Declaring it makes `xlings install dsh` **fail on aarch64 Linux**, where
it previously succeeded with plugin management quietly broken.

That cost is real and is not hand-waved: an install that works but cannot do
the thing the package exists for is a worse default than one that states its
requirements. The gap closes by itself the moment `xim:pnpm` gains an arm64
asset, and the recipe comment says so.

`archs` narrows to `{"x86_64"}` to match. Leaving `aarch64` declared while the
dependency closure cannot resolve there would advertise an architecture the
install cannot reach.

## Test plan

```
pytest tests/d/test_dsh.py -m "static or isolation"  → 10 passed
pytest tests/ -m "static or isolation"               → 1755 passed, 9 skipped
```

CI's install lanes exercise the new closure on Linux, macOS and Windows.


## Second commit: dropping `xim:npm`

Review question: with `xim:node` declared, is `xim:npm` needed? No — and it is
not merely redundant.

`node.lua`'s `config()` already does `xvm.add("npm", ...)` and
`xvm.add("npx", ...)` against the node payload's own bin directory, and that
payload ships `bin/npm` (verified by running it: `npm --version` → 10.8.2).

Declaring both puts **two owners on the xvm name `npm`** with different version
strings — `11.2.0` from `xim:npm` vs `node-24.19.0` from `xim:node`. That is
the case the spec singles out as the dangerous one:

> 两个包注册**同名不同版本** → **接受**，名字变成双 owner。一次 `xvm use`
> 落到另一侧就静默改写…… 第二种更危险，因为安装当下一切正常。

It is already visible in the wild — on a live machine `npm` showed **three
actives across 19 subos in both naming schemes at once**:

```
npm: 19 subos, 3 actives   11.2.0=… , node-24.15.0=… , node-26.7.0=…
```

`bun.lua` and `openclaw.lua` declare the same redundant pair. Out of scope
here; noted in the recipe comment as a follow-up.