### PR TITLE
feat(msvc,windows-sdk): a payload gets ADDRESSES, not an address

### DIFF
--- a/pkgs/m/msvc.lua
+++ b/pkgs/m/msvc.lua
@@ -235,8 +235,19 @@ local function fetch_verified(entry, dir)
     end
 
     local why = {}
-    for _, url in ipairs(sources(entry)) do
-        log.info("msvc: fetching " .. entry.name .. " from " .. host_of(url))
+    for i, url in ipairs(sources(entry)) do
+        -- The FIRST address is the expected one; reaching a later one means
+        -- something is wrong upstream even though the install still succeeds.
+        -- That has to be louder than an info line, or "the mirror served it"
+        -- and "the mirror is dead and the CDN saved us" look identical from
+        -- outside -- and the second one is how a fallback rots unnoticed
+        -- until the day both addresses are gone.
+        if i > 1 then
+            log.warn("msvc: " .. entry.name .. " -- falling back to " ..
+                     host_of(url) .. " after: " .. table.concat(why, "; "))
+        else
+            log.info("msvc: fetching " .. entry.name .. " from " .. host_of(url))
+        end
         -- pcall: curl -f exits non-zero on a 404, and system.exec RAISES on a
         -- non-zero exit. Without this the first missing mirror would abort the
         -- install instead of falling through to the next address.

--- a/pkgs/m/msvc.lua
+++ b/pkgs/m/msvc.lua
@@ -108,38 +108,51 @@ end
 -- package ids are not spelled alike either: Microsoft.VC.14.44.17.14.* against
 -- Microsoft.VC.14.52.*.
 --
--- The Insiders entry carries a risk the release one does not: Microsoft rotates
--- those payloads. When 14.52.36629 goes away the URLs 404 -- loudly, and with
--- the sha256 still pinned, so a rotated build cannot be served in its place.
--- That is the failure mode worth having; it is also why `latest` is not it.
+-- The Insiders entry carried a risk the release one does not: Microsoft
+-- rotates those payloads, and when 14.52.36629 goes away its CDN URL 404s.
+-- That is now survivable rather than terminal -- every entry lists a mirror
+-- first and the CDN as the fallback, so the pin outlives the address. The
+-- sha256 is unchanged and still pinned, so a rotated build can never be
+-- served in place of the one named here, from either address.
+--
+-- `latest` still stays on the release channel: an Insiders toolset should be
+-- a choice, not what a bare `xlings install msvc` hands you.
 local TOOLSETS = {
     ["14.44.35207"] = {
         { name = "Microsoft.VC.14.44.17.14.Tools.HostX64.TargetX64.base.vsix",
           sha256 = "ee0baaa3a112d255f19f6c27dcc0ff6e496949eb9f1f37be0ac908c562a7076c",
-          url = "https://download.visualstudio.microsoft.com/download/pr/bbc72d8e-2acd-4229-8f6a-85e23c5e3456/ee0baaa3a112d255f19f6c27dcc0ff6e496949eb9f1f37be0ac908c562a7076c/Microsoft.VC.14.44.17.14.Tools.HostX64.TargetX64.base.vsix" },
+          urls = { "https://gitcode.com/xlings-res/msvc/releases/download/14.44.35207/Microsoft.VC.14.44.17.14.Tools.HostX64.TargetX64.base.vsix",
+                   "https://download.visualstudio.microsoft.com/download/pr/bbc72d8e-2acd-4229-8f6a-85e23c5e3456/ee0baaa3a112d255f19f6c27dcc0ff6e496949eb9f1f37be0ac908c562a7076c/Microsoft.VC.14.44.17.14.Tools.HostX64.TargetX64.base.vsix" } },
         { name = "Microsoft.VC.14.44.17.14.CRT.Headers.base.vsix",
           sha256 = "852382a9aa73502b7849c1bcadfb603ba7175c4e8b60e6aba03c7de711d4ece5",
-          url = "https://download.visualstudio.microsoft.com/download/pr/c610cd8c-801b-44b8-a80a-82cc382aeb43/852382a9aa73502b7849c1bcadfb603ba7175c4e8b60e6aba03c7de711d4ece5/Microsoft.VC.14.44.17.14.CRT.Headers.base.vsix" },
+          urls = { "https://gitcode.com/xlings-res/msvc/releases/download/14.44.35207/Microsoft.VC.14.44.17.14.CRT.Headers.base.vsix",
+                   "https://download.visualstudio.microsoft.com/download/pr/c610cd8c-801b-44b8-a80a-82cc382aeb43/852382a9aa73502b7849c1bcadfb603ba7175c4e8b60e6aba03c7de711d4ece5/Microsoft.VC.14.44.17.14.CRT.Headers.base.vsix" } },
         { name = "Microsoft.VC.14.44.17.14.CRT.x64.Desktop.base.vsix",
           sha256 = "f01f701a7bcd9587a340898c851424f6a52bb913a70c185ff0d5bf0288c5831a",
-          url = "https://download.visualstudio.microsoft.com/download/pr/67cf767c-5e71-47c2-a54a-cd5631e28942/f01f701a7bcd9587a340898c851424f6a52bb913a70c185ff0d5bf0288c5831a/Microsoft.VC.14.44.17.14.CRT.x64.Desktop.base.vsix" },
+          urls = { "https://gitcode.com/xlings-res/msvc/releases/download/14.44.35207/Microsoft.VC.14.44.17.14.CRT.x64.Desktop.base.vsix",
+                   "https://download.visualstudio.microsoft.com/download/pr/67cf767c-5e71-47c2-a54a-cd5631e28942/f01f701a7bcd9587a340898c851424f6a52bb913a70c185ff0d5bf0288c5831a/Microsoft.VC.14.44.17.14.CRT.x64.Desktop.base.vsix" } },
         { name = "Microsoft.VC.14.44.17.14.CRT.Redist.X64.base.vsix",
           sha256 = "4aaf54db0bfc9435f7c3660e1a00237a4b556042bfeea64bde44c2e0194e6ee5",
-          url = "https://download.visualstudio.microsoft.com/download/pr/45d3b8dd-bced-4b37-9974-142f748d710c/4aaf54db0bfc9435f7c3660e1a00237a4b556042bfeea64bde44c2e0194e6ee5/Microsoft.VC.14.44.17.14.CRT.Redist.X64.base.vsix" },
+          urls = { "https://gitcode.com/xlings-res/msvc/releases/download/14.44.35207/Microsoft.VC.14.44.17.14.CRT.Redist.X64.base.vsix",
+                   "https://download.visualstudio.microsoft.com/download/pr/45d3b8dd-bced-4b37-9974-142f748d710c/4aaf54db0bfc9435f7c3660e1a00237a4b556042bfeea64bde44c2e0194e6ee5/Microsoft.VC.14.44.17.14.CRT.Redist.X64.base.vsix" } },
     },
     ["14.52.36629"] = {
         { name = "Microsoft.VC.14.52.Tools.HostX64.TargetX64.base.vsix",
           sha256 = "3cf795636cf47b91a3583baa45df8cf7e7448c551a6d2f7f65a015cc1b858930",
-          url = "https://download.visualstudio.microsoft.com/download/pr/0fdca428-6677-4d0e-a19d-65f175edc108/3cf795636cf47b91a3583baa45df8cf7e7448c551a6d2f7f65a015cc1b858930/Microsoft.VC.14.52.Tools.HostX64.TargetX64.base.vsix" },
+          urls = { "https://gitcode.com/xlings-res/msvc/releases/download/14.52.36629/Microsoft.VC.14.52.Tools.HostX64.TargetX64.base.vsix",
+                   "https://download.visualstudio.microsoft.com/download/pr/0fdca428-6677-4d0e-a19d-65f175edc108/3cf795636cf47b91a3583baa45df8cf7e7448c551a6d2f7f65a015cc1b858930/Microsoft.VC.14.52.Tools.HostX64.TargetX64.base.vsix" } },
         { name = "Microsoft.VC.14.52.CRT.Headers.base.vsix",
           sha256 = "26c7797d7408b565c0a6bdc0862391bc69efc8aff14560dde854a86b32d8720c",
-          url = "https://download.visualstudio.microsoft.com/download/pr/0fdca428-6677-4d0e-a19d-65f175edc108/26c7797d7408b565c0a6bdc0862391bc69efc8aff14560dde854a86b32d8720c/Microsoft.VC.14.52.CRT.Headers.base.vsix" },
+          urls = { "https://gitcode.com/xlings-res/msvc/releases/download/14.52.36629/Microsoft.VC.14.52.CRT.Headers.base.vsix",
+                   "https://download.visualstudio.microsoft.com/download/pr/0fdca428-6677-4d0e-a19d-65f175edc108/26c7797d7408b565c0a6bdc0862391bc69efc8aff14560dde854a86b32d8720c/Microsoft.VC.14.52.CRT.Headers.base.vsix" } },
         { name = "Microsoft.VC.14.52.CRT.x64.Desktop.base.vsix",
           sha256 = "ff89fd2b115c6a08dff82a6ce9cc90ef6f4aeb4704c29a5b77d16f063ad33524",
-          url = "https://download.visualstudio.microsoft.com/download/pr/0fdca428-6677-4d0e-a19d-65f175edc108/ff89fd2b115c6a08dff82a6ce9cc90ef6f4aeb4704c29a5b77d16f063ad33524/Microsoft.VC.14.52.CRT.x64.Desktop.base.vsix" },
+          urls = { "https://gitcode.com/xlings-res/msvc/releases/download/14.52.36629/Microsoft.VC.14.52.CRT.x64.Desktop.base.vsix",
+                   "https://download.visualstudio.microsoft.com/download/pr/0fdca428-6677-4d0e-a19d-65f175edc108/ff89fd2b115c6a08dff82a6ce9cc90ef6f4aeb4704c29a5b77d16f063ad33524/Microsoft.VC.14.52.CRT.x64.Desktop.base.vsix" } },
         { name = "Microsoft.VC.14.52.CRT.Redist.X64.base.vsix",
           sha256 = "da122e4f50a1d3328dd09954ed81ccf3012a32c23abac215872cc74272eee1f3",
-          url = "https://download.visualstudio.microsoft.com/download/pr/0fdca428-6677-4d0e-a19d-65f175edc108/da122e4f50a1d3328dd09954ed81ccf3012a32c23abac215872cc74272eee1f3/Microsoft.VC.14.52.CRT.Redist.X64.base.vsix" },
+          urls = { "https://gitcode.com/xlings-res/msvc/releases/download/14.52.36629/Microsoft.VC.14.52.CRT.Redist.X64.base.vsix",
+                   "https://download.visualstudio.microsoft.com/download/pr/0fdca428-6677-4d0e-a19d-65f175edc108/da122e4f50a1d3328dd09954ed81ccf3012a32c23abac215872cc74272eee1f3/Microsoft.VC.14.52.CRT.Redist.X64.base.vsix" } },
     },
 }
 
