### PR TITLE
fix(msvc): the packaged toolset could not link a DEFAULT build

### DIFF
--- a/pkgs/m/msvc.lua
+++ b/pkgs/m/msvc.lua
@@ -135,6 +135,28 @@ local TOOLSETS = {
           sha256 = "4aaf54db0bfc9435f7c3660e1a00237a4b556042bfeea64bde44c2e0194e6ee5",
           urls = { "https://gitcode.com/xlings-res/msvc/releases/download/14.44.35207/Microsoft.VC.14.44.17.14.CRT.Redist.X64.base.vsix",
                    "https://download.visualstudio.microsoft.com/download/pr/45d3b8dd-bced-4b37-9974-142f748d710c/4aaf54db0bfc9435f7c3660e1a00237a4b556042bfeea64bde44c2e0194e6ee5/Microsoft.VC.14.44.17.14.CRT.Redist.X64.base.vsix" } },
+        -- ⚠️ "Store" is a misleading name, and skipping it on that basis is
+        -- exactly what happened. THIS is the payload that puts the DYNAMIC
+        -- CRT import libraries in lib/x64:
+        --   msvcprt.lib  msvcrt.lib  vcruntime.lib  oldnames.lib (+ d variants)
+        -- The uwp/ and store/ subdirectories it also carries are the parts the
+        -- name refers to; the desktop libs sit at the top of lib/x64.
+        --
+        -- Without it the toolset can only link /MT. `.Desktop.base` holds the
+        -- STATIC halves (libcmt/libcpmt/libvcruntime) and nothing else, and
+        -- use_ansi.h picks between them by _DLL:
+        --     #if defined(_DLL) && !defined(_STATIC_CPPLIB)
+        --     #define _LIB_STEM "msvcprt"      // /MD  <- was absent
+        --     #else
+        --     #define _LIB_STEM "libcpmt"      // /MT
+        -- so every default (/MD) build failed at link with an unresolved
+        -- msvcprt.lib -- while cl.exe, the headers and std.ixx were all
+        -- present and `installed()` said yes. See installed() below, which no
+        -- longer accepts that state.
+        { name = "Microsoft.VC.14.44.17.14.CRT.x64.Store.base.vsix",
+          sha256 = "9135b03c0df53c7a0aa9bef7230a1c2ff4263a0ee7baa7e419d034f484f6bb56",
+          urls = { "https://gitcode.com/xlings-res/msvc/releases/download/14.44.35207/Microsoft.VC.14.44.17.14.CRT.x64.Store.base.vsix",
+                   "https://download.visualstudio.microsoft.com/download/pr/67cf767c-5e71-47c2-a54a-cd5631e28942/9135b03c0df53c7a0aa9bef7230a1c2ff4263a0ee7baa7e419d034f484f6bb56/Microsoft.VC.14.44.17.14.CRT.x64.Store.base.vsix" } },
     },
     ["14.52.36629"] = {
         { name = "Microsoft.VC.14.52.Tools.HostX64.TargetX64.base.vsix",
@@ -153,6 +175,12 @@ local TOOLSETS = {
           sha256 = "da122e4f50a1d3328dd09954ed81ccf3012a32c23abac215872cc74272eee1f3",
           urls = { "https://gitcode.com/xlings-res/msvc/releases/download/14.52.36629/Microsoft.VC.14.52.CRT.Redist.X64.base.vsix",
                    "https://download.visualstudio.microsoft.com/download/pr/0fdca428-6677-4d0e-a19d-65f175edc108/da122e4f50a1d3328dd09954ed81ccf3012a32c23abac215872cc74272eee1f3/Microsoft.VC.14.52.CRT.Redist.X64.base.vsix" } },
+        -- The dynamic CRT import libs -- see the 14.44 entry above for why a
+        -- payload named "Store" is the one a desktop /MD build needs.
+        { name = "Microsoft.VC.14.52.CRT.x64.Store.base.vsix",
+          sha256 = "54113449899bee687e3d9bd3dc77d5ebbdfce499e5f44b5f35349b010fffa34c",
+          urls = { "https://gitcode.com/xlings-res/msvc/releases/download/14.52.36629/Microsoft.VC.14.52.CRT.x64.Store.base.vsix",
+                   "https://download.visualstudio.microsoft.com/download/pr/0fdca428-6677-4d0e-a19d-65f175edc108/54113449899bee687e3d9bd3dc77d5ebbdfce499e5f44b5f35349b010fffa34c/Microsoft.VC.14.52.CRT.x64.Store.base.vsix" } },
     },
 }
 
