### PR TITLE
feat(msvc): add 14.52.36629 -- the toolset xrgui needs -- and qualify the curl dep

### DIFF
--- a/.github/scripts/check-dep-namespace.lua
+++ b/.github/scripts/check-dep-namespace.lua
@@ -72,8 +72,6 @@ local ROOT = "."
 local EXEMPT = {
     -- ["pkgs/g/godot.lua"] = { ["graphics"] = "#540, remove once published" },
     ["pkgs/x/xmake.lua"] = { ["ncurses"] = "#582, new in this PR; remove once published" },
-    ["pkgs/w/windows-sdk.lua"] = { ["curl"] = "#627, new in this PR; remove once published" },
-    ["pkgs/m/msvc.lua"] = { ["curl"] = "#627, new in this PR; remove once published" },
 }
 
 local function is_exempt(file, name)

--- a/pkgs/m/msvc.lua
+++ b/pkgs/m/msvc.lua
@@ -60,17 +60,20 @@ package = {
     xpm = {
         windows = {
             -- The compiler is useless without the ucrt/um headers and libs,
-            -- and those are a separate product. Declared, not assumed to be
-            -- on the host.
-            -- curl is bare because it is new in this same change; see the
-            -- EXEMPT entry in .github/scripts/check-dep-namespace.lua.
-            -- Qualify it once published.
-            deps = { "xim:windows-sdk@10.0.26100", "curl" },
+            -- and those are a separate product. curl does the fetching. Both
+            -- declared, neither assumed to be on the host.
+            deps = { "xim:windows-sdk@10.0.26100", "xim:curl@8.21.0" },
+
+            -- `latest` stays on the release channel deliberately. 14.52 is an
+            -- Insiders toolset; asking for it should be a choice, not what a
+            -- bare `xlings install msvc` hands you.
             ["latest"] = { ref = "14.44.35207" },
-            -- Empty resource: this package fetches a SET of payloads and the
+
+            -- Empty resources: this package fetches a SET of payloads and the
             -- framework's single-url download cannot express that. install()
             -- does it and checks every sha256 itself.
-            ["14.44.35207"] = { },
+            ["14.44.35207"] = { },   -- release channel, VS 2022 17.14
+            ["14.52.36629"] = { },   -- Insiders, VS 2026 -- see TOOLSETS below
         },
     },
 }
@@ -81,11 +84,16 @@ import("xim.libxpkg.log")
 import("xim.libxpkg.xvm")
 import("xim.libxpkg.subos")
 
--- The directory version inside every payload. Same value as the package
--- version; spelled out rather than derived from it, because they are two
--- different facts that happen to agree.
-local TOOLSET = "14.44.35207"
 local SDK_DIR_VERSION = "10.0.26100.0"
+
+-- The package version IS the toolset's directory name -- that is why the
+-- version is spelled the way it is. Verified per entry rather than assumed:
+-- for 14.44 the payloads carry 35228 / 35220 / 35226 and all unpack into
+-- 14.44.35207, while 14.52's payloads and directory agree at 36629. Getting
+-- this wrong is not subtle; nothing lands where the recipe looks for it.
+local function toolset()
+    return pkginfo.version()
+end
 
 -- path.join mixes separators on Windows -- it keeps the backslashes already in
 -- the store path and adds forward ones. tar does not care; xcopy does.
@@ -93,23 +101,58 @@ local function winpath(p)
     return (p:gsub("/", "\\"))
 end
 