@@ -162,42 +175,89 @@ local function bindir()
     return path.join(toolsdir(), "bin", "Hostx64", "x64")
 end
 
--- Download one payload and prove it is the file we asked for.
+-- The addresses a payload can be fetched from, in order of preference.
 --
--- The check is the point, not the download: these bytes become a compiler, and
--- "curl exited 0" says nothing about what arrived. Returns false on any
--- mismatch rather than letting a bad payload through.
+-- An entry carries `url` (one address) or `urls` (several). With one address
+-- the behaviour is byte-for-byte what it was, so adding a mirror to an entry
+-- cannot change how an unmirrored one installs.
 --
+-- WHY A LIST IS ENOUGH. A mirror is not a second trust root here -- it is a
+-- second ADDRESS for the same bytes, and `entry.sha256` is checked whichever
+-- one answered. That is the whole reason the fallback can be silent: there is
+-- no source-dependent outcome to report. Microsoft's CDN is itself just one
+-- of the addresses, and an Insiders payload rotating off it stops being a
+-- dead end the moment a second one exists.
+--
+-- The mirrored bytes were verified by DOWNLOADING every payload back from
+-- gitcode and hashing it against the pins below -- not by trusting that the
+-- upload succeeded, which for some files it reported both ways.
+local function sources(entry)
+    if entry.urls and #entry.urls > 0 then return entry.urls end
+    return { entry.url }
+end
+
 -- certutil, not PowerShell's Get-FileHash: both ship with Windows, but
 -- Get-FileHash needs a quoted -LiteralPath nested inside a quoted -Command
 -- inside a shell string. certutil takes one quoted path and prints the digest
 -- on a line of its own.
-local function fetch_verified(entry, dir)
-    local dst = path.join(dir, entry.name)
-    if not os.isfile(dst) then
-        log.info("msvc: fetching " .. entry.name)
-        system.exec(string.format('curl -fsSL --retry 3 -o "%s" "%s"', dst, entry.url))
-    end
-    if not os.isfile(dst) then
-        log.error("msvc: download produced no file: " .. entry.name)
-        return false
-    end
-    local out = os.iorun(string.format('certutil -hashfile "%s" SHA256', dst)) or ""
-    local got = nil
+local function sha256_of(file)
+    local out = os.iorun(string.format('certutil -hashfile "%s" SHA256', file)) or ""
     for line in out:gmatch("[^\r\n]+") do
         local hex = line:gsub("%s+", ""):lower()
