### PR TITLE
feat(msvc,curl): close the chain -- the toolset, and the downloader it uses

### DIFF
--- a/.github/scripts/check-dep-namespace.lua
+++ b/.github/scripts/check-dep-namespace.lua
@@ -72,6 +72,8 @@ local ROOT = "."
 local EXEMPT = {
     -- ["pkgs/g/godot.lua"] = { ["graphics"] = "#540, remove once published" },
     ["pkgs/x/xmake.lua"] = { ["ncurses"] = "#582, new in this PR; remove once published" },
+    ["pkgs/w/windows-sdk.lua"] = { ["curl"] = "#627, new in this PR; remove once published" },
+    ["pkgs/m/msvc.lua"] = { ["curl"] = "#627, new in this PR; remove once published" },
 }
 
 local function is_exempt(file, name)

--- a/pkgs/c/curl.lua
+++ b/pkgs/c/curl.lua
@@ -1,0 +1,93 @@
+-- curl, packaged for Windows.
+--
+-- Windows only, and that is the whole point: on Linux and macOS curl is part
+-- of the base system and packaging it would buy nothing. On Windows it also
+-- ships with the OS (System32\curl.exe, since Windows 10 1803) -- but a
+-- recipe that FETCHES things is a different consumer from a user typing curl.
+-- windows-sdk and msvc download a pinned set of payloads and verify every
+-- sha256; leaving the downloader itself to whatever the host happens to have
+-- is the one host dependency left in an otherwise closed chain.
+--
+-- Upstream binaries from curl.se's own Windows page (the curl-for-win build
+-- the project links from https://curl.se/windows/). The `_7` in the archive
+-- name is that build's revision, not curl's -- the package version is curl's.
+package = {
+    spec = "1",
+
+    name = "curl",
+    description = "Command-line tool and library for transferring data with URLs",
+    homepage = "https://curl.se/",
+    maintainers = {"curl"},
+    licenses = {"curl"},
+    repo = "https://github.com/curl/curl",
+    docs = "https://curl.se/docs/",
+
+    type = "package",
+    archs = {"x86_64"},
+    status = "stable",
+    categories = {"cli", "network", "tools"},
+    keywords = {"curl", "http", "download", "transfer", "network"},
+
+    programs = {"curl"},
+    xvm_enable = true,
+
+    xpm = {
+        windows = {
+            ["latest"] = { ref = "8.21.0" },
+            ["8.21.0"] = {
+                url = "https://curl.se/windows/dl-8.21.0_7/curl-8.21.0_7-win64-mingw.zip",
+                sha256 = "e469dcdb219d0eca9236b01c7e4bb34fe04af3d4036d350829178dc60f241ae4",
+            },
+        },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+import("xim.libxpkg.log")
+
+-- The archive's single top-level directory, which is NOT the package version:
+-- curl 8.21.0 ships as curl-8.21.0_7-win64-mingw. Spelled out rather than
+-- derived, because the two are different facts that only look alike.
+local ARCHIVE_DIR = "curl-8.21.0_7-win64-mingw"
+
+function installed()
+    return os.isfile(path.join(pkginfo.install_dir(), "bin", "curl.exe"))
+end
+
+function install()
+    local idir = pkginfo.install_dir()
+    os.tryrm(idir)
+
+    -- The framework extracts the zip next to the download; its top-level
+    -- directory becomes the package root.
+    local extracted = path.join(path.directory(pkginfo.install_file()), ARCHIVE_DIR)
+    if not os.isdir(extracted) then
+        -- Older layouts extract in place; fall back to the sibling named after
+        -- the archive itself before giving up.
+        extracted = pkginfo.install_file():replace(".zip", "")
+    end
+    if not os.isdir(extracted) then
+        log.error("curl: cannot find the extracted archive (expected " .. ARCHIVE_DIR .. ")")
+        return false
+    end
+    os.mv(extracted, idir)
+
+    if not installed() then
+        log.error("curl: unpacked, but bin/curl.exe is not there")
+        return false
+    end
+    return true
+end
+
+function config()
+    -- bin/, not the package root: libcurl-x64.dll and curl-ca-bundle.crt live
+    -- beside the executable and are found relative to it.
+    xvm.add("curl", { bindir = path.join(pkginfo.install_dir(), "bin") })
+    return true
+end
+
+function uninstall()
+    xvm.remove("curl")
+    return true
+end

--- a/pkgs/m/msvc.lua
+++ b/pkgs/m/msvc.lua
@@ -1,57 +1,256 @@
+-- MSVC toolset as an xlings payload package.
+--
+-- Replaces a `type = "config"` recipe that shelled out to vs_BuildTools.exe.
+-- That one installed to C:\Program Files (x86), needed a GUI (--passive) and
+-- elevation, could not express a version finer than "2022", and returned true
+-- without checking whether anything had been installed.
+--
+-- This one downloads the toolset the way Visual Studio itself does and unpacks
+-- it into the xlings payload store. No installer, no elevation, no registry,
+-- no reboot -- and several toolsets can coexist, exactly like gcc.
+--
+-- ── Where the payloads come from ──────────────────────────────────────────
+--
+-- Visual Studio's distribution is manifest-driven, which is the only reason a
+-- specific compiler build can be pinned at all (the bootstrapper always serves
+-- whatever is current):
+--
+--   1. https://aka.ms/vs/17/release/channel        -> channel manifest (JSON)
+--   2. its Microsoft.VisualStudio.Manifests.VisualStudio item
+--                                                  -> package manifest (JSON)
+--   3. each package carries payloads with an exact url + sha256
+--
+-- A `.vsix` payload is a zip whose contents sit under `Contents/`, and for the
+-- toolset that content is already `VC/Tools/MSVC/<ver>/...` -- so unpacking is
+-- "unzip, drop one path component", and the result is the layout every
+-- consumer already knows how to read.
+--
+-- Retention was checked before depending on it: the VS 2019 channel manifest
+-- and its payloads still resolve today, so release-channel URLs are good for
+-- years. Insider-channel payloads rotate and are deliberately NOT offered here.
+--
+-- ── Versioning ────────────────────────────────────────────────────────────
+--
+-- The version is the toolset's own directory name (14.44.35207), not the
+-- product year and not the manifest's package version -- those differ from it
+-- and from each other (Tools 14.44.35228, Headers 14.44.35220, CRT 14.44.35226
+-- all unpack into 14.44.35207). The directory name is what `-vcvars_ver` takes,
+-- what build systems report, and what a second toolset would have to differ in.
 package = {
     spec = "1",
-    name = "msvc",
-    description = "Microsoft Visual Studio C++ Compiler",
-    maintainers = {"Microsoft"},
 
-    type = "config",
-    status = "stable",
-    categories = { "toolchain", "c++", "c", "compiler" },
-    keywords = { "msvc", "c++", "c" },
+    name = "msvc",
+    description = "Microsoft Visual C++ compiler toolset (portable, pinned to a toolset build)",
+
+    maintainers = {"Microsoft"},
+    licenses = {"Proprietary"},
+    homepage = "https://visualstudio.microsoft.com/downloads/",
+    docs = "https://learn.microsoft.com/cpp/",
+
+    type = "package",
+    archs = {"x86_64"},
+    status = "dev",
+    categories = {"toolchain", "compiler", "c++", "c"},
+    keywords = {"msvc", "cl", "c++", "c", "compiler", "windows"},
+
+    programs = {"cl", "link", "lib", "ml64", "dumpbin"},
+
+    xvm_enable = true,
 
     xpm = {
         windows = {
-            deps = { "xim:vs-buildtools@2022" },
-            ["latest"] = { ref = "2022" },
-            ["2022"] = {}, -- v143
+            -- The compiler is useless without the ucrt/um headers and libs,
+            -- and those are a separate product. Declared, not assumed to be
+            -- on the host.
+            -- curl is bare because it is new in this same change; see the
+            -- EXEMPT entry in .github/scripts/check-dep-namespace.lua.
+            -- Qualify it once published.
+            deps = { "xim:windows-sdk@10.0.26100", "curl" },
+            ["latest"] = { ref = "14.44.35207" },
+            -- Empty resource: this package fetches a SET of payloads and the
+            -- framework's single-url download cannot express that. install()
+            -- does it and checks every sha256 itself.
+            ["14.44.35207"] = { },
         },
-    }
+    },
 }
 
-import("xim.libxpkg.pkgmanager")
-import("core.tool.toolchain")
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.system")
+import("xim.libxpkg.log")
+import("xim.libxpkg.xvm")
+import("xim.libxpkg.subos")
 
--- https://learn.microsoft.com/en-us/visualstudio/install/workload-component-id-vs-build-tools?view=vs-2022
---local msvc_compiler = "Microsoft.VisualStudio.Component.VC.Tools.x86.x64"
-local msvc_component = "Microsoft.VisualStudio.Workload.VCTools"
--- kernel32.lib issues need refresh
+-- The directory version inside every payload. Same value as the package
+-- version; spelled out rather than derived from it, because they are two
+-- different facts that happen to agree.
+local TOOLSET = "14.44.35207"
+local SDK_DIR_VERSION = "10.0.26100.0"
+
+-- path.join mixes separators on Windows -- it keeps the backslashes already in
+-- the store path and adds forward ones. tar does not care; xcopy does.
+local function winpath(p)
+    return (p:gsub("/", "\\"))
+end
+
+local PAYLOADS = {
+    { name = "Microsoft.VC.14.44.17.14.Tools.HostX64.TargetX64.base.vsix",
+      sha256 = "ee0baaa3a112d255f19f6c27dcc0ff6e496949eb9f1f37be0ac908c562a7076c",
+      url = "https://download.visualstudio.microsoft.com/download/pr/bbc72d8e-2acd-4229-8f6a-85e23c5e3456/ee0baaa3a112d255f19f6c27dcc0ff6e496949eb9f1f37be0ac908c562a7076c/Microsoft.VC.14.44.17.14.Tools.HostX64.TargetX64.base.vsix" },
+    { name = "Microsoft.VC.14.44.17.14.CRT.Headers.base.vsix",
+      sha256 = "852382a9aa73502b7849c1bcadfb603ba7175c4e8b60e6aba03c7de711d4ece5",
+      url = "https://download.visualstudio.microsoft.com/download/pr/c610cd8c-801b-44b8-a80a-82cc382aeb43/852382a9aa73502b7849c1bcadfb603ba7175c4e8b60e6aba03c7de711d4ece5/Microsoft.VC.14.44.17.14.CRT.Headers.base.vsix" },
+    { name = "Microsoft.VC.14.44.17.14.CRT.x64.Desktop.base.vsix",
+      sha256 = "f01f701a7bcd9587a340898c851424f6a52bb913a70c185ff0d5bf0288c5831a",
+      url = "https://download.visualstudio.microsoft.com/download/pr/67cf767c-5e71-47c2-a54a-cd5631e28942/f01f701a7bcd9587a340898c851424f6a52bb913a70c185ff0d5bf0288c5831a/Microsoft.VC.14.44.17.14.CRT.x64.Desktop.base.vsix" },
+    { name = "Microsoft.VC.14.44.17.14.CRT.Redist.X64.base.vsix",
+      sha256 = "4aaf54db0bfc9435f7c3660e1a00237a4b556042bfeea64bde44c2e0194e6ee5",
+      url = "https://download.visualstudio.microsoft.com/download/pr/45d3b8dd-bced-4b37-9974-142f748d710c/4aaf54db0bfc9435f7c3660e1a00237a4b556042bfeea64bde44c2e0194e6ee5/Microsoft.VC.14.44.17.14.CRT.Redist.X64.base.vsix" },
+}
+
+local function toolsdir()
+    return path.join(pkginfo.install_dir(), "VC", "Tools", "MSVC", TOOLSET)
+end
+
+local function bindir()
+    return path.join(toolsdir(), "bin", "Hostx64", "x64")
+end
+
+-- Download one payload and prove it is the file we asked for.
+--
+-- The check is the point, not the download: these bytes become a compiler, and
+-- "curl exited 0" says nothing about what arrived. Returns false on any
+-- mismatch rather than letting a bad payload through.
+--
+-- certutil, not PowerShell's Get-FileHash: both ship with Windows, but
+-- Get-FileHash needs a quoted -LiteralPath nested inside a quoted -Command
+-- inside a shell string. certutil takes one quoted path and prints the digest
+-- on a line of its own.
+local function fetch_verified(entry, dir)
+    local dst = path.join(dir, entry.name)
+    if not os.isfile(dst) then
+        log.info("msvc: fetching " .. entry.name)
+        system.exec(string.format('curl -fsSL --retry 3 -o "%s" "%s"', dst, entry.url))
+    end
+    if not os.isfile(dst) then
+        log.error("msvc: download produced no file: " .. entry.name)
+        return false
+    end
+    local out = os.iorun(string.format('certutil -hashfile "%s" SHA256', dst)) or ""
+    local got = nil
+    for line in out:gmatch("[^\r\n]+") do
+        local hex = line:gsub("%s+", ""):lower()
+        if #hex == 64 and hex:match("^%x+$") then got = hex break end
+    end
+    -- Case-insensitive: certutil prints uppercase, and the manifest is not
+    -- consistent either -- the VC payloads carry lowercase digests while the
+    -- SDK's are uppercase. Comparing the bytes, not their spelling.
+    if got ~= entry.sha256:lower() then
+        log.error("msvc: sha256 mismatch for " .. entry.name ..
+                  "\n  expected " .. entry.sha256 .. "\n  got      " .. tostring(got))
+        os.tryrm(dst)
+        return false
+    end
+    return true
+end
 
 function installed()
-    local msvc_path = [[C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC]]
-    return os.isdir(msvc_path) or toolchain.load("msvc"):check() == "2022"
+    -- The compiler itself and the STL's std.ixx: the two things whose absence
+    -- turns into a confusing failure much later.
+    return os.isfile(path.join(bindir(), "cl.exe"))
+       and os.isfile(path.join(toolsdir(), "modules", "std.ixx"))
 end
 
 function install()
-    os.exec(
-        "vs_BuildTools.exe" ..
-        -- " --installPath " .. vs_install_path ..
-        " --add " .. msvc_component ..
-        " --includeRecommended" ..
-        -- " --quiet " ..
-        " --passive " ..
-        -- " --norestart " ..
-        " --wait " -- ..
-    )
+    local idir = pkginfo.install_dir()
+    local work = path.join(idir, ".payloads")
+    os.tryrm(idir)
+    os.mkdir(work)
+
+    for _, e in ipairs(PAYLOADS) do
+        if not fetch_verified(e, work) then return false end
+    end
+
+    -- A .vsix is a zip. Windows 10 1803+ ships tar.exe, which reads zip and
+    -- needs no PowerShell module and no temp COM object.
+    local stage = path.join(work, "x")
+    for _, e in ipairs(PAYLOADS) do
+        log.info("msvc: unpacking " .. e.name)
+        os.mkdir(stage)
+        system.exec(string.format('tar -xf "%s" -C "%s"', path.join(work, e.name), stage))
+        -- Everything useful lives under Contents/; the rest is vsix metadata.
+        local contents = path.join(stage, "Contents")
+        if os.isdir(contents) then
+            -- All four payloads unpack into the SAME VC/ tree, so this is a
+            -- merge, not a move. os.cp of a directory INTO an existing one of
+            -- the same name nests it -- measured on windows-sdk, which ended
+            -- up with Include/<ver>/<ver>/ that way -- and a recursive merge
+            -- in Lua would need os.files, which is not in the sandbox.
+            -- xcopy merges, ships with Windows, and returns 0 on success.
+            system.exec(string.format('xcopy "%s\\*" "%s\\" /E /I /Y /Q',
+                                      winpath(contents), winpath(idir)))
+        end
+        os.tryrm(stage)
+    end
+    os.tryrm(work)
+
+    if not installed() then
+        log.error("msvc: unpacked, but cl.exe / std.ixx are not where they should be " ..
+                  "(expected under VC/Tools/MSVC/" .. TOOLSET .. ")")
+        return false
+    end
+    return true
+end
+
+function config()
+    local idir = pkginfo.install_dir()
+    local sdk = pkginfo.dep_install_dir("xim:windows-sdk")
+
+    -- INCLUDE / LIB go on the SHIMS, not into the subos.
+    --
+    -- They are the compiler's own business: cl and link are the processes that
+    -- read them, and they are exactly the processes xlings wraps. Putting them
+    -- in the subos instead would export a Windows-SDK include path to every
+    -- other compiler in the same subos, which is a real way to break an
+    -- unrelated build.
+    local inc = { path.join(idir, "VC", "Tools", "MSVC", TOOLSET, "include") }
+    local lib = { path.join(idir, "VC", "Tools", "MSVC", TOOLSET, "lib", "x64") }
+    if sdk then
+        for _, part in ipairs({"ucrt", "um", "shared"}) do
+            table.insert(inc, path.join(sdk, "Include", SDK_DIR_VERSION, part))
+        end
+        for _, part in ipairs({"ucrt", "um"}) do
+            table.insert(lib, path.join(sdk, "Lib", SDK_DIR_VERSION, part, "x64"))
+        end
+    else
+        log.warn("msvc: windows-sdk did not resolve; cl will not find ucrt/um headers")
+    end
+
+    local envs = {
+        INCLUDE = table.concat(inc, ";"),
+        LIB     = table.concat(lib, ";"),
+    }
+    for _, prog in ipairs(package.programs) do
+        xvm.add(prog, { bindir = bindir(), envs = envs })
+    end
+
+    -- VSINSTALLDIR goes in the SUBOS, because the processes that need it are
+    -- build systems -- mcpp, xmake, cmake -- and xlings never wraps those, so
+    -- a per-shim env cannot reach them. They use it to DISCOVER the toolchain:
+    -- mcpp, for one, accepts any directory that has VC/Tools/MSVC under it.
+    --
+    -- This is a compatibility hook, not the record of which toolchain a build
+    -- used. That record belongs in the project's own manifest.
+    if type(subos.env) == "function" then
+        local tag = package.name .. "@" .. pkginfo.version()
+        subos.env{ var = "VSINSTALLDIR", op = "set", value = "${pkgdir}", binding = tag }
+    end
     return true
 end
 
 function uninstall()
-    if not os.isfile("vs_BuildTools.exe") then pkgmanager.install("vs-buildtools") end
-    os.exec(
-        "vs_BuildTools.exe" ..
-        " --remove " .. msvc_component ..
-        " --passive " ..
-        " --wait "
-    )
+    for _, prog in ipairs(package.programs) do
+        xvm.remove(prog)
+    end
     return true
 end

--- a/pkgs/v/vs-buildtools.lua
+++ b/pkgs/v/vs-buildtools.lua
@@ -1,10 +1,21 @@
+-- DEPRECATED -- use `xim:msvc` instead.
+--
+-- This recipe does not install Visual Studio Build Tools. It downloads the
+-- ~1 MB bootstrapper and stops there (`install()` is `return true`), so
+-- `xlings install vs-buildtools` leaves nothing that can compile anything.
+-- Its only purpose was to be a dependency of the old `msvc` recipe, which
+-- then shelled out to that bootstrapper; `msvc` now unpacks a pinned toolset
+-- into the xlings payload store and needs no installer.
+--
+-- Kept, not deleted, so an existing `xlings install vs-buildtools` keeps
+-- resolving. Nothing in this index depends on it any more.
 package = {
     spec = "1",
     name = "vs-buildtools",
-    description = "Visual Studio Build Tools",
+    description = "Visual Studio Build Tools bootstrapper (DEPRECATED -- use xim:msvc)",
 
     type = "config",
-    status = "stable",
+    status = "deprecated",
     maintainers = {"Microsoft"},
     categories = { "build-tools" },
     keywords = { "msvc" },

--- a/pkgs/w/windows-sdk.lua
+++ b/pkgs/w/windows-sdk.lua
@@ -49,6 +49,13 @@ package = {
             -- Empty resource: this package fetches a SET of payloads, and the
             -- framework's single-url download cannot express that. install()
             -- does it, and checks every sha256 itself.
+            -- curl does the fetching below. Windows ships one since 10 1803,
+            -- but a recipe that downloads and checksums a pinned payload set
+            -- should not leave the downloader itself to the host -- that is
+            -- the one open end in an otherwise closed chain. Bare because curl
+            -- is new in the same change as this dependency; see the EXEMPT
+            -- entry in .github/scripts/check-dep-namespace.lua.
+            deps = { "curl" },
             ["latest"] = { ref = "10.0.26100" },
             ["10.0.26100"] = { },
         },

--- a/tests/c/test_curl.py
+++ b/tests/c/test_curl.py
@@ -1,4 +1,4 @@
-"""测试 msvc 包"""
+"""测试 curl 包"""
 import pytest
 from tests.lib.xpkg_parser import parse_xpkg
 from tests.lib.assertions import (
@@ -8,8 +8,8 @@ from tests.lib.assertions import (
     assert_xim_add_succeeds,
 )
 
-PKG = "msvc"
-PKG_FILE = "pkgs/m/msvc.lua"
+PKG = "curl"
+PKG_FILE = "pkgs/c/curl.lua"
 
 
 @pytest.fixture(scope='module')
@@ -35,16 +35,14 @@ class TestStatic:
         assert_no_typos(PKG_FILE)
 
     @pytest.mark.static
-    def test_every_payload_is_pinned(self):
-        """每个 payload 都必须同时有 url 和 sha256。
+    def test_url_is_pinned(self):
+        """每个 url 都要有 sha256。
 
-        这个包自己下载一组 payload, 框架的单 url 校验覆盖不到它们 ——
-        少一个 sha256 就是少一次校验, 而这些字节会变成编译器。
+        curl 是 windows-sdk / msvc 的下载器 —— 它自己没被校验, 后面
+        那些 sha256 就都建立在一个未经检查的二进制上。
         """
         src = open(PKG_FILE, encoding='utf-8').read()
-        assert src.count('url = "https://') == src.count('sha256 = "'), \
-            "payload 表里 url 与 sha256 数量不一致"
-        assert src.count('sha256 = "') > 0
+        assert src.count('url = "https://') == src.count('sha256 = "') > 0
 
 
 class TestIndex:


### PR DESCRIPTION
接续 #626。`windows-sdk` 已发布，`msvc` 可以指名依赖它了 —— 这个 PR 让整条链闭合：`xlings install msvc` 装到钉死版本的 toolset、它离不开的 SDK，以及**下载它们所用的 curl**。

## 三件事

| 包 | 变化 |
|---|---|
| `msvc` | **重写**为 payload 包，钉到 toolset **14.44.35207** |
| `curl` | **新增**，Windows |
| `vs-buildtools` | 标记 `deprecated` |

### 为什么要打包 curl

Windows 自 10 1803 起自带 `System32\curl.exe`，所以这不是"能不能跑"的问题。

但 `windows-sdk` 和 `msvc` 的工作方式是：**下载一组钉死的 payload，逐个校验 sha256**。如果**下载器本身**取决于宿主上恰好有什么，那这条链就还留着一个开口 —— 后面所有的 sha256 都建立在一个未经检查的二进制上。两个包现在都声明了它。

Linux / macOS 不打包：那两个平台上 curl 属于基础系统，打包不带来任何东西。

## 旧 `msvc` 的问题（为什么是重写不是修补）

`type = "config"`（V1 spec：「系统配置操作，无需下载资源文件」）—— **声明上就没有 payload**：

- `--installPath` 和 `--quiet` 都被注释掉 → 装到 `C:\Program Files (x86)`，`--passive` 带 GUI、要管理员
- 版本粒度只到 `"2022"`
- `install()` 直接 `return true`，从不检查装没装上（R4）
- `installed()` 两个答案源，且硬编码的 `2022\BuildTools` 在 `windows-2025-vs2026` 镜像上永远为假（R3）

## #626 那八轮红 CI 的教训，这里是**套用**而不是重新踩

- **每个 API 都在索引里有先例**。那边失败的三个（`os.execv`、`path.absolute`、`os.files`）在整个索引里**零使用** —— 这个信号我到第三次才用上，现在它是写 recipe 的第一步
- 四个 vsix 解进**同一棵 `VC/` 树**，所以是合并：`os.cp` 目录进同名目录会**嵌套一层**（windows-sdk 就是这样产出了 `Include/<ver>/<ver>/`），而 Lua 里做递归合并需要 `os.files`，它不在沙箱里 → 用 `xcopy`（`robocopy` 成功返回位掩码，会被当失败）
- `path.join` 在 Windows 上混用分隔符 → 给 `xcopy` 全反斜杠路径
- sha256 **大小写无关**比较 —— VS 清单自己就不一致（VC 小写、SDK 大写）
- `installed()` 断言 `cl.exe` 与 `modules/std.ixx`，**两个名字都是从真实 payload 里读出来的**，不是猜的

## 本地已通过

```
static + isolation   1785 passed
lint x3              libpath / blocking-stdin / dep-namespace 全 PASS
```

`msvc` 的解包路径与 `windows-sdk` 同形（下载 → 校验 → 解包 → 合并 → 断言），但**它自己还没在 Windows CI 上跑过** —— 这正是本 PR 的 `windows-test` 要回答的。

## 说明

- `curl` 是本 PR 新增，所以两处依赖用**裸名** + `check-dep-namespace.lua` 的 EXEMPT 条目（同 `xmake.lua` 的 `ncurses` 先例）。发布后应改成 `xim:curl@<ver>` 并移除豁免。
- mcpp 侧的三个适配需求已提：mcpp-community/mcpp#432。前两条修掉后，xrgui workflow 里那个「挪开 `vswhere.exe`」的 workaround 就能整个删掉。
