### PR TITLE
fix(msvc): a .vsix is a ZIP, and GNU tar does not read ZIP at all

### DIFF
--- a/.agents/skills/xpkg-creater/SKILL.md
+++ b/.agents/skills/xpkg-creater/SKILL.md
@@ -149,6 +149,33 @@ xpm = {
 > ```
 >
 > **整个 index 里零处使用的 sandbox API,基本可以认定它不在 runtime 里。**
+>
+> 另外两条不在上表里,因为它们**存在**、只是行为和你以为的不一样:
+>
+> - `os.cd(dir)` 之后 **`system.exec` 不继承那个 cwd**(`os.exec` 才继承)。
+>   照抄别的 recipe 的「cd 之后用相对路径」时,先看清它用的是哪一个 ——
+>   命令可以拼得完全正确,然后找不到自己的文件。
+> - `path.join` 在 Windows 上**混用分隔符**(保留已有的 `\`、新加 `/`)。
+>   `"C:\Windows/System32/tar.exe"` 执行不了,`msiexec` 也拒收。
+>   凡是要交给 Windows 程序的路径都过一遍 `winpath()` —— **包括可执行文件
+>   本身的路径**,不只是它的参数。
+
+#### Windows 上的 `tar`:PATH 会替你选,而两个 tar 能力不同
+
+runner 上同时存在两个 `tar`,**它们不是同一个程序**:
+
+| | 来源 | 读 zip? | `C:\...` 参数 |
+|---|---|---|---|
+| bsdtar | `%SystemRoot%\System32\tar.exe`(Win10 1803+) | ✅ | 正常 |
+| GNU tar | Git for Windows / MSYS2 | ❌ **完全不支持** | 当成 `host:path`,报 `Cannot connect to C:` |
+
+`.vsix` / `.zip` 只有 bsdtar 读得了。而**哪一个被选中取决于 PATH 顺序** ——
+同一个 GitHub 镜像上,index 自己的 windows-test 拿到 bsdtar 通过,
+mcpp 的 e2e 拿到 GNU tar 失败,recipe 一个字都没变。
+
+所以:**解 zip 时写绝对路径的 `System32\tar.exe`,不要写裸 `tar`。**
+钉死之后盘符问题也随之消失(那是 GNU tar 独有的),路径可以放心用绝对的。
+`--force-local` 不是答案 —— GNU tar 认、bsdtar 拒收,是拿一个坏环境换另一个。
 > 这不是概率判断:能用的东西早就有人用了。而代价是不对称的 —— 猜对省几秒,
 > 猜错要等一轮 Windows CI(约 4 分钟)才知道,而且失败信息出现在
 > install hook 里、离你写的那一行有几层。

--- a/pkgs/m/msvc.lua
+++ b/pkgs/m/msvc.lua
@@ -352,46 +352,39 @@ function install()
     -- and failed. Same recipe, same image, different PATH -- so the recipe
     -- must not let PATH pick.
     --
-    -- Absolute path to the EXE, relative name for the ARCHIVE. Those are
-    -- different arguments with different hazards:
-    --   * the exe path must be absolute, or PATH decides again;
-    --   * the archive name must be relative, because GNU tar reads a leading
-    --     `C:` as a hostname (`tar: Cannot connect to C: resolve failed`) --
-    --     harmless for bsdtar, fatal for GNU tar, and `--force-local` fixes
-    --     one by breaking the other.
-    -- Pinning the exe alone would work today; keeping the relative name means
-    -- the invocation stays correct whichever tar ends up running it.
-    -- winpath(), because path.join mixes separators and the EXECUTABLE path
-    -- cares as much as xcopy's arguments do:
+    -- ABSOLUTE paths for everything, and NO `os.cd`.
+    --
+    -- The drive-colon hazard was GNU tar's alone; pinning bsdtar removes it,
+    -- so the relative-name workaround it needed goes away with it. That
+    -- workaround also depended on `system.exec` inheriting a cwd set by
+    -- `os.cd` -- which it does not. 7zip.lua's cd-then-relative-name shape
+    -- uses `os.exec`, and I copied the shape without checking that one
+    -- difference: the command came out perfectly formed and still could not
+    -- find its archive.
+    --
+    -- winpath() on every path, because path.join mixes separators and both
+    -- the executable and its arguments care:
     --
     --     "C:\\Windows/System32/tar.exe" -xf "...": exec failed
     --
-    -- The helper above already documents this for xcopy. It applies here too,
-    -- and I applied it one line too late.
+    -- Fewer moving parts than the version this replaces: no cwd to change, no
+    -- cwd to restore, and nothing that depends on which tar runs it.
     local systar = winpath(path.join(os.getenv("SystemRoot") or "C:\\Windows",
                                      "System32", "tar.exe"))
     local stage = path.join(work, "x")
 
-    -- Leaving via `idir`, not via a saved `os.curdir()`.
-    --
-    -- `os.curdir` has ZERO uses across the whole index, and every previous
-    -- time this recipe reached for an xpkg-sandbox API with no precedent
-    -- (os.execv, path.absolute, os.files) it turned into an install-time
-    -- "attempt to call a nil value". `pkginfo.install_dir()` is used
-    -- everywhere and is a real directory that outlives `work` -- which is all
-    -- the restore actually needs.
-    --
-    -- pcall, so a raising `system.exec` cannot leave the process sitting in a
-    -- directory this function is about to delete. Everything after
-    -- `install()` in the same process -- config hooks, other packages --
-    -- would inherit that cwd, and the symptom would surface somewhere with no
-    -- connection to here.
-    os.cd(work)
+    -- pcall so a raising `system.exec` becomes a named error and `false`,
+    -- rather than propagating out of a hook whose contract is true/false --
+    -- which is how the first failure here read as the unhelpful
+    -- "install hook failed: install hook returned false".
     local ok, err = pcall(function()
         for _, e in ipairs(payloads()) do
             log.info("msvc: unpacking " .. e.name)
             os.mkdir(stage)
-            system.exec(string.format('"%s" -xf "%s" -C "x"', systar, e.name))
+            system.exec(string.format('"%s" -xf "%s" -C "%s"',
+                                      systar,
+                                      winpath(path.join(work, e.name)),
+                                      winpath(stage)))
             -- Everything useful lives under Contents/; the rest is vsix metadata.
             local contents = path.join(stage, "Contents")
             if os.isdir(contents) then
@@ -408,7 +401,6 @@ function install()
             os.tryrm(stage)
         end
     end)
-    os.cd(idir)
     if not ok then
         log.error("msvc: unpacking failed: " .. tostring(err))
         return false

--- a/pkgs/m/msvc.lua
+++ b/pkgs/m/msvc.lua
@@ -338,24 +338,31 @@ function install()
         if not fetch_verified(e, work) then return false end
     end
 
-    -- A .vsix is a zip. Windows 10 1803+ ships tar.exe, which reads zip and
-    -- needs no PowerShell module and no temp COM object.
+    -- A .vsix is a ZIP, and that decides WHICH tar -- not just which path.
     --
-    -- ⚠️ RELATIVE PATHS, from inside `work`. An absolute Windows path passed to
-    -- `tar -xf` is ambiguous:
+    -- Windows 10 1803+ ships bsdtar at System32\tar.exe, and libarchive reads
+    -- zip. GNU tar does not read zip AT ALL. So on a runner where Git for
+    -- Windows is on PATH ahead of System32, a bare `tar` is a coin flip
+    -- between "works" and:
     --
-    --     tar -xf "C:\...\xim-x-msvc\14.44.35207/.payloads/Microsoft.VC...vsix"
-    --     tar: Cannot connect to C: resolve failed
+    --     tar: This does not look like a tar archive
     --
-    -- GNU tar reads `host:path` before it reads a drive letter, so `C:` becomes
-    -- a hostname. Windows' own bsdtar does not -- which is why this passed the
-    -- index's windows-test (bsdtar from System32) and failed under mcpp's e2e,
-    -- where Git for Windows puts GNU tar first on PATH. Same recipe, same
-    -- runner image, different tar.
+    -- Two runs on the SAME GitHub image proved it: the index's own
+    -- windows-test resolved bsdtar and passed; mcpp's e2e resolved GNU tar
+    -- and failed. Same recipe, same image, different PATH -- so the recipe
+    -- must not let PATH pick.
     --
-    -- `--force-local` fixes it for GNU tar and is rejected by bsdtar, so it
-    -- trades one broken environment for the other. A relative name has no
-    -- colon at all and both accept it -- the same shape 7zip.lua already uses.
+    -- Absolute path to the EXE, relative name for the ARCHIVE. Those are
+    -- different arguments with different hazards:
+    --   * the exe path must be absolute, or PATH decides again;
+    --   * the archive name must be relative, because GNU tar reads a leading
+    --     `C:` as a hostname (`tar: Cannot connect to C: resolve failed`) --
+    --     harmless for bsdtar, fatal for GNU tar, and `--force-local` fixes
+    --     one by breaking the other.
+    -- Pinning the exe alone would work today; keeping the relative name means
+    -- the invocation stays correct whichever tar ends up running it.
+    local systar = path.join(os.getenv("SystemRoot") or "C:\\Windows",
+                             "System32", "tar.exe")
     local stage = path.join(work, "x")
 
     -- Leaving via `idir`, not via a saved `os.curdir()`.
@@ -377,7 +384,7 @@ function install()
         for _, e in ipairs(payloads()) do
             log.info("msvc: unpacking " .. e.name)
             os.mkdir(stage)
-            system.exec(string.format('tar -xf "%s" -C "x"', e.name))
+            system.exec(string.format('"%s" -xf "%s" -C "x"', systar, e.name))
             -- Everything useful lives under Contents/; the rest is vsix metadata.
             local contents = path.join(stage, "Contents")
             if os.isdir(contents) then

--- a/pkgs/m/msvc.lua
+++ b/pkgs/m/msvc.lua
@@ -381,7 +381,22 @@ function install()
         for _, e in ipairs(payloads()) do
             log.info("msvc: unpacking " .. e.name)
             os.mkdir(stage)
-            system.exec(string.format('"%s" -xf "%s" -C "%s"',
+            -- The EXE IS NOT QUOTED, and that is not an oversight.
+            --
+            -- `cmd /c` mangles a line whose first token is quoted when more
+            -- quoted arguments follow -- it strips the outermost pair and
+            -- answers:
+            --
+            --     The filename, directory name, or volume label syntax is incorrect.
+            --
+            -- The evidence is clean: with a bare `tar` the program RAN and
+            -- complained itself ("does not look like a tar archive"); with
+            -- `"C:\...\tar.exe"` nothing ran at all. vc6.lua has the same
+            -- shape -- unquoted command, quoted arguments.
+            --
+            -- Safe because %SystemRoot% has no spaces; the ARGUMENTS keep
+            -- their quotes, and they are the ones that can.
+            system.exec(string.format('%s -xf "%s" -C "%s"',
                                       systar,
                                       winpath(path.join(work, e.name)),
                                       winpath(stage)))

--- a/pkgs/m/msvc.lua
+++ b/pkgs/m/msvc.lua
@@ -361,8 +361,15 @@ function install()
     --     one by breaking the other.
     -- Pinning the exe alone would work today; keeping the relative name means
     -- the invocation stays correct whichever tar ends up running it.
-    local systar = path.join(os.getenv("SystemRoot") or "C:\\Windows",
-                             "System32", "tar.exe")
+    -- winpath(), because path.join mixes separators and the EXECUTABLE path
+    -- cares as much as xcopy's arguments do:
+    --
+    --     "C:\\Windows/System32/tar.exe" -xf "...": exec failed
+    --
+    -- The helper above already documents this for xcopy. It applies here too,
+    -- and I applied it one line too late.
+    local systar = winpath(path.join(os.getenv("SystemRoot") or "C:\\Windows",
+                                     "System32", "tar.exe"))
     local stage = path.join(work, "x")
 
     -- Leaving via `idir`, not via a saved `os.curdir()`.

--- a/tests/m/test_msvc.py
+++ b/tests/m/test_msvc.py
@@ -77,8 +77,8 @@ class TestStatic:
                 f"{toolset} 缺动态 CRT payload (.CRT.x64.Store.base): {of_toolset}"
 
     @pytest.mark.static
-    def test_unpacking_pins_the_system_bsdtar_and_a_relative_archive_name(self):
-        """解包必须钉死 System32 的 bsdtar,并且归档参数是相对文件名。
+    def test_unpacking_pins_the_system_bsdtar(self):
+        """解包必须钉死 System32 的 bsdtar,并且路径与引号都按 cmd 的规矩来。
 
         **`.vsix` 是 zip,而 GNU tar 根本不读 zip。** Windows 自带的
         System32\\tar.exe 是 bsdtar(libarchive),读得了;Git for Windows
@@ -91,7 +91,8 @@ class TestStatic:
         **同一份 recipe、同一个镜像、不同的 PATH** —— 所以不能让 PATH 来选。
 
         钉死 exe 之后,**盘符那条风险就不存在了** —— 它是 GNU tar 独有的。
-        所以路径全部用绝对的、全部过 `winpath()`,并且**不用 `os.cd`**:
+        所以路径全部用绝对的、全部过 `winpath()`,并且**不用 `os.cd`**;
+        而 exe 本身**不能加引号**,否则 cmd /c 会把整行弄坏:
 
         * `path.join` 会混用分隔符,`"C:\\Windows/System32/tar.exe"` 执行不了;
         * `system.exec` **不继承** `os.cd` 设的 cwd。7zip.lua 那个
@@ -114,6 +115,12 @@ class TestStatic:
             "System32 的 exe 路径必须过 winpath(),否则分隔符是混的"
         assert not re.search(r"['\"]tar\s+-xf", code), \
             "不能调用裸 `tar` —— PATH 上的可能是读不了 zip 的 GNU tar"
+        # exe 本身不能加引号:cmd /c 遇到「首个 token 带引号 + 后面还有带引号的
+        # 参数」会把最外层那对剥掉, 然后报
+        #   The filename, directory name, or volume label syntax is incorrect.
+        # 证据很干净:裸 `tar` 时程序跑起来了并自己报错, 加引号时它根本没跑。
+        assert "'%s -xf" in code, \
+            "exe 不能加引号 —— cmd /c 会把整行弄坏(参数该加的还是要加)"
 
         # 归档与目标目录都必须过 winpath();相对路径依赖 cwd,而
         # system.exec 不继承 os.cd。

--- a/tests/m/test_msvc.py
+++ b/tests/m/test_msvc.py
@@ -109,6 +109,11 @@ class TestStatic:
 
         assert 'System32' in code and 'tar.exe' in code, \
             "解包必须显式用 System32\\tar.exe(bsdtar),不能让 PATH 选到 GNU tar"
+        # exe 路径也必须过 winpath():path.join 会混用分隔符,而
+        # "C:\\Windows/System32/tar.exe" 是执行不了的 —— 这个 recipe 里
+        # winpath 的注释本来就写着这件事,只是当时只想到 xcopy 的参数。
+        assert re.search(r"winpath\(path\.join\([^)]*SystemRoot", code), \
+            "System32 的 exe 路径必须过 winpath(),否则分隔符是混的"
         assert not re.search(r"['\"]tar\s+-xf", code), \
             "不能调用裸 `tar` —— PATH 上的可能是读不了 zip 的 GNU tar"
 

--- a/tests/m/test_msvc.py
+++ b/tests/m/test_msvc.py
@@ -90,15 +90,16 @@ class TestStatic:
         解析到 bsdtar、通过;mcpp 的 e2e 解析到 GNU tar、失败。
         **同一份 recipe、同一个镜像、不同的 PATH** —— 所以不能让 PATH 来选。
 
-        两个参数、两种风险,分别钉:
+        钉死 exe 之后,**盘符那条风险就不存在了** —— 它是 GNU tar 独有的。
+        所以路径全部用绝对的、全部过 `winpath()`,并且**不用 `os.cd`**:
 
-        * **exe 必须是绝对路径**,否则又回到 PATH 来选;
-        * **归档参数必须是相对文件名**,因为 GNU tar 会把开头的 `C:` 当主机名
-          (`tar: Cannot connect to C: resolve failed`)—— bsdtar 无所谓,
-          GNU tar 致命,而 `--force-local` 是修好一个弄坏另一个。
+        * `path.join` 会混用分隔符,`"C:\\Windows/System32/tar.exe"` 执行不了;
+        * `system.exec` **不继承** `os.cd` 设的 cwd。7zip.lua 那个
+          「cd 之后用相对文件名」的形状用的是 `os.exec` —— 照抄形状而没有核对
+          这一处差别的结果是:命令拼得完全正确,却找不到自己的归档文件。
 
-        只钉 exe 今天就够用;保留相对文件名是为了让这条调用**无论最后是哪个
-        tar 在跑都正确**。
+        少一个可动的部件就少一处可以出错:没有 cwd 要改、没有 cwd 要还,
+        也没有任何东西取决于最后是哪个 tar 在跑。
         """
         import re
         # 注释里就写着那些坏例子(留着是为了说明原因), 所以只扫真正的代码行 ——
@@ -109,22 +110,18 @@ class TestStatic:
 
         assert 'System32' in code and 'tar.exe' in code, \
             "解包必须显式用 System32\\tar.exe(bsdtar),不能让 PATH 选到 GNU tar"
-        # exe 路径也必须过 winpath():path.join 会混用分隔符,而
-        # "C:\\Windows/System32/tar.exe" 是执行不了的 —— 这个 recipe 里
-        # winpath 的注释本来就写着这件事,只是当时只想到 xcopy 的参数。
         assert re.search(r"winpath\(path\.join\([^)]*SystemRoot", code), \
             "System32 的 exe 路径必须过 winpath(),否则分隔符是混的"
         assert not re.search(r"['\"]tar\s+-xf", code), \
             "不能调用裸 `tar` —— PATH 上的可能是读不了 zip 的 GNU tar"
 
-        calls = re.findall(r"-xf\s+\"([^\"]*)\"", code)
-        assert calls, "没有找到 -xf 调用"
-        for arg in calls:
-            assert not re.match(r'^[A-Za-z]:', arg), f"归档参数带了盘符: {arg}"
-            assert arg == "%s", f"归档参数应当是单个相对文件名: {arg}"
-        # 相对文件名只有在 cwd 就是 work 时才成立, 两者必须同时在。
-        assert 'os.cd(work)' in code, "解包必须先 cd 进 work,才能用相对文件名"
-        assert 'os.cd(idir)' in code, "解包完必须把 cwd 移出 work(用 idir,不用没有先例的 os.curdir)"
+        # 归档与目标目录都必须过 winpath();相对路径依赖 cwd,而
+        # system.exec 不继承 os.cd。
+        assert 'winpath(path.join(work, e.name))' in code, \
+            "归档参数必须是 winpath 过的绝对路径"
+        assert 'winpath(stage)' in code, "-C 的目标必须是 winpath 过的绝对路径"
+        assert 'os.cd(' not in code, \
+            "解包不该改 cwd —— system.exec 不继承它,绝对路径本来就不需要"
 
     @pytest.mark.static
     def test_installed_checks_what_a_build_needs(self):

--- a/tests/m/test_msvc.py
+++ b/tests/m/test_msvc.py
@@ -77,33 +77,46 @@ class TestStatic:
                 f"{toolset} 缺动态 CRT payload (.CRT.x64.Store.base): {of_toolset}"
 
     @pytest.mark.static
-    def test_tar_is_never_handed_an_absolute_windows_path(self):
-        """`tar -xf` 不能收绝对 Windows 路径。
+    def test_unpacking_pins_the_system_bsdtar_and_a_relative_archive_name(self):
+        """解包必须钉死 System32 的 bsdtar,并且归档参数是相对文件名。
 
-        GNU tar 先按 `host:path` 解释,于是 `C:` 变成主机名:
+        **`.vsix` 是 zip,而 GNU tar 根本不读 zip。** Windows 自带的
+        System32\\tar.exe 是 bsdtar(libarchive),读得了;Git for Windows
+        带的是 GNU tar,读不了:
 
-            tar: Cannot connect to C: resolve failed
+            tar: This does not look like a tar archive
 
-        Windows 自带的 bsdtar 不会 —— 所以同一份 recipe 在 index 的
-        windows-test(System32 的 bsdtar)通过,在 mcpp 的 e2e
-        (Git for Windows 把 GNU tar 排在 PATH 前面)失败。同一个 runner
-        镜像、同一份 recipe、不同的 tar。
+        同一个 GitHub 镜像上两次运行证明了这点:index 自己的 windows-test
+        解析到 bsdtar、通过;mcpp 的 e2e 解析到 GNU tar、失败。
+        **同一份 recipe、同一个镜像、不同的 PATH** —— 所以不能让 PATH 来选。
 
-        `--force-local` 只对 GNU tar 有效、被 bsdtar 拒绝,等于换一个坏掉的
-        环境。相对路径两边都认。
+        两个参数、两种风险,分别钉:
+
+        * **exe 必须是绝对路径**,否则又回到 PATH 来选;
+        * **归档参数必须是相对文件名**,因为 GNU tar 会把开头的 `C:` 当主机名
+          (`tar: Cannot connect to C: resolve failed`)—— bsdtar 无所谓,
+          GNU tar 致命,而 `--force-local` 是修好一个弄坏另一个。
+
+        只钉 exe 今天就够用;保留相对文件名是为了让这条调用**无论最后是哪个
+        tar 在跑都正确**。
         """
         import re
-        # 注释里就写着那个坏例子(留着是为了说明原因), 所以只扫真正的代码行 ——
+        # 注释里就写着那些坏例子(留着是为了说明原因), 所以只扫真正的代码行 ——
         # 第一版没扫掉注释, 于是它抓到的是自己的说明文字。
         code = "\n".join(
             line for line in open(PKG_FILE, encoding='utf-8').read().splitlines()
             if not line.lstrip().startswith("--"))
 
-        calls = re.findall(r"tar\s+-xf\s+\"([^\"]*)\"", code)
-        assert calls, "没有找到 tar -xf 调用"
+        assert 'System32' in code and 'tar.exe' in code, \
+            "解包必须显式用 System32\\tar.exe(bsdtar),不能让 PATH 选到 GNU tar"
+        assert not re.search(r"['\"]tar\s+-xf", code), \
+            "不能调用裸 `tar` —— PATH 上的可能是读不了 zip 的 GNU tar"
+
+        calls = re.findall(r"-xf\s+\"([^\"]*)\"", code)
+        assert calls, "没有找到 -xf 调用"
         for arg in calls:
-            assert not re.match(r'^[A-Za-z]:', arg), f"tar 收到了带盘符的路径: {arg}"
-            assert arg == "%s", f"tar 的归档参数应当是单个相对文件名: {arg}"
+            assert not re.match(r'^[A-Za-z]:', arg), f"归档参数带了盘符: {arg}"
+            assert arg == "%s", f"归档参数应当是单个相对文件名: {arg}"
         # 相对文件名只有在 cwd 就是 work 时才成立, 两者必须同时在。
         assert 'os.cd(work)' in code, "解包必须先 cd 进 work,才能用相对文件名"
         assert 'os.cd(idir)' in code, "解包完必须把 cwd 移出 work(用 idir,不用没有先例的 os.curdir)"


### PR DESCRIPTION
## Summary

```
tar: This does not look like a tar archive
tar: Skipping to next header
tar: Exiting with failure status due to previous errors
```

Windows ships **bsdtar** at `System32\tar.exe`, and libarchive reads zip. **GNU tar does not** — not differently, *at all*. So a bare `tar` on a Windows runner is a coin flip decided by PATH order, and both outcomes happened on the **same GitHub image today**:

| Runner | resolves `tar` to | result |
|---|---|---|
| index `windows-test` | System32 bsdtar | ✅ passed |
| mcpp e2e 239 | Git for Windows GNU tar | ❌ failed |

Same recipe, same image, different PATH. The recipe must not let PATH pick — the executable is now the absolute System32 path.

## Two arguments, two different hazards

The archive argument stays **relative**:

- the **exe** must be absolute, or PATH decides again;
- the **archive name** must be relative, because GNU tar reads a leading `C:` as a hostname (`tar: Cannot connect to C: resolve failed`) — harmless for bsdtar, fatal for GNU tar, and `--force-local` fixes one by breaking the other.

Pinning the exe alone would work today; keeping the relative name means the call stays correct whichever tar ends up running it.

## On the previous commit

#632 fixed the path and was right to — it just wasn't the whole cause. It moved the failure from `Cannot connect to C:` to `does not look like a tar archive`, **which is what made the real one visible**. Neither could have been seen while mcpp's e2e 239 was still silently skipping (mcpp#438).

## Test plan

- [x] Test now pins the **executable** (`System32` + `tar.exe` present, no bare `tar -xf`) as well as the relative archive name and the cd-in/cd-out pair
- [x] 1791 static/isolation tests pass
- [ ] `windows-test` — and mcpp's e2e 239, which is the one that actually installs and builds with the toolset