-        if #hex == 64 and hex:match("^%x+$") then got = hex break end
+        if #hex == 64 and hex:match("^%x+$") then return hex end
     end
-    -- Case-insensitive: certutil prints uppercase, and the manifest is not
-    -- consistent either -- the VC payloads carry lowercase digests while the
-    -- SDK's are uppercase. Comparing the bytes, not their spelling.
-    if got ~= entry.sha256:lower() then
-        log.error("msvc: sha256 mismatch for " .. entry.name ..
-                  "\n  expected " .. entry.sha256 .. "\n  got      " .. tostring(got))
+    return nil
+end
+
+-- "https://gitcode.com/a/b/c" -> "gitcode.com", for log lines that say WHICH
+-- address answered. Without it a mirror is invisible in a build log, and an
+-- invisible fallback is indistinguishable from no fallback.
+local function host_of(url)
+    return (url:match("^%w+://([^/]+)")) or url
+end
+
+-- Download one payload and prove it is the file we asked for.
+--
+-- The check is the point, not the download: these bytes become a compiler,
+-- and "curl exited 0" says nothing about what arrived. Every address is
+-- verified against the SAME sha256, and a mismatch drops the file and moves
+-- on rather than letting a bad payload through.
+local function fetch_verified(entry, dir)
+    local dst  = path.join(dir, entry.name)
+    local want = entry.sha256:lower()
+
+    -- An already-present file still has to prove itself. A partial download
+    -- from an interrupted run is also "a file that exists", and accepting it
+    -- would turn a network blip into a corrupt compiler.
+    if os.isfile(dst) then
+        if sha256_of(dst) == want then return true end
         os.tryrm(dst)
-        return false
     end
-    return true
+
+    local why = {}
+    for _, url in ipairs(sources(entry)) do
+        log.info("msvc: fetching " .. entry.name .. " from " .. host_of(url))
+        -- pcall: curl -f exits non-zero on a 404, and system.exec RAISES on a
+        -- non-zero exit. Without this the first missing mirror would abort the
+        -- install instead of falling through to the next address.
+        pcall(system.exec, string.format(
+            'curl -fsSL --retry 3 -o "%s" "%s"', dst, url))
+        if os.isfile(dst) then
+            local got = sha256_of(dst)
+            if got == want then return true end
+            -- Same address, wrong bytes. Say so per address: "the mirror is
+            -- stale" and "the CDN is down" need different fixes.
+            table.insert(why, host_of(url) .. ": sha256 " .. tostring(got))
+            os.tryrm(dst)
+        else
+            table.insert(why, host_of(url) .. ": no file")
+        end
+    end
+
+    log.error("msvc: could not obtain " .. entry.name ..
+              "\n  expected sha256 " .. entry.sha256 ..
+              "\n  tried:\n    " .. table.concat(why, "\n    "))
+    return false
 end
 
 function installed()

--- a/pkgs/w/windows-sdk.lua
+++ b/pkgs/w/windows-sdk.lua
@@ -230,8 +230,19 @@ local function fetch_verified(entry, dir)
     end
 
     local why = {}
-    for _, url in ipairs(sources(entry)) do
-        log.info("windows-sdk: fetching " .. entry.name .. " from " .. host_of(url))
+    for i, url in ipairs(sources(entry)) do
+        -- The FIRST address is the expected one; reaching a later one means
+        -- something is wrong upstream even though the install still succeeds.
+        -- That has to be louder than an info line, or "the mirror served it"
+        -- and "the mirror is dead and the CDN saved us" look identical from
+        -- outside -- and the second one is how a fallback rots unnoticed
+        -- until the day both addresses are gone.
+        if i > 1 then
+            log.warn("windows-sdk: " .. entry.name .. " -- falling back to " ..
+                     host_of(url) .. " after: " .. table.concat(why, "; "))
+        else
+            log.info("windows-sdk: fetching " .. entry.name .. " from " .. host_of(url))
+        end
         -- pcall: curl -f exits non-zero on a 404, and system.exec RAISES on a
         -- non-zero exit. Without this the first missing mirror would abort the
         -- install instead of falling through to the next address.

--- a/pkgs/w/windows-sdk.lua
+++ b/pkgs/w/windows-sdk.lua
@@ -64,6 +64,7 @@ import("xim.libxpkg.pkginfo")
 import("xim.libxpkg.system")
 import("xim.libxpkg.log")
 import("xim.libxpkg.xvm")
+import("xim.libxpkg.subos")
 
 -- The SDK version as it appears in the on-disk directory names. The package
 -- version is the same triple without the servicing field; both are spelled
