### PR TITLE
test: installed() must be a cover, and windows-test must RUN what it installs

### DIFF
--- a/.agents/skills/xpkg-creater/SKILL.md
+++ b/.agents/skills/xpkg-creater/SKILL.md
@@ -223,6 +223,78 @@ rm -rf ~/.xlings/data/xpkgs/{xim,local}-x-<pkg>/<version>
 - 可先 `os.tryrm(pkginfo.install_dir())` 再 `os.mv(...)`
 - 若是 Linux 预构建 ELF，必要时做可重定位修复（如 patchelf）
 
+### 2.2.1 installed() 约束 —— 「装好了」必须等于「能用」⚠️
+
+`installed()` 的含义是:**payload 处于「这份 recipe 产出的状态」**,
+不是「这儿有个目录」。两者只在 recipe 变更时不一样,而那正是它要紧的时候。
+
+2026-08-16 这一轮 MSVC 生态里,**九层缺陷有四层是这一条**:每一层的
+windows-test 都是绿的,而包对使用者是坏的。
+
+#### (a) 必须查文件,不能查目录
+
+```lua
+-- ❌ 目录在 ≠ 里面有东西
+if os.isdir(path.join(d, "Lib", VER, "um", "x64")) then return true end
+
+-- ✅ 查那个只有它才提供的文件
+if not os.isfile(path.join(d, "Lib", VER, "um", "x64", "kernel32.lib")) then
+    return false
+end
+```
+
+真实后果:少了带 `kernel32.lib` 的那个 MSI,目录照样存在(另外 341 个 um 库
+落进去了),`installed()` 说 yes,而**任何程序的链接都失败**。
+
+> Windows 文件系统**大小写不敏感**,`os.isfile("kernel32.lib")` 照样匹配磁盘上的
+> `Kernel32.Lib`。不要用"文件名大小写不确定"当作查目录的理由。
+
+#### (b) 必须是覆盖,不是抽样
+
+一个 payload 一条断言,而且那条断言的文件**只有那个 payload 提供**。
+这样哪个 payload 没下来/没解开/没合并,报错就点名哪一个。
+
+`windows-sdk` 的做法(8 个 payload → 7 条断言):
+
+| 断言的文件 | 唯一提供它的 payload |
+|---|---|
+| `Include/<v>/ucrt/corecrt.h` | Universal CRT |
+| `Include/<v>/um/winnt.h` | Store Apps Headers |
+| `Include/<v>/shared/windef.h` | Store Apps Headers OnecoreUap |
+| `Lib/<v>/um/x64/kernel32.lib` | Store Apps Libs |
+| `Lib/<v>/um/x64/gdi32.lib` | Desktop Libs x64 |
+| `bin/<v>/x64/rc.exe` / `mt.exe` | Store Apps Tools |
+
+选 `gdi32.lib` 而不是随便一个库,是因为它**只在** Desktop Libs 里 ——
+那 365 个库和 Store Apps Libs 的 116 个**完全不相交**。抽样会漏,覆盖不会。
+
+#### (c) 必须能表达「什么**不该**在」
+
+包的版本号**不会**因为 recipe 改了就变。所以对已经装了旧布局的机器,
+`installed()` 是**唯一**能把它们拉回来的东西:
+
+```lua
+-- 新 recipe 不再安装 vctip.exe(它占着 payload 让整个包卸不掉)。
+-- 只写"不装"对已经装了的机器毫无作用 —— 必须让 installed() 认出旧产物。
+for _, d in ipairs(bin_arch_dirs()) do
+    if os.isfile(path.join(d, "vctip.exe")) then return false end
+end
+```
+
+> **新增**的文件靠断言"它在"就能发现;**删掉**的文件必须显式说"它不该在"。
+
+#### (d) 失败时要点名缺哪个文件
+
+```lua
+local missing = {}
+for _, f in ipairs(required_files()) do
+    if not os.isfile(f) then table.insert(missing, f) end
+end
+log.error("... 不在应该在的位置:\n    " .. table.concat(missing, "\n    "))
+```
+
+「wanted: <四个路径>」不算 —— 那是把清单再抄一遍,读的人还得自己比对。
+
 ### 2.3 config() 约束
 
 `config()` 负责将该版本注册到 xvm（subos 隔离路由）：