@@ -271,11 +299,33 @@ local function fetch_verified(entry, dir)
     return false
 end
 
+-- What a build actually needs, not merely what unpacked.
+--
+-- The first two were here from the start. `msvcprt.lib` was not, and its
+-- absence was invisible for exactly that reason: cl.exe and std.ixx were
+-- present, `installed()` said yes, the index's windows-test went green, and
+-- every DEFAULT (/MD) build then failed at link on a library nothing had
+-- noticed was missing. `.Desktop.base` ships only the static halves; the
+-- dynamic import libs come from the `.x64.Store.base` payload added above.
+--
+-- Both CRT models are asserted, because each alone leaves the other free to
+-- go missing the same silent way:
+--   libcpmt.lib  -- /MT, from CRT.x64.Desktop.base
+--   msvcprt.lib  -- /MD, from CRT.x64.Store.base  (the DEFAULT model)
+local function required_files()
+    return {
+        path.join(bindir(), "cl.exe"),
+        path.join(toolsdir(), "modules", "std.ixx"),
+        path.join(toolsdir(), "lib", "x64", "libcpmt.lib"),
+        path.join(toolsdir(), "lib", "x64", "msvcprt.lib"),
+    }
+end
+
 function installed()
-    -- The compiler itself and the STL's std.ixx: the two things whose absence
-    -- turns into a confusing failure much later.
-    return os.isfile(path.join(bindir(), "cl.exe"))
-       and os.isfile(path.join(toolsdir(), "modules", "std.ixx"))
+    for _, f in ipairs(required_files()) do
+        if not os.isfile(f) then return false end
+    end
+    return true
 end
 
 function install()
@@ -312,8 +362,16 @@ function install()
     os.tryrm(work)
 
     if not installed() then
-        log.error("msvc: unpacked, but cl.exe / std.ixx are not where they should be " ..
-                  "(expected under VC/Tools/MSVC/" .. toolset() .. ")")
+        -- Name the MISSING file, not the category. "cl.exe / std.ixx are not
+        -- where they should be" was true and useless when the missing thing
+        -- was neither of them.
+        local missing = {}
+        for _, f in ipairs(required_files()) do
+            if not os.isfile(f) then table.insert(missing, f) end
+        end
+        log.error("msvc: unpacked, but these are not where they should be:\n    " ..
+                  table.concat(missing, "\n    ") ..
+                  "\n  (expected under VC/Tools/MSVC/" .. toolset() .. ")")
         return false
     end
     return true

--- a/tests/m/test_msvc.py
+++ b/tests/m/test_msvc.py
@@ -51,6 +51,44 @@ class TestStatic:
             assert e["urls"], f"{e['name']} 没有任何下载地址"
 
     @pytest.mark.static
