### PR TITLE
fix(msvc): cl.exe cannot RUN without its message resources

### DIFF
--- a/pkgs/m/msvc.lua
+++ b/pkgs/m/msvc.lua
@@ -75,6 +75,34 @@ package = {
             ["14.44.35207"] = { },   -- release channel, VS 2022 17.14
             ["14.52.36629"] = { },   -- Insiders, VS 2026 -- see TOOLSETS below
         },
+        -- cl.exe cannot RUN without this one. It carries
+        -- bin/Hostx64/x64/1033/clui.dll -- the compiler's message resources --
+        -- and without it every invocation, including `cl` with no arguments,
+        -- dies before it can say anything:
+        --
+        --     fatal error C1510: Cannot load language resource clui.dll
+        --
+        -- Which means a toolset missing it fails the FIRST thing any consumer
+        -- does: read the banner to identify the compiler. `.Res.base` reads
+        -- like localisation trim; it is not optional.
+        { name = "Microsoft.VC.14.44.17.14.Tools.HostX64.TargetX64.Res.base.enu.vsix",
+          sha256 = "6e31f47833bfa585f56d55716a1ef081f1434f93ad77160eab49c6e193765832",
+          urls = { "https://gitcode.com/xlings-res/msvc/releases/download/14.44.35207/Microsoft.VC.14.44.17.14.Tools.HostX64.TargetX64.Res.base.enu.vsix",
+                   "https://download.visualstudio.microsoft.com/download/pr/bbc72d8e-2acd-4229-8f6a-85e23c5e3456/6e31f47833bfa585f56d55716a1ef081f1434f93ad77160eab49c6e193765832/Microsoft.VC.14.44.17.14.Tools.HostX64.TargetX64.Res.base.enu.vsix" } },
+        -- cl.exe cannot RUN without this one. It carries
+        -- bin/Hostx64/x64/1033/clui.dll -- the compiler's message resources --
+        -- and without it every invocation, including `cl` with no arguments,
+        -- dies before it can say anything:
+        --
+        --     fatal error C1510: Cannot load language resource clui.dll
+        --
+        -- Which means a toolset missing it fails the FIRST thing any consumer
+        -- does: read the banner to identify the compiler. `.Res.base` reads
+        -- like localisation trim; it is not optional.
+        { name = "Microsoft.VC.14.52.Tools.HostX64.TargetX64.Res.base.enu.vsix",
+          sha256 = "46f6aa187a41842ce6b13a85a6337b8002aae577803de2202d7bdd368e06eaed",
+          urls = { "https://gitcode.com/xlings-res/msvc/releases/download/14.52.36629/Microsoft.VC.14.52.Tools.HostX64.TargetX64.Res.base.enu.vsix",
+                   "https://download.visualstudio.microsoft.com/download/pr/0fdca428-6677-4d0e-a19d-65f175edc108/46f6aa187a41842ce6b13a85a6337b8002aae577803de2202d7bdd368e06eaed/Microsoft.VC.14.52.Tools.HostX64.TargetX64.Res.base.enu.vsix" } },
     },
 }
 