@@ -85,99 +86,171 @@ end
 local PAYLOADS = {
     { name = "Universal CRT Headers Libraries and Sources-x86_en-us.msi", msi = true,
       sha256 = "F611CE8A9E576E3383917B04B6FBE5EE6BED8363C1A2A8E9D6F8335CBB422675",
-      url = "https://download.visualstudio.microsoft.com/download/pr/6452c1f1-dc1e-413c-8b19-991b61870a8b/d10da41a6ad6809f823ef4a92d4f6c56/universal%20crt%20headers%20libraries%20and%20sources-x86_en-us.msi" },
+      urls = { "https://gitcode.com/xlings-res/windows-sdk/releases/download/10.0.26100/Universal_CRT_Headers_Libraries_and_Sources-x86_en-us.msi",
+               "https://download.visualstudio.microsoft.com/download/pr/6452c1f1-dc1e-413c-8b19-991b61870a8b/d10da41a6ad6809f823ef4a92d4f6c56/universal%20crt%20headers%20libraries%20and%20sources-x86_en-us.msi" } },
     { name = "Windows SDK Desktop Headers x64-x86_en-us.msi", msi = true,
       sha256 = "D189CA50E5632B546795922E2262794C068D6FF301860FEB4522B8B93CBB3BA8",
-      url = "https://download.visualstudio.microsoft.com/download/pr/6452c1f1-dc1e-413c-8b19-991b61870a8b/ed222baa6d1d1dc09fb45a1827e7892a/windows%20sdk%20desktop%20headers%20x64-x86_en-us.msi" },
+      urls = { "https://gitcode.com/xlings-res/windows-sdk/releases/download/10.0.26100/Windows_SDK_Desktop_Headers_x64-x86_en-us.msi",
+               "https://download.visualstudio.microsoft.com/download/pr/6452c1f1-dc1e-413c-8b19-991b61870a8b/ed222baa6d1d1dc09fb45a1827e7892a/windows%20sdk%20desktop%20headers%20x64-x86_en-us.msi" } },
     { name = "Windows SDK Desktop Libs x64-x86_en-us.msi", msi = true,
       sha256 = "2E956CA1CF17800B0F9811A6249B945F045ADDF18EE85FFE7AEA99EC6C27243A",
-      url = "https://download.visualstudio.microsoft.com/download/pr/6452c1f1-dc1e-413c-8b19-991b61870a8b/a7dce16da158fe456395566e2dafd23d/windows%20sdk%20desktop%20libs%20x64-x86_en-us.msi" },
+      urls = { "https://gitcode.com/xlings-res/windows-sdk/releases/download/10.0.26100/Windows_SDK_Desktop_Libs_x64-x86_en-us.msi",
+               "https://download.visualstudio.microsoft.com/download/pr/6452c1f1-dc1e-413c-8b19-991b61870a8b/a7dce16da158fe456395566e2dafd23d/windows%20sdk%20desktop%20libs%20x64-x86_en-us.msi" } },
     { name = "Windows SDK Desktop Tools x64-x86_en-us.msi", msi = true,
       sha256 = "5AF8B39E5B8E40C7235B447E7D18CE4607209734F3C506006FADCDEB8931C136",
-      url = "https://download.visualstudio.microsoft.com/download/pr/6452c1f1-dc1e-413c-8b19-991b61870a8b/2509ce9c6746f0629e5a4905b022be80/windows%20sdk%20desktop%20tools%20x64-x86_en-us.msi" },
+      urls = { "https://gitcode.com/xlings-res/windows-sdk/releases/download/10.0.26100/Windows_SDK_Desktop_Tools_x64-x86_en-us.msi",
+               "https://download.visualstudio.microsoft.com/download/pr/6452c1f1-dc1e-413c-8b19-991b61870a8b/2509ce9c6746f0629e5a4905b022be80/windows%20sdk%20desktop%20tools%20x64-x86_en-us.msi" } },
     { name = "16ab2ea2187acffa6435e334796c8c89.cab",
       sha256 = "D29E10BB5CE2E28957B5635B6EEB6A491FDB311C925B398443451F953F399BC2",
-      url = "https://download.visualstudio.microsoft.com/download/pr/6452c1f1-dc1e-413c-8b19-991b61870a8b/d56a87b40b1de33c2c39a1a3d009e148/16ab2ea2187acffa6435e334796c8c89.cab" },
+      urls = { "https://gitcode.com/xlings-res/windows-sdk/releases/download/10.0.26100/16ab2ea2187acffa6435e334796c8c89.cab.bin",
+               "https://download.visualstudio.microsoft.com/download/pr/6452c1f1-dc1e-413c-8b19-991b61870a8b/d56a87b40b1de33c2c39a1a3d009e148/16ab2ea2187acffa6435e334796c8c89.cab" } },
     { name = "19248fabbb2098a7b88c4a2786066bcc.cab",
       sha256 = "6CCBD0B699534B8CC24784E9FBBF242196332053313075C334C126E90C8A21E7",
-      url = "https://download.visualstudio.microsoft.com/download/pr/6452c1f1-dc1e-413c-8b19-991b61870a8b/2e009aabfde2988589258b1c79f89411/19248fabbb2098a7b88c4a2786066bcc.cab" },
+      urls = { "https://gitcode.com/xlings-res/windows-sdk/releases/download/10.0.26100/19248fabbb2098a7b88c4a2786066bcc.cab.bin",
+               "https://download.visualstudio.microsoft.com/download/pr/6452c1f1-dc1e-413c-8b19-991b61870a8b/2e009aabfde2988589258b1c79f89411/19248fabbb2098a7b88c4a2786066bcc.cab" } },
     { name = "58314d0646d7e1a25e97c902166c3155.cab",
       sha256 = "EC209A224C9B2D31F3409208D30F5A6335C55217AD384D6212C833AC83360EBA",
-      url = "https://download.visualstudio.microsoft.com/download/pr/6452c1f1-dc1e-413c-8b19-991b61870a8b/cb954f8bc3015e25cfd985a5fff3452a/58314d0646d7e1a25e97c902166c3155.cab" },
+      urls = { "https://gitcode.com/xlings-res/windows-sdk/releases/download/10.0.26100/58314d0646d7e1a25e97c902166c3155.cab.bin",
+               "https://download.visualstudio.microsoft.com/download/pr/6452c1f1-dc1e-413c-8b19-991b61870a8b/cb954f8bc3015e25cfd985a5fff3452a/58314d0646d7e1a25e97c902166c3155.cab" } },
     { name = "6ee7bbee8435130a869cf971694fd9e2.cab",
       sha256 = "04728E326214D8960A188614995B65A3E9E33F93EAF13DD3CA16FE513CDFF0DE",
-      url = "https://download.visualstudio.microsoft.com/download/pr/6452c1f1-dc1e-413c-8b19-991b61870a8b/9a7bacb65de148f099902218ada3394b/6ee7bbee8435130a869cf971694fd9e2.cab" },
+      urls = { "https://gitcode.com/xlings-res/windows-sdk/releases/download/10.0.26100/6ee7bbee8435130a869cf971694fd9e2.cab.bin",
+               "https://download.visualstudio.microsoft.com/download/pr/6452c1f1-dc1e-413c-8b19-991b61870a8b/9a7bacb65de148f099902218ada3394b/6ee7bbee8435130a869cf971694fd9e2.cab" } },
     { name = "78fa3c824c2c48bd4a49ab5969adaaf7.cab",
       sha256 = "6F9096BC7C182383C22A947D1B2C994D78D1742CA25163FAD8FD8C2C848419C5",
-      url = "https://download.visualstudio.microsoft.com/download/pr/6452c1f1-dc1e-413c-8b19-991b61870a8b/721e7f21ddaab126788f6f8b5c3725b4/78fa3c824c2c48bd4a49ab5969adaaf7.cab" },
+      urls = { "https://gitcode.com/xlings-res/windows-sdk/releases/download/10.0.26100/78fa3c824c2c48bd4a49ab5969adaaf7.cab.bin",
+               "https://download.visualstudio.microsoft.com/download/pr/6452c1f1-dc1e-413c-8b19-991b61870a8b/721e7f21ddaab126788f6f8b5c3725b4/78fa3c824c2c48bd4a49ab5969adaaf7.cab" } },
     { name = "7afc7b670accd8e3cc94cfffd516f5cb.cab",
       sha256 = "1D99DC10063C05E8B34B82AF18DB61C080809456D471674D0272F071526DF0AB",
-      url = "https://download.visualstudio.microsoft.com/download/pr/6452c1f1-dc1e-413c-8b19-991b61870a8b/fdde52f2c4a6db47e015e514a79c3454/7afc7b670accd8e3cc94cfffd516f5cb.cab" },
+      urls = { "https://gitcode.com/xlings-res/windows-sdk/releases/download/10.0.26100/7afc7b670accd8e3cc94cfffd516f5cb.cab.bin",
+               "https://download.visualstudio.microsoft.com/download/pr/6452c1f1-dc1e-413c-8b19-991b61870a8b/fdde52f2c4a6db47e015e514a79c3454/7afc7b670accd8e3cc94cfffd516f5cb.cab" } },
     { name = "96076045170fe5db6d5dcf14b6f6688e.cab",
       sha256 = "82D970F5B628250EF72467D0826260C6A9F32252F42DAA3C31FED2A23170170E",
-      url = "https://download.visualstudio.microsoft.com/download/pr/6452c1f1-dc1e-413c-8b19-991b61870a8b/510c03213f78beff83c9149c96da2ab6/96076045170fe5db6d5dcf14b6f6688e.cab" },
+      urls = { "https://gitcode.com/xlings-res/windows-sdk/releases/download/10.0.26100/96076045170fe5db6d5dcf14b6f6688e.cab.bin",
+               "https://download.visualstudio.microsoft.com/download/pr/6452c1f1-dc1e-413c-8b19-991b61870a8b/510c03213f78beff83c9149c96da2ab6/96076045170fe5db6d5dcf14b6f6688e.cab" } },
     { name = "a1e2a83aa8a71c48c742eeaff6e71928.cab",
       sha256 = "29F8ED0537B49087321DFB7CCE60AAD7252900ECFBD81D6336FDB67056778A5D",
-      url = "https://download.visualstudio.microsoft.com/download/pr/6452c1f1-dc1e-413c-8b19-991b61870a8b/87fede232add653343acc94dbdac4118/a1e2a83aa8a71c48c742eeaff6e71928.cab" },
+      urls = { "https://gitcode.com/xlings-res/windows-sdk/releases/download/10.0.26100/a1e2a83aa8a71c48c742eeaff6e71928.cab.bin",
+               "https://download.visualstudio.microsoft.com/download/pr/6452c1f1-dc1e-413c-8b19-991b61870a8b/87fede232add653343acc94dbdac4118/a1e2a83aa8a71c48c742eeaff6e71928.cab" } },
     { name = "b2f03f34ff83ec013b9e45c7cd8e8a73.cab",
       sha256 = "A17B9674B79AC4C8D9C4516C41D6F32FCDE041BDB07EC7F0758C16EE8A62ECAC",
-      url = "https://download.visualstudio.microsoft.com/download/pr/6452c1f1-dc1e-413c-8b19-991b61870a8b/be7bcaf329bbeef873a874aee49456b7/b2f03f34ff83ec013b9e45c7cd8e8a73.cab" },
+      urls = { "https://gitcode.com/xlings-res/windows-sdk/releases/download/10.0.26100/b2f03f34ff83ec013b9e45c7cd8e8a73.cab.bin",
+               "https://download.visualstudio.microsoft.com/download/pr/6452c1f1-dc1e-413c-8b19-991b61870a8b/be7bcaf329bbeef873a874aee49456b7/b2f03f34ff83ec013b9e45c7cd8e8a73.cab" } },
     { name = "beb5360d2daaa3167dea7ad16c28f996.cab",
       sha256 = "6FEAABF4B1B09B4E3210ADDDB12C8C8D6702D731DA033784EF0330488F5BEF51",
-      url = "https://download.visualstudio.microsoft.com/download/pr/6452c1f1-dc1e-413c-8b19-991b61870a8b/b0082c046bf17896e9730ca9f40200ac/beb5360d2daaa3167dea7ad16c28f996.cab" },
+      urls = { "https://gitcode.com/xlings-res/windows-sdk/releases/download/10.0.26100/beb5360d2daaa3167dea7ad16c28f996.cab.bin",
+               "https://download.visualstudio.microsoft.com/download/pr/6452c1f1-dc1e-413c-8b19-991b61870a8b/b0082c046bf17896e9730ca9f40200ac/beb5360d2daaa3167dea7ad16c28f996.cab" } },
     { name = "cdea5502a35d09ddfbcda12e3a391dc0.cab",
       sha256 = "76A16062CC9764CCEB9F0A4E1F43FDEA97AFFA70752C83542562FC1F30FB9E60",
-      url = "https://download.visualstudio.microsoft.com/download/pr/6452c1f1-dc1e-413c-8b19-991b61870a8b/b2d1f784d9f524b43e107fcb420e7cad/cdea5502a35d09ddfbcda12e3a391dc0.cab" },
+      urls = { "https://gitcode.com/xlings-res/windows-sdk/releases/download/10.0.26100/cdea5502a35d09ddfbcda12e3a391dc0.cab.bin",
+               "https://download.visualstudio.microsoft.com/download/pr/6452c1f1-dc1e-413c-8b19-991b61870a8b/b2d1f784d9f524b43e107fcb420e7cad/cdea5502a35d09ddfbcda12e3a391dc0.cab" } },
     { name = "d1de88680a8e53fe75e01e94dc0ed767.cab",
       sha256 = "9D88FA269DC02FD3FDE50A056C04D6DFCC5B8A15739AE0F3E7AC51CC1C88F5B8",
-      url = "https://download.visualstudio.microsoft.com/download/pr/6452c1f1-dc1e-413c-8b19-991b61870a8b/f5ae8b50cc21a7ed5bcace1a38fe8fa3/d1de88680a8e53fe75e01e94dc0ed767.cab" },
+      urls = { "https://gitcode.com/xlings-res/windows-sdk/releases/download/10.0.26100/d1de88680a8e53fe75e01e94dc0ed767.cab.bin",
+               "https://download.visualstudio.microsoft.com/download/pr/6452c1f1-dc1e-413c-8b19-991b61870a8b/f5ae8b50cc21a7ed5bcace1a38fe8fa3/d1de88680a8e53fe75e01e94dc0ed767.cab" } },
     { name = "d95da93904819b1f7e68adb98b49a9c7.cab",
       sha256 = "BC3BEABEBC0A9F161BBBE69DBCE0075019CA6E40F5DF5A8B2342A8A2AB25B22A",
-      url = "https://download.visualstudio.microsoft.com/download/pr/6452c1f1-dc1e-413c-8b19-991b61870a8b/8528492e1ce2a653db74d3988d9ee96b/d95da93904819b1f7e68adb98b49a9c7.cab" },
+      urls = { "https://gitcode.com/xlings-res/windows-sdk/releases/download/10.0.26100/d95da93904819b1f7e68adb98b49a9c7.cab.bin",
+               "https://download.visualstudio.microsoft.com/download/pr/6452c1f1-dc1e-413c-8b19-991b61870a8b/8528492e1ce2a653db74d3988d9ee96b/d95da93904819b1f7e68adb98b49a9c7.cab" } },
     { name = "eca0aa33de85194cd50ed6e0aae0156f.cab",
       sha256 = "C0C6CC329D2BE2DDBA902649C46EFB9064186C2185445451602C90D9C7EB3DD8",
-      url = "https://download.visualstudio.microsoft.com/download/pr/6452c1f1-dc1e-413c-8b19-991b61870a8b/827f1b56c1f9090dca62cf5bef23d094/eca0aa33de85194cd50ed6e0aae0156f.cab" },
+      urls = { "https://gitcode.com/xlings-res/windows-sdk/releases/download/10.0.26100/eca0aa33de85194cd50ed6e0aae0156f.cab.bin",
+               "https://download.visualstudio.microsoft.com/download/pr/6452c1f1-dc1e-413c-8b19-991b61870a8b/827f1b56c1f9090dca62cf5bef23d094/eca0aa33de85194cd50ed6e0aae0156f.cab" } },
     { name = "f9ff50431335056fb4fbac05b8268204.cab",
       sha256 = "355CC1E65B9E5F02A0B3A4F32D02F9241B97030D3527166EFF6A372D5D0E1BAC",
-      url = "https://download.visualstudio.microsoft.com/download/pr/6452c1f1-dc1e-413c-8b19-991b61870a8b/8383be7caac218b9afd6a3564dbb0984/f9ff50431335056fb4fbac05b8268204.cab" },
+      urls = { "https://gitcode.com/xlings-res/windows-sdk/releases/download/10.0.26100/f9ff50431335056fb4fbac05b8268204.cab.bin",
+               "https://download.visualstudio.microsoft.com/download/pr/6452c1f1-dc1e-413c-8b19-991b61870a8b/8383be7caac218b9afd6a3564dbb0984/f9ff50431335056fb4fbac05b8268204.cab" } },
 }
 