-local PAYLOADS = {
-    { name = "Microsoft.VC.14.44.17.14.Tools.HostX64.TargetX64.base.vsix",
-      sha256 = "ee0baaa3a112d255f19f6c27dcc0ff6e496949eb9f1f37be0ac908c562a7076c",
-      url = "https://download.visualstudio.microsoft.com/download/pr/bbc72d8e-2acd-4229-8f6a-85e23c5e3456/ee0baaa3a112d255f19f6c27dcc0ff6e496949eb9f1f37be0ac908c562a7076c/Microsoft.VC.14.44.17.14.Tools.HostX64.TargetX64.base.vsix" },
-    { name = "Microsoft.VC.14.44.17.14.CRT.Headers.base.vsix",
-      sha256 = "852382a9aa73502b7849c1bcadfb603ba7175c4e8b60e6aba03c7de711d4ece5",
-      url = "https://download.visualstudio.microsoft.com/download/pr/c610cd8c-801b-44b8-a80a-82cc382aeb43/852382a9aa73502b7849c1bcadfb603ba7175c4e8b60e6aba03c7de711d4ece5/Microsoft.VC.14.44.17.14.CRT.Headers.base.vsix" },
-    { name = "Microsoft.VC.14.44.17.14.CRT.x64.Desktop.base.vsix",
-      sha256 = "f01f701a7bcd9587a340898c851424f6a52bb913a70c185ff0d5bf0288c5831a",
-      url = "https://download.visualstudio.microsoft.com/download/pr/67cf767c-5e71-47c2-a54a-cd5631e28942/f01f701a7bcd9587a340898c851424f6a52bb913a70c185ff0d5bf0288c5831a/Microsoft.VC.14.44.17.14.CRT.x64.Desktop.base.vsix" },
-    { name = "Microsoft.VC.14.44.17.14.CRT.Redist.X64.base.vsix",
-      sha256 = "4aaf54db0bfc9435f7c3660e1a00237a4b556042bfeea64bde44c2e0194e6ee5",
-      url = "https://download.visualstudio.microsoft.com/download/pr/45d3b8dd-bced-4b37-9974-142f748d710c/4aaf54db0bfc9435f7c3660e1a00237a4b556042bfeea64bde44c2e0194e6ee5/Microsoft.VC.14.44.17.14.CRT.Redist.X64.base.vsix" },
+-- One payload set per toolset, keyed by that toolset's directory version.
+--
+-- 14.44 comes from the release channel (aka.ms/vs/17/release/channel), 14.52
+-- from Insiders (aka.ms/vs/18/insiders/channel) -- two manifests, and the
+-- package ids are not spelled alike either: Microsoft.VC.14.44.17.14.* against
+-- Microsoft.VC.14.52.*.
+--
+-- The Insiders entry carries a risk the release one does not: Microsoft rotates
+-- those payloads. When 14.52.36629 goes away the URLs 404 -- loudly, and with
+-- the sha256 still pinned, so a rotated build cannot be served in its place.
+-- That is the failure mode worth having; it is also why `latest` is not it.
+local function payloads()
+    local set = TOOLSETS[toolset()]
+    if not set then
+        log.error("msvc: no payload set for toolset " .. tostring(toolset()))
+    end
+    return set or {}
+end
+
+local TOOLSETS = {
+    ["14.44.35207"] = {
+        { name = "Microsoft.VC.14.44.17.14.Tools.HostX64.TargetX64.base.vsix",
+          sha256 = "ee0baaa3a112d255f19f6c27dcc0ff6e496949eb9f1f37be0ac908c562a7076c",
+          url = "https://download.visualstudio.microsoft.com/download/pr/bbc72d8e-2acd-4229-8f6a-85e23c5e3456/ee0baaa3a112d255f19f6c27dcc0ff6e496949eb9f1f37be0ac908c562a7076c/Microsoft.VC.14.44.17.14.Tools.HostX64.TargetX64.base.vsix" },
+        { name = "Microsoft.VC.14.44.17.14.CRT.Headers.base.vsix",
+          sha256 = "852382a9aa73502b7849c1bcadfb603ba7175c4e8b60e6aba03c7de711d4ece5",
+          url = "https://download.visualstudio.microsoft.com/download/pr/c610cd8c-801b-44b8-a80a-82cc382aeb43/852382a9aa73502b7849c1bcadfb603ba7175c4e8b60e6aba03c7de711d4ece5/Microsoft.VC.14.44.17.14.CRT.Headers.base.vsix" },
+        { name = "Microsoft.VC.14.44.17.14.CRT.x64.Desktop.base.vsix",
+          sha256 = "f01f701a7bcd9587a340898c851424f6a52bb913a70c185ff0d5bf0288c5831a",
+          url = "https://download.visualstudio.microsoft.com/download/pr/67cf767c-5e71-47c2-a54a-cd5631e28942/f01f701a7bcd9587a340898c851424f6a52bb913a70c185ff0d5bf0288c5831a/Microsoft.VC.14.44.17.14.CRT.x64.Desktop.base.vsix" },
+        { name = "Microsoft.VC.14.44.17.14.CRT.Redist.X64.base.vsix",
+          sha256 = "4aaf54db0bfc9435f7c3660e1a00237a4b556042bfeea64bde44c2e0194e6ee5",
+          url = "https://download.visualstudio.microsoft.com/download/pr/45d3b8dd-bced-4b37-9974-142f748d710c/4aaf54db0bfc9435f7c3660e1a00237a4b556042bfeea64bde44c2e0194e6ee5/Microsoft.VC.14.44.17.14.CRT.Redist.X64.base.vsix" },
+    },
+    ["14.52.36629"] = {
+        { name = "Microsoft.VC.14.52.Tools.HostX64.TargetX64.base.vsix",
+          sha256 = "3cf795636cf47b91a3583baa45df8cf7e7448c551a6d2f7f65a015cc1b858930",
+          url = "https://download.visualstudio.microsoft.com/download/pr/0fdca428-6677-4d0e-a19d-65f175edc108/3cf795636cf47b91a3583baa45df8cf7e7448c551a6d2f7f65a015cc1b858930/Microsoft.VC.14.52.Tools.HostX64.TargetX64.base.vsix" },
+        { name = "Microsoft.VC.14.52.CRT.Headers.base.vsix",
+          sha256 = "26c7797d7408b565c0a6bdc0862391bc69efc8aff14560dde854a86b32d8720c",
+          url = "https://download.visualstudio.microsoft.com/download/pr/0fdca428-6677-4d0e-a19d-65f175edc108/26c7797d7408b565c0a6bdc0862391bc69efc8aff14560dde854a86b32d8720c/Microsoft.VC.14.52.CRT.Headers.base.vsix" },
+        { name = "Microsoft.VC.14.52.CRT.x64.Desktop.base.vsix",
+          sha256 = "ff89fd2b115c6a08dff82a6ce9cc90ef6f4aeb4704c29a5b77d16f063ad33524",
+          url = "https://download.visualstudio.microsoft.com/download/pr/0fdca428-6677-4d0e-a19d-65f175edc108/ff89fd2b115c6a08dff82a6ce9cc90ef6f4aeb4704c29a5b77d16f063ad33524/Microsoft.VC.14.52.CRT.x64.Desktop.base.vsix" },
+        { name = "Microsoft.VC.14.52.CRT.Redist.X64.base.vsix",
+          sha256 = "da122e4f50a1d3328dd09954ed81ccf3012a32c23abac215872cc74272eee1f3",
+          url = "https://download.visualstudio.microsoft.com/download/pr/0fdca428-6677-4d0e-a19d-65f175edc108/da122e4f50a1d3328dd09954ed81ccf3012a32c23abac215872cc74272eee1f3/Microsoft.VC.14.52.CRT.Redist.X64.base.vsix" },
+    },
 }
 
 local function toolsdir()
-    return path.join(pkginfo.install_dir(), "VC", "Tools", "MSVC", TOOLSET)
+    return path.join(pkginfo.install_dir(), "VC", "Tools", "MSVC", toolset())
 end
 
 local function bindir()
@@ -167,14 +210,14 @@ function install()
     os.tryrm(idir)
     os.mkdir(work)
 
-    for _, e in ipairs(PAYLOADS) do
+    for _, e in ipairs(payloads()) do
         if not fetch_verified(e, work) then return false end
     end
 
     -- A .vsix is a zip. Windows 10 1803+ ships tar.exe, which reads zip and
     -- needs no PowerShell module and no temp COM object.
     local stage = path.join(work, "x")
-    for _, e in ipairs(PAYLOADS) do
+    for _, e in ipairs(payloads()) do
         log.info("msvc: unpacking " .. e.name)
         os.mkdir(stage)
         system.exec(string.format('tar -xf "%s" -C "%s"', path.join(work, e.name), stage))
@@ -196,7 +239,7 @@ function install()
 
     if not installed() then
         log.error("msvc: unpacked, but cl.exe / std.ixx are not where they should be " ..
-                  "(expected under VC/Tools/MSVC/" .. TOOLSET .. ")")
+                  "(expected under VC/Tools/MSVC/" .. toolset() .. ")")
         return false
     end
     return true