@@ -315,6 +343,12 @@ end
 local function required_files()
     return {
         path.join(bindir(), "cl.exe"),
+        -- cl.exe EXISTING is not cl.exe RUNNING. Without its message
+        -- resources every invocation dies at
+        --     fatal error C1510: Cannot load language resource clui.dll
+        -- before printing a single useful word -- including the banner every
+        -- consumer reads first to identify the compiler.
+        path.join(bindir(), "1033", "clui.dll"),
         path.join(toolsdir(), "modules", "std.ixx"),
         path.join(toolsdir(), "lib", "x64", "libcpmt.lib"),
         path.join(toolsdir(), "lib", "x64", "msvcprt.lib"),

--- a/pkgs/m/msvc.lua
+++ b/pkgs/m/msvc.lua
@@ -75,34 +75,6 @@ package = {
             ["14.44.35207"] = { },   -- release channel, VS 2022 17.14
             ["14.52.36629"] = { },   -- Insiders, VS 2026 -- see TOOLSETS below
         },
-        -- cl.exe cannot RUN without this one. It carries
-        -- bin/Hostx64/x64/1033/clui.dll -- the compiler's message resources --
-        -- and without it every invocation, including `cl` with no arguments,
-        -- dies before it can say anything:
-        --
-        --     fatal error C1510: Cannot load language resource clui.dll
-        --
-        -- Which means a toolset missing it fails the FIRST thing any consumer
-        -- does: read the banner to identify the compiler. `.Res.base` reads
-        -- like localisation trim; it is not optional.
-        { name = "Microsoft.VC.14.44.17.14.Tools.HostX64.TargetX64.Res.base.enu.vsix",
-          sha256 = "6e31f47833bfa585f56d55716a1ef081f1434f93ad77160eab49c6e193765832",
-          urls = { "https://gitcode.com/xlings-res/msvc/releases/download/14.44.35207/Microsoft.VC.14.44.17.14.Tools.HostX64.TargetX64.Res.base.enu.vsix",
-                   "https://download.visualstudio.microsoft.com/download/pr/bbc72d8e-2acd-4229-8f6a-85e23c5e3456/6e31f47833bfa585f56d55716a1ef081f1434f93ad77160eab49c6e193765832/Microsoft.VC.14.44.17.14.Tools.HostX64.TargetX64.Res.base.enu.vsix" } },
-        -- cl.exe cannot RUN without this one. It carries
-        -- bin/Hostx64/x64/1033/clui.dll -- the compiler's message resources --
-        -- and without it every invocation, including `cl` with no arguments,
-        -- dies before it can say anything:
-        --
-        --     fatal error C1510: Cannot load language resource clui.dll
-        --
-        -- Which means a toolset missing it fails the FIRST thing any consumer
-        -- does: read the banner to identify the compiler. `.Res.base` reads
-        -- like localisation trim; it is not optional.
-        { name = "Microsoft.VC.14.52.Tools.HostX64.TargetX64.Res.base.enu.vsix",
-          sha256 = "46f6aa187a41842ce6b13a85a6337b8002aae577803de2202d7bdd368e06eaed",
-          urls = { "https://gitcode.com/xlings-res/msvc/releases/download/14.52.36629/Microsoft.VC.14.52.Tools.HostX64.TargetX64.Res.base.enu.vsix",
-                   "https://download.visualstudio.microsoft.com/download/pr/0fdca428-6677-4d0e-a19d-65f175edc108/46f6aa187a41842ce6b13a85a6337b8002aae577803de2202d7bdd368e06eaed/Microsoft.VC.14.52.Tools.HostX64.TargetX64.Res.base.enu.vsix" } },
     },
 }
 
@@ -185,6 +157,20 @@ local TOOLSETS = {
           sha256 = "9135b03c0df53c7a0aa9bef7230a1c2ff4263a0ee7baa7e419d034f484f6bb56",
           urls = { "https://gitcode.com/xlings-res/msvc/releases/download/14.44.35207/Microsoft.VC.14.44.17.14.CRT.x64.Store.base.vsix",
                    "https://download.visualstudio.microsoft.com/download/pr/67cf767c-5e71-47c2-a54a-cd5631e28942/9135b03c0df53c7a0aa9bef7230a1c2ff4263a0ee7baa7e419d034f484f6bb56/Microsoft.VC.14.44.17.14.CRT.x64.Store.base.vsix" } },
