### PR TITLE
fix(windows-sdk): add OnecoreUap Headers x86 — windowsx.h and 197 more

### DIFF
--- a/pkgs/w/windows-sdk.lua
+++ b/pkgs/w/windows-sdk.lua
@@ -14,10 +14,10 @@
 --   Windows SDK Desktop Headers x86               1685 headers -- the DESKTOP
 --                                                 half of um/: ShlObj.h,
 --                                                 ShObjIdl.h  <- core
---   Windows SDK OnecoreUap Headers x86            198 more, incl. windowsx.h
---                                                 <- core. NOT the same MSI as
---                                                 "...Store Apps Headers
---                                                 OnecoreUap" above
+--   Windows SDK OnecoreUap Headers x86            198 MORE shared/ headers:
+--                                                 windowsx.h  <- core. A
+--                                                 DIFFERENT MSI from the one
+--                                                 above, disjoint from it
 --   Windows SDK for Windows Store Apps Libs       kernel32/user32/advapi32/
 --                                                 ole32/oleaut32/uuid  <- core
 --   Windows SDK for Windows Store Apps Headers    528 um headers: windows.h,
@@ -259,11 +259,23 @@ local PAYLOADS = {
     -- forty minutes into a build that had already compiled hundreds of TUs.
     -- The required_files() cover below now names it, so a payload set that
     -- loses it again fails at install instead.
-    -- windowsx.h and 197 others, and the name collides with an MSI already in
-    -- this list: "Windows SDK **for Windows Store Apps** Headers OnecoreUap"
-    -- (shared/: windef.h, sal.h) is a DIFFERENT payload from "Windows SDK
-    -- OnecoreUap Headers x86" (um/: windowsx.h). Having both is not
-    -- redundancy.
+    -- shared/ IS SPLIT ACROSS TWO MSIs whose names are nearly the same, and
+    -- they do not overlap by a single file:
+    --
+    --   ... for Windows Store Apps Headers OnecoreUap    92 shared/ headers
+    --                                                    (windef.h, sal.h)
+    --   ... OnecoreUap Headers x86                      198 shared/ headers
+    --                                                    (windowsx.h)
+    --
+    -- Measured: 92 unique, 198 unique, 0 in common. Having both is not
+    -- redundancy, and having only the first is how `#include <windowsx.h>`
+    -- fails while windef.h resolves.
+    --
+    -- NOTE THE DIRECTORY: windowsx.h is in shared/, not um/, despite being a
+    -- Win32 UI header. required_files() below says shared/ for that reason --
+    -- an earlier revision of this entry asserted um/windowsx.h and installed()
+    -- correctly rejected the install, which is the cover rule catching the
+    -- person writing it rather than a payload.
     --
     -- Its x64 and arm64 siblings ship one and three files; only x86 is
     -- substantial. Same shape as the Desktop Headers set.
@@ -498,7 +510,7 @@ local function required_files()
         path.join(d, "Include", SDK_DIR_VERSION, "ucrt", "corecrt.h"),    -- UCRT
         path.join(d, "Include", SDK_DIR_VERSION, "um", "winnt.h"),        -- StoreApps Headers
         path.join(d, "Include", SDK_DIR_VERSION, "um", "ShlObj.h"),       -- Desktop Headers x86
-        path.join(d, "Include", SDK_DIR_VERSION, "um", "windowsx.h"),     -- OnecoreUap Headers x86
+        path.join(d, "Include", SDK_DIR_VERSION, "shared", "windowsx.h"), -- OnecoreUap Headers x86
         path.join(d, "Include", SDK_DIR_VERSION, "shared", "windef.h"),   -- ... OnecoreUap
         path.join(d, "Lib", SDK_DIR_VERSION, "um", "x64", "kernel32.lib"),-- StoreApps Libs
         path.join(d, "Lib", SDK_DIR_VERSION, "um", "x64", "gdi32.lib"),   -- Desktop Libs x64

--- a/pkgs/w/windows-sdk.lua
+++ b/pkgs/w/windows-sdk.lua
@@ -14,6 +14,10 @@
 --   Windows SDK Desktop Headers x86               1685 headers -- the DESKTOP
 --                                                 half of um/: ShlObj.h,
 --                                                 ShObjIdl.h  <- core
+--   Windows SDK OnecoreUap Headers x86            198 more, incl. windowsx.h
+--                                                 <- core. NOT the same MSI as
+--                                                 "...Store Apps Headers
+--                                                 OnecoreUap" above
 --   Windows SDK for Windows Store Apps Libs       kernel32/user32/advapi32/
 --                                                 ole32/oleaut32/uuid  <- core
 --   Windows SDK for Windows Store Apps Headers    528 um headers: windows.h,
@@ -255,6 +259,23 @@ local PAYLOADS = {
     -- forty minutes into a build that had already compiled hundreds of TUs.
     -- The required_files() cover below now names it, so a payload set that
     -- loses it again fails at install instead.
+    -- windowsx.h and 197 others, and the name collides with an MSI already in
+    -- this list: "Windows SDK **for Windows Store Apps** Headers OnecoreUap"
+    -- (shared/: windef.h, sal.h) is a DIFFERENT payload from "Windows SDK
+    -- OnecoreUap Headers x86" (um/: windowsx.h). Having both is not
+    -- redundancy.
+    --
+    -- Its x64 and arm64 siblings ship one and three files; only x86 is
+    -- substantial. Same shape as the Desktop Headers set.
+    { name = "Windows SDK OnecoreUap Headers x86-x86_en-us.msi", msi = true,
+      sha256 = "09725127B70E645FD0C86F004A1B0204AE72D685D70B2E3856EFC00533AAEEC3",
+      urls = { "https://gitcode.com/xlings-res/windows-sdk/releases/download/10.0.26100/Windows_SDK_OnecoreUap_Headers_x86-x86_en-us.msi",
+               "https://download.visualstudio.microsoft.com/download/pr/6452c1f1-dc1e-413c-8b19-991b61870a8b/bf4c8a484028b6e592a6a9d818c21777/windows%20sdk%20onecoreuap%20headers%20x86-x86_en-us.msi" } },
+    { name = "f2e05dfd38ed343d3de77209cf3ecdae.cab",
+      sha256 = "C536E6742D56A05C47310C23E09A9E5A5552D914F5752FF9050EEE88E009BCF9",
+      urls = { "https://gitcode.com/xlings-res/windows-sdk/releases/download/10.0.26100/f2e05dfd38ed343d3de77209cf3ecdae.cab.bin",
+               "https://download.visualstudio.microsoft.com/download/pr/6452c1f1-dc1e-413c-8b19-991b61870a8b/107cd9d9170325d1ded9e4cc47a9c4cc/f2e05dfd38ed343d3de77209cf3ecdae.cab" } },
+
     { name = "Windows SDK Desktop Headers x86-x86_en-us.msi", msi = true,
       sha256 = "F1E5159FEB948CE90A81DCC6A427DDE844610230CB6ED787E35D422DE527A5F8",
       urls = { "https://gitcode.com/xlings-res/windows-sdk/releases/download/10.0.26100/Windows_SDK_Desktop_Headers_x86-x86_en-us.msi",
@@ -467,7 +488,7 @@ end
 -- One file per MSI that matters, chosen so a missing payload cannot pass.
 --
 -- Not a sample -- a cover. Each line below is the file that only ONE of the
--- nine payloads provides, so whichever one failed to download, extract or
+-- ten payloads provides, so whichever one failed to download, extract or
 -- merge, exactly this list names it. The last two are the `programs` this
 -- package registers with xvm: a package that advertises rc and mt and then
 -- ships neither is worse than one that admits it has no tools.
@@ -477,6 +498,7 @@ local function required_files()
         path.join(d, "Include", SDK_DIR_VERSION, "ucrt", "corecrt.h"),    -- UCRT
         path.join(d, "Include", SDK_DIR_VERSION, "um", "winnt.h"),        -- StoreApps Headers
         path.join(d, "Include", SDK_DIR_VERSION, "um", "ShlObj.h"),       -- Desktop Headers x86
+        path.join(d, "Include", SDK_DIR_VERSION, "um", "windowsx.h"),     -- OnecoreUap Headers x86
         path.join(d, "Include", SDK_DIR_VERSION, "shared", "windef.h"),   -- ... OnecoreUap
         path.join(d, "Lib", SDK_DIR_VERSION, "um", "x64", "kernel32.lib"),-- StoreApps Libs
         path.join(d, "Lib", SDK_DIR_VERSION, "um", "x64", "gdi32.lib"),   -- Desktop Libs x64


### PR DESCRIPTION
上一个修复(`ShlObj.h`)让构建越过了 `src/platform/font.ixx`,进到 glfw,然后卡在
`windowsx.h`。**不再一个个补** —— 这一次把问题一次问完。

## 量了什么

把 xrgui、它三个 submodule、以及它实际编译的第三方源里**所有** `#include <*.h>`
(156 个不同的头)拿出来,对着这个包的头文件 MSI **实际安装内容的并集**(离线解
File/Component/Directory 表得到)逐个核对。

加上这个 MSI 之后:**没有一个 Windows SDK 头是缺的**。

剩下未解析的全都不该由本包提供 —— 编译器自带的(`intrin.h`、`stdint.h`、
`immintrin.h` 在 MSVC toolset 里)、MFC、MinGW、macOS、第三方。

## 它的名字和已在列表里的一个撞了

这正是它看起来"已经覆盖"的原因:

```
Windows SDK for Windows Store Apps Headers OnecoreUap   shared/: windef.h, sal.h   ← 已在
Windows SDK OnecoreUap Headers x86                      um/:     windowsx.h        ← 缺的
```

**两个不同的 payload,同时存在不是冗余。** 它的 x64 / arm64 兄弟分别只有 1 个和
3 个文件,只有 x86 是实质性的 —— 和 Desktop Headers 那一组同样的形状。

## cover 这一轮兑现了

`required_files()` 加 `um/windowsx.h`。而上一轮正好验证了这条规则的价值:那次重跑
恢复的缓存里是**旧的八件套 SDK**,`installed()` 因为缺 `ShlObj.h` 判定为未安装并重装,
而不是安静地拿旧的去编 —— 如果它是 sample 而不是 cover,这一轮会以完全相同的错误
再红一次,且看不出是缓存问题。

## 镜像

两个新文件均已补齐,**真实 GET + sha256** 核验通过。