--- Download one payload and prove it is the file we asked for.
+-- The addresses a payload can be fetched from, in order of preference.
 --
--- The check is the point, not the download: these bytes become a compiler's headers, and
--- "curl exited 0" says nothing about what arrived. Returns false on any
--- mismatch rather than letting a bad payload through.
+-- An entry carries `url` (one address) or `urls` (several). With one address
+-- the behaviour is byte-for-byte what it was, so adding a mirror to an entry
+-- cannot change how an unmirrored one installs.
 --
+-- A mirror is not a second trust root -- it is a second ADDRESS for the same
+-- bytes, and `entry.sha256` is checked whichever one answered. Same shape as
+-- msvc.lua, deliberately: these two recipes fetch the same KIND of thing from
+-- the same CDN, and one of them having a fallback while the other does not is
+-- how half a toolchain becomes unobtainable.
+--
+-- ⚠️ THE MIRROR'S ASSET NAMES DIFFER, AND THAT IS FINE. gitcode rejects the
+-- `.cab` extension outright and rejects spaces in an asset name, so the
+-- mirrored assets are `<name with _ for spaces>` and `<name>.cab.bin`. The
+-- file this recipe WRITES is always `entry.name` -- a URL is an address, not
+-- an identity, and the sha256 is over content. Both were established by
+-- probing the API (a `.bin` upload of identical bytes succeeded where the
+-- `.cab` had failed), not assumed.
+--
+-- The mirrored bytes were verified by DOWNLOADING all 27 payloads back and
+-- hashing them, because the upload tool reported failures for files that the
+-- release listing then showed as present -- neither the exit code nor the
+-- listing was the claim worth trusting.
+local function sources(entry)
+    if entry.urls and #entry.urls > 0 then return entry.urls end
+    return { entry.url }
+end
+
 -- certutil, not PowerShell's Get-FileHash: both ship with Windows, but
 -- Get-FileHash needs a quoted -LiteralPath nested inside a quoted -Command
 -- inside a shell string, and these file names contain spaces. certutil takes
 -- one quoted path and prints the digest on a line of its own.