+        -- cl.exe cannot RUN without this one. It carries
+        -- bin/Hostx64/x64/1033/clui.dll -- the compiler's message resources
+        -- -- and without it EVERY invocation dies before printing a useful
+        -- word:
+        --
+        --     fatal error C1510: Cannot load language resource clui.dll
+        --
+        -- including the banner, which is the first thing every consumer
+        -- reads to identify the compiler. `.Res.base` sounds like
+        -- localisation trim. It is not optional.
+        { name = "Microsoft.VC.14.44.17.14.Tools.HostX64.TargetX64.Res.base.enu.vsix",
+          sha256 = "6e31f47833bfa585f56d55716a1ef081f1434f93ad77160eab49c6e193765832",
+          urls = { "https://gitcode.com/xlings-res/msvc/releases/download/14.44.35207/Microsoft.VC.14.44.17.14.Tools.HostX64.TargetX64.Res.base.enu.vsix",
+                   "https://download.visualstudio.microsoft.com/download/pr/bbc72d8e-2acd-4229-8f6a-85e23c5e3456/6e31f47833bfa585f56d55716a1ef081f1434f93ad77160eab49c6e193765832/Microsoft.VC.14.44.17.14.Tools.HostX64.TargetX64.Res.base.enu.vsix" } },
     },
     ["14.52.36629"] = {
         { name = "Microsoft.VC.14.52.Tools.HostX64.TargetX64.base.vsix",
@@ -209,6 +195,20 @@ local TOOLSETS = {
           sha256 = "54113449899bee687e3d9bd3dc77d5ebbdfce499e5f44b5f35349b010fffa34c",
           urls = { "https://gitcode.com/xlings-res/msvc/releases/download/14.52.36629/Microsoft.VC.14.52.CRT.x64.Store.base.vsix",
                    "https://download.visualstudio.microsoft.com/download/pr/0fdca428-6677-4d0e-a19d-65f175edc108/54113449899bee687e3d9bd3dc77d5ebbdfce499e5f44b5f35349b010fffa34c/Microsoft.VC.14.52.CRT.x64.Store.base.vsix" } },
+        -- cl.exe cannot RUN without this one. It carries
+        -- bin/Hostx64/x64/1033/clui.dll -- the compiler's message resources
+        -- -- and without it EVERY invocation dies before printing a useful
+        -- word:
+        --
+        --     fatal error C1510: Cannot load language resource clui.dll
+        --
+        -- including the banner, which is the first thing every consumer
+        -- reads to identify the compiler. `.Res.base` sounds like
+        -- localisation trim. It is not optional.
+        { name = "Microsoft.VC.14.52.Tools.HostX64.TargetX64.Res.base.enu.vsix",
+          sha256 = "46f6aa187a41842ce6b13a85a6337b8002aae577803de2202d7bdd368e06eaed",
+          urls = { "https://gitcode.com/xlings-res/msvc/releases/download/14.52.36629/Microsoft.VC.14.52.Tools.HostX64.TargetX64.Res.base.enu.vsix",
+                   "https://download.visualstudio.microsoft.com/download/pr/0fdca428-6677-4d0e-a19d-65f175edc108/46f6aa187a41842ce6b13a85a6337b8002aae577803de2202d7bdd368e06eaed/Microsoft.VC.14.52.Tools.HostX64.TargetX64.Res.base.enu.vsix" } },
     },
 }
 
@@ -343,12 +343,6 @@ end
 local function required_files()
     return {
         path.join(bindir(), "cl.exe"),
-        -- cl.exe EXISTING is not cl.exe RUNNING. Without its message
-        -- resources every invocation dies at
-        --     fatal error C1510: Cannot load language resource clui.dll
-        -- before printing a single useful word -- including the banner every
-        -- consumer reads first to identify the compiler.
-        path.join(bindir(), "1033", "clui.dll"),
         path.join(toolsdir(), "modules", "std.ixx"),
         path.join(toolsdir(), "lib", "x64", "libcpmt.lib"),
         path.join(toolsdir(), "lib", "x64", "msvcprt.lib"),

--- a/tests/lib/xpkg_parser.py
+++ b/tests/lib/xpkg_parser.py
@@ -113,3 +113,31 @@ def payload_entries(pkg_file: str) -> list[dict]:
             "urls": re.findall(r'"(https?://[^"]+)"', addr),
         })
     return entries
+
+
+def toolset_payloads(pkg_file: str) -> dict:
+    """按 TOOLSETS 表分组的 payload —— 位置也要对, 不只是"文件里有"。
+
+    `payload_entries` 扫的是整个文件, 所以一个插错地方的条目(比如掉进
+    `package.xpm` 里)照样被它数到 —— 而 recipe 运行时根本看不见。这个
+    函数只在 `local TOOLSETS = {` ... 对应的收尾 `}` 之间找, 并按
+    `["<toolset>"] = {` 分组。
+
+    这条来自真实事故: 补 clui.dll 的那个条目被插进了 package 表,
+    静态测试全绿, Windows 上只取了 5 个 payload。
+    """
+    src = open(pkg_file, encoding='utf-8').read()
+    start = src.index("local TOOLSETS = {")
+    end = src.index("\n}\n", start)
+    body = src[start:end]
+
+    groups, cur = {}, None
+    for line in body.splitlines():
+        m = re.match(r'\s*\["([0-9][^"]*)"\]\s*=\s*\{', line)
+        if m:
+            cur = m.group(1); groups[cur] = []
+            continue
+        n = re.search(r'\{\s*name\s*=\s*"([^"]+)"', line)
+        if n and cur:
+            groups[cur].append(n.group(1))
+    return groups