+    def test_both_crt_models_are_shipped(self):
+        """每个 toolset 必须同时带静态和动态 CRT 的 payload。
+
+        这条来自一个真实缺陷: payload 集里只有 `.CRT.x64.Desktop.base`
+        (静态: libcmt / libcpmt / libvcruntime), 而**默认**的 /MD 构建需要
+        `msvcprt.lib` —— 它在 `.CRT.x64.Store.base` 里。名字带 Store,
+        实际把桌面用的动态导入库放进 lib/x64。
+
+        当时 cl.exe、头文件、std.ixx 全在, `installed()` 说 yes,
+        index 的 windows-test 全绿 —— 而任何默认构建都会在链接期挂掉。
+        判据取 use_ansi.h 自己的选择:
+
+            #if defined(_DLL) && !defined(_STATIC_CPPLIB)
+            #define _LIB_STEM "msvcprt"     // /MD
+            #else
+            #define _LIB_STEM "libcpmt"     // /MT
+        """
+        names = [e["name"] for e in payload_entries(PKG_FILE)]
+        for toolset, tag in (("14.44", "14.44"), ("14.52", "14.52")):
+            of_toolset = [n for n in names if f".{tag}." in n or f"VC.{tag}" in n]
+            assert any("Desktop.base" in n for n in of_toolset), \
+                f"{toolset} 缺静态 CRT payload (.CRT.x64.Desktop.base): {of_toolset}"
+            assert any("Store.base" in n for n in of_toolset), \
+                f"{toolset} 缺动态 CRT payload (.CRT.x64.Store.base): {of_toolset}"
+
+    @pytest.mark.static
+    def test_installed_checks_what_a_build_needs(self):
+        """installed() 必须验到两种 CRT 模型的导入库。
+
+        它原本只查 cl.exe 和 std.ixx —— 这正是上面那个缺陷能一路绿着
+        走到用户面前的原因。一个"装好了"的判据如果比"能用"弱, 那它报的
+        就不是安装成功, 而是解压成功。
+        """
+        src = open(PKG_FILE, encoding='utf-8').read()
+        for lib in ("libcpmt.lib", "msvcprt.lib"):
+            assert lib in src, f"installed() 没有检查 {lib}"
+
+    @pytest.mark.static
     def test_mirror_never_replaces_the_official_address(self):
         """有镜像的条目必须仍然保留官方地址。
 


### PR DESCRIPTION
## Summary

The payload set carried only the **static** CRT. `.CRT.x64.Desktop.base` ships `libcmt` / `libcpmt` / `libvcruntime` and nothing else, so `/MT` linked and `/MD` — the default for mcpp, cmake, xmake and cl itself — failed on an unresolved `msvcprt.lib`.

The header decides, and it is unambiguous (`use_ansi.h`):

```c
#if defined(_DLL) && !defined(_STATIC_CPPLIB)
#define _LIB_STEM "msvcprt"      // /MD  <- absent from the payload set
#else
#define _LIB_STEM "libcpmt"      // /MT  <- present
```

`msvcprt.lib`, `msvcrt.lib`, `vcruntime.lib` and `oldnames.lib` come from **`Microsoft.VC.<ver>.CRT.x64.Store.base`**. The name is why it was skipped — it sounds like UWP. It *does* carry `uwp/` and `store/` subdirectories, but the **desktop** dynamic import libs sit at the top of `lib/x64`, and nothing else ships them.

Added for both toolsets (14.44.35207 and 14.52.36629), mirrored to gitcode, and verified by downloading both back — sha256 identical to Microsoft's.

## Why nothing caught it

`installed()` checked `cl.exe` and `std.ixx`. Both were there. So the install reported success, `windows-test` went green on a real Windows runner, and the toolchain was **unusable for its default configuration** — the failure would have surfaced in a user's link step, three layers from its cause.

That is the actual defect; the missing payload is just what it let through.

`installed()` now asserts **one import library per CRT model** — `libcpmt.lib` for `/MT`, `msvcprt.lib` for `/MD` — so neither can go missing the same silent way. The failure also names the missing file instead of a category ("cl.exe / std.ixx are not where they should be" was true and useless when the missing thing was neither).

## How it was found

By inspecting the payload contents, not by a failing build: nothing in this repo's CI links anything with this toolset, so no gate here could have reported it. Turned up while checking whether the packaged 14.52 could build a real project (xrgui) — the answer was no, and would have been no for every project.

## Test plan

- [x] Two new static tests: every toolset ships **both** CRT payloads; `installed()` checks an import library for each model
- [x] 1790 static/isolation tests pass
- [x] Both new payloads downloaded and sha256-verified against the VS manifest, then re-downloaded from the mirror and verified again
- [ ] `windows-test` — installs both toolsets; the strengthened `installed()` is now what makes that run meaningful