### PR TITLE
docs(windows-sdk): the cover comment still said eight payloads

### DIFF
--- a/pkgs/w/windows-sdk.lua
+++ b/pkgs/w/windows-sdk.lua
@@ -467,7 +467,7 @@ end
 -- One file per MSI that matters, chosen so a missing payload cannot pass.
 --
 -- Not a sample -- a cover. Each line below is the file that only ONE of the
--- eight payloads provides, so whichever one failed to download, extract or
+-- nine payloads provides, so whichever one failed to download, extract or
 -- merge, exactly this list names it. The last two are the `programs` this
 -- package registers with xvm: a package that advertises rc and mt and then
 -- ships neither is worse than one that admits it has no tools.


### PR DESCRIPTION
`required_files()` 的注释说 "each line below is the file that only ONE of the **eight** payloads provides" —— 加了 Desktop Headers x86 之后是**九个**。

一个数错了自己所解释之物的注释,正是下一个读者据以认为这个清单是全的的东西 —— 而那恰好是这个包反复出的那个毛病。