--- a/tests/m/test_msvc.py
+++ b/tests/m/test_msvc.py
@@ -139,8 +139,26 @@ class TestStatic:
         就不是安装成功, 而是解压成功。
         """
         src = open(PKG_FILE, encoding='utf-8').read()
-        for lib in ("libcpmt.lib", "msvcprt.lib"):
-            assert lib in src, f"installed() 没有检查 {lib}"
+        for f in ("libcpmt.lib", "msvcprt.lib", "clui.dll"):
+            assert f in src, f"installed() 没有检查 {f}"
+
+    @pytest.mark.static
+    def test_compiler_resources_are_shipped(self):
+        """每个 toolset 必须带 `.Res.base` —— 没有它 cl.exe 跑不起来。
+
+        它装的是 `bin/Hostx64/x64/1033/clui.dll`(编译器的消息资源)。
+        缺了之后**任何**一次调用都会在说出任何有用的话之前死掉:
+
+            fatal error C1510: Cannot load language resource clui.dll
+
+        包括每个消费者做的第一件事 —— 读 banner 来识别编译器。
+        `.Res.base` 的名字听起来像是本地化裁剪,它不是可选的。
+        """
+        names = [e["name"] for e in payload_entries(PKG_FILE)]
+        for tag in ("14.44", "14.52"):
+            of_toolset = [n for n in names if f".{tag}." in n or f"VC.{tag}" in n]
+            assert any("Res.base" in n for n in of_toolset), \
+                f"{tag} 缺编译器资源 payload (.Tools.*.Res.base): {of_toolset}"
 
     @pytest.mark.static
     def test_mirror_never_replaces_the_official_address(self):

--- a/tests/m/test_msvc.py
+++ b/tests/m/test_msvc.py
@@ -1,6 +1,6 @@
 """测试 msvc 包"""
 import pytest
-from tests.lib.xpkg_parser import parse_xpkg, payload_entries
+from tests.lib.xpkg_parser import parse_xpkg, payload_entries, toolset_payloads
 from tests.lib.assertions import (
     assert_required_fields, assert_valid_spec, assert_valid_type,
     assert_no_typos, assert_no_exec_xvm, assert_no_bashrc_modification,
@@ -68,13 +68,14 @@ class TestStatic:
             #else
             #define _LIB_STEM "libcpmt"     // /MT
         """
-        names = [e["name"] for e in payload_entries(PKG_FILE)]
-        for toolset, tag in (("14.44", "14.44"), ("14.52", "14.52")):
-            of_toolset = [n for n in names if f".{tag}." in n or f"VC.{tag}" in n]
-            assert any("Desktop.base" in n for n in of_toolset), \
-                f"{toolset} 缺静态 CRT payload (.CRT.x64.Desktop.base): {of_toolset}"
-            assert any("Store.base" in n for n in of_toolset), \
-                f"{toolset} 缺动态 CRT payload (.CRT.x64.Store.base): {of_toolset}"
+        # 按 TOOLSETS 表分组, 不是扫全文件 —— 见 test_every_toolset_is_complete。
+        groups = toolset_payloads(PKG_FILE)
+        assert groups, "TOOLSETS 表里没有解析到 toolset"
+        for toolset, names in groups.items():
+            assert any("Desktop.base" in n for n in names), \
+                f"{toolset} 缺静态 CRT payload (.CRT.x64.Desktop.base): {names}"
+            assert any(".CRT.x64.Store.base" in n for n in names), \
+                f"{toolset} 缺动态 CRT payload (.CRT.x64.Store.base): {names}"
 
     @pytest.mark.static
     def test_unpacking_pins_the_system_bsdtar(self):
