### PR TITLE
fix(msvc): a payload that still has vctip.exe is not installed

### DIFF
--- a/pkgs/m/msvc.lua
+++ b/pkgs/m/msvc.lua
@@ -349,9 +349,34 @@ local function required_files()
     }
 end
 
+-- Every bin/<host>/<arch> a toolset payload can have. Written out rather than
+-- discovered because os.files/os.dirs are not in the xpkg sandbox.
+local function bin_arch_dirs()
+    local out = {}
+    for _, host in ipairs({"Hostx64", "Hostx86", "Hostarm64"}) do
+        for _, arch in ipairs({"x64", "x86", "arm64", "arm"}) do
+            table.insert(out, path.join(toolsdir(), "bin", host, arch))
+        end
+    end
+    return out
+end
+
 function installed()
     for _, f in ipairs(required_files()) do
         if not os.isfile(f) then return false end
+    end
+    -- A payload that still carries vctip.exe was unpacked by a recipe from
+    -- BEFORE it was dropped, and it is the one thing that makes this package
+    -- impossible to uninstall (see install()). Reporting it as installed
+    -- would strand every existing machine on the broken layout forever --
+    -- the package version does not change when the recipe does, so this
+    -- predicate is the ONLY thing that can pull them forward.
+    --
+    -- `installed()` means "the payload is in the state this recipe produces",
+    -- not "some payload is here". The two differ exactly when a recipe
+    -- changes, which is when it matters.
+    for _, d in ipairs(bin_arch_dirs()) do
+        if os.isfile(path.join(d, "vctip.exe")) then return false end
     end
     return true
 end
@@ -474,11 +499,8 @@ function install()
     -- A toolchain payload should also not phone home on a user's machine
     -- because they compiled something, so this deletion is not purely
     -- mechanical convenience.
-    local bin = path.join(toolsdir(), "bin")
-    for _, host in ipairs({"Hostx64", "Hostx86", "Hostarm64"}) do
-        for _, arch in ipairs({"x64", "x86", "arm64", "arm"}) do
-            os.tryrm(path.join(bin, host, arch, "vctip.exe"))
-        end
+    for _, d in ipairs(bin_arch_dirs()) do
+        os.tryrm(path.join(d, "vctip.exe"))
     end
 
     if not installed() then

--- a/tests/m/test_msvc.py
+++ b/tests/m/test_msvc.py
@@ -207,6 +207,24 @@ class TestStatic:
         assert "os.tryrm" in code
 
     @pytest.mark.static
+    def test_installed_rejects_a_payload_that_still_has_vctip(self):
+        """`installed()` 必须把「还带着 vctip.exe 的 payload」判为**没装**。
+
+        包版本号不会因为 recipe 改了就变,所以已经装了旧布局的机器
+        **只能靠这个判据**被拉回来 —— 否则它们永远停在卸不掉的那个版本上。
+
+        `installed()` 的含义是「payload 处于**这份 recipe 产出的状态**」,
+        不是「这儿有个 payload」。两者只在 recipe 变更时不一样,
+        而那正是它要紧的时候。
+        """
+        src = open(PKG_FILE, encoding='utf-8').read()
+        body = src[src.index("function installed()"):src.index("function install()")]
+        code = "\n".join(l for l in body.splitlines()
+                          if not l.lstrip().startswith("--"))
+        assert "vctip.exe" in code, \
+            "installed() 没有排除 vctip.exe —— 老机器会永远卸不掉"
+
+    @pytest.mark.static
     def test_mirror_never_replaces_the_official_address(self):
         """有镜像的条目必须仍然保留官方地址。
 


### PR DESCRIPTION
#637 stopped **installing** `vctip.exe`. It did nothing for machines that **already have it** — and those are exactly the ones that cannot uninstall the package.

The package version does not change when a recipe does, so `installed()` is the only thing that can pull an existing machine forward. It was answering *yes* for a payload unpacked by the older recipe, which strands that machine permanently: xim skips the install hook, `vctip.exe` stays, `cl.exe` keeps spawning it, and every `remove` keeps failing on

```
...\bin\Hostx64\x64\Microsoft.VisualStudio.Telemetry.dll
```

This is not hypothetical — it is mcpp#440's e2e 239 still failing after #637 was merged and published, on a self-hosted runner whose payload predates it.

### The rule

`installed()` means **"the payload is in the state THIS recipe produces"**, not "some payload is here". The two differ exactly when a recipe changes — which is when it matters. `install()` already wipes the directory first, so a false answer here is a clean reinstall.

Same mechanism that carried the windows-sdk fix (#636) to existing machines with no version bump, where it worked because `installed()` asserts files rather than a directory. Stated once more for what a newer recipe **removes** rather than adds.

Test run against its own defect: dropping the guard fails it.