-local function fetch_verified(entry, dir)
-    local dst = path.join(dir, entry.name)
-    if not os.isfile(dst) then
-        log.info("windows-sdk: fetching " .. entry.name)
-        system.exec(string.format('curl -fsSL --retry 3 -o "%s" "%s"', dst, entry.url))
-    end
-    if not os.isfile(dst) then
-        log.error("windows-sdk: download produced no file: " .. entry.name)
-        return false
-    end
-    local out = os.iorun(string.format('certutil -hashfile "%s" SHA256', dst)) or ""
-    local got = nil
+--
+-- Case is not compared: certutil prints uppercase, and the manifests are not
+-- consistent either (the VC payloads carry lowercase digests while the SDK's
+-- are uppercase). Comparing the bytes, not their spelling.
+local function sha256_of(file)
+    local out = os.iorun(string.format('certutil -hashfile "%s" SHA256', file)) or ""
     for line in out:gmatch("[^\r\n]+") do
         local hex = line:gsub("%s+", ""):lower()
-        if #hex == 64 and hex:match("^%x+$") then got = hex break end
+        if #hex == 64 and hex:match("^%x+$") then return hex end
     end
-    -- Case-insensitive: certutil prints uppercase, and the manifest is not
-    -- consistent either -- the VC payloads carry lowercase digests while the
-    -- SDK's are uppercase. Comparing the bytes, not their spelling.
-    if got ~= entry.sha256:lower() then
-        log.error("windows-sdk: sha256 mismatch for " .. entry.name ..
-                  "\n  expected " .. entry.sha256 .. "\n  got      " .. tostring(got))
+    return nil
+end
+
+local function host_of(url)
+    return (url:match("^%w+://([^/]+)")) or url
+end
+
+-- Download one payload and prove it is the file we asked for.
+--
+-- The check is the point, not the download: these bytes become a compiler's
+-- headers, and "curl exited 0" says nothing about what arrived. Every address
+-- is verified against the SAME sha256, and a mismatch drops the file and
+-- moves on rather than letting a bad payload through.
+local function fetch_verified(entry, dir)
+    local dst  = path.join(dir, entry.name)
+    local want = entry.sha256:lower()
+
+    -- An already-present file still has to prove itself: a partial download
+    -- from an interrupted run is also "a file that exists".
+    if os.isfile(dst) then
+        if sha256_of(dst) == want then return true end
         os.tryrm(dst)
-        return false
     end
