### PR TITLE
fix(msvc): delete vctip.exe — it makes the toolset uninstallable

### DIFF
--- a/pkgs/m/msvc.lua
+++ b/pkgs/m/msvc.lua
@@ -450,6 +450,37 @@ function install()
     end
     os.tryrm(work)
 
+    -- Drop vctip.exe: it is a background telemetry uploader that cl.exe
+    -- spawns, and it makes the toolset UNINSTALLABLE.
+    --
+    -- vctip.exe outlives the compiler, holds
+    -- `Microsoft.VisualStudio.Telemetry.dll` open from inside the payload
+    -- directory, and Windows then refuses to delete that directory:
+    --
+    --     error: remove failed: Access is denied.
+    --              stuck at: ...\bin\Hostx64\x64\Microsoft.VisualStudio.Telemetry.dll
+    --
+    -- Removing it is safe by cl.exe's OWN design, not by hope -- these are
+    -- strings inside cl.exe:
+    --
+    --     Not launching VCTIP: Binary not found @ '%S'
+    --     Not launching VCTIP: CLR not present
+    --
+    -- The absent binary is a case it already handles and moves on from.
+    -- There is no environment variable to ask for this: cl.exe carries no
+    -- telemetry opt-out switch (vctip's own `-upload:optout` writes MACHINE
+    -- state, which a package install has no business doing).
+    --
+    -- A toolchain payload should also not phone home on a user's machine
+    -- because they compiled something, so this deletion is not purely
+    -- mechanical convenience.
+    local tools = path.join(pkginfo.install_dir(), "VC", "Tools", "MSVC", toolset(), "bin")
+    for _, host in ipairs({"Hostx64", "Hostx86", "Hostarm64"}) do
+        for _, arch in ipairs({"x64", "x86", "arm64", "arm"}) do
+            os.tryrm(path.join(tools, host, arch, "vctip.exe"))
+        end
+    end
+
     if not installed() then
         -- Name the MISSING file, not the category. "cl.exe / std.ixx are not
         -- where they should be" was true and useless when the missing thing

--- a/tests/m/test_msvc.py
+++ b/tests/m/test_msvc.py
@@ -182,6 +182,31 @@ class TestStatic:
                     f"{toolset} 缺 {need}: {names}"
 
     @pytest.mark.static
+    def test_vctip_is_deleted_after_unpacking(self):
+        """install() 必须删掉 vctip.exe —— 不然这个 toolset **卸不掉**。
+
+        vctip.exe 是 cl.exe 拉起来的后台遥测上传进程,它比编译器活得久,
+        并且从 payload 目录**里面**占着
+        `Microsoft.VisualStudio.Telemetry.dll`。于是:
+
+            error: remove failed: Access is denied.
+                     stuck at: ...\\bin\\Hostx64\\x64\\Microsoft.VisualStudio.Telemetry.dll
+
+        删它是安全的,依据是 cl.exe **自己的**字符串:
+
+            Not launching VCTIP: Binary not found @ '%S'
+
+        —— 二进制不在是它本来就处理的一条分支。没有环境变量可以关掉它
+        (vctip 自己的 `-upload:optout` 写的是**机器级**状态,装个包不该动那个)。
+        """
+        src = open(PKG_FILE, encoding="utf-8").read()
+        body = src[src.index("function install()"):]
+        code = "\n".join(l for l in body.splitlines()
+                          if not l.lstrip().startswith("--"))
+        assert "vctip.exe" in code, "install() 没有删 vctip.exe —— toolset 会卸不掉"
+        assert "os.tryrm" in code
+
+    @pytest.mark.static
     def test_mirror_never_replaces_the_official_address(self):
         """有镜像的条目必须仍然保留官方地址。
 


### PR DESCRIPTION
`cl.exe` spawns `vctip.exe`, a background telemetry uploader. It outlives the
compiler and holds `Microsoft.VisualStudio.Telemetry.dll` open **from inside
the payload directory**, so Windows refuses to delete that directory:

```
error: remove failed: Access is denied.
         stuck at: ...\bin\Hostx64\x64\Microsoft.VisualStudio.Telemetry.dll
```

This is mcpp's e2e 239 failing on its **last** step — after install, build,
run, and the `msvc@system` round-trip all passed.

### Why deleting it is safe

Not a guess. These strings are inside `cl.exe` itself:

```
Not launching VCTIP: Binary not found @ '%S'
Not launching VCTIP: CLR not present
```

An absent binary is a branch cl.exe already handles and moves on from.

There is **no environment variable** for this: cl.exe carries no telemetry
opt-out switch, and vctip's own `-upload:optout` writes *machine* state, which
installing a package has no business doing.

### Why here and not in mcpp

Neither mcpp nor xlings can delete a file another process holds open, so a
consumer-side fix cannot work. `xlings remove msvc` had exactly the same
problem. Fixing it at the payload fixes it for everyone.

A build toolchain should also not phone home because someone compiled
something.

### Test

`test_vctip_is_deleted_after_unpacking` was run against its own defect —
dropping the deletion fails it.

Companion to mcpp-community/mcpp#440, which adds the diagnostic that named
this file in the first place.