--- a/.github/scripts/windows-test.ps1
+++ b/.github/scripts/windows-test.ps1
@@ -307,6 +307,55 @@ foreach ($relFile in $files) {
         Log-Info "no new shim appeared (type='$pkgType'; declared programs may have been re-pointed)"
     }
 
+    # --- run what the package advertises -------------------------------
+    #
+    # WHY THIS STEP EXISTS. Everything above proves the payload UNPACKED: a
+    # directory is there, a shim name is there. Nothing had ever RUN the
+    # thing, and that is a different question.
+    #
+    # It cost a full day. `cl.exe` spawns `vctip.exe`, a background telemetry
+    # uploader that outlives it and holds a DLL open INSIDE the payload, so
+    # the package became impossible to uninstall for anyone who had actually
+    # compiled something. This script's own "post-uninstall checks" went green
+    # through all of it, because it uninstalled a toolset that had never
+    # compiled anything.
+    #
+    # Exit codes are deliberately ignored: `rc.exe` with no arguments is a
+    # usage error, and that is fine — the claim being tested is "this binary
+    # executes on this machine, and whatever it starts, we uninstall around
+    # it", not "it accepts these flags".
+    if ($expectArtifacts -and $meta.programs -and $meta.programs.Count -gt 0) {
+        Log-Step "[$pkg] run declared programs (they must EXECUTE, not just exist)"
+        foreach ($prog in $meta.programs) {
+            $exe = $shimsAfter.Keys | Where-Object {
+                $_ -eq $prog -or $_ -eq "$prog.exe" -or $_ -eq "$prog.cmd" } |
+                Select-Object -First 1
+            if (-not $exe) { continue }
+            $full = Join-Path $shimDir $exe
+            # Bounded: a program that waits on stdin would otherwise hang the
+            # whole job (there is a lint for blocking reads in hooks, but a
+            # shipped binary is not a hook).
+            $proc = Start-Process -FilePath $full -ArgumentList "/?" `
+                        -NoNewWindow -PassThru -ErrorAction SilentlyContinue
+            if (-not $proc) {
+                # Could not be launched at all: the payload is missing
+                # something the binary needs to start -- a sibling DLL, its
+                # resource DLL, the CRT it links against. That is exactly the
+                # class of defect this step exists for.
+                Log-Fail "declared program '$prog' could not be executed"
+                $failures += "$relFile (program-not-executable:$prog)"
+                continue
+            }
+            if ($proc.WaitForExit(30000)) {
+                Log-Pass "ran $prog (exit $($proc.ExitCode))"
+            } else {
+                try { $proc.Kill() } catch { }
+                Log-Fail "declared program '$prog' did not exit within 30s"
+                $failures += "$relFile (program-hangs:$prog)"
+            }
+        }
+    }
+
     # --- uninstall ---
     # Remove exactly what this test installed, not "whatever is active".
     #

--- a/tests/test_installed_is_a_cover.py
+++ b/tests/test_installed_is_a_cover.py
@@ -1,0 +1,138 @@
+"""`installed()` 必须是「这份 recipe 产出的状态」的覆盖,不是抽样。
+
+来历:2026-08-16 那一轮 MSVC 生态,九层缺陷有四层是同一条 ——
+`installed()` 比"能用"弱,于是每一层的 windows-test 都是绿的,
+而包对使用者是坏的:
+
+  * 只查 `cl.exe` / `std.ixx` → 少了动态 CRT 导入库,默认构建链接不了
+  * 只查**目录** → 少了带 `kernel32.lib` 的 MSI,目录还在,任何链接都失败
+  * 一个 payload 一条断言没做到 → 少了 um 头 / shared 头 / rc / mt
+  * 不表达"什么不该在" → 已经装了旧布局的机器永远拉不回来
+
+这条 lint 挡住的是第三条:**多 payload 的包,断言数不能退化成抽样。**
+规则本身写在 `.agents/skills/xpkg-creater/SKILL.md` §2.2.1。
+"""
+import re
+import pathlib
+import pytest
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+
+# 多 payload 包:install() 自己下载/解压一组 payload,而不是框架单 url 下载。
+# 这类包正是"少一个 payload 也说装好了"能发生的地方。
+PAYLOAD_SET_MARKER = re.compile(r"^\s*local\s+PAYLOADS\s*=\s*\{", re.M)
+
+
+def _payload_names(src: str) -> list[str]:
+    """PAYLOADS 表里的 name = "..." 条目。"""
+    start = PAYLOAD_SET_MARKER.search(src)
+    if not start:
+        return []
+    body = src[start.end():]
+    end = body.find("\n}")
+    if end != -1:
+        body = body[:end]
+    return re.findall(r'name\s*=\s*"([^"]+)"', body)
+
+
+def _asserted_paths(src: str) -> list[str]:
+    """required_files() / installed() 里按名字断言的文件(去掉注释行)。"""
+    for anchor in ("local function required_files", "function installed()"):
+        i = src.find(anchor)
+        if i != -1:
+            break
+    else:
+        return []
+    j = src.find("function install()", i)
+    body = src[i: j if j != -1 else len(src)]
+    code = "\n".join(l for l in body.splitlines()
+                     if not l.lstrip().startswith("--"))
+    # path.join(..., "name.ext") 的最后一段字面量
+    return re.findall(r'"([^"/\\]+\.[A-Za-z0-9_]+)"', code)
+
+
+def _multi_payload_recipes():
+    out = []
+    for lua in sorted((REPO / "pkgs").rglob("*.lua")):
+        src = lua.read_text(encoding="utf-8", errors="replace")
+        names = _payload_names(src)
+        # 只看真正抓一组 payload 的包;单 payload 的包没有这个失效模式
+        if len(names) >= 2:
+            out.append((lua, src, names))
+    return out
+
+
+@pytest.mark.static
+def test_a_multi_payload_recipe_asserts_more_than_one_file():
+    """一个 payload 一条断言 —— 至少不能只断言一个文件。
+
+    这是"覆盖 vs 抽样"能被机械检查的那一半:抓了 N 个 payload 却只查 1 个
+    文件,意味着 N-1 个 payload 没下来时 `installed()` 照样说 yes。
+    """
+    bad = []
+    for lua, src, names in _multi_payload_recipes():
+        asserted = set(_asserted_paths(src))
+        if len(asserted) < 2:
+            bad.append(f"{lua.relative_to(REPO)}: "
+                       f"{len(names)} payload,只断言 {sorted(asserted)}")
+    assert not bad, (
+        "多 payload 的包必须逐个 payload 断言(SKILL.md §2.2.1):\n  "
+        + "\n  ".join(bad))
+
+
+@pytest.mark.static
+def test_installed_checks_files_not_directories():
+    """`installed()` 不许用 os.isdir 当判据。
+
+    目录存在不代表里面有链接需要的文件 —— windows-sdk 正是这样绿着发布的。
+    """
+    bad = []
+    for lua, src, _ in _multi_payload_recipes():
+        i = src.find("function installed()")
+        if i == -1:
+            continue
+        j = src.find("function install()", i)
+        body = src[i: j if j != -1 else len(src)]
+        code = "\n".join(l for l in body.splitlines()
+                         if not l.lstrip().startswith("--"))
+        if "os.isdir" in code:
+            bad.append(str(lua.relative_to(REPO)))
+    assert not bad, (
+        "installed() 用了 os.isdir —— 目录在不代表能用(SKILL.md §2.2.1):\n  "
+        + "\n  ".join(bad))
+
+
+@pytest.mark.static
+def test_the_recipes_this_rule_came_from_still_obey_it():
+    """回归钉子:msvc 和 windows-sdk 是这条规则的来源,不能悄悄退化。
+
+    单独钉住是因为上面两条是通用下限,而这两个包的断言集是**逐 payload 推导
+    出来的**(解 MSI 的 File/Component/Directory 表算出来的),退化成"还剩两条
+    断言"仍然会通过通用检查。
+    """
+    expect = {
+        "pkgs/w/windows-sdk.lua": {"corecrt.h", "winnt.h", "windef.h",
+                                   "kernel32.lib", "gdi32.lib",
+                                   "rc.exe", "mt.exe"},
+        "pkgs/m/msvc.lua": {"cl.exe", "std.ixx", "libcpmt.lib", "msvcprt.lib"},
+    }
+    for rel, want in expect.items():
+        src = (REPO / rel).read_text(encoding="utf-8")
+        got = set(_asserted_paths(src))
+        missing = want - got
+        assert not missing, f"{rel}: installed() 不再断言 {sorted(missing)}"
+
+
+@pytest.mark.static
+def test_msvc_still_rejects_a_payload_carrying_vctip():
+    """"什么不该在"这一半 —— 见 SKILL.md §2.2.1 (c)。
+
+    包版本号不随 recipe 变,所以这是唯一能把已经装了旧布局的机器拉回来的东西。
+    """
+    src = (REPO / "pkgs/m/msvc.lua").read_text(encoding="utf-8")
+    i = src.index("function installed()")
+    j = src.index("function install()", i)
+    code = "\n".join(l for l in src[i:j].splitlines()
+                     if not l.lstrip().startswith("--"))
+    assert "vctip.exe" in code, (
+        "installed() 不再排除 vctip.exe —— 老机器会永远卸不掉")


### PR DESCRIPTION
Two halves of the same lesson from the MSVC round: **four of nine defect layers were `installed()` being weaker than "usable"**, and every one of them shipped with a green `windows-test`.

## The rule → `.agents/skills/xpkg-creater/SKILL.md` §2.2.1

`installed()` means **"the payload is in the state THIS recipe produces"**, not "there is a directory here". The two differ exactly when a recipe changes — which is when it matters. Four sub-rules, each with the real counter-example behind it:

| rule | what happened without it |
|---|---|
| check files, not directories | the MSI carrying `kernel32.lib` was missing; the directory existed (341 other um libs landed), `installed()` said yes, **every link failed** |
| one assertion per payload | um headers / shared headers / `rc.exe` / `mt.exe` were all absent at once |
| express what must **not** be there | #637 stopped installing `vctip.exe`; machines that already had it were stranded until #639 |
| name the missing file | "wanted: \<4 paths\>" is the list copied again — the reader still has to diff it |

The cover discipline is why `gdi32.lib` is the Desktop-Libs assertion: its 365 libs and Store Apps Libs' 116 are **disjoint sets**, so it can only be satisfied by the payload it stands for.

## The lint

Enforces what is mechanically checkable. **Each assertion was run against the regression it describes** — reverting `installed()` to a directory check, degrading the cover back to a sample, and dropping the vctip absence check each fail exactly one test, and nothing else.

## windows-test now runs the declared programs

This is the gap that let `vctip.exe` through. The script proved payloads **unpack** — a directory exists, a shim name exists — and never that they **run**. So it uninstalled a toolset that had never compiled anything, went green, and the package was unremovable for anyone who had.

A program that cannot be launched now fails the job, which also covers the missing-`clui.dll` shape from #635 (cl.exe unpacked fine and could not start). Bounded at 30s each: a shipped binary is not a hook, so the blocking-stdin lint does not reach it.

> Companion to the architecture review in mcpp `.agents/docs/2026-08-16-toolchain-architecture-review.md` §4 and §5.