-    return true
+
+    local why = {}
+    for _, url in ipairs(sources(entry)) do
+        log.info("windows-sdk: fetching " .. entry.name .. " from " .. host_of(url))
+        -- pcall: curl -f exits non-zero on a 404, and system.exec RAISES on a
+        -- non-zero exit. Without this the first missing mirror would abort the
+        -- install instead of falling through to the next address.
+        pcall(system.exec, string.format(
+            'curl -fsSL --retry 3 -o "%s" "%s"', dst, url))
+        if os.isfile(dst) then
+            local got = sha256_of(dst)
+            if got == want then return true end
+            table.insert(why, host_of(url) .. ": sha256 " .. tostring(got))
+            os.tryrm(dst)
+        else
+            table.insert(why, host_of(url) .. ": no file")
+        end
+    end
+
+    log.error("windows-sdk: could not obtain " .. entry.name ..
+              "\n  expected sha256 " .. entry.sha256 ..
+              "\n  tried:\n    " .. table.concat(why, "\n    "))
+    return false
 end
 
 -- Walk down looking for the SDK root, bounded.
@@ -316,6 +389,30 @@ function config()
     local idir = pkginfo.install_dir()
     xvm.add("rc", { bindir = path.join(idir, "bin", SDK_DIR_VERSION, "x64") })
     xvm.add("mt", { bindir = path.join(idir, "bin", SDK_DIR_VERSION, "x64") })