@@ -213,8 +256,8 @@ function config()
     -- in the subos instead would export a Windows-SDK include path to every
     -- other compiler in the same subos, which is a real way to break an
     -- unrelated build.
-    local inc = { path.join(idir, "VC", "Tools", "MSVC", TOOLSET, "include") }
-    local lib = { path.join(idir, "VC", "Tools", "MSVC", TOOLSET, "lib", "x64") }
+    local inc = { path.join(idir, "VC", "Tools", "MSVC", toolset(), "include") }
+    local lib = { path.join(idir, "VC", "Tools", "MSVC", toolset(), "lib", "x64") }
     if sdk then
         for _, part in ipairs({"ucrt", "um", "shared"}) do
             table.insert(inc, path.join(sdk, "Include", SDK_DIR_VERSION, part))

--- a/pkgs/m/msvc.lua
+++ b/pkgs/m/msvc.lua
@@ -112,14 +112,6 @@ end
 -- those payloads. When 14.52.36629 goes away the URLs 404 -- loudly, and with
 -- the sha256 still pinned, so a rotated build cannot be served in its place.
 -- That is the failure mode worth having; it is also why `latest` is not it.
-local function payloads()
-    local set = TOOLSETS[toolset()]
-    if not set then
-        log.error("msvc: no payload set for toolset " .. tostring(toolset()))
-    end
-    return set or {}
-end
-
 local TOOLSETS = {
     ["14.44.35207"] = {
         { name = "Microsoft.VC.14.44.17.14.Tools.HostX64.TargetX64.base.vsix",
@@ -150,6 +142,17 @@ local TOOLSETS = {
           url = "https://download.visualstudio.microsoft.com/download/pr/0fdca428-6677-4d0e-a19d-65f175edc108/da122e4f50a1d3328dd09954ed81ccf3012a32c23abac215872cc74272eee1f3/Microsoft.VC.14.52.CRT.Redist.X64.base.vsix" },
     },
 }
+
+-- After TOOLSETS, not before it: a function that closes over a local must be
+-- defined below that local, or the name it captures is a global -- which reads
+-- as `attempt to index a nil value (global 'TOOLSETS')` at install time.
+local function payloads()
+    local set = TOOLSETS[toolset()]
+    if not set then
+        log.error("msvc: no payload set for toolset " .. tostring(toolset()))
+    end
+    return set or {}
+end
 
 local function toolsdir()
     return path.join(pkginfo.install_dir(), "VC", "Tools", "MSVC", toolset())

--- a/pkgs/w/windows-sdk.lua
+++ b/pkgs/w/windows-sdk.lua
@@ -52,10 +52,8 @@ package = {
             -- curl does the fetching below. Windows ships one since 10 1803,
             -- but a recipe that downloads and checksums a pinned payload set
             -- should not leave the downloader itself to the host -- that is
-            -- the one open end in an otherwise closed chain. Bare because curl
-            -- is new in the same change as this dependency; see the EXEMPT
-            -- entry in .github/scripts/check-dep-namespace.lua.
-            deps = { "curl" },
+            -- the one open end in an otherwise closed chain.
+            deps = { "xim:curl@8.21.0" },
             ["latest"] = { ref = "10.0.26100" },
             ["10.0.26100"] = { },
         },


### PR DESCRIPTION
接续 #626 / #627。两件事，第一件比看上去重要。

## 1. 加上 xrgui 真正需要的 toolset：`14.52.36629`

`msvc` 目前只有 `14.44.35207`（release 通道，VS 2022 17.14），而**它构建不了 [Sunrisepeak/xrgui#3](https://github.com/Sunrisepeak/xrgui/pull/3)** —— 那个仓库需要 14.52 preview，而比它低一级的 14.51 不是「差一点」，是**直接 ICE**：

```
mo_yanxi_utility/src/utility/math/basic/vector2.ixx(67):
  fatal error C1001: Internal compiler error.   note: IFC import detected.
```

14.44 更老，从来就不可能满足它。所以这个包在补上 14.52 之前，对最初驱动它的那个用例是没用的。

**14.52 来自 Insiders 通道**（`aka.ms/vs/18/insiders/channel`）—— 另一份清单，包 id 的拼法也不一样：`Microsoft.VC.14.52.*` 而不是 `Microsoft.VC.14.44.17.14.*`。

### 它带着一个 release 条目没有的风险

微软会**轮换 Insiders 的 payload**。等 14.52.36629 下架，这些 URL 会 404 —— **响亮地失败**，而且 sha256 仍然钉着，所以一个轮换后的新构建**不可能悄悄顶替它**。这正是值得拥有的失败模式。

也正因如此 **`latest` 留在 release 通道**：要一个 preview toolset 应当是个明确的选择，而不是 `xlings install msvc` 默认给你的东西。

## 2. 多版本从「方案上支持」变成「真的有两个」

payload 表现在按 toolset 分组，所以 `xlings use msvc <ver>` 有东西可切。

每个版本的**目录版本都是从真实 payload 里读出来的，不是推断的** —— 这一步不能省：

| toolset | payload 包版本 | 解压后的目录版本 |
|---|---|---|
| 14.44 | Tools 35228 / Headers 35220 / CRT 35226 | **14.44.35207**（三者都解到这里） |
| 14.52 | 36629 | **14.52.36629**（一致） |

两者规律不同，猜错的话没有任何东西会落在 recipe 查找的位置。

## 3. curl 依赖限定 + 移除豁免

`curl` 已随 #627 发布，所以两处裸名依赖改成 `xim:curl@8.21.0`，`check-dep-namespace.lua` 里的两条 EXEMPT 移除 —— 这正是那个列表自己的注释要求的：

> REMOVE it in the follow-up that lands after publication. An entry left behind is the bug this check exists to catch, wearing a permit.

## 本地已通过

```
static + isolation   1785 passed
lint x3              libpath / blocking-stdin / dep-namespace 全 PASS
payload 表求值       两个版本各 4 个 payload，url/sha256 成对、长度合法
```

`windows-test` 会实际安装 —— 注意它测的是 `latest`（14.44），**14.52 那条路径本 PR 不会被 CI 覆盖**，两者的差异只在 payload URL 和目录版本，而后者已按上表逐个核对过。