@@ -154,11 +155,31 @@ class TestStatic:
         包括每个消费者做的第一件事 —— 读 banner 来识别编译器。
         `.Res.base` 的名字听起来像是本地化裁剪,它不是可选的。
         """
-        names = [e["name"] for e in payload_entries(PKG_FILE)]
-        for tag in ("14.44", "14.52"):
-            of_toolset = [n for n in names if f".{tag}." in n or f"VC.{tag}" in n]
-            assert any("Res.base" in n for n in of_toolset), \
-                f"{tag} 缺编译器资源 payload (.Tools.*.Res.base): {of_toolset}"
+        for toolset, names in toolset_payloads(PKG_FILE).items():
+            assert any("Res.base" in n for n in names), \
+                f"{toolset} 缺编译器资源 payload (.Tools.*.Res.base): {names}"
+
+    @pytest.mark.static
+    def test_every_toolset_is_complete_and_entries_live_in_TOOLSETS(self):
+        """条目必须在 TOOLSETS 表**里面**, 而且每个 toolset 都要齐。
+
+        这条来自一个真实事故: 补 clui.dll 的两个条目被插进了
+        `package.xpm` 表 —— 静态测试全绿(它们扫的是整个文件, "文件里有"
+        就算数), 而 recipe 运行时只取到 5 个 payload, Windows 上照旧失败。
+
+        **"文件里有"和"表里有"是两个问题。** 位置错了的条目对 recipe 来说
+        根本不存在, 所以判据必须按表来, 不能按文本。
+        """
+        groups = toolset_payloads(PKG_FILE)
+        assert set(groups) == {"14.44.35207", "14.52.36629"}, \
+            f"TOOLSETS 的 key 不对: {sorted(groups)}"
+        for toolset, names in groups.items():
+            assert len(names) == len(set(names)), f"{toolset} 有重复条目"
+            for need in ("Tools.HostX64.TargetX64.base", "CRT.Headers.base",
+                         "CRT.x64.Desktop.base", "CRT.Redist", 
+                         "CRT.x64.Store.base", "Res.base"):
+                assert any(need in n for n in names), \
+                    f"{toolset} 缺 {need}: {names}"
 
     @pytest.mark.static
     def test_mirror_never_replaces_the_official_address(self):


### PR DESCRIPTION
## Summary

```
fatal error C1510: Cannot load language resource clui.dll.
```

`Microsoft.VC.<ver>.Tools.HostX64.TargetX64.Res.base.enu` carries `bin/Hostx64/x64/1033/clui.dll`, and without it **every** `cl` invocation dies before printing a useful word — including the banner, which is the first thing any consumer reads to identify the compiler.

mcpp got as far as resolving the right `cl.exe` and then could not ask it what it was:

```
Resolved msvc@14.44.35207 → …\xim-x-msvc\14.44.35207\VC\Tools\MSVC\14.44.35207\bin\Hostx64\x64\cl.exe
error: … looks like MSVC cl but produced no recognizable banner:
fatal error C1510: Cannot load language resource clui.dll.
```

`.Res.base` reads like localisation trim, which is presumably why it was skipped. **It is not optional.**

Added for both toolsets, mirrored, and verified by downloading both back — sha256 identical to Microsoft's, and `clui.dll` confirmed inside each.

## `installed()` again

That predicate keeps being the thing that matters in this recipe. It has now caught up with three separate ways a payload set can be "unpacked" and unusable:

| requirement | what its absence breaks |
|---|---|
| `cl.exe` | nothing to run |
| `1033/clui.dll` | **cl cannot start** — C1510 |
| `libcpmt.lib` | `/MT` link |
| `msvcprt.lib` | `/MD` link (the default) |
| `modules/std.ixx` | `import std` |

## How it was found

Only because the toolset finally installed *and resolved* far enough to be **run**. Every earlier defect (openxlings/xim-pkgindex#632, #633, mcpp-community/mcpp#440) stopped short of that, so nothing could have reported this one.

## Test plan

- [x] New static test: every toolset ships a `.Tools.*.Res.base` payload
- [x] `installed()` test extended to require `clui.dll`
- [x] 1792 static/isolation tests pass
- [ ] `windows-test`, then mcpp e2e 239 — which is now the only step left before a managed toolset builds a project end to end