### PR TITLE
refactor(msvc): the tools dir already has a name — use it

### DIFF
--- a/pkgs/m/msvc.lua
+++ b/pkgs/m/msvc.lua
@@ -474,10 +474,10 @@ function install()
     -- A toolchain payload should also not phone home on a user's machine
     -- because they compiled something, so this deletion is not purely
     -- mechanical convenience.
-    local tools = path.join(pkginfo.install_dir(), "VC", "Tools", "MSVC", toolset(), "bin")
+    local bin = path.join(toolsdir(), "bin")
     for _, host in ipairs({"Hostx64", "Hostx86", "Hostarm64"}) do
         for _, arch in ipairs({"x64", "x86", "arm64", "arm"}) do
-            os.tryrm(path.join(tools, host, arch, "vctip.exe"))
+            os.tryrm(path.join(bin, host, arch, "vctip.exe"))
         end
     end
 


### PR DESCRIPTION
`toolsdir()` already computes `VC/Tools/MSVC/<toolset>`. The vctip deletion added in #637 spelled the same path out by hand.

Two spellings of one layout is how the third one drifts — which is exactly the defect #436 fixed (`toolchain list` had inlined a third copy of the MSVC layout and got it wrong).

No behaviour change; full static suite green.