### PR TITLE
fix(msvc): tar was handed an absolute Windows path, and GNU tar read `C:` as a hostname

### DIFF
--- a/.agents/skills/xpkg-creater/SKILL.md
+++ b/.agents/skills/xpkg-creater/SKILL.md
@@ -136,6 +136,22 @@ xpm = {
 |------|------|------|
 | `os.exists(p)` | `attempt to call a nil value (field 'exists')` | `os.isdir(p) or os.isfile(p)` |
 | `os.arch()` | 返回 nil / `_RUNTIME.arch` 为空 | 从 `pkginfo.install_file()` 推导 |
+| `os.curdir()` | `attempt to call a nil value (field 'curdir')` | `os.cd` 之后用一个已知目录回去(`pkginfo.install_dir()`) |
+| `os.execv(...)` | 同上 | `system.exec` / `os.exec` |
+| `os.files(...)` | 同上 | `os.dirs` 递归,或交给 `xcopy` / shell |
+| `path.absolute(p)` | 同上 | `pkginfo.install_dir()` 本来就是绝对路径 |
+
+> **先 grep,再写。** 上面五条都是同一个形状,而每一条在写下去之前都能用一条
+> 命令排除:
+>
+> ```bash
+> grep -rn "os\.curdir" pkgs/ | wc -l    # 0 → 别用
+> ```
+>
+> **整个 index 里零处使用的 sandbox API,基本可以认定它不在 runtime 里。**
+> 这不是概率判断:能用的东西早就有人用了。而代价是不对称的 —— 猜对省几秒,
+> 猜错要等一轮 Windows CI(约 4 分钟)才知道,而且失败信息出现在
+> install hook 里、离你写的那一行有几层。
 
 危险的地方在于**表现形式**：install hook 抛错之后，安装目录里往往只剩一个 `.xpkg.lua`、
 没有 payload，而外层可能仍然打印 `✓ N package(s) installed`。所以

--- a/pkgs/m/msvc.lua
+++ b/pkgs/m/msvc.lua
@@ -340,11 +340,29 @@ function install()
 
     -- A .vsix is a zip. Windows 10 1803+ ships tar.exe, which reads zip and
     -- needs no PowerShell module and no temp COM object.
+    --
+    -- ⚠️ RELATIVE PATHS, from inside `work`. An absolute Windows path passed to
+    -- `tar -xf` is ambiguous:
+    --
+    --     tar -xf "C:\...\xim-x-msvc\14.44.35207/.payloads/Microsoft.VC...vsix"
+    --     tar: Cannot connect to C: resolve failed
+    --
+    -- GNU tar reads `host:path` before it reads a drive letter, so `C:` becomes
+    -- a hostname. Windows' own bsdtar does not -- which is why this passed the
+    -- index's windows-test (bsdtar from System32) and failed under mcpp's e2e,
+    -- where Git for Windows puts GNU tar first on PATH. Same recipe, same
+    -- runner image, different tar.
+    --
+    -- `--force-local` fixes it for GNU tar and is rejected by bsdtar, so it
+    -- trades one broken environment for the other. A relative name has no
+    -- colon at all and both accept it -- the same shape 7zip.lua already uses.
     local stage = path.join(work, "x")
+    local prevdir = os.curdir()
+    os.cd(work)
     for _, e in ipairs(payloads()) do
         log.info("msvc: unpacking " .. e.name)
         os.mkdir(stage)
-        system.exec(string.format('tar -xf "%s" -C "%s"', path.join(work, e.name), stage))
+        system.exec(string.format('tar -xf "%s" -C "x"', e.name))
         -- Everything useful lives under Contents/; the rest is vsix metadata.
         local contents = path.join(stage, "Contents")
         if os.isdir(contents) then
@@ -359,6 +377,7 @@ function install()
         end
         os.tryrm(stage)
     end
+    os.cd(prevdir)
     os.tryrm(work)
 
     if not installed() then

--- a/pkgs/m/msvc.lua
+++ b/pkgs/m/msvc.lua
@@ -358,26 +358,39 @@ function install()
     -- colon at all and both accept it -- the same shape 7zip.lua already uses.
     local stage = path.join(work, "x")
     local prevdir = os.curdir()
+
+    -- pcall, so a raising `system.exec` cannot leave the process sitting in a
+    -- directory this function is about to delete. Everything after `install()`
+    -- in the same process -- config hooks, other packages -- would inherit
+    -- that cwd, and the symptom would surface somewhere with no connection to
+    -- here.
     os.cd(work)
-    for _, e in ipairs(payloads()) do
-        log.info("msvc: unpacking " .. e.name)
-        os.mkdir(stage)
-        system.exec(string.format('tar -xf "%s" -C "x"', e.name))
-        -- Everything useful lives under Contents/; the rest is vsix metadata.
-        local contents = path.join(stage, "Contents")
-        if os.isdir(contents) then
-            -- All four payloads unpack into the SAME VC/ tree, so this is a
-            -- merge, not a move. os.cp of a directory INTO an existing one of
-            -- the same name nests it -- measured on windows-sdk, which ended
-            -- up with Include/<ver>/<ver>/ that way -- and a recursive merge
-            -- in Lua would need os.files, which is not in the sandbox.
-            -- xcopy merges, ships with Windows, and returns 0 on success.
-            system.exec(string.format('xcopy "%s\\*" "%s\\" /E /I /Y /Q',
-                                      winpath(contents), winpath(idir)))
+    local ok, err = pcall(function()
+        for _, e in ipairs(payloads()) do
+            log.info("msvc: unpacking " .. e.name)
+            os.mkdir(stage)
+            system.exec(string.format('tar -xf "%s" -C "x"', e.name))
+            -- Everything useful lives under Contents/; the rest is vsix metadata.
+            local contents = path.join(stage, "Contents")
+            if os.isdir(contents) then
+                -- All the payloads unpack into the SAME VC/ tree, so this is a
+                -- merge, not a move. os.cp of a directory INTO an existing one
+                -- of the same name nests it -- measured on windows-sdk, which
+                -- ended up with Include/<ver>/<ver>/ that way -- and a
+                -- recursive merge in Lua would need os.files, which is not in
+                -- the sandbox.
+                -- xcopy merges, ships with Windows, and returns 0 on success.
+                system.exec(string.format('xcopy "%s\\*" "%s\\" /E /I /Y /Q',
+                                          winpath(contents), winpath(idir)))
+            end
+            os.tryrm(stage)
         end
-        os.tryrm(stage)
-    end
+    end)
     os.cd(prevdir)
+    if not ok then
+        log.error("msvc: unpacking failed: " .. tostring(err))
+        return false
+    end
     os.tryrm(work)
 
     if not installed() then

--- a/pkgs/m/msvc.lua
+++ b/pkgs/m/msvc.lua
@@ -357,13 +357,21 @@ function install()
     -- trades one broken environment for the other. A relative name has no
     -- colon at all and both accept it -- the same shape 7zip.lua already uses.
     local stage = path.join(work, "x")
-    local prevdir = os.curdir()
 
+    -- Leaving via `idir`, not via a saved `os.curdir()`.
+    --
+    -- `os.curdir` has ZERO uses across the whole index, and every previous
+    -- time this recipe reached for an xpkg-sandbox API with no precedent
+    -- (os.execv, path.absolute, os.files) it turned into an install-time
+    -- "attempt to call a nil value". `pkginfo.install_dir()` is used
+    -- everywhere and is a real directory that outlives `work` -- which is all
+    -- the restore actually needs.
+    --
     -- pcall, so a raising `system.exec` cannot leave the process sitting in a
-    -- directory this function is about to delete. Everything after `install()`
-    -- in the same process -- config hooks, other packages -- would inherit
-    -- that cwd, and the symptom would surface somewhere with no connection to
-    -- here.
+    -- directory this function is about to delete. Everything after
+    -- `install()` in the same process -- config hooks, other packages --
+    -- would inherit that cwd, and the symptom would surface somewhere with no
+    -- connection to here.
     os.cd(work)
     local ok, err = pcall(function()
         for _, e in ipairs(payloads()) do
@@ -386,7 +394,7 @@ function install()
             os.tryrm(stage)
         end
     end)
-    os.cd(prevdir)
+    os.cd(idir)
     if not ok then
         log.error("msvc: unpacking failed: " .. tostring(err))
         return false

--- a/tests/m/test_msvc.py
+++ b/tests/m/test_msvc.py
@@ -77,6 +77,38 @@ class TestStatic:
                 f"{toolset} 缺动态 CRT payload (.CRT.x64.Store.base): {of_toolset}"
 
     @pytest.mark.static
+    def test_tar_is_never_handed_an_absolute_windows_path(self):
+        """`tar -xf` 不能收绝对 Windows 路径。
+
+        GNU tar 先按 `host:path` 解释,于是 `C:` 变成主机名:
+
+            tar: Cannot connect to C: resolve failed
+
+        Windows 自带的 bsdtar 不会 —— 所以同一份 recipe 在 index 的
+        windows-test(System32 的 bsdtar)通过,在 mcpp 的 e2e
+        (Git for Windows 把 GNU tar 排在 PATH 前面)失败。同一个 runner
+        镜像、同一份 recipe、不同的 tar。
+
+        `--force-local` 只对 GNU tar 有效、被 bsdtar 拒绝,等于换一个坏掉的
+        环境。相对路径两边都认。
+        """
+        import re
+        # 注释里就写着那个坏例子(留着是为了说明原因), 所以只扫真正的代码行 ——
+        # 第一版没扫掉注释, 于是它抓到的是自己的说明文字。
+        code = "\n".join(
+            line for line in open(PKG_FILE, encoding='utf-8').read().splitlines()
+            if not line.lstrip().startswith("--"))
+
+        calls = re.findall(r"tar\s+-xf\s+\"([^\"]*)\"", code)
+        assert calls, "没有找到 tar -xf 调用"
+        for arg in calls:
+            assert not re.match(r'^[A-Za-z]:', arg), f"tar 收到了带盘符的路径: {arg}"
+            assert arg == "%s", f"tar 的归档参数应当是单个相对文件名: {arg}"
+        # 相对文件名只有在 cwd 就是 work 时才成立, 两者必须同时在。
+        assert 'os.cd(work)' in code, "解包必须先 cd 进 work,才能用相对文件名"
+        assert 'os.cd(prevdir)' in code, "解包完必须把 cwd 还回去"
+
+    @pytest.mark.static
     def test_installed_checks_what_a_build_needs(self):
         """installed() 必须验到两种 CRT 模型的导入库。
 

--- a/tests/m/test_msvc.py
+++ b/tests/m/test_msvc.py
@@ -106,7 +106,7 @@ class TestStatic:
             assert arg == "%s", f"tar 的归档参数应当是单个相对文件名: {arg}"
         # 相对文件名只有在 cwd 就是 work 时才成立, 两者必须同时在。
         assert 'os.cd(work)' in code, "解包必须先 cd 进 work,才能用相对文件名"
-        assert 'os.cd(prevdir)' in code, "解包完必须把 cwd 还回去"
+        assert 'os.cd(idir)' in code, "解包完必须把 cwd 移出 work(用 idir,不用没有先例的 os.curdir)"
 
     @pytest.mark.static
     def test_installed_checks_what_a_build_needs(self):


### PR DESCRIPTION
## Summary

```
tar -xf "C:\Users\...\xim-x-msvc\14.44.35207/.payloads/Microsoft.VC...vsix"
tar: Cannot connect to C: resolve failed
```

GNU tar checks for `host:path` **before** it checks for a drive letter. Windows' own bsdtar does not — which is why this recipe passed the index's `windows-test` (bsdtar, from `System32`) and failed under mcpp's e2e, where Git for Windows puts GNU tar first on PATH.

**Same runner image, same recipe, different `tar`.**

`--force-local` fixes GNU tar and is *rejected* by bsdtar, so it trades one broken environment for the other. Extraction now runs from inside the payloads directory with a relative file name — no colon, both accept it — which is the shape `7zip.lua` already uses.

## How it was found

On the first Windows run where the package was actually installable (mcpp e2e 239, after `xim:msvc` was published). Worth noting what that run also showed:

```
msvc: fetching Microsoft.VC.14.44.17.14.Tools.HostX64.TargetX64.base.vsix from gitcode.com
msvc: fetching Microsoft.VC.14.44.17.14.CRT.Headers.base.vsix          from gitcode.com
msvc: fetching Microsoft.VC.14.44.17.14.CRT.x64.Desktop.base.vsix      from gitcode.com
msvc: fetching Microsoft.VC.14.44.17.14.CRT.Redist.X64.base.vsix       from gitcode.com
msvc: fetching Microsoft.VC.14.44.17.14.CRT.x64.Store.base.vsix        from gitcode.com
```

All five payloads — including the `Store.base` one added in #630 — fetched from the **mirror**, on a real Windows runner. The download half of #629/#630 is confirmed working; unpacking is what broke.

## Test plan

- [x] New static test: the archive argument must be a bare relative name, and the `cd` in and `cd` out must both be present (a relative name is only correct while the cwd is the payloads directory)
- [x] The test skips comment lines — the comment above deliberately contains the broken example, and the first version of the test matched its own explanation
- [x] 1791 static/isolation tests pass
- [ ] `windows-test` — installs both toolsets; and mcpp's e2e 239 is the one that will actually exercise this path end to end