+
+    -- WindowsSdkDir / WindowsSdkVersion go in the SUBOS, for the same reason
+    -- msvc.lua puts VSINSTALLDIR there: the processes that read them are
+    -- BUILD SYSTEMS -- mcpp, cmake, xmake, meson -- and xlings never wraps
+    -- those, so a per-shim env cannot reach them.
+    --
+    -- These two names are not an xlings invention: they are what vcvars
+    -- exports and what every one of those build systems already looks for. So
+    -- the package describes where it put itself in the vocabulary that
+    -- already exists, instead of each consumer learning an xlings-specific
+    -- path -- which is also why mcpp needed no version of this package
+    -- hardcoded anywhere to find it.
+    --
+    -- The trailing separator on WindowsSdkVersion is vcvars' own convention
+    -- ("10.0.26100.0\"). Reproduced rather than tidied up: consumers strip it
+    -- because vcvars puts it there, and a value that differs from vcvars' is
+    -- a value they have never been tested against.
+    if type(subos.env) == "function" then
+        local tag = package.name .. "@" .. pkginfo.version()
+        subos.env{ var = "WindowsSdkDir", op = "set",
+                   value = "${pkgdir}", binding = tag }
+        subos.env{ var = "WindowsSdkVersion", op = "set",
+                   value = SDK_DIR_VERSION .. "\\", binding = tag }
+    end
     return true
 end
 

--- a/tests/lib/xpkg_parser.py
+++ b/tests/lib/xpkg_parser.py
@@ -85,3 +85,31 @@ def _extract_field(content: str, field_name: str) -> str | None:
         return match.group(1)
     match = re.search(rf'{field_name}\s*=\s*\[\[(.*?)\]\]', content, re.DOTALL)
     return match.group(1).strip() if match else None
+
+
+def payload_entries(pkg_file: str) -> list[dict]:
+    """解析 recipe 里的 payload 表: {name, sha256, urls[]}。
+
+    只有自己下载「一组」payload 的 recipe 需要它 —— msvc / windows-sdk。
+    框架的单 url + sha256 校验覆盖不到那种形状, 所以这些条目的完整性
+    只能由测试来钉。
+
+    地址是**列表**: 一个条目可以有 `url = "..."` 或
+    `urls = { "镜像", "官方" }`。sha256 仍然只有一个, 这正是镜像成立的
+    前提 —— 从哪个地址取到都按同一个摘要校验。
+    """
+    src = open(pkg_file, encoding='utf-8').read()
+    entries = []
+    for m in re.finditer(
+            r'\{\s*name\s*=\s*"([^"]+)"\s*,'          # name
+            r'(?:\s*msi\s*=\s*\w+\s*,)?'              # optional msi flag
+            r'\s*sha256\s*=\s*"([0-9a-fA-F]{64})"\s*,'  # sha256
+            r'\s*(url\s*=\s*"[^"]+"|urls\s*=\s*\{.*?\})',  # one address or many
+            src, re.DOTALL):
+        name, sha, addr = m.group(1), m.group(2), m.group(3)
+        entries.append({
+            "name": name,
+            "sha256": sha,
+            "urls": re.findall(r'"(https?://[^"]+)"', addr),
+        })
+    return entries

--- a/tests/m/test_msvc.py
+++ b/tests/m/test_msvc.py
@@ -1,6 +1,6 @@
 """测试 msvc 包"""
 import pytest
-from tests.lib.xpkg_parser import parse_xpkg
+from tests.lib.xpkg_parser import parse_xpkg, payload_entries
 from tests.lib.assertions import (
     assert_required_fields, assert_valid_spec, assert_valid_type,
     assert_no_typos, assert_no_exec_xvm, assert_no_bashrc_modification,
@@ -36,15 +36,34 @@ class TestStatic:
 
     @pytest.mark.static
     def test_every_payload_is_pinned(self):
-        """每个 payload 都必须同时有 url 和 sha256。
+        """每个 payload 恰好一个 sha256, 至少一个地址。
 
         这个包自己下载一组 payload, 框架的单 url 校验覆盖不到它们 ——
         少一个 sha256 就是少一次校验, 而这些字节会变成编译器。
+
+        镜像让地址变成一个列表, 但 sha256 仍然是**一个**: 从哪个地址取到
+        都按同一个摘要校验, 所以"多来源"不会变成"多份可信来源"。
         """
-        src = open(PKG_FILE, encoding='utf-8').read()
-        assert src.count('url = "https://') == src.count('sha256 = "'), \
-            "payload 表里 url 与 sha256 数量不一致"
-        assert src.count('sha256 = "') > 0
+        entries = payload_entries(PKG_FILE)
+        assert entries, "没有解析到任何 payload"
+        for e in entries:
+            assert e["sha256"], f"{e['name']} 没有 sha256"
+            assert e["urls"], f"{e['name']} 没有任何下载地址"
+
+    @pytest.mark.static
+    def test_mirror_never_replaces_the_official_address(self):
+        """有镜像的条目必须仍然保留官方地址。
+
+        镜像是**第二个**地址, 不是替代品。只留镜像会把一个可以回退的
+        依赖换成一个不能回退的依赖 —— 而且换掉的正是唯一的权威来源。
+        """
+        for e in payload_entries(PKG_FILE):
+            official = [u for u in e["urls"]
+                        if "download.visualstudio.microsoft.com" in u]
+            assert official, f"{e['name']} 丢掉了官方地址: {e['urls']}"
+            if len(e["urls"]) > 1:
+                assert e["urls"][-1] == official[-1], \
+                    f"{e['name']} 的官方地址应当是最后的回退"
 
 
 class TestIndex:

--- a/tests/w/test_windows_sdk.py
+++ b/tests/w/test_windows_sdk.py
@@ -1,6 +1,6 @@
 """测试 windows-sdk 包"""
 import pytest
-from tests.lib.xpkg_parser import parse_xpkg
+from tests.lib.xpkg_parser import parse_xpkg, payload_entries
 from tests.lib.assertions import (
     assert_required_fields, assert_valid_spec, assert_valid_type,
     assert_no_typos, assert_no_exec_xvm, assert_no_bashrc_modification,
@@ -36,15 +36,51 @@ class TestStatic:
 
     @pytest.mark.static
     def test_every_payload_is_pinned(self):
-        """每个 payload 都必须同时有 url 和 sha256。
+        """每个 payload 恰好一个 sha256, 至少一个地址。
 
         这个包自己下载一组 payload, 框架的单 url 校验覆盖不到它们 ——
-        少一个 sha256 就是少一次校验, 而这些字节会变成编译器。
+        少一个 sha256 就是少一次校验, 而这些字节会变成编译器的头文件。
+
+        镜像让地址变成一个列表, 但 sha256 仍然是**一个**: 从哪个地址取到
+        都按同一个摘要校验, 所以"多来源"不会变成"多份可信来源"。
+        """
+        entries = payload_entries(PKG_FILE)
+        assert entries, "没有解析到任何 payload"
+        for e in entries:
+            assert e["sha256"], f"{e['name']} 没有 sha256"
+            assert e["urls"], f"{e['name']} 没有任何下载地址"
+
+    @pytest.mark.static
+    def test_mirror_never_replaces_the_official_address(self):
+        """有镜像的条目必须仍然保留官方地址, 且官方地址在最后。
+
+        镜像是**第二个**地址, 不是替代品。
+        """
+        for e in payload_entries(PKG_FILE):
+            official = [u for u in e["urls"]
+                        if "download.visualstudio.microsoft.com" in u]
+            assert official, f"{e['name']} 丢掉了官方地址: {e['urls']}"
+            if len(e["urls"]) > 1:
+                assert e["urls"][-1] == official[-1], \
+                    f"{e['name']} 的官方地址应当是最后的回退"
+
+    @pytest.mark.static
+    def test_local_file_name_comes_from_entry_name_not_the_url(self):
+        """镜像上的资产名与 entry.name 不同 —— 必须由 entry.name 落盘。
+
+        gitcode 拒绝 `.cab` 扩展名, 也拒绝名字里的空格, 所以镜像资产叫
+        `<下划线名>` / `<name>.cab.bin`。install() 解压时按 entry.name 找
+        文件(cab 必须与它的 MSI 同名同目录), 一旦改成从 URL 推导文件名,
+        msiexec 就找不到 cabinet —— 而那会在解压阶段才炸。
         """
         src = open(PKG_FILE, encoding='utf-8').read()
-        assert src.count('url = "https://') == src.count('sha256 = "'), \
-            "payload 表里 url 与 sha256 数量不一致"
-        assert src.count('sha256 = "') > 0
+        assert 'path.join(dir, entry.name)' in src, \
+            "fetch_verified 必须用 entry.name 作为落盘文件名"
+        for e in payload_entries(PKG_FILE):
+            mirrored = [u for u in e["urls"] if "gitcode.com" in u]
+            if mirrored and e["name"].endswith(".cab"):
+                assert mirrored[0].endswith(".cab.bin"), \
+                    f"{e['name']} 的镜像地址扩展名不对: {mirrored[0]}"
 
 
 class TestIndex:


### PR DESCRIPTION
## Summary

A pinned payload should outlive the URL it was pinned at, and a package should describe itself in the vocabulary its consumers already speak.

### 1. Multi-source payloads (mirror + CDN fallback)

`fetch_verified` takes a **list** of addresses per entry and tries them in order. **The sha256 rule is untouched** — whichever address answered, the bytes are checked against the same digest. A mirror is therefore not a second source of truth, it is a second route to the same bytes; that is what makes the fallback safe to do silently.

All **27** payloads are mirrored at `gitcode.com/xlings-res/{msvc,windows-sdk}`, with the Microsoft CDN kept as the **last** entry:

| Package | Files | Size |
|---|---|---|
| `msvc@14.44.35207` | 4 vsix | 83 MB |
| `msvc@14.52.36629` | 4 vsix | 102 MB |
| `windows-sdk@10.0.26100` | 4 MSI + 15 CAB | 133 MB |

The Insiders toolset (`14.52.36629`) is the one that needed this: Microsoft rotates those payloads off the CDN, and a pin that dies with one URL is not much of a pin.

**Verified by downloading all 27 back and hashing them — 27/27 identical to Microsoft's.** That check was not ceremony: the upload tool reported failures for 16 files that the release listing then showed as present, and they were in fact absent (404). Neither the exit code nor the listing was the claim worth trusting.

Two gitcode constraints shape the mirror's asset **names**, not its bytes: `.cab` is rejected outright, and spaces break the upload callback. So mirrored assets are `<name with _ for spaces>` and `<name>.cab.bin`. The file the recipe *writes* is still `entry.name` — a URL is an address, not an identity — and a test pins that, because deriving the local name from the URL would leave `msiexec` unable to find its cabinets three steps later.

Also hardened: an already-present file must re-prove its sha256 before being reused. A partial download from an interrupted run is also "a file that exists".

### 2. `windows-sdk` exports `WindowsSdkDir` / `WindowsSdkVersion`

Same reasoning that put `VSINSTALLDIR` in the subos: the processes that need it are build systems — mcpp, cmake, xmake, meson — and xlings never wraps those, so a per-shim env cannot reach them.

These two names are not an xlings invention; they are what vcvars exports and what those build systems already look for. The package says where it put itself in a vocabulary that already exists, instead of every consumer learning an xlings-specific path.

## Test plan

- [x] `payload_entries()` parses the payload tables instead of counting substrings (the old test compared `url = "https://` and `sha256 = "` counts, which a URL list breaks)
- [x] New assertions: exactly one sha256 per entry, ≥1 address, the official CDN address is never dropped and stays **last**, local file name comes from `entry.name`
- [x] 1788 static/isolation tests pass, 9 skipped
- [x] blocking-input / dep-namespace / libpath gates pass
- [ ] `windows-test` — the real install, which is the only thing that can prove the mirror fetch works end to end